### PR TITLE
Librosa consistency

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -3,7 +3,7 @@ import torch
 import torchaudio
 import math
 import os
-
+import numpy as np
 
 class Test_LoadSave(unittest.TestCase):
     test_dirpath = os.path.dirname(os.path.realpath(__file__))
@@ -168,6 +168,85 @@ class Test_LoadSave(unittest.TestCase):
         self.assertEqual(si.length, samples)
         self.assertEqual(si.rate, rate)
         self.assertEqual(ei.bits_per_sample, precision)
+
+    def test_6_librosa_consistency(self):
+        try:
+            import librosa
+            import scipy
+        except:
+            return
+        input_path = os.path.join(self.test_dirpath, 'assets', 'sinewave.wav')
+        sound, sample_rate = torchaudio.load(input_path)
+        sound_librosa = sound.cpu().numpy().squeeze().T # squeeze batch and channel first
+
+
+        n_fft = 400
+        hop_length = 200
+        power = 2.0
+        n_mels = 128
+        n_mfcc = 40
+        sample_rate = 16000
+
+        # test core spectrogram 
+        spect_transform = torchaudio.transforms.Spectrogram(n_fft=n_fft, hop=hop_length, power=2)
+        out_librosa, _ = librosa.core.spectrum._spectrogram(y=sound_librosa, n_fft=n_fft, hop_length=hop_length, power=2)
+
+        out_torch = spect_transform(sound).squeeze().numpy().T
+        self.assertTrue(np.allclose(out_torch, out_librosa, atol=1e-5))
+
+        # test mel spectrogram
+        melspect_transform = torchaudio.transforms.MelSpectrogram(sr=sample_rate,window=torch.hann_window,
+                                                        hop=hop_length, n_mels=n_mels, n_fft=n_fft)
+        librosa_mel = librosa.feature.melspectrogram(y=sound_librosa, sr=sample_rate,
+                                                     n_fft=n_fft, hop_length=hop_length, n_mels=n_mels, 
+                                                     htk=True,norm=None)
+        torch_mel = melspect_transform(sound).squeeze().numpy().T
+
+        # lower tolerance, think it's double vs. float 
+        self.assertTrue(np.allclose(torch_mel, librosa_mel, atol=5e-3))
+
+
+        # test s2db
+
+        db_transform = torchaudio.transforms.SpectrogramToDB("power", 80.)
+        db_torch = db_transform(spect_transform(sound)).squeeze().numpy().T
+        db_librosa = librosa.core.spectrum.power_to_db(out_librosa)
+
+        self.assertTrue(np.allclose(db_torch, db_librosa, atol=5e-3))
+        
+        db_torch = db_transform(melspect_transform(sound)).squeeze().numpy().T
+        db_librosa = librosa.core.spectrum.power_to_db(librosa_mel)
+    
+        self.assertTrue(np.allclose(db_torch, db_librosa, atol=5e-3))
+
+
+        # test MFCC
+        melkwargs = {'hop': hop_length, 'n_fft': n_fft}
+        mfcc_transform = torchaudio.transforms.MFCC(sr=sample_rate,
+                                                    n_mfcc=n_mfcc,
+                                                    norm='ortho',
+                                                    melkwargs=melkwargs)
+       
+
+        # librosa.feature.mfcc doesn't pass kwargs properly since some of the
+        # kwargs for melspectrogram and mfcc are the same. We just follow the
+        # function body in https://librosa.github.io/librosa/_modules/librosa/feature/spectral.html#melspectrogram
+        # to mirror this:
+
+#         librosa_mfcc = librosa.feature.mfcc(y=sound_librosa,
+                                            # sr=sample_rate,
+                                            # n_mfcc = n_mfcc,
+                                            # hop_length=hop_length,
+                                            # n_fft=n_fft,
+                                            # htk=True,
+                                            # norm=None,
+                                            # n_mels=n_mels)
+
+        librosa_mfcc = scipy.fftpack.dct(db_librosa, axis=0, type=2, norm='ortho')[:n_mfcc]
+        torch_mfcc = mfcc_transform(sound).squeeze().numpy().T
+
+        self.assertTrue(np.allclose(torch_mfcc, librosa_mfcc, atol=5e-3))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -86,22 +86,6 @@ class Tester(unittest.TestCase):
         repr_test = transforms.LC2CL()
         self.assertTrue(repr_test.__repr__())
 
-    def test_mel(self):
-
-        audio = self.sig.clone()
-        audio = transforms.Scale()(audio)
-        self.assertTrue(audio.dim() == 2)
-        result = transforms.MEL()(audio)
-        self.assertTrue(result.dim() == 3)
-        result = transforms.BLC2CBL()(result)
-        self.assertTrue(result.dim() == 3)
-
-        repr_test = transforms.MEL()
-        self.assertTrue(repr_test.__repr__())
-
-        repr_test = transforms.BLC2CBL()
-        self.assertTrue(repr_test.__repr__())
-
     def test_compose(self):
 
         audio_orig = self.sig.clone()
@@ -155,7 +139,7 @@ class Tester(unittest.TestCase):
         audio_orig = self.sig.clone()  # (16000, 1)
         audio_scaled = transforms.Scale()(audio_orig)  # (16000, 1)
         audio_scaled = transforms.LC2CL()(audio_scaled)  # (1, 16000)
-        mel_transform = transforms.MEL2()
+        mel_transform = transforms.MelSpectrogram()
         # check defaults
         spectrogram_torch = mel_transform(audio_scaled)  # (1, 319, 40)
         self.assertTrue(spectrogram_torch.dim() == 3)
@@ -166,7 +150,7 @@ class Tester(unittest.TestCase):
         self.assertTrue(mel_transform.fm.fb.sum(1).le(1.).all())
         self.assertTrue(mel_transform.fm.fb.sum(1).ge(0.).all())
         # check options
-        mel_transform2 = transforms.MEL2(window=torch.hamming_window, pad=10, ws=500, hop=125, n_fft=800, n_mels=50)
+        mel_transform2 = transforms.MelSpectrogram(window=torch.hamming_window, pad=10, ws=500, hop=125, n_fft=800, n_mels=50)
         spectrogram2_torch = mel_transform2(audio_scaled)  # (1, 506, 50)
         self.assertTrue(spectrogram2_torch.dim() == 3)
         self.assertTrue(spectrogram2_torch.le(0.).all())
@@ -183,7 +167,7 @@ class Tester(unittest.TestCase):
         self.assertTrue(spectrogram_stereo.ge(mel_transform.top_db).all())
         self.assertEqual(spectrogram_stereo.size(-1), mel_transform.n_mels)
         # check filterbank matrix creation
-        fb_matrix_transform = transforms.F2M(n_mels=100, sr=16000, f_max=None, f_min=0., n_stft=400)
+        fb_matrix_transform = transforms.MelScale(n_mels=100, sr=16000, f_max=None, f_min=0., n_stft=400)
         self.assertTrue(fb_matrix_transform.fb.sum(1).le(1.).all())
         self.assertTrue(fb_matrix_transform.fb.sum(1).ge(0.).all())
         self.assertEqual(fb_matrix_transform.fb.size(), (400, 100))

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -136,15 +136,17 @@ class Tester(unittest.TestCase):
         self.assertTrue(repr_test.__repr__())
 
     def test_mel2(self):
+        top_db = 80.
+        s2db = transforms.SpectrogramToDB("power", top_db)
+
         audio_orig = self.sig.clone()  # (16000, 1)
         audio_scaled = transforms.Scale()(audio_orig)  # (16000, 1)
         audio_scaled = transforms.LC2CL()(audio_scaled)  # (1, 16000)
         mel_transform = transforms.MelSpectrogram()
         # check defaults
-        spectrogram_torch = mel_transform(audio_scaled)  # (1, 319, 40)
+        spectrogram_torch = s2db(mel_transform(audio_scaled))  # (1, 319, 40)
         self.assertTrue(spectrogram_torch.dim() == 3)
-        self.assertTrue(spectrogram_torch.le(0.).all())
-        self.assertTrue(spectrogram_torch.ge(mel_transform.top_db).all())
+        self.assertTrue(spectrogram_torch.ge(spectrogram_torch.max() - top_db).all())
         self.assertEqual(spectrogram_torch.size(-1), mel_transform.n_mels)
         # check correctness of filterbank conversion matrix
         self.assertTrue(mel_transform.fm.fb.sum(1).le(1.).all())
@@ -152,26 +154,139 @@ class Tester(unittest.TestCase):
         # check options
         kwargs = {"window": torch.hamming_window, "pad": 10, "ws": 500, "hop": 125, "n_fft": 800, "n_mels": 50}
         mel_transform2 = transforms.MelSpectrogram(**kwargs)
-        spectrogram2_torch = mel_transform2(audio_scaled)  # (1, 506, 50)
+        spectrogram2_torch = s2db(mel_transform2(audio_scaled))  # (1, 506, 50)
         self.assertTrue(spectrogram2_torch.dim() == 3)
-        self.assertTrue(spectrogram2_torch.le(0.).all())
-        self.assertTrue(spectrogram2_torch.ge(mel_transform.top_db).all())
+        self.assertTrue(spectrogram_torch.ge(spectrogram_torch.max() - top_db).all())
         self.assertEqual(spectrogram2_torch.size(-1), mel_transform2.n_mels)
         self.assertTrue(mel_transform2.fm.fb.sum(1).le(1.).all())
         self.assertTrue(mel_transform2.fm.fb.sum(1).ge(0.).all())
         # check on multi-channel audio
         x_stereo, sr_stereo = torchaudio.load(self.test_filepath)
-        spectrogram_stereo = mel_transform(x_stereo)
+        spectrogram_stereo = s2db(mel_transform(x_stereo))
         self.assertTrue(spectrogram_stereo.dim() == 3)
         self.assertTrue(spectrogram_stereo.size(0) == 2)
-        self.assertTrue(spectrogram_stereo.le(0.).all())
-        self.assertTrue(spectrogram_stereo.ge(mel_transform.top_db).all())
+        self.assertTrue(spectrogram_torch.ge(spectrogram_torch.max() - top_db).all())
         self.assertEqual(spectrogram_stereo.size(-1), mel_transform.n_mels)
         # check filterbank matrix creation
         fb_matrix_transform = transforms.MelScale(n_mels=100, sr=16000, f_max=None, f_min=0., n_stft=400)
         self.assertTrue(fb_matrix_transform.fb.sum(1).le(1.).all())
         self.assertTrue(fb_matrix_transform.fb.sum(1).ge(0.).all())
         self.assertEqual(fb_matrix_transform.fb.size(), (400, 100))
+
+    def test_mfcc(self):
+        audio_orig = self.sig.clone()
+        audio_scaled = transforms.Scale()(audio_orig)  # (16000, 1)
+        audio_scaled = transforms.LC2CL()(audio_scaled)  # (1, 16000)
+
+        sample_rate = 16000
+        n_mfcc = 40
+        n_mels = 128
+        mfcc_transform = torchaudio.transforms.MFCC(sr=sample_rate,
+                                                    n_mfcc=n_mfcc,
+                                                    norm='ortho')
+        # check defaults
+        torch_mfcc = mfcc_transform(audio_scaled)
+        self.assertTrue(torch_mfcc.dim() == 3)
+        self.assertTrue(torch_mfcc.shape[2] == n_mfcc)
+        self.assertTrue(torch_mfcc.shape[1] == 321)
+        # check melkwargs are passed through
+        melkwargs = {'ws': 200}
+        mfcc_transform2 = torchaudio.transforms.MFCC(sr=sample_rate,
+                                                     n_mfcc=n_mfcc,
+                                                     norm='ortho',
+                                                     melkwargs=melkwargs)
+        torch_mfcc2 = mfcc_transform2(audio_scaled)
+        self.assertTrue(torch_mfcc2.shape[1] == 641)
+
+        # check norms work correctly
+        mfcc_transform_norm_none = torchaudio.transforms.MFCC(sr=sample_rate,
+                                                              n_mfcc=n_mfcc,
+                                                              norm='None')
+        torch_mfcc_norm_none = mfcc_transform_norm_none(audio_scaled)
+
+        norm_check = torch_mfcc.clone()
+        norm_check[:, :, 0] *= np.sqrt(n_mels) * 2
+        norm_check[:, :, 1:] *= np.sqrt(n_mels / 2) * 2
+
+        self.assertTrue(torch_mfcc_norm_none.allclose(norm_check))
+
+    def test_librosa_consistency(self):
+        try:
+            import librosa
+            import scipy
+        except:
+            return
+
+        input_path = os.path.join(self.test_dirpath, 'assets', 'sinewave.wav')
+        sound, sample_rate = torchaudio.load(input_path)
+        sound_librosa = sound.cpu().numpy().squeeze().T  # squeeze batch and channel first
+
+        n_fft = 400
+        hop_length = 200
+        power = 2.0
+        n_mels = 128
+        n_mfcc = 40
+        sample_rate = 16000
+
+        # test core spectrogram
+        spect_transform = torchaudio.transforms.Spectrogram(n_fft=n_fft, hop=hop_length, power=2)
+        out_librosa, _ = librosa.core.spectrum._spectrogram(y=sound_librosa,
+                                                            n_fft=n_fft,
+                                                            hop_length=hop_length,
+                                                            power=2)
+
+        out_torch = spect_transform(sound).squeeze().cpu().numpy().T
+        self.assertTrue(np.allclose(out_torch, out_librosa, atol=1e-5))
+
+        # test mel spectrogram
+        melspect_transform = torchaudio.transforms.MelSpectrogram(sr=sample_rate, window=torch.hann_window,
+                                                                  hop=hop_length, n_mels=n_mels, n_fft=n_fft)
+        librosa_mel = librosa.feature.melspectrogram(y=sound_librosa, sr=sample_rate,
+                                                     n_fft=n_fft, hop_length=hop_length, n_mels=n_mels,
+                                                     htk=True, norm=None)
+        torch_mel = melspect_transform(sound).squeeze().cpu().numpy().T
+
+        # lower tolerance, think it's double vs. float
+        self.assertTrue(np.allclose(torch_mel, librosa_mel, atol=5e-3))
+
+        # test s2db
+
+        db_transform = torchaudio.transforms.SpectrogramToDB("power", 80.)
+        db_torch = db_transform(spect_transform(sound)).squeeze().cpu().numpy().T
+        db_librosa = librosa.core.spectrum.power_to_db(out_librosa)
+        self.assertTrue(np.allclose(db_torch, db_librosa, atol=5e-3))
+
+        db_torch = db_transform(melspect_transform(sound)).squeeze().cpu().numpy().T
+        db_librosa = librosa.core.spectrum.power_to_db(librosa_mel)
+
+        self.assertTrue(np.allclose(db_torch, db_librosa, atol=5e-3))
+
+        # test MFCC
+        melkwargs = {'hop': hop_length, 'n_fft': n_fft}
+        mfcc_transform = torchaudio.transforms.MFCC(sr=sample_rate,
+                                                    n_mfcc=n_mfcc,
+                                                    norm='ortho',
+                                                    melkwargs=melkwargs)
+
+        # librosa.feature.mfcc doesn't pass kwargs properly since some of the
+        # kwargs for melspectrogram and mfcc are the same. We just follow the
+        # function body in https://librosa.github.io/librosa/_modules/librosa/feature/spectral.html#melspectrogram
+        # to mirror this function call with correct args:
+
+#         librosa_mfcc = librosa.feature.mfcc(y=sound_librosa,
+#                                             sr=sample_rate,
+#                                             n_mfcc = n_mfcc,
+#                                             hop_length=hop_length,
+#                                             n_fft=n_fft,
+#                                             htk=True,
+#                                             norm=None,
+#                                             n_mels=n_mels)
+
+        librosa_mfcc = scipy.fftpack.dct(db_librosa, axis=0, type=2, norm='ortho')[:n_mfcc]
+        torch_mfcc = mfcc_transform(sound).squeeze().cpu().numpy().T
+
+        self.assertTrue(np.allclose(torch_mfcc, librosa_mfcc, atol=5e-3))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -201,7 +201,7 @@ class Tester(unittest.TestCase):
         # check norms work correctly
         mfcc_transform_norm_none = torchaudio.transforms.MFCC(sr=sample_rate,
                                                               n_mfcc=n_mfcc,
-                                                              norm='None')
+                                                              norm=None)
         torch_mfcc_norm_none = mfcc_transform_norm_none(audio_scaled)
 
         norm_check = torch_mfcc.clone()

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -214,7 +214,7 @@ class Tester(unittest.TestCase):
         try:
             import librosa
             import scipy
-        except:
+        except ImportError:
             return
 
         input_path = os.path.join(self.test_dirpath, 'assets', 'sinewave.wav')

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -172,7 +172,7 @@ class Spectrogram(object):
         normalize (bool) : whether to normalize by magnitude after stft
         wkwargs (dict, optional): arguments for window function
     """
-    def __init__(self, n_fft=400, ws=None, hop=None, 
+    def __init__(self, n_fft=400, ws=None, hop=None,
                  pad=0, window=torch.hann_window,
                  power=2, normalize=False, wkwargs=None):
         self.n_fft = n_fft
@@ -210,7 +210,7 @@ class Spectrogram(object):
                             self.window, center=True,
                             normalized=False, onesided=True,
                             pad_mode='reflect').transpose(1, 2)
-        if self.normalize: 
+        if self.normalize:
             spec_f /= self.window.pow(2).sum().sqrt()
         spec_f = spec_f.pow(self.power).sum(-1)  # get power of "complex" tensor (c, l, n_fft)
         return spec_f
@@ -280,8 +280,6 @@ class MelScale(object):
         return 700. * (10**(mel / 2595.) - 1.)
 
 
-
-
 class SpectrogramToDB(object):
     """Turns a spectrogram from the power/amplitude scale to the decibel scale.
 
@@ -332,7 +330,11 @@ class MFCC(object):
         self.melkwargs = melkwargs
         self.top_db = 80.
         self.s2db = SpectrogramToDB("power", self.top_db)
-        self.MelSpectrogram = MelSpectrogram(sr=self.sr, **melkwargs) if melkwargs is not None else MelSpectrogram(sr=self.sr)
+
+        if melkwargs is not None:
+            self.MelSpectrogram = MelSpectrogram(sr=self.sr, **melkwargs)
+        else:
+            self.MelSpectrogram = MelSpectrogram(sr=self.sr)
 
     def __call__(self, sig):
         """
@@ -397,7 +399,7 @@ class MelSpectrogram(object):
 
     def __call__(self, sig):
         """
-        Args: 
+        Args:
             sig (Tensor): Tensor of audio of size (channels [c], samples [n])
 
         Returns:

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -160,10 +160,9 @@ class Spectrogram(object):
     """Create a spectrogram from a raw audio signal
 
     Args:
-        sr (int): sample rate of audio signal
-        ws (int): window size
+        n_fft (int, optional): size of fft, creates n_fft // 2 + 1 bins
+        ws (int): window size. default: n_fft
         hop (int, optional): length of hop between STFT windows. default: ws // 2
-        n_fft (int, optional): size of fft, creates n_fft // 2 + 1 bins. default: ws
         pad (int): two sided padding of signal
         window (torch windowing function): default: torch.hann_window
         power (int > 0 ) : Exponent for the magnitude spectrogram,

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -379,7 +379,7 @@ class MFCC(object):
                 number of mel bins.
         """
         mel_spect_db = self.s2db(self.MelSpectrogram(sig))
-        mfcc = torch.matmul(mel_spect_db, self.dct_mat)
+        mfcc = torch.matmul(mel_spect_db, self.dct_mat.to(sig.device))
         return mfcc
 
 

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -379,7 +379,7 @@ class MFCC(object):
                 number of mel bins.
         """
         mel_spect_db = self.s2db(self.MelSpectrogram(sig))
-        mfcc = torch.matmul(mel_spect_db, self.dct_mat.to(sig.device))
+        mfcc = torch.matmul(mel_spect_db, self.dct_mat.to(mel_spect_db.device))
         return mfcc
 
 

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -352,7 +352,8 @@ class MFCC(object):
         """
         Creates a DCT transformation matrix with shape (num_mels, num_mfcc),
         normalized depending on self.norm
-        @return The transformation matrix, to be right-multiplied to row-wise data.
+        Returns:
+            The transformation matrix, to be right-multiplied to row-wise data.
         """
         outdim = self.n_mfcc
         dim = self.MelSpectrogram.n_mels
@@ -376,7 +377,6 @@ class MFCC(object):
             spec_mel_db (Tensor): channels x hops x n_mels (c, l, m), where channels
                 is unchanged, hops is the number of hops, and n_mels is the
                 number of mel bins.
-
         """
         mel_spect_db = self.s2db(self.MelSpectrogram(sig))
         mfcc = torch.matmul(mel_spect_db, self.dct_mat)

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -350,11 +350,8 @@ class MFCC(object):
 
     def create_dct(self):
         """
-        Creates a DCT transformation matrix.
-        @param dim: Dimensionality of input data to transform
-        @param outdim: If given, create a matrix for the first 'outdim' DCT
-            coefficients only. If omitted, create a full (squared) DCT matrix.
-        @param orthogonal: If given, makes the transform orthogonal
+        Creates a DCT transformation matrix with shape (num_mels, num_mfcc),
+        normalized depending on self.norm
         @return The transformation matrix, to be right-multiplied to row-wise data.
         """
         outdim = self.n_mfcc

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -1,11 +1,6 @@
 from __future__ import division, print_function
 import torch
 import numpy as np
-try:
-    import librosa
-except ImportError:
-    librosa = None
-
 
 class Compose(object):
     """Composes several transforms together.
@@ -155,7 +150,7 @@ class LC2CL(object):
         return self.__class__.__name__ + '()'
 
 
-class SPECTROGRAM(object):
+class Spectrogram(object):
     """Create a spectrogram from a raw audio signal
 
     Args:
@@ -205,17 +200,17 @@ class SPECTROGRAM(object):
         return spec_f
 
 
-class F2M(object):
-    """This turns a normal STFT into a MEL Frequency STFT, using a conversion
+class MelScale(object):
+    """This turns a normal STFT into a mel frequency STFT, using a conversion
        matrix.  This uses triangular filter banks.
 
     Args:
-        n_mels (int): number of MEL bins
+        n_mels (int): number of mel bins
         sr (int): sample rate of audio signal
         f_max (float, optional): maximum frequency. default: `sr` // 2
         f_min (float): minimum frequency. default: 0
         n_stft (int, optional): number of filter banks from stft. Calculated from first input
-            if `None` is given.  See `n_fft` in `SPECTROGRAM`.
+            if `None` is given.  See `n_fft` in `Spectrogram`.
     """
     def __init__(self, n_mels=40, sr=16000, f_max=None, f_min=0., n_stft=None):
         self.n_mels = n_mels
@@ -261,7 +256,7 @@ class F2M(object):
         return 700. * (10**(mel / 2595.) - 1.)
 
 
-class SPEC2DB(object):
+class SpectogramToDB(object):
     """Turns a spectrogram from the power/amplitude scale to the decibel scale.
 
     Args:
@@ -285,10 +280,9 @@ class SPEC2DB(object):
         return spec_db
 
 
-class MEL2(object):
+class MelSpectrogram(object):
     """Create MEL Spectrograms from a raw audio signal using the stft
-       function in PyTorch.  Hopefully this solves the speed issue of using
-       librosa.
+       function in PyTorch.
 
     Sources:
         * https://gist.github.com/kastnerkyle/179d6e9a88202ab0a2fe
@@ -300,6 +294,8 @@ class MEL2(object):
         ws (int): window size
         hop (int, optional): length of hop between STFT windows. default: `ws` // 2
         n_fft (int, optional): number of fft bins. default: `ws` // 2 + 1
+        f_max (float, optional): maximum frequency. default: `sr` // 2
+        f_min (float): minimum frequency. default: 0
         pad (int): two sided padding of signal
         n_mels (int): number of MEL bins
         window (torch windowing function): default: `torch.hann_window`
@@ -307,9 +303,9 @@ class MEL2(object):
 
     Example:
         >>> sig, sr = torchaudio.load("test.wav", normalization=True)
-        >>> spec_mel = transforms.MEL2(sr)(sig)  # (c, l, m)
+        >>> spec_mel = transforms.MelSpectrogram(sr)(sig)  # (c, l, m)
     """
-    def __init__(self, sr=16000, ws=400, hop=None, n_fft=None, fmin=0., fmax=None,
+    def __init__(self, sr=16000, ws=400, hop=None, n_fft=None, f_min=0., f_max=None,
                  pad=0, n_mels=40, window=torch.hann_window, wkwargs=None):
         self.window = window
         self.sr = sr
@@ -320,12 +316,12 @@ class MEL2(object):
         self.n_mels = n_mels  # number of mel frequency bins
         self.wkwargs = wkwargs
         self.top_db = -80.
-        self.f_max = fmax
-        self.f_min = fmin
-        self.spec = SPECTROGRAM(self.ws, self.hop, self.n_fft,
+        self.f_max = f_max
+        self.f_min = f_min
+        self.spec = Spectrogram(self.ws, self.hop, self.n_fft,
                                 self.pad, self.window, self.wkwargs)
-        self.fm = F2M(self.n_mels, self.sr, self.f_max, self.f_min)
-        self.s2db = SPEC2DB("power", self.top_db)
+        self.fm = MelScale(self.n_mels, self.sr, self.f_max, self.f_min)
+        self.s2db = SpectogramToDB("power", self.top_db)
         self.transforms = Compose([
             self.spec, self.fm, self.s2db,
         ])
@@ -344,48 +340,6 @@ class MEL2(object):
         spec_mel_db = self.transforms(sig)
 
         return spec_mel_db
-
-
-class MEL(object):
-    """Create MEL Spectrograms from a raw audio signal. Relatively pretty slow.
-
-       Usage (see librosa.feature.melspectrogram docs):
-           MEL(sr=16000, n_fft=1600, hop_length=800, n_mels=64)
-    """
-
-    def __init__(self, **kwargs):
-        self.kwargs = kwargs
-
-    def __call__(self, tensor):
-        """
-
-        Args:
-            tensor (Tensor): Tensor of audio of size (samples [n] x channels [c])
-
-        Returns:
-            tensor (Tensor): n_mels x hops x channels (BxLxC), where n_mels is
-                the number of mel bins, hops is the number of hops, and channels
-                is unchanged.
-
-        """
-
-        if librosa is None:
-            print("librosa not installed, cannot create spectrograms")
-            return tensor
-        L = []
-        for i in range(tensor.size(1)):
-            nparr = tensor[:, i].numpy()  # (samples, )
-            sgram = librosa.feature.melspectrogram(
-                nparr, **self.kwargs)  # (n_mels, hops)
-            L.append(sgram)
-        L = np.stack(L, 2)  # (n_mels, hops, channels)
-        tensor = torch.from_numpy(L).type_as(tensor)
-
-        return tensor
-
-    def __repr__(self):
-        return self.__class__.__name__ + '()'
-
 
 class BLC2CBL(object):
     """Permute a 3d tensor from Bands x Sample length x Channels to Channels x


### PR DESCRIPTION
This is a start, appreciate comments and any advice on achieving consistency with torch codebase.
Main modifications:
- switched the argument orders of Spectrogram, MelSpectrogram so that n_fft is the default way to construct as opposed to window size
- made normalization after torch.stft in Spectrogram a parametrized option
- changed SpectrogramToDB to the librosa implementation, which is more numerically stable
- fixed a bug in MelScale where the matrix multiply would fail if the input tensor was on a different device than the filterbank matrix
- changed default n_mels in MelScale, MelSpectrogram to align with librosa's
- added MFCC function that calculates the MFCC features for an input audio file. This uses a torch DCT implementation from another repo. Am unsure of whether it makes sense to use that repo as a library or just credit and use the function, and whether or not to make DCT into a transform class. Probably depends on how much need there is for the other types of DCT. 
- added tests for consistency against librosa for new features, which also provides visibility into which default librosa options are changed for using this library. All tests pass on my machine, for CPU and Cuda. 
Future modifications:
- adding in non-HTK mel frequencies https://librosa.github.io/librosa/_modules/librosa/core/time_frequency.html#mel_frequencies

Appreciate any comments. This is my first PR to a torch repo so open to all feedback. Thanks!
-Phil 