### PR TITLE
cffi dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Installation
 ------------
 
 ```bash
+sudo pip install cffi
 python setup.py install
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Installation
 ------------
 
 ```bash
-sudo pip install cffi
+pip install cffi
 python setup.py install
 ```
 


### PR DESCRIPTION
ImportError: No module named 'cffi'. Necessary for both mac and linux installations