### PR TITLE
stringify filename on load for compatibility with pathlib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# temp files
+~*
+*.swp
+
 # C extensions / folders
 *.so
 _ext/

--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -26,7 +26,7 @@ def load(filepath,
     """Loads an audio file from disk into a Tensor
 
     Args:
-        filepath (string): path to audio file
+        filepath (string or pathlib.Path): path to audio file
         out (Tensor, optional): an output Tensor to use instead of creating one
         normalization (bool, number, or callable, optional): If boolean `True`, then output is divided by `1 << 31`
                                                              (assumes signed 32-bit audio), and normalizes to `[0, 1]`.
@@ -60,6 +60,8 @@ def load(filepath,
         1.
 
     """
+    # stringify if `pathlib.Path` (noop if already `str`)
+    filepath = str(filepath)
     # check if valid file
     if not os.path.isfile(filepath):
         raise OSError("{} not found or is a directory".format(filepath))

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -306,7 +306,7 @@ class MEL2(object):
         >>> sig, sr = torchaudio.load("test.wav", normalization=True)
         >>> spec_mel = transforms.MEL2(sr)(sig)  # (c, l, m)
     """
-    def __init__(self, sr=16000, ws=400, hop=None, n_fft=None,
+    def __init__(self, sr=16000, ws=400, hop=None, n_fft=None, fmin=0., fmax=None,
                  pad=0, n_mels=40, window=torch.hann_window, wkwargs=None):
         self.window = window
         self.sr = sr
@@ -317,8 +317,8 @@ class MEL2(object):
         self.n_mels = n_mels  # number of mel frequency bins
         self.wkwargs = wkwargs
         self.top_db = -80.
-        self.f_max = None
-        self.f_min = 0.
+        self.f_max = fmax
+        self.f_min = fmin
         self.spec = SPECTROGRAM(self.ws, self.hop, self.n_fft,
                                 self.pad, self.window, self.wkwargs)
         self.fm = F2M(self.n_mels, self.sr, self.f_max, self.f_min)


### PR DESCRIPTION
`pathlib` is recommended for path handling nowadays. Simply using `str()`  makes it compatible with pathlib, without introducing a dependency (although it's been part of stdlib for quite a while now).