### PR TITLE
CI build fix

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -37,7 +37,6 @@ then
              -O miniconda.sh
     fi
     chmod +x miniconda.sh && ./miniconda.sh -b -f
-    conda update --yes conda
     echo "Creating environment to run tests in."
     conda create -n testenv --yes python="$PYTHON_VERSION"
 fi

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -37,6 +37,7 @@ then
              -O miniconda.sh
     fi
     chmod +x miniconda.sh && ./miniconda.sh -b -f
+    conda update --yes conda
     echo "Creating environment to run tests in."
     conda create -n testenv --yes python="$PYTHON_VERSION"
 fi

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -230,10 +230,10 @@ class Tester(unittest.TestCase):
             librosa_mel = librosa.feature.melspectrogram(y=sound_librosa, sr=sample_rate,
                                                          n_fft=n_fft, hop_length=hop_length, n_mels=n_mels,
                                                          htk=True, norm=None)
+            librosa_mel_tensor = torch.from_numpy(librosa_mel)
             torch_mel = melspect_transform(sound).squeeze().cpu().t()
 
-            # lower tolerance, think it's double vs. float
-            self.assertTrue(torch.allclose(torch_mel.type(torch.double), torch.from_numpy(librosa_mel), atol=5e-3))
+            self.assertTrue(torch.allclose(torch_mel.type(librosa_mel_tensor.dtype), librosa_mel_tensor, atol=5e-3))
 
             # test s2db
 
@@ -244,8 +244,9 @@ class Tester(unittest.TestCase):
 
             db_torch = db_transform(melspect_transform(sound)).squeeze().cpu().t()
             db_librosa = librosa.core.spectrum.power_to_db(librosa_mel)
+            db_librosa_tensor = torch.from_numpy(db_librosa)
 
-            self.assertTrue(torch.allclose(db_torch.type(torch.double), torch.from_numpy(db_librosa), atol=5e-3))
+            self.assertTrue(torch.allclose(db_torch.type(db_librosa_tensor.dtype), db_librosa_tensor, atol=5e-3))
 
             # test MFCC
             melkwargs = {'hop': hop_length, 'n_fft': n_fft}
@@ -269,9 +270,10 @@ class Tester(unittest.TestCase):
     #                                             n_mels=n_mels)
 
             librosa_mfcc = scipy.fftpack.dct(db_librosa, axis=0, type=2, norm='ortho')[:n_mfcc]
+            librosa_mfcc_tensor = torch.from_numpy(librosa_mfcc)
             torch_mfcc = mfcc_transform(sound).squeeze().cpu().t()
 
-            self.assertTrue(torch.allclose(torch_mfcc.type(torch.double), torch.from_numpy(librosa_mfcc), atol=5e-3))
+            self.assertTrue(torch.allclose(torch_mfcc.type(librosa_mfcc_tensor.dtype), librosa_mfcc_tensor, atol=5e-3))
 
         kwargs1 = {
             'n_fft': 400,


### PR DESCRIPTION
In test_transforms.py, the tensors returned back are floats which throws an error when trying to compare a double with a float.

```
RuntimeError: expected device cpu and dtype Double but got device cpu and dtype Float
```