### PR TITLE
Normalized range should be [-1, 1]

### DIFF
--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -29,7 +29,7 @@ def load(filepath,
         filepath (string or pathlib.Path): path to audio file
         out (Tensor, optional): an output Tensor to use instead of creating one
         normalization (bool, number, or callable, optional): If boolean `True`, then output is divided by `1 << 31`
-                                                             (assumes signed 32-bit audio), and normalizes to `[0, 1]`.
+                                                             (assumes signed 32-bit audio), and normalizes to `[-1, 1]`.
                                                              If `number`, then output is divided by that number
                                                              If `callable`, then the output is passed as a parameter
                                                              to the given function, then the output is divided by


### PR DESCRIPTION
If sox uses 32-bit signed audio internally, dividing by `1 << 31` should yield -1 to 1.