### PR TITLE
clarify sox info length field

### DIFF
--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -200,7 +200,7 @@ def sox_signalinfo_t():
       - rate (float), sample rate as a float, practically will likely be an integer float
       - channel (int), number of audio channels
       - precision (int), bit precision
-      - length (int), length of audio, 0 for unspecified and -1 for unknown
+      - length (int), length of audio in samples * channels, 0 for unspecified and -1 for unknown
       - mult (float, optional), headroom multiplier for effects and None for no multiplier
 
     Example::


### PR DESCRIPTION
I fell for this myself. The sox info struct is specifying the total number of samples and not the number of sample per channel as it is normally used.

Its probably better to clarify this, since not everyone knows the difference between samples, length, frames....