### PR TITLE
CI fix

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -53,7 +53,7 @@ pip install -r requirements.txt
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then
     # PyTorch (nightly as 1.1 does not have Optional for type annotations)
-    conda install --yes pytorch-nightly-cpu=1.2.0.dev20190715 -c pytorch
+    conda install --yes pytorch-nightly-cpu=1.2.0.dev20190711 -c pytorch
 
      # TorchAudio CPP Extensions
     pip install .

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -53,7 +53,7 @@ pip install -r requirements.txt
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then
     # PyTorch (nightly as 1.1 does not have Optional for type annotations)
-    conda install --yes pytorch-nightly-cpu -c pytorch
+    conda install --yes pytorch-nightly-cpu=1.2.0.dev20190701 -c pytorch
 
      # TorchAudio CPP Extensions
     pip install .

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -53,7 +53,7 @@ pip install -r requirements.txt
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then
     # PyTorch (nightly as 1.1 does not have Optional for type annotations)
-    conda install --yes pytorch-nightly-cpu=1.1.0.dev20190516 -c pytorch
+    conda install --yes pytorch-nightly-cpu -c pytorch
 
      # TorchAudio CPP Extensions
     pip install .

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -53,7 +53,7 @@ pip install -r requirements.txt
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then
     # PyTorch (nightly as 1.1 does not have Optional for type annotations)
-    conda install --yes pytorch-nightly-cpu=1.2.0.dev20190711 -c pytorch
+    conda install --yes pytorch-nightly-cpu=1.2.0.dev20190516 -c pytorch
 
      # TorchAudio CPP Extensions
     pip install .

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -53,7 +53,7 @@ pip install -r requirements.txt
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then
     # PyTorch (nightly as 1.1 does not have Optional for type annotations)
-    conda install --yes pytorch-nightly-cpu=1.2.0.dev20190516 -c pytorch
+    conda install --yes pytorch-nightly-cpu=1.1.0.dev20190516 -c pytorch
 
      # TorchAudio CPP Extensions
     pip install .

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -53,7 +53,7 @@ pip install -r requirements.txt
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then
     # PyTorch (nightly as 1.1 does not have Optional for type annotations)
-    conda install --yes pytorch-nightly-cpu=1.2.0.dev20190701 -c pytorch
+    conda install --yes pytorch-nightly-cpu=1.2.0.dev20190715 -c pytorch
 
      # TorchAudio CPP Extensions
     pip install .

--- a/build_tools/travis/test_script.sh
+++ b/build_tools/travis/test_script.sh
@@ -9,7 +9,7 @@ python --version
 
 run_tests() {
   # find all the test files that match "test*.py"
-  TEST_FILES="$(find test/ -type f -name "test*.py" | sort)"
+  TEST_FILES="$(find test -type f -name "test*.py" | sort)"
   echo "Test files are:"
   echo $TEST_FILES
 

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -101,7 +101,7 @@ def LC2CL(tensor):
     """
     return tensor.transpose(0, 1).contiguous()
 
-
+# TODO: remove this once https://github.com/pytorch/pytorch/issues/21478 gets solved
 @torch.jit.ignore
 def _stft(input, n_fft, hop_length, win_length, window, center, pad_mode, normalized, onesided):
     # type: (Tensor, int, Optional[int], Optional[int], Optional[Tensor], bool, str, bool, bool) -> Tensor

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -102,6 +102,7 @@ def LC2CL(tensor):
     return tensor.transpose(0, 1).contiguous()
 
 
+@torch.jit.ignore
 def _stft(input, n_fft, hop_length, win_length, window, center, pad_mode, normalized, onesided):
     # type: (Tensor, int, Optional[int], Optional[int], Optional[Tensor], bool, str, bool, bool) -> Tensor
     return torch.stft(input, n_fft, hop_length, win_length, window, center, pad_mode, normalized, onesided)


### PR DESCRIPTION
Travis CI using pytorch-nightly has been annoying. Occasionally pytorch/audio master would be passing and then the next day the same test would be fail due to changes in pytorch.
The last passing installs for our python 3.5/3.6 tests were:

```
pytorch-nightly-cpu-1.1.0.dev20190516|      py3.5_cpu_0
pytorch-nightly-cpu-1.2.0.dev20190716|      py3.6_cpu_0
```

so want to fix it on 1.1.0.dev20190516