### PR TITLE
torch.cos not implemented for LongTensor fix

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -92,7 +92,7 @@ class Test_LoadSave(unittest.TestCase):
         volume = 0.3
 
         y = (torch.cos(
-            2 * math.pi * torch.arange(0, 4 * sr) * freq / sr)).float()
+            2 * math.pi * torch.arange(0, 4 * sr).float() * freq / sr))
         y.unsqueeze_(1)
         # y is between -1 and 1, so must scale
         y = (y * volume * 2**31).long()

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -11,7 +11,7 @@ class Tester(unittest.TestCase):
     sr = 16000
     freq = 440
     volume = .3
-    sig = (torch.cos(2 * np.pi * torch.arange(0, 4 * sr) * freq / sr)).float()
+    sig = (torch.cos(2 * np.pi * torch.arange(0, 4 * sr).float() * freq / sr))
     # sig = (torch.cos((1+torch.arange(0, 4 * sr) * 2) / sr * 2 * np.pi * torch.arange(0, 4 * sr) * freq / sr)).float()
     sig.unsqueeze_(1)
     sig = (sig * volume * 2**31).long()


### PR DESCRIPTION
The tests fail because torch.cos is not implemented for LongTensor.  This is a simple fix that moves the conversion of the result of the cos function to float to the conversion of the inner function (torch.arange) to float.  Below the error message I received using the master branch of pytorch.

```
======================================================================
ERROR: test_save (__main__.Test_LoadSave)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test.py", line 95, in test_save
    2 * math.pi * torch.arange(0, 4 * sr) * freq / sr)).float()
RuntimeError: "cos" not implemented for 'torch.LongTensor'

----------------------------------------------------------------------
```