### PR TITLE
TST: add travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+dist: xenial
+matrix:
+  include:
+    - python: "3.5"
+addons:
+    apt:
+        packages:
+            sox
+            libsox-dev
+            libsox-fmt-all
+            libpython3.5-dev
+install:
+  - pip install torch
+  - python setup.py install
+script:
+  - python -m unittest


### PR DESCRIPTION
Add `.travis.yml` file to run test automatically on travis as it is done for [pytorch/vision](https://github.com/pytorch/vision) as well.

The result can be seen here: [![Build Status](https://travis-ci.org/hagenw/audio.svg?branch=travis-test)](https://travis-ci.org/hagenw/audio)

Currently it is failing which is unrelated to this pull request and covered by this issue: #101 