### PR TITLE
 Remove numpy support in transforms.py and functional.py

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -107,18 +107,7 @@ class Tester(unittest.TestCase):
 
     def test_mu_law_companding(self):
 
-        sig = self.sig.clone()
-
         quantization_channels = 256
-        sig = self.sig.numpy()
-        sig = sig / np.abs(sig).max()
-        self.assertTrue(sig.min() >= -1. and sig.max() <= 1.)
-
-        sig_mu = transforms.MuLawEncoding(quantization_channels)(sig)
-        self.assertTrue(sig_mu.min() >= 0. and sig.max() <= quantization_channels)
-
-        sig_exp = transforms.MuLawExpanding(quantization_channels)(sig_mu)
-        self.assertTrue(sig_exp.min() >= -1. and sig_exp.max() <= 1.)
 
         sig = self.sig.clone()
         sig = sig / torch.abs(sig).max()

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -316,6 +316,7 @@ def mu_law_encoding(x, qc):
     Outputs:
         Tensor: Input after mu-law companding
     """
+    assert(isinstance(x, torch.Tensor)), 'mu_law_encoding expects a Tensor'
     mu = qc - 1.
     if not x.dtype.is_floating_point:
         x = x.to(torch.float)
@@ -341,6 +342,7 @@ def mu_law_expanding(x_mu, qc):
     Outputs:
         Tensor: Input after decoding
     """
+    assert(isinstance(x_mu, torch.Tensor)), 'mu_law_expanding expects a Tensor'
     mu = qc - 1.
     if not x_mu.dtype.is_floating_point:
         x_mu = x_mu.to(torch.float)

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -316,7 +316,7 @@ def mu_law_encoding(x, qc):
     Outputs:
         Tensor: Input after mu-law companding
     """
-    assert(isinstance(x, torch.Tensor)), 'mu_law_encoding expects a Tensor'
+    assert isinstance(x, torch.Tensor), 'mu_law_encoding expects a Tensor'
     mu = qc - 1.
     if not x.dtype.is_floating_point:
         x = x.to(torch.float)
@@ -342,7 +342,7 @@ def mu_law_expanding(x_mu, qc):
     Outputs:
         Tensor: Input after decoding
     """
-    assert(isinstance(x_mu, torch.Tensor)), 'mu_law_expanding expects a Tensor'
+    assert isinstance(x_mu, torch.Tensor), 'mu_law_expanding expects a Tensor'
     mu = qc - 1.
     if not x_mu.dtype.is_floating_point:
         x_mu = x_mu.to(torch.float)

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -323,7 +323,7 @@ def mu_law_encoding(x, qc):
     mu = torch.tensor(mu, dtype=x.dtype)
     x_mu = torch.sign(x) * torch.log1p(mu *
                                        torch.abs(x)) / torch.log1p(mu)
-    x_mu = ((x_mu + 1) / 2 * mu + 0.5).long()
+    x_mu = ((x_mu + 1) / 2 * mu + 0.5).to(torch.int64)
     return x_mu
 
 

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -245,8 +245,8 @@ def create_dct(n_mfcc, n_mels, norm):
     outdim = n_mfcc
     dim = n_mels
     # http://en.wikipedia.org/wiki/Discrete_cosine_transform#DCT-II
-    n = torch.arange(dim, dtype=torch.float32)
-    k = torch.arange(outdim, dtype=torch.float32)[:, None]
+    n = torch.arange(dim, dtype=torch.get_default_dtype())
+    k = torch.arange(outdim, dtype=torch.get_default_dtype())[:, None]
     dct = torch.cos(math.pi / dim * (n + 0.5) * k)
     if norm == 'ortho':
         dct[0] *= 1.0 / math.sqrt(2.0)

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -434,10 +434,10 @@ class MuLawExpanding(object):
         """
 
         Args:
-            x_mu (FloatTensor/LongTensor)
+            x_mu (Tensor)
 
         Returns:
-            x (FloatTensor)
+            x (Tensor)
 
         """
         return F.mu_law_expanding(x_mu, self.qc)

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function
 from warnings import warn
+import math
 import torch
-import numpy as np
 from . import functional as F
 
 
@@ -234,7 +234,7 @@ class SpectrogramToDB(object):
         self.multiplier = 10. if stype == "power" else 20.
         self.amin = 1e-10
         self.ref_value = 1.
-        self.db_multiplier = np.log10(np.maximum(self.amin, self.ref_value))
+        self.db_multiplier = math.log10(max(self.amin, self.ref_value))
 
     def __call__(self, spec):
         # numerically stable implementation from librosa
@@ -403,10 +403,10 @@ class MuLawEncoding(object):
         """
 
         Args:
-            x (FloatTensor/LongTensor or ndarray)
+            x (FloatTensor/LongTensor)
 
         Returns:
-            x_mu (LongTensor or ndarray)
+            x_mu (LongTensor)
 
         """
         return F.mu_law_encoding(x, self.qc)
@@ -434,10 +434,10 @@ class MuLawExpanding(object):
         """
 
         Args:
-            x_mu (FloatTensor/LongTensor or ndarray)
+            x_mu (FloatTensor/LongTensor)
 
         Returns:
-            x (FloatTensor or ndarray)
+            x (FloatTensor)
 
         """
         return F.mu_law_expanding(x_mu, self.qc)


### PR DESCRIPTION
From previous pull request:
"In general we don't want to support this. If someone wants to use numpy, they'll need to use our 0-cost conversions from their numpy array to a tensor, then pass it into this and then convert it back. We also don't want to use numpy to do our computations."

The major difference is mu_law_expanding and mu_law_encoding no longer accepts numpy arrays as input/output.