### PR TITLE
bytes function requires type

### DIFF
--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -23,7 +23,7 @@ def load(filename, out=None):
     typename = type(out).__name__.replace('Tensor', '')
     func = getattr(th_sox, 'libthsox_{}_read_audio_file'.format(typename))
     sample_rate_p = ffi.new('int*')
-    func(bytes(filename), out, sample_rate_p)
+    func(bytes(filename, "ascii"), out, sample_rate_p)
     sample_rate = sample_rate_p[0]
     return out, sample_rate
 
@@ -37,4 +37,4 @@ def save(filepath, src, sample_rate):
     typename = type(src).__name__.replace('Tensor', '')
     func = getattr(th_sox, 'libthsox_{}_write_audio_file'.format(typename))
 
-    func(bytes(filepath), src, extension[1:], sample_rate)
+    func(bytes(filepath, "ascii"), src, extension[1:], sample_rate)


### PR DESCRIPTION
I had the following error after installation.  This patch fixed the problem.

>>> import torchaudio
>>> torchaudio.load("ffea344c-e8a6-4697-a952-2580c4c15e48.mp3")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/david/miniconda3/envs/hu/lib/python3.6/site-packages/torchaudio-0.1-py3.6-linux-x86_64.egg/torchaudio/__init__.py", line 26, in load
    func(bytes(filename), out, sample_rate_p)
TypeError: string argument without an encoding
