### PR TITLE
Cleanup torch_sox.h/.cpp

### DIFF
--- a/torchaudio/torch_sox.cpp
+++ b/torchaudio/torch_sox.cpp
@@ -1,14 +1,15 @@
-#include <torch/extension.h>
-
-#include <sox.h>
+#include "torch_sox.h"
 
 #include <algorithm>
 #include <cstdint>
 #include <stdexcept>
+#include <string>
+#include <tuple>
 #include <vector>
 
-namespace torch {
-namespace audio {
+#include <sox.h>
+#include <torch/extension.h>
+
 namespace {
 /// Helper struct to safely close the sox_format_t descriptor.
 struct SoxDescriptor {
@@ -17,15 +18,9 @@ struct SoxDescriptor {
   SoxDescriptor(SoxDescriptor&& other) = delete;
   SoxDescriptor& operator=(const SoxDescriptor& other) = delete;
   SoxDescriptor& operator=(SoxDescriptor&& other) = delete;
-  ~SoxDescriptor() {
-    sox_close(fd_);
-  }
-  sox_format_t* operator->() noexcept {
-    return fd_;
-  }
-  sox_format_t* get() noexcept {
-    return fd_;
-  }
+  ~SoxDescriptor() { sox_close(fd_); }
+  sox_format_t* operator->() noexcept { return fd_; }
+  sox_format_t* get() noexcept { return fd_; }
 
  private:
   sox_format_t* fd_;
@@ -45,10 +40,7 @@ int64_t write_audio(SoxDescriptor& fd, at::Tensor tensor) {
   return samples_written;
 }
 
-void read_audio(
-    SoxDescriptor& fd,
-    at::Tensor output,
-    int64_t buffer_length) {
+void read_audio(SoxDescriptor& fd, at::Tensor output, int64_t buffer_length) {
   std::vector<sox_sample_t> buffer(buffer_length);
 
   int number_of_channels = fd->signal.channels;
@@ -66,49 +58,15 @@ void read_audio(
     std::copy(buffer.begin(), buffer.begin() + samples_read, data);
   });
 }
-} // namespace
+}  // namespace
 
-struct SoxEffect {
-  SoxEffect() : ename(""), eopts({""})  { }
-  std::string ename;
-  std::vector<std::string> eopts;
-};
+namespace torch {
+namespace audio {
 
-std::tuple<sox_signalinfo_t, sox_encodinginfo_t> get_info(
-    const std::string& file_name
-  ) {
-  SoxDescriptor fd(sox_open_read(
-      file_name.c_str(),
-      /*signal=*/nullptr,
-      /*encoding=*/nullptr,
-      /*filetype=*/nullptr));
-  if (fd.get() == nullptr) {
-    throw std::runtime_error("Error opening audio file");
-  }
-  return std::make_tuple(fd->signal, fd->encoding);
-}
-
-std::vector<std::string> get_effect_names() {
-  sox_effect_fn_t const * fns = sox_get_effect_fns();
-  std::vector<std::string> sv;
-  for(int i = 0; fns[i]; ++i) {
-    const sox_effect_handler_t *eh = fns[i] ();
-    if(eh && eh->name)
-      sv.push_back(eh->name);
-  }
-  return sv;
-}
-
-int read_audio_file(
-    const std::string& file_name,
-    at::Tensor output,
-    bool ch_first,
-    int64_t nframes,
-    int64_t offset,
-    sox_signalinfo_t* si,
-    sox_encodinginfo_t* ei,
-    const char* ft) {
-
+int read_audio_file(const std::string& file_name, at::Tensor output,
+                    bool ch_first, int64_t nframes, int64_t offset,
+                    sox_signalinfo_t* si, sox_encodinginfo_t* ei,
+                    const char* ft) {
   SoxDescriptor fd(sox_open_read(file_name.c_str(), si, ei, ft));
   if (fd.get() == nullptr) {
     throw std::runtime_error("Error opening audio file");
@@ -134,15 +92,16 @@ int read_audio_file(
   // calculate buffer length
   int64_t buffer_length = total_length;
   if (offset > 0) {
-      buffer_length -= offset;
+    buffer_length -= offset;
   }
   if (nframes > 0 && buffer_length > nframes) {
-      buffer_length = nframes;
+    buffer_length = nframes;
   }
 
   // seek to offset point before reading data
   if (sox_seek(fd.get(), offset, 0) == SOX_EOF) {
-    throw std::runtime_error("sox_seek reached EOF, try reducing offset or num_samples");
+    throw std::runtime_error(
+        "sox_seek reached EOF, try reducing offset or num_samples");
   }
 
   // read data and fill output tensor
@@ -156,28 +115,21 @@ int read_audio_file(
   return sample_rate;
 }
 
-void write_audio_file(
-    const std::string& file_name,
-    const at::Tensor& tensor,
-    sox_signalinfo_t* si,
-    sox_encodinginfo_t* ei,
-    const char* file_type) {
+void write_audio_file(const std::string& file_name, const at::Tensor& tensor,
+                      sox_signalinfo_t* si, sox_encodinginfo_t* ei,
+                      const char* file_type) {
   if (!tensor.is_contiguous()) {
     throw std::runtime_error(
         "Error writing audio file: input tensor must be contiguous");
   }
 
-#if SOX_LIB_VERSION_CODE >= 918272 // >= 14.3.0
+#if SOX_LIB_VERSION_CODE >= 918272  // >= 14.3.0
   si->mult = nullptr;
 #endif
 
-  SoxDescriptor fd(sox_open_write(
-      file_name.c_str(),
-      si,
-      ei,
-      file_type,
-      /*oob=*/nullptr,
-      /*overwrite=*/nullptr));
+  SoxDescriptor fd(sox_open_write(file_name.c_str(), si, ei, file_type,
+                                  /*oob=*/nullptr,
+                                  /*overwrite=*/nullptr));
 
   if (fd.get() == nullptr) {
     throw std::runtime_error(
@@ -192,31 +144,40 @@ void write_audio_file(
   }
 }
 
-int initialize_sox() {
-  /* Initializion for sox effects.  Only initialize once  */
-  return sox_init();
+std::tuple<sox_signalinfo_t, sox_encodinginfo_t> get_info(
+    const std::string& file_name) {
+  SoxDescriptor fd(sox_open_read(file_name.c_str(),
+                                 /*signal=*/nullptr,
+                                 /*encoding=*/nullptr,
+                                 /*filetype=*/nullptr));
+  if (fd.get() == nullptr) {
+    throw std::runtime_error("Error opening audio file");
+  }
+  return std::make_tuple(fd->signal, fd->encoding);
 }
 
-int shutdown_sox() {
-  /* Shutdown for sox effects.  Do not shutdown between multiple calls  */
-  return sox_quit();
+std::vector<std::string> get_effect_names() {
+  sox_effect_fn_t const* fns = sox_get_effect_fns();
+  std::vector<std::string> sv;
+  for (int i = 0; fns[i]; ++i) {
+    const sox_effect_handler_t* eh = fns[i]();
+    if (eh && eh->name) sv.push_back(eh->name);
+  }
+  return sv;
 }
 
-int build_flow_effects(const std::string& file_name,
-                       at::Tensor otensor,
-                       bool ch_first,
-                       sox_signalinfo_t* target_signal,
+int build_flow_effects(const std::string& file_name, at::Tensor otensor,
+                       bool ch_first, sox_signalinfo_t* target_signal,
                        sox_encodinginfo_t* target_encoding,
-                       const char* file_type,
-                       std::vector<SoxEffect> pyeffs,
+                       const char* file_type, std::vector<SoxEffect> pyeffs,
                        int max_num_eopts) {
-
   /* This function builds an effects flow and puts the results into a tensor.
      It can also be used to re-encode audio using any of the available encoding
-     options in SoX including sample rate and channel re-encoding.              */
+     options in SoX including sample rate and channel re-encoding. */
 
   // open input
-  sox_format_t* input = sox_open_read(file_name.c_str(), nullptr, nullptr, nullptr);
+  sox_format_t* input =
+      sox_open_read(file_name.c_str(), nullptr, nullptr, nullptr);
   if (input == nullptr) {
     throw std::runtime_error("Error opening audio file");
   }
@@ -226,28 +187,33 @@ int build_flow_effects(const std::string& file_name,
   sox_encodinginfo_t empty_encoding;
 
   // set signalinfo and encodinginfo if blank
-  if(target_signal == nullptr) {
+  if (target_signal == nullptr) {
     target_signal = &empty_signal;
     target_signal->rate = input->signal.rate;
     target_signal->channels = input->signal.channels;
     target_signal->length = SOX_UNSPEC;
     target_signal->precision = input->signal.precision;
-#if SOX_LIB_VERSION_CODE >= 918272 // >= 14.3.0
+#if SOX_LIB_VERSION_CODE >= 918272  // >= 14.3.0
     target_signal->mult = nullptr;
 #endif
   }
-  if(target_encoding == nullptr) {
+  if (target_encoding == nullptr) {
     target_encoding = &empty_encoding;
-    target_encoding->encoding = SOX_ENCODING_SIGN2; // Sample format
-    target_encoding->bits_per_sample = input->signal.precision; // Bits per sample
-    target_encoding->compression = 0.0; // Compression factor
-    target_encoding->reverse_bytes = sox_option_default; // Should bytes be reversed
-    target_encoding->reverse_nibbles = sox_option_default; // Should nibbles be reversed
-    target_encoding->reverse_bits = sox_option_default; // Should bits be reversed (pairs of bits?)
-    target_encoding->opposite_endian = sox_false; // Reverse endianness
+    target_encoding->encoding = SOX_ENCODING_SIGN2;  // Sample format
+    target_encoding->bits_per_sample =
+        input->signal.precision;         // Bits per sample
+    target_encoding->compression = 0.0;  // Compression factor
+    target_encoding->reverse_bytes =
+        sox_option_default;  // Should bytes be reversed
+    target_encoding->reverse_nibbles =
+        sox_option_default;  // Should nibbles be reversed
+    target_encoding->reverse_bits =
+        sox_option_default;  // Should bits be reversed (pairs of bits?)
+    target_encoding->opposite_endian = sox_false;  // Reverse endianness
   }
 
-  // check for rate or channels effect and change the output signalinfo accordingly
+  // check for rate or channels effect and change the output signalinfo
+  // accordingly
   for (SoxEffect se : pyeffs) {
     if (se.ename == "rate") {
       target_signal->rate = std::stod(se.eopts[0]);
@@ -265,25 +231,23 @@ int build_flow_effects(const std::string& file_name,
   char tmp_name[] = "/tmp/fileXXXXXX";
   int tmp_fd = mkstemp(tmp_name);
   close(tmp_fd);
-  sox_format_t* output = sox_open_write(tmp_name, target_signal,
-                                        target_encoding, "wav", nullptr, nullptr);
+  sox_format_t* output = sox_open_write(
+      tmp_name, target_signal, target_encoding, "wav", nullptr, nullptr);
 #else
   // create buffer and buffer_size for output in memwrite
   char* buffer;
   size_t buffer_size;
   // in-memory descriptor (this may not work for OSX)
-  sox_format_t* output = sox_open_memstream_write(&buffer,
-                                                  &buffer_size,
-                                                  target_signal,
-                                                  target_encoding,
-                                                  file_type, nullptr);
+  sox_format_t* output =
+      sox_open_memstream_write(&buffer, &buffer_size, target_signal,
+                               target_encoding, file_type, nullptr);
 #endif
   if (output == nullptr) {
     throw std::runtime_error("Error opening output memstream/temporary file");
   }
   // Setup the effects chain to decode/resample
   sox_effects_chain_t* chain =
-    sox_create_effects_chain(&input->encoding, &output->encoding);
+      sox_create_effects_chain(&input->encoding, &output->encoding);
 
   sox_effect_t* e = sox_create_effect(sox_find_effect("input"));
   char* io_args[1];
@@ -292,23 +256,25 @@ int build_flow_effects(const std::string& file_name,
   sox_add_effect(chain, e, &interm_signal, &input->signal);
   free(e);
 
-  for(SoxEffect tae : pyeffs) {
-    if(tae.ename == "no_effects") break;
+  for (SoxEffect tae : pyeffs) {
+    if (tae.ename == "no_effects") break;
     e = sox_create_effect(sox_find_effect(tae.ename.c_str()));
     e->global_info->global_info->verbosity = 1;
-    if(tae.eopts[0] == "") {
+    if (tae.eopts[0] == "") {
       sox_effect_options(e, 0, nullptr);
     } else {
       int num_opts = tae.eopts.size();
       char* sox_args[max_num_eopts];
-      for(std::vector<std::string>::size_type i = 0; i != tae.eopts.size(); i++) {
-        sox_args[i] = (char*) tae.eopts[i].c_str();
+      for (std::vector<std::string>::size_type i = 0; i != tae.eopts.size();
+           i++) {
+        sox_args[i] = (char*)tae.eopts[i].c_str();
       }
-      if(sox_effect_options(e, num_opts, sox_args) != SOX_SUCCESS) {
+      if (sox_effect_options(e, num_opts, sox_args) != SOX_SUCCESS) {
 #ifdef __APPLE__
         unlink(tmp_name);
 #endif
-        throw std::runtime_error("invalid effect options, see SoX docs for details");
+        throw std::runtime_error(
+            "invalid effect options, see SoX docs for details");
       }
     }
     sox_add_effect(chain, e, &interm_signal, &output->signal);
@@ -325,7 +291,8 @@ int build_flow_effects(const std::string& file_name,
   sox_flow_effects(chain, nullptr, nullptr);
   sox_delete_effects_chain(chain);
 
-  // Close sox handles, buffer does not get properly sized until these are closed
+  // Close sox handles, buffer does not get properly sized until these are
+  // closed
   sox_close(output);
   sox_close(input);
 
@@ -334,18 +301,20 @@ int build_flow_effects(const std::string& file_name,
 #ifdef __APPLE__
   /*
      Temporary filetype must have a valid header.  Wav seems to work here while
-     raw does not.  Certain effects like chorus caused strange behavior on the mac.
+     raw does not.  Certain effects like chorus caused strange behavior on the
+     mac.
   */
   // read_audio_file reads the temporary file and returns the sr and otensor
-  sr = read_audio_file(tmp_name, otensor, ch_first, 0, 0,
-                       target_signal, target_encoding, "wav");
+  sr = read_audio_file(tmp_name, otensor, ch_first, 0, 0, target_signal,
+                       target_encoding, "wav");
   // delete temporary audio file
   unlink(tmp_name);
 #else
-  // Resize output tensor to desired dimensions, different effects result in output->signal.length,
-  // interm_signal.length and buffer size being inconsistent with the result of the file output.
-  // We prioritize in the order: output->signal.length > interm_signal.length > buffer_size
-  // Could be related to: https://sourceforge.net/p/sox/bugs/314/
+  // Resize output tensor to desired dimensions, different effects result in
+  // output->signal.length, interm_signal.length and buffer size being
+  // inconsistent with the result of the file output. We prioritize in the
+  // order: output->signal.length > interm_signal.length > buffer_size Could be
+  // related to: https://sourceforge.net/p/sox/bugs/314/
   int nc, ns;
   if (output->signal.length == 0) {
     // sometimes interm_signal length is extremely large, but the buffer_size
@@ -360,10 +329,11 @@ int build_flow_effects(const std::string& file_name,
     nc = output->signal.channels;
     ns = output->signal.length;
   }
-  otensor.resize_({ns/nc, nc});
+  otensor.resize_({ns / nc, nc});
   otensor = otensor.contiguous();
 
-  input = sox_open_mem_read(buffer, buffer_size, target_signal, target_encoding, file_type);
+  input = sox_open_mem_read(buffer, buffer_size, target_signal, target_encoding,
+                            file_type);
   std::vector<sox_sample_t> samples(buffer_size);
   const int64_t samples_read = sox_read(input, samples.data(), buffer_size);
   assert(samples_read != nc * ns && samples_read != 0);
@@ -384,131 +354,133 @@ int build_flow_effects(const std::string& file_name,
   // return sample rate, output tensor modified in-place
   return sr;
 }
-} // namespace audio
-} // namespace torch
 
+int initialize_sox() {
+  /* Initializion for sox effects.  Only initialize once  */
+  return sox_init();
+}
+
+int shutdown_sox() {
+  /* Shutdown for sox effects.  Do not shutdown between multiple calls  */
+  return sox_quit();
+}
+}  // namespace audio
+}  // namespace torch
+
+namespace {
 PYBIND11_MODULE(_torch_sox, m) {
   py::class_<torch::audio::SoxEffect>(m, "SoxEffect")
-       .def(py::init<>())
-       .def("__repr__", [](const torch::audio::SoxEffect &self) {
-         std::stringstream ss;
-         std::string sep;
-         ss << "SoxEffect (" << self.ename << " ,[";
-         for(std::string s : self.eopts) {
-           ss << sep << "\"" << s << "\"";
-           sep = ", ";
-         }
-         ss << "])\n";
-         return ss.str();
-       })
-       .def_readwrite("ename", &torch::audio::SoxEffect::ename)
-       .def_readwrite("eopts", &torch::audio::SoxEffect::eopts);
+      .def(py::init<>())
+      .def("__repr__",
+           [](const torch::audio::SoxEffect& self) {
+             std::stringstream ss;
+             std::string sep;
+             ss << "SoxEffect (" << self.ename << " ,[";
+             for (std::string s : self.eopts) {
+               ss << sep << "\"" << s << "\"";
+               sep = ", ";
+             }
+             ss << "])\n";
+             return ss.str();
+           })
+      .def_readwrite("ename", &torch::audio::SoxEffect::ename)
+      .def_readwrite("eopts", &torch::audio::SoxEffect::eopts);
   py::class_<sox_signalinfo_t>(m, "sox_signalinfo_t")
-       .def(py::init<>())
-       .def("__repr__", [](const sox_signalinfo_t &self) {
-         std::stringstream ss;
-         ss << "sox_signalinfo_t {\n"
-            << "  rate-> " << self.rate << "\n"
-            << "  channels-> " << self.channels << "\n"
-            << "  precision-> " << self.precision << "\n"
-            << "  length-> " << self.length << "\n"
-            << "  mult-> " << self.mult << "\n"
-            << "}\n";
-         return ss.str();
-       })
-       .def_readwrite("rate", &sox_signalinfo_t::rate)
-       .def_readwrite("channels", &sox_signalinfo_t::channels)
-       .def_readwrite("precision", &sox_signalinfo_t::precision)
-       .def_readwrite("length", &sox_signalinfo_t::length)
-       .def_readwrite("mult", &sox_signalinfo_t::mult);
+      .def(py::init<>())
+      .def("__repr__",
+           [](const sox_signalinfo_t& self) {
+             std::stringstream ss;
+             ss << "sox_signalinfo_t {\n"
+                << "  rate-> " << self.rate << "\n"
+                << "  channels-> " << self.channels << "\n"
+                << "  precision-> " << self.precision << "\n"
+                << "  length-> " << self.length << "\n"
+                << "  mult-> " << self.mult << "\n"
+                << "}\n";
+             return ss.str();
+           })
+      .def_readwrite("rate", &sox_signalinfo_t::rate)
+      .def_readwrite("channels", &sox_signalinfo_t::channels)
+      .def_readwrite("precision", &sox_signalinfo_t::precision)
+      .def_readwrite("length", &sox_signalinfo_t::length)
+      .def_readwrite("mult", &sox_signalinfo_t::mult);
   py::class_<sox_encodinginfo_t>(m, "sox_encodinginfo_t")
-       .def(py::init<>())
-       .def("__repr__", [](const sox_encodinginfo_t &self) {
-         std::stringstream ss;
-         ss << "sox_encodinginfo_t {\n"
-            << "  encoding-> " << self.encoding << "\n"
-            << "  bits_per_sample-> " << self.bits_per_sample << "\n"
-            << "  compression-> " << self.compression << "\n"
-            << "  reverse_bytes-> " << self.reverse_bytes << "\n"
-            << "  reverse_nibbles-> " << self.reverse_nibbles << "\n"
-            << "  reverse_bits-> " << self.reverse_bits << "\n"
-            << "  opposite_endian-> " << self.opposite_endian << "\n"
-            << "}\n";
-         return ss.str();
-       })
-       .def_readwrite("encoding", &sox_encodinginfo_t::encoding)
-       .def_readwrite("bits_per_sample", &sox_encodinginfo_t::bits_per_sample)
-       .def_readwrite("compression", &sox_encodinginfo_t::compression)
-       .def_readwrite("reverse_bytes", &sox_encodinginfo_t::reverse_bytes)
-       .def_readwrite("reverse_nibbles", &sox_encodinginfo_t::reverse_nibbles)
-       .def_readwrite("reverse_bits", &sox_encodinginfo_t::reverse_bits)
-       .def_readwrite("opposite_endian", &sox_encodinginfo_t::opposite_endian);
+      .def(py::init<>())
+      .def("__repr__",
+           [](const sox_encodinginfo_t& self) {
+             std::stringstream ss;
+             ss << "sox_encodinginfo_t {\n"
+                << "  encoding-> " << self.encoding << "\n"
+                << "  bits_per_sample-> " << self.bits_per_sample << "\n"
+                << "  compression-> " << self.compression << "\n"
+                << "  reverse_bytes-> " << self.reverse_bytes << "\n"
+                << "  reverse_nibbles-> " << self.reverse_nibbles << "\n"
+                << "  reverse_bits-> " << self.reverse_bits << "\n"
+                << "  opposite_endian-> " << self.opposite_endian << "\n"
+                << "}\n";
+             return ss.str();
+           })
+      .def_readwrite("encoding", &sox_encodinginfo_t::encoding)
+      .def_readwrite("bits_per_sample", &sox_encodinginfo_t::bits_per_sample)
+      .def_readwrite("compression", &sox_encodinginfo_t::compression)
+      .def_readwrite("reverse_bytes", &sox_encodinginfo_t::reverse_bytes)
+      .def_readwrite("reverse_nibbles", &sox_encodinginfo_t::reverse_nibbles)
+      .def_readwrite("reverse_bits", &sox_encodinginfo_t::reverse_bits)
+      .def_readwrite("opposite_endian", &sox_encodinginfo_t::opposite_endian);
   py::enum_<sox_encoding_t>(m, "sox_encoding_t")
-       .value("SOX_ENCODING_UNKNOWN", sox_encoding_t::SOX_ENCODING_UNKNOWN)
-       .value("SOX_ENCODING_SIGN2", sox_encoding_t::SOX_ENCODING_SIGN2)
-       .value("SOX_ENCODING_UNSIGNED", sox_encoding_t::SOX_ENCODING_UNSIGNED)
-       .value("SOX_ENCODING_FLOAT", sox_encoding_t::SOX_ENCODING_FLOAT)
-       .value("SOX_ENCODING_FLOAT_TEXT", sox_encoding_t::SOX_ENCODING_FLOAT_TEXT)
-       .value("SOX_ENCODING_FLAC", sox_encoding_t::SOX_ENCODING_FLAC)
-       .value("SOX_ENCODING_HCOM", sox_encoding_t::SOX_ENCODING_HCOM)
-       .value("SOX_ENCODING_WAVPACK", sox_encoding_t::SOX_ENCODING_WAVPACK)
-       .value("SOX_ENCODING_WAVPACKF", sox_encoding_t::SOX_ENCODING_WAVPACKF)
-       .value("SOX_ENCODING_ULAW", sox_encoding_t::SOX_ENCODING_ULAW)
-       .value("SOX_ENCODING_ALAW", sox_encoding_t::SOX_ENCODING_ALAW)
-       .value("SOX_ENCODING_G721", sox_encoding_t::SOX_ENCODING_G721)
-       .value("SOX_ENCODING_G723", sox_encoding_t::SOX_ENCODING_G723)
-       .value("SOX_ENCODING_CL_ADPCM", sox_encoding_t::SOX_ENCODING_CL_ADPCM)
-       .value("SOX_ENCODING_CL_ADPCM16", sox_encoding_t::SOX_ENCODING_CL_ADPCM16)
-       .value("SOX_ENCODING_MS_ADPCM", sox_encoding_t::SOX_ENCODING_MS_ADPCM)
-       .value("SOX_ENCODING_IMA_ADPCM", sox_encoding_t::SOX_ENCODING_IMA_ADPCM)
-       .value("SOX_ENCODING_OKI_ADPCM", sox_encoding_t::SOX_ENCODING_OKI_ADPCM)
-       .value("SOX_ENCODING_DPCM", sox_encoding_t::SOX_ENCODING_DPCM)
-       .value("SOX_ENCODING_DWVW", sox_encoding_t::SOX_ENCODING_DWVW)
-       .value("SOX_ENCODING_DWVWN", sox_encoding_t::SOX_ENCODING_DWVWN)
-       .value("SOX_ENCODING_GSM", sox_encoding_t::SOX_ENCODING_GSM)
-       .value("SOX_ENCODING_MP3", sox_encoding_t::SOX_ENCODING_MP3)
-       .value("SOX_ENCODING_VORBIS", sox_encoding_t::SOX_ENCODING_VORBIS)
-       .value("SOX_ENCODING_AMR_WB", sox_encoding_t::SOX_ENCODING_AMR_WB)
-       .value("SOX_ENCODING_AMR_NB", sox_encoding_t::SOX_ENCODING_AMR_NB)
-       .value("SOX_ENCODING_LPC10", sox_encoding_t::SOX_ENCODING_LPC10)
-       //.value("SOX_ENCODING_OPUS", sox_encoding_t::SOX_ENCODING_OPUS)  // creates a compile error
-       .value("SOX_ENCODINGS", sox_encoding_t::SOX_ENCODINGS)
-       .export_values();
+      .value("SOX_ENCODING_UNKNOWN", sox_encoding_t::SOX_ENCODING_UNKNOWN)
+      .value("SOX_ENCODING_SIGN2", sox_encoding_t::SOX_ENCODING_SIGN2)
+      .value("SOX_ENCODING_UNSIGNED", sox_encoding_t::SOX_ENCODING_UNSIGNED)
+      .value("SOX_ENCODING_FLOAT", sox_encoding_t::SOX_ENCODING_FLOAT)
+      .value("SOX_ENCODING_FLOAT_TEXT", sox_encoding_t::SOX_ENCODING_FLOAT_TEXT)
+      .value("SOX_ENCODING_FLAC", sox_encoding_t::SOX_ENCODING_FLAC)
+      .value("SOX_ENCODING_HCOM", sox_encoding_t::SOX_ENCODING_HCOM)
+      .value("SOX_ENCODING_WAVPACK", sox_encoding_t::SOX_ENCODING_WAVPACK)
+      .value("SOX_ENCODING_WAVPACKF", sox_encoding_t::SOX_ENCODING_WAVPACKF)
+      .value("SOX_ENCODING_ULAW", sox_encoding_t::SOX_ENCODING_ULAW)
+      .value("SOX_ENCODING_ALAW", sox_encoding_t::SOX_ENCODING_ALAW)
+      .value("SOX_ENCODING_G721", sox_encoding_t::SOX_ENCODING_G721)
+      .value("SOX_ENCODING_G723", sox_encoding_t::SOX_ENCODING_G723)
+      .value("SOX_ENCODING_CL_ADPCM", sox_encoding_t::SOX_ENCODING_CL_ADPCM)
+      .value("SOX_ENCODING_CL_ADPCM16", sox_encoding_t::SOX_ENCODING_CL_ADPCM16)
+      .value("SOX_ENCODING_MS_ADPCM", sox_encoding_t::SOX_ENCODING_MS_ADPCM)
+      .value("SOX_ENCODING_IMA_ADPCM", sox_encoding_t::SOX_ENCODING_IMA_ADPCM)
+      .value("SOX_ENCODING_OKI_ADPCM", sox_encoding_t::SOX_ENCODING_OKI_ADPCM)
+      .value("SOX_ENCODING_DPCM", sox_encoding_t::SOX_ENCODING_DPCM)
+      .value("SOX_ENCODING_DWVW", sox_encoding_t::SOX_ENCODING_DWVW)
+      .value("SOX_ENCODING_DWVWN", sox_encoding_t::SOX_ENCODING_DWVWN)
+      .value("SOX_ENCODING_GSM", sox_encoding_t::SOX_ENCODING_GSM)
+      .value("SOX_ENCODING_MP3", sox_encoding_t::SOX_ENCODING_MP3)
+      .value("SOX_ENCODING_VORBIS", sox_encoding_t::SOX_ENCODING_VORBIS)
+      .value("SOX_ENCODING_AMR_WB", sox_encoding_t::SOX_ENCODING_AMR_WB)
+      .value("SOX_ENCODING_AMR_NB", sox_encoding_t::SOX_ENCODING_AMR_NB)
+      .value("SOX_ENCODING_LPC10", sox_encoding_t::SOX_ENCODING_LPC10)
+      //.value("SOX_ENCODING_OPUS", sox_encoding_t::SOX_ENCODING_OPUS)  //
+      // creates a compile error
+      .value("SOX_ENCODINGS", sox_encoding_t::SOX_ENCODINGS)
+      .export_values();
   py::enum_<sox_option_t>(m, "sox_option_t")
-       .value("sox_option_no", sox_option_t::sox_option_no)
-       .value("sox_option_yes", sox_option_t::sox_option_yes)
-       .value("sox_option_default", sox_option_t::sox_option_default)
-       .export_values();
+      .value("sox_option_no", sox_option_t::sox_option_no)
+      .value("sox_option_yes", sox_option_t::sox_option_yes)
+      .value("sox_option_default", sox_option_t::sox_option_default)
+      .export_values();
   py::enum_<sox_bool>(m, "sox_bool")
-       .value("sox_false", sox_bool::sox_false)
-       .value("sox_true", sox_bool::sox_true)
-       .export_values();
-  m.def(
-      "read_audio_file",
-      &torch::audio::read_audio_file,
-      "Reads an audio file into a tensor");
-  m.def(
-      "write_audio_file",
-      &torch::audio::write_audio_file,
-      "Writes data from a tensor into an audio file");
-  m.def(
-      "get_info",
-      &torch::audio::get_info,
-      "Gets information about an audio file");
-  m.def(
-      "get_effect_names",
-      &torch::audio::get_effect_names,
-      "Gets the names of all available effects");
-  m.def(
-      "build_flow_effects",
-      &torch::audio::build_flow_effects,
-      "build effects and flow chain into tensors");
-  m.def(
-      "initialize_sox",
-      &torch::audio::initialize_sox,
-      "initialize sox for effects");
-  m.def(
-      "shutdown_sox",
-      &torch::audio::shutdown_sox,
-      "shutdown sox for effects");
+      .value("sox_false", sox_bool::sox_false)
+      .value("sox_true", sox_bool::sox_true)
+      .export_values();
+  m.def("read_audio_file", &torch::audio::read_audio_file,
+        "Reads an audio file into a tensor");
+  m.def("write_audio_file", &torch::audio::write_audio_file,
+        "Writes data from a tensor into an audio file");
+  m.def("get_info", &torch::audio::get_info,
+        "Gets information about an audio file");
+  m.def("get_effect_names", &torch::audio::get_effect_names,
+        "Gets the names of all available effects");
+  m.def("build_flow_effects", &torch::audio::build_flow_effects,
+        "build effects and flow chain into tensors");
+  m.def("initialize_sox", &torch::audio::initialize_sox,
+        "initialize sox for effects");
+  m.def("shutdown_sox", &torch::audio::shutdown_sox,
+        "shutdown sox for effects");
 }
+}  // namespace

--- a/torchaudio/torch_sox.h
+++ b/torchaudio/torch_sox.h
@@ -1,54 +1,44 @@
 #include <string>
+#include <tuple>
+#include <vector>
 
-namespace at {
-struct Tensor;
-} // namespace at
+#include <sox.h>
+#include <torch/extension.h>
 
-namespace torch { namespace audio {
+namespace torch {
+namespace audio {
 
 /// Reads an audio file from the given `path` into the `output` `Tensor` and
 /// returns the sample rate of the audio file.
 /// Throws `std::runtime_error` if the audio file could not be opened, or an
 /// error ocurred during reading of the audio data.
-int read_audio_file(
-    const std::string& file_name,
-    at::Tensor output,
-    bool ch_first,
-    int64_t nframes,
-    int64_t offset,
-    sox_signalinfo_t* si,
-    sox_encodinginfo_t* ei,
-    const char* ft)
+int read_audio_file(const std::string& file_name, at::Tensor output,
+                    bool ch_first, int64_t nframes, int64_t offset,
+                    sox_signalinfo_t* si, sox_encodinginfo_t* ei,
+                    const char* ft);
 
-/// Writes the data of a `Tensor` into an audio file at the given `path`, with
-/// a certain extension (e.g. `wav`or `mp3`) and sample rate.
-/// Throws `std::runtime_error` when the audio file could not be opened for
+/// Writes the data of a `Tensor` into an audio file at the given `path`,
+/// with a certain extension (e.g. `wav`or `mp3`) and sample rate. Throws
+/// `std::runtime_error` when the audio file could not be opened for
 /// writing, or an error ocurred during writing of the audio data.
-void write_audio_file(
-    const std::string& file_name,
-    at::Tensor& tensor,
-    sox_signalinfo_t* si,
-    sox_encodinginfo_t* ei,
-    const char* file_type)
+void write_audio_file(const std::string& file_name, const at::Tensor& tensor,
+                      sox_signalinfo_t* si, sox_encodinginfo_t* ei,
+                      const char* file_type);
 
 /// Reads an audio file from the given `path` and returns a tuple of
 /// sox_signalinfo_t and sox_encodinginfo_t, which contain information about
-/// the audio file such as sample rate, length, bit precision, encoding and more.
-/// Throws `std::runtime_error` if the audio file could not be opened, or an
-/// error ocurred during reading of the audio data.
+/// the audio file such as sample rate, length, bit precision, encoding and
+/// more. Throws `std::runtime_error` if the audio file could not be opened,
+/// or an error ocurred during reading of the audio data.
 std::tuple<sox_signalinfo_t, sox_encodinginfo_t> get_info(
     const std::string& file_name);
 
 // get names of all sox effects
 std::vector<std::string> get_effect_names();
 
-// Initialize and Shutdown SoX effects chain.  These functions should only be run once.
-int initialize_sox();
-int shutdown_sox();
-
 // Struct for build_flow_effects function
 struct SoxEffect {
-  SoxEffect() : ename(""), eopts({""})  { }
+  SoxEffect() : ename(""), eopts({""}) {}
   std::string ename;
   std::vector<std::string> eopts;
 };
@@ -56,15 +46,18 @@ struct SoxEffect {
 /// Build a SoX chain, flow the effects, and capture the results in a tensor.
 /// An audio file from the given `path` flows through an effects chain given
 /// by a list of effects and effect options to an output buffer which is encoded
-/// into memory to a target signal type and target signal encoding.  The resulting
-/// buffer is then placed into a tensor.  This function returns the output tensor
-/// and the sample rate of the output tensor.
-int build_flow_effects(const std::string& file_name,
-                       at::Tensor otensor,
-                       bool ch_first,
-                       sox_signalinfo_t* target_signal,
+/// into memory to a target signal type and target signal encoding.  The
+/// resulting buffer is then placed into a tensor.  This function returns the
+/// output tensor and the sample rate of the output tensor.
+int build_flow_effects(const std::string& file_name, at::Tensor otensor,
+                       bool ch_first, sox_signalinfo_t* target_signal,
                        sox_encodinginfo_t* target_encoding,
-                       const char* file_type,
-                       std::vector<SoxEffect> pyeffs,
+                       const char* file_type, std::vector<SoxEffect> pyeffs,
                        int max_num_eopts);
-}} // namespace torch::audio
+
+// Initialize and Shutdown SoX effects chain.  These functions should only be
+// run once.
+int initialize_sox();
+int shutdown_sox();
+}  // namespace audio
+}  // namespace torch


### PR DESCRIPTION
-Ran clangtidy on torch_sox.h/.cpp
-Add the header "torch_sox.h" to torch_sox.cpp. Previously torch_sox.h was not used by any files
-Reorder functions in torch_sox.h/.cpp to match the order they are defined in PYBIND11_MODULE