### PR TITLE
Quick and dirty fix for "bytes" (in torchaudio.save) not available in python2

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import torch
 import torchaudio
 import torchaudio.transforms as transforms

--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import torch
 
@@ -9,6 +10,11 @@ from ._ext import th_sox
 
 from torchaudio import transforms
 from torchaudio import datasets
+
+if sys.version_info >= (3, 0):
+    _bytes = bytes
+else:
+    _bytes = lambda s, e: s.encode(e)
 
 def check_input(src):
     if not torch.is_tensor(src):
@@ -64,4 +70,4 @@ def save(filepath, src, sample_rate):
     check_input(src)
     typename = type(src).__name__.replace('Tensor', '')
     func = getattr(th_sox, 'libthsox_{}_write_audio_file'.format(typename))
-    func(bytes(filepath, "utf-8"), src, bytes(extension[1:], "utf-8"), sample_rate)
+    func(_bytes(filepath, "utf-8"), src, _bytes(extension[1:], "utf-8"), sample_rate)

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import division, print_function
 import torch
 import numpy as np
 try:


### PR DESCRIPTION
Since pytorch is python2 compatible, torchaudio should also be python2 compatible.