### PR TITLE
[BC] Standardization of Transforms/Functionals

### DIFF
--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -2,6 +2,7 @@ import math
 
 import torch
 import torchaudio
+import torchaudio.functional as F
 import pytest
 import unittest
 import test.common_utils
@@ -212,8 +213,7 @@ def test_phase_vocoder(complex_specgrams, rate, hop_length):
     complex_specgrams = complex_specgrams.type(torch.float64)
     phase_advance = torch.linspace(0, np.pi * hop_length, complex_specgrams.shape[-3], dtype=torch.float64)[..., None]
 
-    complex_specgrams_stretch = torchaudio.functional.phase_vocoder(
-        complex_specgrams, rate=rate, phase_advance=phase_advance)
+    complex_specgrams_stretch = F.phase_vocoder(complex_specgrams, rate=rate, phase_advance=phase_advance)
 
     # == Test shape
     expected_size = list(complex_specgrams.size())
@@ -244,7 +244,7 @@ def test_phase_vocoder(complex_specgrams, rate, hop_length):
 @pytest.mark.parametrize('power', [1, 2, 0.7])
 def test_complex_norm(complex_tensor, power):
     expected_norm_tensor = complex_tensor.pow(2).sum(-1).pow(power / 2)
-    norm_tensor = torchaudio.functional.complex_norm(complex_tensor, power)
+    norm_tensor = F.complex_norm(complex_tensor, power)
 
     assert torch.allclose(expected_norm_tensor, norm_tensor, atol=1e-5)
 

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -2,6 +2,7 @@ import math
 
 import torch
 import torchaudio
+import pytest
 import unittest
 import test.common_utils
 
@@ -11,8 +12,6 @@ if IMPORT_LIBROSA:
     import numpy as np
     import librosa
 
-import pytest
-import torchaudio.functional as F
 xfail = pytest.mark.xfail
 
 
@@ -197,54 +196,6 @@ def _num_stft_bins(signal_len, fft_len, hop_length, pad):
     return (signal_len + 2 * pad - fft_len + hop_length) // hop_length
 
 
-@pytest.mark.parametrize('fft_length', [512])
-@pytest.mark.parametrize('hop_length', [256])
-@pytest.mark.parametrize('waveform', [
-    (torch.randn(1, 100000)),
-    (torch.randn(1, 2, 100000)),
-    pytest.param(torch.randn(1, 100), marks=xfail(raises=RuntimeError)),
-])
-@pytest.mark.parametrize('pad_mode', [
-    # 'constant',
-    'reflect',
-])
-@unittest.skipIf(not IMPORT_LIBROSA, 'Librosa is not available')
-def test_stft(waveform, fft_length, hop_length, pad_mode):
-    """
-    Test STFT for multi-channel signals.
-
-    Padding: Value in having padding outside of torch.stft?
-    """
-    pad = fft_length // 2
-    window = torch.hann_window(fft_length)
-    complex_spec = F.stft(waveform,
-                          fft_length=fft_length,
-                          hop_length=hop_length,
-                          window=window,
-                          pad_mode=pad_mode)
-    mag_spec, phase_spec = F.magphase(complex_spec)
-
-    # == Test shape
-    expected_size = list(waveform.size()[:-1])
-    expected_size += [fft_length // 2 + 1, _num_stft_bins(
-        waveform.size(-1), fft_length, hop_length, pad), 2]
-    assert complex_spec.dim() == waveform.dim() + 2
-    assert complex_spec.size() == torch.Size(expected_size)
-
-    # == Test values
-    fft_config = dict(n_fft=fft_length, hop_length=hop_length, pad_mode=pad_mode)
-    # note that librosa *automatically* pad with fft_length // 2.
-    expected_complex_spec = np.apply_along_axis(librosa.stft, -1,
-                                                waveform.numpy(), **fft_config)
-    expected_mag_spec, _ = librosa.magphase(expected_complex_spec)
-    # Convert torch to np.complex
-    complex_spec = complex_spec.numpy()
-    complex_spec = complex_spec[..., 0] + 1j * complex_spec[..., 1]
-
-    assert np.allclose(complex_spec, expected_complex_spec, atol=1e-5)
-    assert np.allclose(mag_spec.numpy(), expected_mag_spec, atol=1e-5)
-
-
 @pytest.mark.parametrize('rate', [0.5, 1.01, 1.3])
 @pytest.mark.parametrize('complex_specgrams', [
     torch.randn(1, 2, 1025, 400, 2),
@@ -261,7 +212,8 @@ def test_phase_vocoder(complex_specgrams, rate, hop_length):
     complex_specgrams = complex_specgrams.type(torch.float64)
     phase_advance = torch.linspace(0, np.pi * hop_length, complex_specgrams.shape[-3], dtype=torch.float64)[..., None]
 
-    complex_specgrams_stretch = F.phase_vocoder(complex_specgrams, rate=rate, phase_advance=phase_advance)
+    complex_specgrams_stretch = torchaudio.functional.phase_vocoder(
+        complex_specgrams, rate=rate, phase_advance=phase_advance)
 
     # == Test shape
     expected_size = list(complex_specgrams.size())
@@ -292,7 +244,7 @@ def test_phase_vocoder(complex_specgrams, rate, hop_length):
 @pytest.mark.parametrize('power', [1, 2, 0.7])
 def test_complex_norm(complex_tensor, power):
     expected_norm_tensor = complex_tensor.pow(2).sum(-1).pow(power / 2)
-    norm_tensor = F.complex_norm(complex_tensor, power)
+    norm_tensor = torchaudio.functional.complex_norm(complex_tensor, power)
 
     assert torch.allclose(expected_norm_tensor, norm_tensor, atol=1e-5)
 

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -13,8 +13,6 @@ if IMPORT_LIBROSA:
     import numpy as np
     import librosa
 
-xfail = pytest.mark.xfail
-
 
 class TestFunctional(unittest.TestCase):
     data_sizes = [(2, 20), (3, 15), (4, 10)]

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -52,25 +52,6 @@ class Test_JIT(unittest.TestCase):
 
         self._test_script_module(tensor, transforms.PadTrim, max_len)
 
-    def test_torchscript_downmix_mono(self):
-        @torch.jit.script
-        def jit_method(tensor):
-            # type: (Tensor) -> Tensor
-            return F.downmix_mono(tensor)
-
-        tensor = torch.rand((2, 10))
-
-        jit_out = jit_method(tensor)
-        py_out = F.downmix_mono(tensor)
-
-        self.assertTrue(torch.allclose(jit_out, py_out))
-
-    @unittest.skipIf(not RUN_CUDA, "no CUDA")
-    def test_scriptmodule_downmix_mono(self):
-        tensor = torch.rand((2, 10), device="cuda")
-
-        self._test_script_module(tensor, transforms.DownmixMono)
-
     def test_torchscript_spectrogram(self):
         @torch.jit.script
         def jit_method(sig, pad, window, n_fft, hop, ws, power, normalize):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -33,11 +33,11 @@ class Test_JIT(unittest.TestCase):
     def test_torchscript_scale(self):
         @torch.jit.script
         def jit_method(tensor, factor):
-            # type: (Tensor, int) -> Tensor
+            # type: (Tensor, float) -> Tensor
             return F.scale(tensor, factor)
 
-        tensor = torch.rand((10, 1))
-        factor = 2
+        tensor = torch.rand((1, 10))
+        factor = 2.0
 
         jit_out = jit_method(tensor, factor)
         py_out = F.scale(tensor, factor)
@@ -46,24 +46,22 @@ class Test_JIT(unittest.TestCase):
 
     @unittest.skipIf(not RUN_CUDA, "no CUDA")
     def test_scriptmodule_scale(self):
-        tensor = torch.rand((10, 1), device="cuda")
+        tensor = torch.rand((1, 10), device="cuda")
 
         self._test_script_module(tensor, transforms.Scale)
 
     def test_torchscript_pad_trim(self):
         @torch.jit.script
-        def jit_method(tensor, ch_dim, max_len, len_dim, fill_value):
-            # type: (Tensor, int, int, int, float) -> Tensor
-            return F.pad_trim(tensor, ch_dim, max_len, len_dim, fill_value)
+        def jit_method(tensor, max_len, fill_value):
+            # type: (Tensor, int, float) -> Tensor
+            return F.pad_trim(tensor, max_len, fill_value)
 
-        tensor = torch.rand((10, 1))
-        ch_dim = 1
+        tensor = torch.rand((1, 10))
         max_len = 5
-        len_dim = 0
         fill_value = 3.
 
-        jit_out = jit_method(tensor, ch_dim, max_len, len_dim, fill_value)
-        py_out = F.pad_trim(tensor, ch_dim, max_len, len_dim, fill_value)
+        jit_out = jit_method(tensor, max_len, fill_value)
+        py_out = F.pad_trim(tensor, max_len, fill_value)
 
         self.assertTrue(torch.allclose(jit_out, py_out))
 
@@ -76,21 +74,20 @@ class Test_JIT(unittest.TestCase):
 
     def test_torchscript_downmix_mono(self):
         @torch.jit.script
-        def jit_method(tensor, ch_dim):
-            # type: (Tensor, int) -> Tensor
-            return F.downmix_mono(tensor, ch_dim)
+        def jit_method(tensor):
+            # type: (Tensor) -> Tensor
+            return F.downmix_mono(tensor)
 
-        tensor = torch.rand((10, 1))
-        ch_dim = 1
+        tensor = torch.rand((2, 10))
 
-        jit_out = jit_method(tensor, ch_dim)
-        py_out = F.downmix_mono(tensor, ch_dim)
+        jit_out = jit_method(tensor)
+        py_out = F.downmix_mono(tensor)
 
         self.assertTrue(torch.allclose(jit_out, py_out))
 
     @unittest.skipIf(not RUN_CUDA, "no CUDA")
     def test_scriptmodule_downmix_mono(self):
-        tensor = torch.rand((1, 10), device="cuda")
+        tensor = torch.rand((2, 10), device="cuda")
 
         self._test_script_module(tensor, transforms.DownmixMono)
 
@@ -211,32 +208,13 @@ class Test_JIT(unittest.TestCase):
 
         self._test_script_module(tensor, transforms.MelSpectrogram)
 
-    def test_torchscript_BLC2CBL(self):
-        @torch.jit.script
-        def jit_method(tensor):
-            # type: (Tensor) -> Tensor
-            return F.BLC2CBL(tensor)
-
-        tensor = torch.rand((10, 1000, 1))
-
-        jit_out = jit_method(tensor)
-        py_out = F.BLC2CBL(tensor)
-
-        self.assertTrue(torch.allclose(jit_out, py_out))
-
-    @unittest.skipIf(not RUN_CUDA, "no CUDA")
-    def test_scriptmodule_BLC2CBL(self):
-        tensor = torch.rand((10, 1000, 1), device="cuda")
-
-        self._test_script_module(tensor, transforms.BLC2CBL)
-
     def test_torchscript_mu_law_encoding(self):
         @torch.jit.script
         def jit_method(tensor, qc):
             # type: (Tensor, int) -> Tensor
             return F.mu_law_encoding(tensor, qc)
 
-        tensor = torch.rand((10, 1))
+        tensor = torch.rand((1, 10))
         qc = 256
 
         jit_out = jit_method(tensor, qc)
@@ -246,7 +224,7 @@ class Test_JIT(unittest.TestCase):
 
     @unittest.skipIf(not RUN_CUDA, "no CUDA")
     def test_scriptmodule_MuLawEncoding(self):
-        tensor = torch.rand((10, 1), device="cuda")
+        tensor = torch.rand((1, 10), device="cuda")
 
         self._test_script_module(tensor, transforms.MuLawEncoding)
 
@@ -256,7 +234,7 @@ class Test_JIT(unittest.TestCase):
             # type: (Tensor, int) -> Tensor
             return F.mu_law_expanding(tensor, qc)
 
-        tensor = torch.rand((10, 1))
+        tensor = torch.rand((1, 10))
         qc = 256
 
         jit_out = jit_method(tensor, qc)
@@ -266,7 +244,7 @@ class Test_JIT(unittest.TestCase):
 
     @unittest.skipIf(not RUN_CUDA, "no CUDA")
     def test_scriptmodule_MuLawExpanding(self):
-        tensor = torch.rand((10, 1), device="cuda")
+        tensor = torch.rand((1, 10), device="cuda")
 
         self._test_script_module(tensor, transforms.MuLawExpanding)
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -30,26 +30,6 @@ class Test_JIT(unittest.TestCase):
 
         self.assertTrue(torch.allclose(jit_out, py_out))
 
-    def test_torchscript_scale(self):
-        @torch.jit.script
-        def jit_method(tensor, factor):
-            # type: (Tensor, float) -> Tensor
-            return F.scale(tensor, factor)
-
-        tensor = torch.rand((1, 10))
-        factor = 2.0
-
-        jit_out = jit_method(tensor, factor)
-        py_out = F.scale(tensor, factor)
-
-        self.assertTrue(torch.allclose(jit_out, py_out))
-
-    @unittest.skipIf(not RUN_CUDA, "no CUDA")
-    def test_scriptmodule_scale(self):
-        tensor = torch.rand((1, 10), device="cuda")
-
-        self._test_script_module(tensor, transforms.Scale)
-
     def test_torchscript_pad_trim(self):
         @torch.jit.script
         def jit_method(tensor, max_len, fill_value):
@@ -90,25 +70,6 @@ class Test_JIT(unittest.TestCase):
         tensor = torch.rand((2, 10), device="cuda")
 
         self._test_script_module(tensor, transforms.DownmixMono)
-
-    def test_torchscript_LC2CL(self):
-        @torch.jit.script
-        def jit_method(tensor):
-            # type: (Tensor) -> Tensor
-            return F.LC2CL(tensor)
-
-        tensor = torch.rand((10, 1))
-
-        jit_out = jit_method(tensor)
-        py_out = F.LC2CL(tensor)
-
-        self.assertTrue(torch.allclose(jit_out, py_out))
-
-    @unittest.skipIf(not RUN_CUDA, "no CUDA")
-    def test_scriptmodule_LC2CL(self):
-        tensor = torch.rand((10, 1), device="cuda")
-
-        self._test_script_module(tensor, transforms.LC2CL)
 
     def test_torchscript_spectrogram(self):
         @torch.jit.script

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -164,7 +164,7 @@ class Test_JIT(unittest.TestCase):
             # type: (Tensor, float, float, float, Optional[float]) -> Tensor
             return F.spectrogram_to_DB(spec, multiplier, amin, db_multiplier, top_db)
 
-        spec = torch.rand((10, 1))
+        spec = torch.rand((6, 201))
         multiplier = 10.
         amin = 1e-10
         db_multiplier = 0.
@@ -177,7 +177,7 @@ class Test_JIT(unittest.TestCase):
 
     @unittest.skipIf(not RUN_CUDA, "no CUDA")
     def test_scriptmodule_SpectrogramToDB(self):
-        spec = torch.rand((10, 1), device="cuda")
+        spec = torch.rand((6, 201), device="cuda")
 
         self._test_script_module(spec, transforms.SpectrogramToDB)
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -106,171 +106,168 @@ class Tester(unittest.TestCase):
         audio_scaled = transforms.Scale()(audio_orig)  # (1, 16000)
         mel_transform = transforms.MelSpectrogram()
         # check defaults
-        spectrogram_torch = s2db(mel_transform(audio_scaled))  # (1, 319, 40)
-        print(spectrogram_torch.shape)
+        spectrogram_torch = s2db(mel_transform(audio_scaled))  # (1, 128, 321)
         self.assertTrue(spectrogram_torch.dim() == 3)
         self.assertTrue(spectrogram_torch.ge(spectrogram_torch.max() - top_db).all())
-        self.assertEqual(spectrogram_torch.size(-1), mel_transform.n_mels)
+        self.assertEqual(spectrogram_torch.size(1), mel_transform.n_mels)
         # check correctness of filterbank conversion matrix
         self.assertTrue(mel_transform.fm.fb.sum(1).le(1.).all())
         self.assertTrue(mel_transform.fm.fb.sum(1).ge(0.).all())
         # check options
         kwargs = {"window": torch.hamming_window, "pad": 10, "ws": 500, "hop": 125, "n_fft": 800, "n_mels": 50}
         mel_transform2 = transforms.MelSpectrogram(**kwargs)
-        spectrogram2_torch = s2db(mel_transform2(audio_scaled))  # (1, 506, 50)
+        spectrogram2_torch = s2db(mel_transform2(audio_scaled))  # (1, 50, 513)
         self.assertTrue(spectrogram2_torch.dim() == 3)
         self.assertTrue(spectrogram_torch.ge(spectrogram_torch.max() - top_db).all())
-        self.assertEqual(spectrogram2_torch.size(-1), mel_transform2.n_mels)
+        self.assertEqual(spectrogram2_torch.size(1), mel_transform2.n_mels)
         self.assertTrue(mel_transform2.fm.fb.sum(1).le(1.).all())
         self.assertTrue(mel_transform2.fm.fb.sum(1).ge(0.).all())
         # check on multi-channel audio
-        x_stereo, sr_stereo = torchaudio.load(self.test_filepath)
-        spectrogram_stereo = s2db(mel_transform(x_stereo))
+        x_stereo, sr_stereo = torchaudio.load(self.test_filepath)  # (2, 278756), 44100
+        spectrogram_stereo = s2db(mel_transform(x_stereo))  # (2, 128, 1394)
         self.assertTrue(spectrogram_stereo.dim() == 3)
         self.assertTrue(spectrogram_stereo.size(0) == 2)
         self.assertTrue(spectrogram_torch.ge(spectrogram_torch.max() - top_db).all())
-        self.assertEqual(spectrogram_stereo.size(-1), mel_transform.n_mels)
+        self.assertEqual(spectrogram_stereo.size(1), mel_transform.n_mels)
         # check filterbank matrix creation
         fb_matrix_transform = transforms.MelScale(n_mels=100, sr=16000, f_max=None, f_min=0., n_stft=400)
         self.assertTrue(fb_matrix_transform.fb.sum(1).le(1.).all())
         self.assertTrue(fb_matrix_transform.fb.sum(1).ge(0.).all())
         self.assertEqual(fb_matrix_transform.fb.size(), (400, 100))
 
-    # def test_mfcc(self):
-    #     audio_orig = self.sig.clone()
-    #     audio_scaled = transforms.Scale()(audio_orig)  # (16000, 1)
-    #     audio_scaled = transforms.LC2CL()(audio_scaled)  # (1, 16000)
-    #
-    #     sample_rate = 16000
-    #     n_mfcc = 40
-    #     n_mels = 128
-    #     mfcc_transform = torchaudio.transforms.MFCC(sr=sample_rate,
-    #                                                 n_mfcc=n_mfcc,
-    #                                                 norm='ortho')
-    #     # check defaults
-    #     torch_mfcc = mfcc_transform(audio_scaled)
-    #     self.assertTrue(torch_mfcc.dim() == 3)
-    #     self.assertTrue(torch_mfcc.shape[2] == n_mfcc)
-    #     self.assertTrue(torch_mfcc.shape[1] == 321)
-    #     # check melkwargs are passed through
-    #     melkwargs = {'ws': 200}
-    #     mfcc_transform2 = torchaudio.transforms.MFCC(sr=sample_rate,
-    #                                                  n_mfcc=n_mfcc,
-    #                                                  norm='ortho',
-    #                                                  melkwargs=melkwargs)
-    #     torch_mfcc2 = mfcc_transform2(audio_scaled)
-    #     self.assertTrue(torch_mfcc2.shape[1] == 641)
-    #
-    #     # check norms work correctly
-    #     mfcc_transform_norm_none = torchaudio.transforms.MFCC(sr=sample_rate,
-    #                                                           n_mfcc=n_mfcc,
-    #                                                           norm=None)
-    #     torch_mfcc_norm_none = mfcc_transform_norm_none(audio_scaled)
-    #
-    #     norm_check = torch_mfcc.clone()
-    #     norm_check[:, :, 0] *= math.sqrt(n_mels) * 2
-    #     norm_check[:, :, 1:] *= math.sqrt(n_mels / 2) * 2
-    #
-    #     self.assertTrue(torch_mfcc_norm_none.allclose(norm_check))
-    #
-    # @unittest.skipIf(not IMPORT_LIBROSA or not IMPORT_SCIPY, 'Librosa and scipy are not available')
-    # def test_librosa_consistency(self):
-    #     def _test_librosa_consistency_helper(n_fft, hop_length, power, n_mels, n_mfcc, sample_rate):
-    #         input_path = os.path.join(self.test_dirpath, 'assets', 'sinewave.wav')
-    #         sound, sample_rate = torchaudio.load(input_path)
-    #         sound_librosa = sound.cpu().numpy().squeeze().T  # squeeze batch and channel first
-    #
-    #         # test core spectrogram
-    #         spect_transform = torchaudio.transforms.Spectrogram(n_fft=n_fft, hop=hop_length, power=2)
-    #         out_librosa, _ = librosa.core.spectrum._spectrogram(y=sound_librosa,
-    #                                                             n_fft=n_fft,
-    #                                                             hop_length=hop_length,
-    #                                                             power=2)
-    #
-    #         out_torch = spect_transform(sound).squeeze().cpu().t()
-    #         self.assertTrue(torch.allclose(out_torch, torch.from_numpy(out_librosa), atol=1e-5))
-    #
-    #         # test mel spectrogram
-    #         melspect_transform = torchaudio.transforms.MelSpectrogram(sr=sample_rate, window=torch.hann_window,
-    #                                                                   hop=hop_length, n_mels=n_mels, n_fft=n_fft)
-    #         librosa_mel = librosa.feature.melspectrogram(y=sound_librosa, sr=sample_rate,
-    #                                                      n_fft=n_fft, hop_length=hop_length, n_mels=n_mels,
-    #                                                      htk=True, norm=None)
-    #         librosa_mel_tensor = torch.from_numpy(librosa_mel)
-    #         torch_mel = melspect_transform(sound).squeeze().cpu().t()
-    #
-    #         self.assertTrue(torch.allclose(torch_mel.type(librosa_mel_tensor.dtype), librosa_mel_tensor, atol=5e-3))
-    #
-    #         # test s2db
-    #
-    #         db_transform = torchaudio.transforms.SpectrogramToDB("power", 80.)
-    #         db_torch = db_transform(spect_transform(sound)).squeeze().cpu().t()
-    #         db_librosa = librosa.core.spectrum.power_to_db(out_librosa)
-    #         self.assertTrue(torch.allclose(db_torch, torch.from_numpy(db_librosa), atol=5e-3))
-    #
-    #         db_torch = db_transform(melspect_transform(sound)).squeeze().cpu().t()
-    #         db_librosa = librosa.core.spectrum.power_to_db(librosa_mel)
-    #         db_librosa_tensor = torch.from_numpy(db_librosa)
-    #
-    #         self.assertTrue(torch.allclose(db_torch.type(db_librosa_tensor.dtype), db_librosa_tensor, atol=5e-3))
-    #
-    #         # test MFCC
-    #         melkwargs = {'hop': hop_length, 'n_fft': n_fft}
-    #         mfcc_transform = torchaudio.transforms.MFCC(sr=sample_rate,
-    #                                                     n_mfcc=n_mfcc,
-    #                                                     norm='ortho',
-    #                                                     melkwargs=melkwargs)
-    #
-    #         # librosa.feature.mfcc doesn't pass kwargs properly since some of the
-    #         # kwargs for melspectrogram and mfcc are the same. We just follow the
-    #         # function body in https://librosa.github.io/librosa/_modules/librosa/feature/spectral.html#melspectrogram
-    #         # to mirror this function call with correct args:
-    #
-    # #         librosa_mfcc = librosa.feature.mfcc(y=sound_librosa,
-    # #                                             sr=sample_rate,
-    # #                                             n_mfcc = n_mfcc,
-    # #                                             hop_length=hop_length,
-    # #                                             n_fft=n_fft,
-    # #                                             htk=True,
-    # #                                             norm=None,
-    # #                                             n_mels=n_mels)
-    #
-    #         librosa_mfcc = scipy.fftpack.dct(db_librosa, axis=0, type=2, norm='ortho')[:n_mfcc]
-    #         librosa_mfcc_tensor = torch.from_numpy(librosa_mfcc)
-    #         torch_mfcc = mfcc_transform(sound).squeeze().cpu().t()
-    #
-    #         self.assertTrue(torch.allclose(torch_mfcc.type(librosa_mfcc_tensor.dtype), librosa_mfcc_tensor, atol=5e-3))
-    #
-    #     kwargs1 = {
-    #         'n_fft': 400,
-    #         'hop_length': 200,
-    #         'power': 2.0,
-    #         'n_mels': 128,
-    #         'n_mfcc': 40,
-    #         'sample_rate': 16000
-    #     }
-    #
-    #     kwargs2 = {
-    #         'n_fft': 600,
-    #         'hop_length': 100,
-    #         'power': 2.0,
-    #         'n_mels': 128,
-    #         'n_mfcc': 20,
-    #         'sample_rate': 16000
-    #     }
-    #
-    #     kwargs3 = {
-    #         'n_fft': 200,
-    #         'hop_length': 50,
-    #         'power': 2.0,
-    #         'n_mels': 128,
-    #         'n_mfcc': 50,
-    #         'sample_rate': 24000
-    #     }
-    #
-    #     _test_librosa_consistency_helper(**kwargs1)
-    #     _test_librosa_consistency_helper(**kwargs2)
-    #     _test_librosa_consistency_helper(**kwargs3)
+    def test_mfcc(self):
+        audio_orig = self.sig.clone()
+        audio_scaled = transforms.Scale()(audio_orig)  # (1, 16000)
+
+        sample_rate = 16000
+        n_mfcc = 40
+        n_mels = 128
+        mfcc_transform = torchaudio.transforms.MFCC(sr=sample_rate,
+                                                    n_mfcc=n_mfcc,
+                                                    norm='ortho')
+        # check defaults
+        torch_mfcc = mfcc_transform(audio_scaled)  # (1, 40, 321)
+        self.assertTrue(torch_mfcc.dim() == 3)
+        self.assertTrue(torch_mfcc.shape[1] == n_mfcc)
+        self.assertTrue(torch_mfcc.shape[2] == 321)
+        # check melkwargs are passed through
+        melkwargs = {'ws': 200}
+        mfcc_transform2 = torchaudio.transforms.MFCC(sr=sample_rate,
+                                                     n_mfcc=n_mfcc,
+                                                     norm='ortho',
+                                                     melkwargs=melkwargs)
+        torch_mfcc2 = mfcc_transform2(audio_scaled)  # (1, 40, 641)
+        self.assertTrue(torch_mfcc2.shape[2] == 641)
+
+        # check norms work correctly
+        mfcc_transform_norm_none = torchaudio.transforms.MFCC(sr=sample_rate,
+                                                              n_mfcc=n_mfcc,
+                                                              norm=None)
+        torch_mfcc_norm_none = mfcc_transform_norm_none(audio_scaled)  # (1, 40, 321)
+
+        norm_check = torch_mfcc.clone()
+        norm_check[:, 0, :] *= math.sqrt(n_mels) * 2
+        norm_check[:, 1:, :] *= math.sqrt(n_mels / 2) * 2
+
+        self.assertTrue(torch_mfcc_norm_none.allclose(norm_check))
+
+    @unittest.skipIf(not IMPORT_LIBROSA or not IMPORT_SCIPY, 'Librosa and scipy are not available')
+    def test_librosa_consistency(self):
+        def _test_librosa_consistency_helper(n_fft, hop_length, power, n_mels, n_mfcc, sample_rate):
+            input_path = os.path.join(self.test_dirpath, 'assets', 'sinewave.wav')
+            sound, sample_rate = torchaudio.load(input_path)
+            sound_librosa = sound.cpu().numpy().squeeze()  # (64000)
+
+            # test core spectrogram
+            spect_transform = torchaudio.transforms.Spectrogram(n_fft=n_fft, hop=hop_length, power=2)
+            out_librosa, _ = librosa.core.spectrum._spectrogram(y=sound_librosa,
+                                                                n_fft=n_fft,
+                                                                hop_length=hop_length,
+                                                                power=2)
+
+            out_torch = spect_transform(sound).squeeze().cpu()
+            self.assertTrue(torch.allclose(out_torch, torch.from_numpy(out_librosa), atol=1e-5))
+
+            # test mel spectrogram
+            melspect_transform = torchaudio.transforms.MelSpectrogram(sr=sample_rate, window=torch.hann_window,
+                                                                      hop=hop_length, n_mels=n_mels, n_fft=n_fft)
+            librosa_mel = librosa.feature.melspectrogram(y=sound_librosa, sr=sample_rate,
+                                                         n_fft=n_fft, hop_length=hop_length, n_mels=n_mels,
+                                                         htk=True, norm=None)
+            librosa_mel_tensor = torch.from_numpy(librosa_mel)
+            torch_mel = melspect_transform(sound).squeeze().cpu()
+
+            self.assertTrue(torch.allclose(torch_mel.type(librosa_mel_tensor.dtype), librosa_mel_tensor, atol=5e-3))
+
+            # test s2db
+            db_transform = torchaudio.transforms.SpectrogramToDB("power", 80.)
+            db_torch = db_transform(spect_transform(sound)).squeeze().cpu()
+            db_librosa = librosa.core.spectrum.power_to_db(out_librosa)
+            self.assertTrue(torch.allclose(db_torch, torch.from_numpy(db_librosa), atol=5e-3))
+
+            db_torch = db_transform(melspect_transform(sound)).squeeze().cpu()
+            db_librosa = librosa.core.spectrum.power_to_db(librosa_mel)
+            db_librosa_tensor = torch.from_numpy(db_librosa)
+
+            self.assertTrue(torch.allclose(db_torch.type(db_librosa_tensor.dtype), db_librosa_tensor, atol=5e-3))
+
+            # test MFCC
+            melkwargs = {'hop': hop_length, 'n_fft': n_fft}
+            mfcc_transform = torchaudio.transforms.MFCC(sr=sample_rate,
+                                                        n_mfcc=n_mfcc,
+                                                        norm='ortho',
+                                                        melkwargs=melkwargs)
+
+            # librosa.feature.mfcc doesn't pass kwargs properly since some of the
+            # kwargs for melspectrogram and mfcc are the same. We just follow the
+            # function body in https://librosa.github.io/librosa/_modules/librosa/feature/spectral.html#melspectrogram
+            # to mirror this function call with correct args:
+
+    #         librosa_mfcc = librosa.feature.mfcc(y=sound_librosa,
+    #                                             sr=sample_rate,
+    #                                             n_mfcc = n_mfcc,
+    #                                             hop_length=hop_length,
+    #                                             n_fft=n_fft,
+    #                                             htk=True,
+    #                                             norm=None,
+    #                                             n_mels=n_mels)
+
+            librosa_mfcc = scipy.fftpack.dct(db_librosa, axis=0, type=2, norm='ortho')[:n_mfcc]
+            librosa_mfcc_tensor = torch.from_numpy(librosa_mfcc)
+            torch_mfcc = mfcc_transform(sound).squeeze().cpu()
+
+            self.assertTrue(torch.allclose(torch_mfcc.type(librosa_mfcc_tensor.dtype), librosa_mfcc_tensor, atol=5e-3))
+
+        kwargs1 = {
+            'n_fft': 400,
+            'hop_length': 200,
+            'power': 2.0,
+            'n_mels': 128,
+            'n_mfcc': 40,
+            'sample_rate': 16000
+        }
+
+        kwargs2 = {
+            'n_fft': 600,
+            'hop_length': 100,
+            'power': 2.0,
+            'n_mels': 128,
+            'n_mfcc': 20,
+            'sample_rate': 16000
+        }
+
+        kwargs3 = {
+            'n_fft': 200,
+            'hop_length': 50,
+            'power': 2.0,
+            'n_mels': 128,
+            'n_mfcc': 50,
+            'sample_rate': 24000
+        }
+
+        _test_librosa_consistency_helper(**kwargs1)
+        _test_librosa_consistency_helper(**kwargs2)
+        _test_librosa_consistency_helper(**kwargs3)
 
     def test_resample_size(self):
         input_path = os.path.join(self.test_dirpath, 'assets', 'sinewave.wav')

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -47,25 +47,21 @@ class Tester(unittest.TestCase):
 
     def test_pad_trim(self):
 
-        audio_orig = self.sig.clone()
-        length_orig = audio_orig.size(0)
+        audio_orig = self.sig.clone().t()
+        length_orig = audio_orig.size(1)
         length_new = int(length_orig * 1.2)
 
-        result = transforms.PadTrim(max_len=length_new, channels_first=False)(audio_orig)
-        self.assertEqual(result.size(0), length_new)
-
-        result = transforms.PadTrim(max_len=length_new, channels_first=True)(audio_orig.transpose(0, 1))
+        result = transforms.PadTrim(max_len=length_new)(audio_orig)
         self.assertEqual(result.size(1), length_new)
 
         audio_orig = self.sig.clone()
-        length_orig = audio_orig.size(0)
         length_new = int(length_orig * 0.8)
 
-        result = transforms.PadTrim(max_len=length_new, channels_first=False)(audio_orig)
+        result = transforms.PadTrim(max_len=length_new)(audio_orig)
 
-        self.assertEqual(result.size(0), length_new)
+        self.assertEqual(result.size(1), length_new)
 
-        repr_test = transforms.PadTrim(max_len=length_new, channels_first=False)
+        repr_test = transforms.PadTrim(max_len=length_new)
         self.assertTrue(repr_test.__repr__())
 
     def test_downmix_mono(self):

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -23,7 +23,7 @@ class Tester(unittest.TestCase):
     freq = 440
     volume = .3
     sig = (torch.cos(2 * math.pi * torch.arange(0, 4 * sr).float() * freq / sr))
-    sig.unsqueeze_(1)  # (64000, 1)
+    sig.unsqueeze_(0)  # (1, 64000)
     sig = (sig * volume * 2**31).long()
     # file for stereo stft test
     test_dirpath, test_dir = test.common_utils.create_temp_assets_dir()
@@ -37,24 +37,22 @@ class Tester(unittest.TestCase):
         self.assertTrue(result.min() >= -1. and result.max() <= 1.)
 
         maxminmax = max(abs(audio_orig.min()), abs(audio_orig.max())).item()
-        result = transforms.Scale(factor=maxminmax)(audio_orig)
+        result = transforms.Scale(factor=float(maxminmax))(audio_orig)
 
         self.assertTrue((result.min() == -1. or result.max() == 1.) and
                         result.min() >= -1. and result.max() <= 1.)
 
         repr_test = transforms.Scale()
-        self.assertTrue(repr_test.__repr__())
 
     def test_pad_trim(self):
 
-        audio_orig = self.sig.clone().t()
+        audio_orig = self.sig.clone()
         length_orig = audio_orig.size(1)
         length_new = int(length_orig * 1.2)
 
         result = transforms.PadTrim(max_len=length_new)(audio_orig)
         self.assertEqual(result.size(1), length_new)
 
-        audio_orig = self.sig.clone()
         length_new = int(length_orig * 0.8)
 
         result = transforms.PadTrim(max_len=length_new)(audio_orig)
@@ -62,7 +60,6 @@ class Tester(unittest.TestCase):
         self.assertEqual(result.size(1), length_new)
 
         repr_test = transforms.PadTrim(max_len=length_new)
-        self.assertTrue(repr_test.__repr__())
 
     def test_downmix_mono(self):
 
@@ -71,43 +68,21 @@ class Tester(unittest.TestCase):
         R_idx = int(audio_R.size(0) * 0.1)
         audio_R = torch.cat((audio_R[R_idx:], audio_R[:R_idx]))
 
-        audio_Stereo = torch.cat((audio_L, audio_R), dim=1)
+        audio_Stereo = torch.cat((audio_L, audio_R), dim=0)
 
-        self.assertTrue(audio_Stereo.size(1) == 2)
+        self.assertTrue(audio_Stereo.size(0) == 2)
 
-        result = transforms.DownmixMono(channels_first=False)(audio_Stereo)
+        result = transforms.DownmixMono()(audio_Stereo)
 
-        self.assertTrue(result.size(1) == 1)
-
-        repr_test = transforms.DownmixMono(channels_first=False)
-        self.assertTrue(repr_test.__repr__())
+        self.assertTrue(result.size(0) == 1)
 
     def test_lc2cl(self):
 
-        audio = self.sig.clone()
+        audio = self.sig.clone().t()
         result = transforms.LC2CL()(audio)
         self.assertTrue(result.size()[::-1] == audio.size())
 
         repr_test = transforms.LC2CL()
-        self.assertTrue(repr_test.__repr__())
-
-    def test_compose(self):
-
-        audio_orig = self.sig.clone()
-        length_orig = audio_orig.size(0)
-        length_new = int(length_orig * 1.2)
-        maxminmax = max(abs(audio_orig.min()), abs(audio_orig.max())).item()
-
-        tset = (transforms.Scale(factor=maxminmax),
-                transforms.PadTrim(max_len=length_new, channels_first=False))
-        result = transforms.Compose(tset)(audio_orig)
-
-        self.assertTrue(max(abs(result.min()), abs(result.max())) == 1.)
-
-        self.assertTrue(result.size(0) == length_new)
-
-        repr_test = transforms.Compose(tset)
-        self.assertTrue(repr_test.__repr__())
 
     def test_mu_law_companding(self):
 
@@ -123,21 +98,16 @@ class Tester(unittest.TestCase):
         sig_exp = transforms.MuLawExpanding(quantization_channels)(sig_mu)
         self.assertTrue(sig_exp.min() >= -1. and sig_exp.max() <= 1.)
 
-        repr_test = transforms.MuLawEncoding(quantization_channels)
-        self.assertTrue(repr_test.__repr__())
-        repr_test = transforms.MuLawExpanding(quantization_channels)
-        self.assertTrue(repr_test.__repr__())
-
     def test_mel2(self):
         top_db = 80.
         s2db = transforms.SpectrogramToDB("power", top_db)
 
-        audio_orig = self.sig.clone()  # (16000, 1)
-        audio_scaled = transforms.Scale()(audio_orig)  # (16000, 1)
-        audio_scaled = transforms.LC2CL()(audio_scaled)  # (1, 16000)
+        audio_orig = self.sig.clone()  # (1, 16000)
+        audio_scaled = transforms.Scale()(audio_orig)  # (1, 16000)
         mel_transform = transforms.MelSpectrogram()
         # check defaults
         spectrogram_torch = s2db(mel_transform(audio_scaled))  # (1, 319, 40)
+        print(spectrogram_torch.shape)
         self.assertTrue(spectrogram_torch.dim() == 3)
         self.assertTrue(spectrogram_torch.ge(spectrogram_torch.max() - top_db).all())
         self.assertEqual(spectrogram_torch.size(-1), mel_transform.n_mels)
@@ -166,141 +136,141 @@ class Tester(unittest.TestCase):
         self.assertTrue(fb_matrix_transform.fb.sum(1).ge(0.).all())
         self.assertEqual(fb_matrix_transform.fb.size(), (400, 100))
 
-    def test_mfcc(self):
-        audio_orig = self.sig.clone()
-        audio_scaled = transforms.Scale()(audio_orig)  # (16000, 1)
-        audio_scaled = transforms.LC2CL()(audio_scaled)  # (1, 16000)
-
-        sample_rate = 16000
-        n_mfcc = 40
-        n_mels = 128
-        mfcc_transform = torchaudio.transforms.MFCC(sr=sample_rate,
-                                                    n_mfcc=n_mfcc,
-                                                    norm='ortho')
-        # check defaults
-        torch_mfcc = mfcc_transform(audio_scaled)
-        self.assertTrue(torch_mfcc.dim() == 3)
-        self.assertTrue(torch_mfcc.shape[2] == n_mfcc)
-        self.assertTrue(torch_mfcc.shape[1] == 321)
-        # check melkwargs are passed through
-        melkwargs = {'ws': 200}
-        mfcc_transform2 = torchaudio.transforms.MFCC(sr=sample_rate,
-                                                     n_mfcc=n_mfcc,
-                                                     norm='ortho',
-                                                     melkwargs=melkwargs)
-        torch_mfcc2 = mfcc_transform2(audio_scaled)
-        self.assertTrue(torch_mfcc2.shape[1] == 641)
-
-        # check norms work correctly
-        mfcc_transform_norm_none = torchaudio.transforms.MFCC(sr=sample_rate,
-                                                              n_mfcc=n_mfcc,
-                                                              norm=None)
-        torch_mfcc_norm_none = mfcc_transform_norm_none(audio_scaled)
-
-        norm_check = torch_mfcc.clone()
-        norm_check[:, :, 0] *= math.sqrt(n_mels) * 2
-        norm_check[:, :, 1:] *= math.sqrt(n_mels / 2) * 2
-
-        self.assertTrue(torch_mfcc_norm_none.allclose(norm_check))
-
-    @unittest.skipIf(not IMPORT_LIBROSA or not IMPORT_SCIPY, 'Librosa and scipy are not available')
-    def test_librosa_consistency(self):
-        def _test_librosa_consistency_helper(n_fft, hop_length, power, n_mels, n_mfcc, sample_rate):
-            input_path = os.path.join(self.test_dirpath, 'assets', 'sinewave.wav')
-            sound, sample_rate = torchaudio.load(input_path)
-            sound_librosa = sound.cpu().numpy().squeeze().T  # squeeze batch and channel first
-
-            # test core spectrogram
-            spect_transform = torchaudio.transforms.Spectrogram(n_fft=n_fft, hop=hop_length, power=2)
-            out_librosa, _ = librosa.core.spectrum._spectrogram(y=sound_librosa,
-                                                                n_fft=n_fft,
-                                                                hop_length=hop_length,
-                                                                power=2)
-
-            out_torch = spect_transform(sound).squeeze().cpu().t()
-            self.assertTrue(torch.allclose(out_torch, torch.from_numpy(out_librosa), atol=1e-5))
-
-            # test mel spectrogram
-            melspect_transform = torchaudio.transforms.MelSpectrogram(sr=sample_rate, window=torch.hann_window,
-                                                                      hop=hop_length, n_mels=n_mels, n_fft=n_fft)
-            librosa_mel = librosa.feature.melspectrogram(y=sound_librosa, sr=sample_rate,
-                                                         n_fft=n_fft, hop_length=hop_length, n_mels=n_mels,
-                                                         htk=True, norm=None)
-            librosa_mel_tensor = torch.from_numpy(librosa_mel)
-            torch_mel = melspect_transform(sound).squeeze().cpu().t()
-
-            self.assertTrue(torch.allclose(torch_mel.type(librosa_mel_tensor.dtype), librosa_mel_tensor, atol=5e-3))
-
-            # test s2db
-
-            db_transform = torchaudio.transforms.SpectrogramToDB("power", 80.)
-            db_torch = db_transform(spect_transform(sound)).squeeze().cpu().t()
-            db_librosa = librosa.core.spectrum.power_to_db(out_librosa)
-            self.assertTrue(torch.allclose(db_torch, torch.from_numpy(db_librosa), atol=5e-3))
-
-            db_torch = db_transform(melspect_transform(sound)).squeeze().cpu().t()
-            db_librosa = librosa.core.spectrum.power_to_db(librosa_mel)
-            db_librosa_tensor = torch.from_numpy(db_librosa)
-
-            self.assertTrue(torch.allclose(db_torch.type(db_librosa_tensor.dtype), db_librosa_tensor, atol=5e-3))
-
-            # test MFCC
-            melkwargs = {'hop': hop_length, 'n_fft': n_fft}
-            mfcc_transform = torchaudio.transforms.MFCC(sr=sample_rate,
-                                                        n_mfcc=n_mfcc,
-                                                        norm='ortho',
-                                                        melkwargs=melkwargs)
-
-            # librosa.feature.mfcc doesn't pass kwargs properly since some of the
-            # kwargs for melspectrogram and mfcc are the same. We just follow the
-            # function body in https://librosa.github.io/librosa/_modules/librosa/feature/spectral.html#melspectrogram
-            # to mirror this function call with correct args:
-
-    #         librosa_mfcc = librosa.feature.mfcc(y=sound_librosa,
-    #                                             sr=sample_rate,
-    #                                             n_mfcc = n_mfcc,
-    #                                             hop_length=hop_length,
-    #                                             n_fft=n_fft,
-    #                                             htk=True,
-    #                                             norm=None,
-    #                                             n_mels=n_mels)
-
-            librosa_mfcc = scipy.fftpack.dct(db_librosa, axis=0, type=2, norm='ortho')[:n_mfcc]
-            librosa_mfcc_tensor = torch.from_numpy(librosa_mfcc)
-            torch_mfcc = mfcc_transform(sound).squeeze().cpu().t()
-
-            self.assertTrue(torch.allclose(torch_mfcc.type(librosa_mfcc_tensor.dtype), librosa_mfcc_tensor, atol=5e-3))
-
-        kwargs1 = {
-            'n_fft': 400,
-            'hop_length': 200,
-            'power': 2.0,
-            'n_mels': 128,
-            'n_mfcc': 40,
-            'sample_rate': 16000
-        }
-
-        kwargs2 = {
-            'n_fft': 600,
-            'hop_length': 100,
-            'power': 2.0,
-            'n_mels': 128,
-            'n_mfcc': 20,
-            'sample_rate': 16000
-        }
-
-        kwargs3 = {
-            'n_fft': 200,
-            'hop_length': 50,
-            'power': 2.0,
-            'n_mels': 128,
-            'n_mfcc': 50,
-            'sample_rate': 24000
-        }
-
-        _test_librosa_consistency_helper(**kwargs1)
-        _test_librosa_consistency_helper(**kwargs2)
-        _test_librosa_consistency_helper(**kwargs3)
+    # def test_mfcc(self):
+    #     audio_orig = self.sig.clone()
+    #     audio_scaled = transforms.Scale()(audio_orig)  # (16000, 1)
+    #     audio_scaled = transforms.LC2CL()(audio_scaled)  # (1, 16000)
+    #
+    #     sample_rate = 16000
+    #     n_mfcc = 40
+    #     n_mels = 128
+    #     mfcc_transform = torchaudio.transforms.MFCC(sr=sample_rate,
+    #                                                 n_mfcc=n_mfcc,
+    #                                                 norm='ortho')
+    #     # check defaults
+    #     torch_mfcc = mfcc_transform(audio_scaled)
+    #     self.assertTrue(torch_mfcc.dim() == 3)
+    #     self.assertTrue(torch_mfcc.shape[2] == n_mfcc)
+    #     self.assertTrue(torch_mfcc.shape[1] == 321)
+    #     # check melkwargs are passed through
+    #     melkwargs = {'ws': 200}
+    #     mfcc_transform2 = torchaudio.transforms.MFCC(sr=sample_rate,
+    #                                                  n_mfcc=n_mfcc,
+    #                                                  norm='ortho',
+    #                                                  melkwargs=melkwargs)
+    #     torch_mfcc2 = mfcc_transform2(audio_scaled)
+    #     self.assertTrue(torch_mfcc2.shape[1] == 641)
+    #
+    #     # check norms work correctly
+    #     mfcc_transform_norm_none = torchaudio.transforms.MFCC(sr=sample_rate,
+    #                                                           n_mfcc=n_mfcc,
+    #                                                           norm=None)
+    #     torch_mfcc_norm_none = mfcc_transform_norm_none(audio_scaled)
+    #
+    #     norm_check = torch_mfcc.clone()
+    #     norm_check[:, :, 0] *= math.sqrt(n_mels) * 2
+    #     norm_check[:, :, 1:] *= math.sqrt(n_mels / 2) * 2
+    #
+    #     self.assertTrue(torch_mfcc_norm_none.allclose(norm_check))
+    #
+    # @unittest.skipIf(not IMPORT_LIBROSA or not IMPORT_SCIPY, 'Librosa and scipy are not available')
+    # def test_librosa_consistency(self):
+    #     def _test_librosa_consistency_helper(n_fft, hop_length, power, n_mels, n_mfcc, sample_rate):
+    #         input_path = os.path.join(self.test_dirpath, 'assets', 'sinewave.wav')
+    #         sound, sample_rate = torchaudio.load(input_path)
+    #         sound_librosa = sound.cpu().numpy().squeeze().T  # squeeze batch and channel first
+    #
+    #         # test core spectrogram
+    #         spect_transform = torchaudio.transforms.Spectrogram(n_fft=n_fft, hop=hop_length, power=2)
+    #         out_librosa, _ = librosa.core.spectrum._spectrogram(y=sound_librosa,
+    #                                                             n_fft=n_fft,
+    #                                                             hop_length=hop_length,
+    #                                                             power=2)
+    #
+    #         out_torch = spect_transform(sound).squeeze().cpu().t()
+    #         self.assertTrue(torch.allclose(out_torch, torch.from_numpy(out_librosa), atol=1e-5))
+    #
+    #         # test mel spectrogram
+    #         melspect_transform = torchaudio.transforms.MelSpectrogram(sr=sample_rate, window=torch.hann_window,
+    #                                                                   hop=hop_length, n_mels=n_mels, n_fft=n_fft)
+    #         librosa_mel = librosa.feature.melspectrogram(y=sound_librosa, sr=sample_rate,
+    #                                                      n_fft=n_fft, hop_length=hop_length, n_mels=n_mels,
+    #                                                      htk=True, norm=None)
+    #         librosa_mel_tensor = torch.from_numpy(librosa_mel)
+    #         torch_mel = melspect_transform(sound).squeeze().cpu().t()
+    #
+    #         self.assertTrue(torch.allclose(torch_mel.type(librosa_mel_tensor.dtype), librosa_mel_tensor, atol=5e-3))
+    #
+    #         # test s2db
+    #
+    #         db_transform = torchaudio.transforms.SpectrogramToDB("power", 80.)
+    #         db_torch = db_transform(spect_transform(sound)).squeeze().cpu().t()
+    #         db_librosa = librosa.core.spectrum.power_to_db(out_librosa)
+    #         self.assertTrue(torch.allclose(db_torch, torch.from_numpy(db_librosa), atol=5e-3))
+    #
+    #         db_torch = db_transform(melspect_transform(sound)).squeeze().cpu().t()
+    #         db_librosa = librosa.core.spectrum.power_to_db(librosa_mel)
+    #         db_librosa_tensor = torch.from_numpy(db_librosa)
+    #
+    #         self.assertTrue(torch.allclose(db_torch.type(db_librosa_tensor.dtype), db_librosa_tensor, atol=5e-3))
+    #
+    #         # test MFCC
+    #         melkwargs = {'hop': hop_length, 'n_fft': n_fft}
+    #         mfcc_transform = torchaudio.transforms.MFCC(sr=sample_rate,
+    #                                                     n_mfcc=n_mfcc,
+    #                                                     norm='ortho',
+    #                                                     melkwargs=melkwargs)
+    #
+    #         # librosa.feature.mfcc doesn't pass kwargs properly since some of the
+    #         # kwargs for melspectrogram and mfcc are the same. We just follow the
+    #         # function body in https://librosa.github.io/librosa/_modules/librosa/feature/spectral.html#melspectrogram
+    #         # to mirror this function call with correct args:
+    #
+    # #         librosa_mfcc = librosa.feature.mfcc(y=sound_librosa,
+    # #                                             sr=sample_rate,
+    # #                                             n_mfcc = n_mfcc,
+    # #                                             hop_length=hop_length,
+    # #                                             n_fft=n_fft,
+    # #                                             htk=True,
+    # #                                             norm=None,
+    # #                                             n_mels=n_mels)
+    #
+    #         librosa_mfcc = scipy.fftpack.dct(db_librosa, axis=0, type=2, norm='ortho')[:n_mfcc]
+    #         librosa_mfcc_tensor = torch.from_numpy(librosa_mfcc)
+    #         torch_mfcc = mfcc_transform(sound).squeeze().cpu().t()
+    #
+    #         self.assertTrue(torch.allclose(torch_mfcc.type(librosa_mfcc_tensor.dtype), librosa_mfcc_tensor, atol=5e-3))
+    #
+    #     kwargs1 = {
+    #         'n_fft': 400,
+    #         'hop_length': 200,
+    #         'power': 2.0,
+    #         'n_mels': 128,
+    #         'n_mfcc': 40,
+    #         'sample_rate': 16000
+    #     }
+    #
+    #     kwargs2 = {
+    #         'n_fft': 600,
+    #         'hop_length': 100,
+    #         'power': 2.0,
+    #         'n_mels': 128,
+    #         'n_mfcc': 20,
+    #         'sample_rate': 16000
+    #     }
+    #
+    #     kwargs3 = {
+    #         'n_fft': 200,
+    #         'hop_length': 50,
+    #         'power': 2.0,
+    #         'n_mels': 128,
+    #         'n_mfcc': 50,
+    #         'sample_rate': 24000
+    #     }
+    #
+    #     _test_librosa_consistency_helper(**kwargs1)
+    #     _test_librosa_consistency_helper(**kwargs2)
+    #     _test_librosa_consistency_helper(**kwargs3)
 
     def test_resample_size(self):
         input_path = os.path.join(self.test_dirpath, 'assets', 'sinewave.wav')

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -50,7 +50,6 @@ class Tester(unittest.TestCase):
         result = transforms.PadTrim(max_len=length_new)(waveform)
         self.assertEqual(result.size(1), length_new)
 
-
     def test_mu_law_companding(self):
 
         quantization_channels = 256

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -19,56 +19,50 @@ if IMPORT_SCIPY:
 class Tester(unittest.TestCase):
 
     # create a sinewave signal for testing
-    sr = 16000
+    sample_rate = 16000
     freq = 440
     volume = .3
-    sig = (torch.cos(2 * math.pi * torch.arange(0, 4 * sr).float() * freq / sr))
-    sig.unsqueeze_(0)  # (1, 64000)
-    sig = (sig * volume * 2**31).long()
+    waveform = (torch.cos(2 * math.pi * torch.arange(0, 4 * sample_rate).float() * freq / sample_rate))
+    waveform.unsqueeze_(0)  # (1, 64000)
+    waveform = (waveform * volume * 2**31).long()
     # file for stereo stft test
     test_dirpath, test_dir = test.common_utils.create_temp_assets_dir()
-    test_filepath = os.path.join(test_dirpath, "assets",
-                                 "steam-train-whistle-daniel_simon.mp3")
+    test_filepath = os.path.join(test_dirpath, 'assets',
+                                 'steam-train-whistle-daniel_simon.mp3')
 
     def test_scale(self):
 
-        audio_orig = self.sig.clone()
-        result = transforms.Scale()(audio_orig)
+        waveform = self.waveform.clone()
+        result = transforms.Scale()(waveform)
         self.assertTrue(result.min() >= -1. and result.max() <= 1.)
 
-        maxminmax = max(abs(audio_orig.min()), abs(audio_orig.max())).item()
-        result = transforms.Scale(factor=float(maxminmax))(audio_orig)
-
+        maxminmax = max(abs(waveform.min()), abs(waveform.max())).item()
+        result = transforms.Scale(factor=float(maxminmax))(waveform)
         self.assertTrue((result.min() == -1. or result.max() == 1.) and
                         result.min() >= -1. and result.max() <= 1.)
 
-        repr_test = transforms.Scale()
-
     def test_pad_trim(self):
 
-        audio_orig = self.sig.clone()
-        length_orig = audio_orig.size(1)
+        waveform = self.waveform.clone()
+        length_orig = waveform.size(1)
         length_new = int(length_orig * 1.2)
 
-        result = transforms.PadTrim(max_len=length_new)(audio_orig)
+        result = transforms.PadTrim(max_len=length_new)(waveform)
         self.assertEqual(result.size(1), length_new)
 
         length_new = int(length_orig * 0.8)
 
-        result = transforms.PadTrim(max_len=length_new)(audio_orig)
-
+        result = transforms.PadTrim(max_len=length_new)(waveform)
         self.assertEqual(result.size(1), length_new)
-
-        repr_test = transforms.PadTrim(max_len=length_new)
 
     def test_downmix_mono(self):
 
-        audio_L = self.sig.clone()
-        audio_R = self.sig.clone()
-        R_idx = int(audio_R.size(0) * 0.1)
-        audio_R = torch.cat((audio_R[R_idx:], audio_R[:R_idx]))
+        waveform_L = self.waveform.clone()
+        waveform_R = self.waveform.clone()
+        R_idx = int(waveform_R.size(0) * 0.1)
+        waveform_R = torch.cat((waveform_R[R_idx:], waveform_R[:R_idx]))
 
-        audio_Stereo = torch.cat((audio_L, audio_R), dim=0)
+        audio_Stereo = torch.cat((waveform_L, waveform_R), dim=0)
 
         self.assertTrue(audio_Stereo.size(0) == 2)
 
@@ -78,50 +72,49 @@ class Tester(unittest.TestCase):
 
     def test_lc2cl(self):
 
-        audio = self.sig.clone().t()
-        result = transforms.LC2CL()(audio)
-        self.assertTrue(result.size()[::-1] == audio.size())
-
-        repr_test = transforms.LC2CL()
+        waveform = self.waveform.clone().t()
+        result = transforms.LC2CL()(waveform)
+        self.assertTrue(result.size()[::-1] == waveform.size())
 
     def test_mu_law_companding(self):
 
         quantization_channels = 256
 
-        sig = self.sig.clone()
-        sig = sig / torch.abs(sig).max()
-        self.assertTrue(sig.min() >= -1. and sig.max() <= 1.)
+        waveform = self.waveform.clone()
+        waveform /= torch.abs(waveform).max()
+        self.assertTrue(waveform.min() >= -1. and waveform.max() <= 1.)
 
-        sig_mu = transforms.MuLawEncoding(quantization_channels)(sig)
-        self.assertTrue(sig_mu.min() >= 0. and sig.max() <= quantization_channels)
+        waveform_mu = transforms.MuLawEncoding(quantization_channels)(waveform)
+        self.assertTrue(waveform_mu.min() >= 0. and waveform_mu.max() <= quantization_channels)
 
-        sig_exp = transforms.MuLawExpanding(quantization_channels)(sig_mu)
-        self.assertTrue(sig_exp.min() >= -1. and sig_exp.max() <= 1.)
+        waveform_exp = transforms.MuLawExpanding(quantization_channels)(waveform_mu)
+        self.assertTrue(waveform_exp.min() >= -1. and waveform_exp.max() <= 1.)
 
     def test_mel2(self):
         top_db = 80.
-        s2db = transforms.SpectrogramToDB("power", top_db)
+        s2db = transforms.SpectrogramToDB('power', top_db)
 
-        audio_orig = self.sig.clone()  # (1, 16000)
-        audio_scaled = transforms.Scale()(audio_orig)  # (1, 16000)
+        waveform = self.waveform.clone()  # (1, 16000)
+        waveform_scaled = transforms.Scale()(waveform)  # (1, 16000)
         mel_transform = transforms.MelSpectrogram()
         # check defaults
-        spectrogram_torch = s2db(mel_transform(audio_scaled))  # (1, 128, 321)
+        spectrogram_torch = s2db(mel_transform(waveform_scaled))  # (1, 128, 321)
         self.assertTrue(spectrogram_torch.dim() == 3)
         self.assertTrue(spectrogram_torch.ge(spectrogram_torch.max() - top_db).all())
         self.assertEqual(spectrogram_torch.size(1), mel_transform.n_mels)
         # check correctness of filterbank conversion matrix
-        self.assertTrue(mel_transform.fm.fb.sum(1).le(1.).all())
-        self.assertTrue(mel_transform.fm.fb.sum(1).ge(0.).all())
+        self.assertTrue(mel_transform.mel_scale.fb.sum(1).le(1.).all())
+        self.assertTrue(mel_transform.mel_scale.fb.sum(1).ge(0.).all())
         # check options
-        kwargs = {"window": torch.hamming_window, "pad": 10, "ws": 500, "hop": 125, "n_fft": 800, "n_mels": 50}
+        kwargs = {'window_fn': torch.hamming_window, 'pad': 10, 'win_length': 500,
+                  'hop_length': 125, 'n_fft': 800, 'n_mels': 50}
         mel_transform2 = transforms.MelSpectrogram(**kwargs)
-        spectrogram2_torch = s2db(mel_transform2(audio_scaled))  # (1, 50, 513)
+        spectrogram2_torch = s2db(mel_transform2(waveform_scaled))  # (1, 50, 513)
         self.assertTrue(spectrogram2_torch.dim() == 3)
         self.assertTrue(spectrogram_torch.ge(spectrogram_torch.max() - top_db).all())
         self.assertEqual(spectrogram2_torch.size(1), mel_transform2.n_mels)
-        self.assertTrue(mel_transform2.fm.fb.sum(1).le(1.).all())
-        self.assertTrue(mel_transform2.fm.fb.sum(1).ge(0.).all())
+        self.assertTrue(mel_transform2.mel_scale.fb.sum(1).le(1.).all())
+        self.assertTrue(mel_transform2.mel_scale.fb.sum(1).ge(0.).all())
         # check on multi-channel audio
         x_stereo, sr_stereo = torchaudio.load(self.test_filepath)  # (2, 278756), 44100
         spectrogram_stereo = s2db(mel_transform(x_stereo))  # (2, 128, 1394)
@@ -130,19 +123,20 @@ class Tester(unittest.TestCase):
         self.assertTrue(spectrogram_torch.ge(spectrogram_torch.max() - top_db).all())
         self.assertEqual(spectrogram_stereo.size(1), mel_transform.n_mels)
         # check filterbank matrix creation
-        fb_matrix_transform = transforms.MelScale(n_mels=100, sr=16000, f_max=None, f_min=0., n_stft=400)
+        fb_matrix_transform = transforms.MelScale(
+            n_mels=100, sample_rate=16000, f_min=0., f_max=None, n_stft=400)
         self.assertTrue(fb_matrix_transform.fb.sum(1).le(1.).all())
         self.assertTrue(fb_matrix_transform.fb.sum(1).ge(0.).all())
         self.assertEqual(fb_matrix_transform.fb.size(), (400, 100))
 
     def test_mfcc(self):
-        audio_orig = self.sig.clone()
+        audio_orig = self.waveform.clone()
         audio_scaled = transforms.Scale()(audio_orig)  # (1, 16000)
 
         sample_rate = 16000
         n_mfcc = 40
         n_mels = 128
-        mfcc_transform = torchaudio.transforms.MFCC(sr=sample_rate,
+        mfcc_transform = torchaudio.transforms.MFCC(sample_rate=sample_rate,
                                                     n_mfcc=n_mfcc,
                                                     norm='ortho')
         # check defaults
@@ -151,8 +145,8 @@ class Tester(unittest.TestCase):
         self.assertTrue(torch_mfcc.shape[1] == n_mfcc)
         self.assertTrue(torch_mfcc.shape[2] == 321)
         # check melkwargs are passed through
-        melkwargs = {'ws': 200}
-        mfcc_transform2 = torchaudio.transforms.MFCC(sr=sample_rate,
+        melkwargs = {'win_length': 200}
+        mfcc_transform2 = torchaudio.transforms.MFCC(sample_rate=sample_rate,
                                                      n_mfcc=n_mfcc,
                                                      norm='ortho',
                                                      melkwargs=melkwargs)
@@ -160,7 +154,7 @@ class Tester(unittest.TestCase):
         self.assertTrue(torch_mfcc2.shape[2] == 641)
 
         # check norms work correctly
-        mfcc_transform_norm_none = torchaudio.transforms.MFCC(sr=sample_rate,
+        mfcc_transform_norm_none = torchaudio.transforms.MFCC(sample_rate=sample_rate,
                                                               n_mfcc=n_mfcc,
                                                               norm=None)
         torch_mfcc_norm_none = mfcc_transform_norm_none(audio_scaled)  # (1, 40, 321)
@@ -179,7 +173,7 @@ class Tester(unittest.TestCase):
             sound_librosa = sound.cpu().numpy().squeeze()  # (64000)
 
             # test core spectrogram
-            spect_transform = torchaudio.transforms.Spectrogram(n_fft=n_fft, hop=hop_length, power=2)
+            spect_transform = torchaudio.transforms.Spectrogram(n_fft=n_fft, hop_length=hop_length, power=2)
             out_librosa, _ = librosa.core.spectrum._spectrogram(y=sound_librosa,
                                                                 n_fft=n_fft,
                                                                 hop_length=hop_length,
@@ -189,8 +183,9 @@ class Tester(unittest.TestCase):
             self.assertTrue(torch.allclose(out_torch, torch.from_numpy(out_librosa), atol=1e-5))
 
             # test mel spectrogram
-            melspect_transform = torchaudio.transforms.MelSpectrogram(sr=sample_rate, window=torch.hann_window,
-                                                                      hop=hop_length, n_mels=n_mels, n_fft=n_fft)
+            melspect_transform = torchaudio.transforms.MelSpectrogram(
+                sample_rate=sample_rate, window_fn=torch.hann_window,
+                hop_length=hop_length, n_mels=n_mels, n_fft=n_fft)
             librosa_mel = librosa.feature.melspectrogram(y=sound_librosa, sr=sample_rate,
                                                          n_fft=n_fft, hop_length=hop_length, n_mels=n_mels,
                                                          htk=True, norm=None)
@@ -200,7 +195,7 @@ class Tester(unittest.TestCase):
             self.assertTrue(torch.allclose(torch_mel.type(librosa_mel_tensor.dtype), librosa_mel_tensor, atol=5e-3))
 
             # test s2db
-            db_transform = torchaudio.transforms.SpectrogramToDB("power", 80.)
+            db_transform = torchaudio.transforms.SpectrogramToDB('power', 80.)
             db_torch = db_transform(spect_transform(sound)).squeeze().cpu()
             db_librosa = librosa.core.spectrum.power_to_db(out_librosa)
             self.assertTrue(torch.allclose(db_torch, torch.from_numpy(db_librosa), atol=5e-3))
@@ -212,8 +207,8 @@ class Tester(unittest.TestCase):
             self.assertTrue(torch.allclose(db_torch.type(db_librosa_tensor.dtype), db_librosa_tensor, atol=5e-3))
 
             # test MFCC
-            melkwargs = {'hop': hop_length, 'n_fft': n_fft}
-            mfcc_transform = torchaudio.transforms.MFCC(sr=sample_rate,
+            melkwargs = {'hop_length': hop_length, 'n_fft': n_fft}
+            mfcc_transform = torchaudio.transforms.MFCC(sample_rate=sample_rate,
                                                         n_mfcc=n_mfcc,
                                                         norm='ortho',
                                                         melkwargs=melkwargs)
@@ -271,27 +266,27 @@ class Tester(unittest.TestCase):
 
     def test_resample_size(self):
         input_path = os.path.join(self.test_dirpath, 'assets', 'sinewave.wav')
-        sound, sample_rate = torchaudio.load(input_path)
+        waveform, sample_rate = torchaudio.load(input_path)
 
         upsample_rate = sample_rate * 2
         downsample_rate = sample_rate // 2
         invalid_resample = torchaudio.transforms.Resample(sample_rate, upsample_rate, resampling_method='foo')
 
-        self.assertRaises(ValueError, invalid_resample, sound)
+        self.assertRaises(ValueError, invalid_resample, waveform)
 
         upsample_resample = torchaudio.transforms.Resample(
             sample_rate, upsample_rate, resampling_method='sinc_interpolation')
-        up_sampled = upsample_resample(sound)
+        up_sampled = upsample_resample(waveform)
 
         # we expect the upsampled signal to have twice as many samples
-        self.assertTrue(up_sampled.size(-1) == sound.size(-1) * 2)
+        self.assertTrue(up_sampled.size(-1) == waveform.size(-1) * 2)
 
         downsample_resample = torchaudio.transforms.Resample(
             sample_rate, downsample_rate, resampling_method='sinc_interpolation')
-        down_sampled = downsample_resample(sound)
+        down_sampled = downsample_resample(waveform)
 
         # we expect the downsampled signal to have half as many samples
-        self.assertTrue(down_sampled.size(-1) == sound.size(-1) // 2)
+        self.assertTrue(down_sampled.size(-1) == waveform.size(-1) // 2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -50,20 +50,6 @@ class Tester(unittest.TestCase):
         result = transforms.PadTrim(max_len=length_new)(waveform)
         self.assertEqual(result.size(1), length_new)
 
-    def test_downmix_mono(self):
-
-        waveform_L = self.waveform.clone()
-        waveform_R = self.waveform.clone()
-        R_idx = int(waveform_R.size(0) * 0.1)
-        waveform_R = torch.cat((waveform_R[R_idx:], waveform_R[:R_idx]))
-
-        audio_Stereo = torch.cat((waveform_L, waveform_R), dim=0)
-
-        self.assertTrue(audio_Stereo.size(0) == 2)
-
-        result = transforms.DownmixMono()(audio_Stereo)
-
-        self.assertTrue(result.size(0) == 1)
 
     def test_mu_law_companding(self):
 

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -395,7 +395,8 @@ def complex_norm(complex_tensor, power=1.0):
 
 
 def angle(complex_tensor):
-    r"""
+    r"""Compute the angle of complex tensor input.
+
     Args:
         complex_tensor (torch.Tensor): Tensor shape of `(*, complex=2)`
 

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -3,10 +3,8 @@ import torch
 
 
 __all__ = [
-    'scale',
     'pad_trim',
     'downmix_mono',
-    'LC2CL',
     'istft',
     'spectrogram',
     'spectrogram_to_DB',
@@ -15,25 +13,6 @@ __all__ = [
     'mu_law_encoding',
     'mu_law_expanding'
 ]
-
-
-@torch.jit.script
-def scale(tensor, factor):
-    # type: (Tensor, float) -> Tensor
-    r"""Scales tensor by a factor. By default, assuming the input is int32, it
-    will scale the tensor to have values between -1.0 and 1.0.
-
-    Args:
-        tensor (torch.Tensor): Tensor input to scale
-        factor (float): Factor to scale by
-
-    Returns:
-        torch.Tensor: Scaled by the scale factor
-    """
-    if not tensor.is_floating_point():
-        tensor = tensor.to(torch.float32)
-
-    return tensor / factor
 
 
 @torch.jit.script
@@ -75,20 +54,6 @@ def downmix_mono(waveform):
 
     waveform = torch.mean(waveform, 0, True)
     return waveform
-
-
-@torch.jit.script
-def LC2CL(tensor):
-    # type: (Tensor) -> Tensor
-    r"""Permute a 2D tensor from samples (n, c) to (c, n).
-
-    Args:
-        tensor (torch.Tensor): Tensor of audio signal with shape (n, c)
-
-    Returns:
-        torch.Tensor: Tensor of audio signal with shape (c, n)
-    """
-    return tensor.transpose(0, 1).contiguous()
 
 
 # TODO: remove this once https://github.com/pytorch/pytorch/issues/21478 gets solved

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -89,7 +89,8 @@ def istft(stft_matrix,          # type: Tensor
 
     Args:
         stft_matrix (torch.Tensor): Output of stft where each row of a batch is a frequency and each
-            column is a window. it has a shape of (fft_size, n_frames, 2)
+            column is a window. it has a shape of either (batch, fft_size, n_frames, 2) or (
+            fft_size, n_frames, 2)
         n_fft (int): Size of Fourier transform
         hop_length (Optional[int]): The distance between neighboring sliding window frames.
             (Default: ``win_length // 4``)
@@ -106,13 +107,10 @@ def istft(stft_matrix,          # type: Tensor
 
     Returns:
         torch.Tensor: Least squares estimation of the original signal of size
-        (signal_length)
+        (batch, signal_length) or (signal_length)
     """
     stft_matrix_dim = stft_matrix.dim()
-    # Technically this function can accept either (batch, fft_size, n_frames, 2) or
-    # (fft_size, n_frames, 2). But going to temporarily remove batch support (
-    # through adding an assert) to make torchaudio functions consistent.
-    assert stft_matrix_dim == 3, ('Incorrect stft dimension: %d' % (stft_matrix_dim))
+    assert 3 <= stft_matrix_dim <= 4, ('Incorrect stft dimension: %d' % (stft_matrix_dim))
 
     if stft_matrix_dim == 3:
         # add a batch dimension

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -364,8 +364,8 @@ def create_dct(n_mfcc, n_mels, norm):
         row-wise data of size (`n_mels`, `n_mfcc`).
     """
     # http://en.wikipedia.org/wiki/Discrete_cosine_transform#DCT-II
-    n = torch.arange(n_mels, dtype=torch.get_default_dtype())
-    k = torch.arange(n_mfcc, dtype=torch.get_default_dtype()).unsqueeze(1)
+    n = torch.arange(float(n_mels))
+    k = torch.arange(float(n_mfcc)).unsqueeze(1)
     dct = torch.cos(math.pi / float(n_mels) * (n + 0.5) * k)  # size (n_mfcc, n_mels)
     if norm is None:
         dct *= 2.0

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -92,6 +92,7 @@ def LC2CL(tensor):
     return tensor.transpose(0, 1).contiguous()
 
 
+@torch.jit.ignore
 def _stft(input, n_fft, hop_length, win_length, window, center, pad_mode, normalized, onesided):
     # type: (Tensor, int, Optional[int], Optional[int], Optional[Tensor], bool, str, bool, bool) -> Tensor
     return torch.stft(input, n_fft, hop_length, win_length, window, center, pad_mode, normalized, onesided)

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -121,8 +121,8 @@ def istft(stft_matrix,          # type: Tensor
     device = stft_matrix.device
     fft_size = stft_matrix.size(1)
     assert (onesided and n_fft // 2 + 1 == fft_size) or (not onesided and n_fft == fft_size), (
-        'one_sided implies that n_fft // 2 + 1 == fft_size and not one_sided implies n_fft == fft_size. '
-        + 'Given values were onesided: %s, n_fft: %d, fft_size: %d' % ('True' if onesided else False, n_fft, fft_size))
+        'one_sided implies that n_fft // 2 + 1 == fft_size and not one_sided implies n_fft == fft_size. ' +
+        'Given values were onesided: %s, n_fft: %d, fft_size: %d' % ('True' if onesided else False, n_fft, fft_size))
 
     # use stft defaults for Optionals
     if win_length is None:
@@ -383,11 +383,11 @@ def complex_norm(complex_tensor, power=1.0):
     """Compute the norm of complex tensor input
 
     Args:
-        complex_tensor (Tensor): Tensor shape of `(*, complex=2)`
+        complex_tensor (torch.Tensor): Tensor shape of `(*, complex=2)`
         power (float): Power of the norm. Defaults to `1.0`.
 
     Returns:
-        Tensor: power of the normed input tensor, shape of `(*, )`
+        torch.Tensor: power of the normed input tensor, shape of `(*, )`
     """
     if power == 1.0:
         return torch.norm(complex_tensor, 2, -1)
@@ -417,15 +417,14 @@ def phase_vocoder(complex_specgrams, rate, phase_advance):
     without modifying pitch by a factor of `rate`.
 
     Args:
-        complex_specgrams (Tensor):
-            (*, channel, num_freqs, time, complex=2)
+        complex_specgrams (torch.Tensor): Size of (*, c, f, t, complex=2)
         rate (float): Speed-up factor.
-        phase_advance (Tensor): Expected phase advance in
-            each bin. (num_freqs, 1).
+        phase_advance (torch.Tensor): Expected phase advance in
+            each bin. Size of (f, 1).
 
     Returns:
-        complex_specgrams_stretch (Tensor):
-            (*, channel, num_freqs, ceil(time/rate), complex=2).
+        complex_specgrams_stretch (torch.Tensor):
+            (*, c, f, ceil(t/rate), complex=2).
 
     Example:
         >>> num_freqs, hop_length = 1025, 512

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -89,8 +89,7 @@ def istft(stft_matrix,          # type: Tensor
 
     Args:
         stft_matrix (torch.Tensor): Output of stft where each row of a batch is a frequency and each
-            column is a window. it has a shape of either (batch, fft_size, n_frames, 2) or (
-            fft_size, n_frames, 2)
+            column is a window. it has a shape of (fft_size, n_frames, 2)
         n_fft (int): Size of Fourier transform
         hop_length (Optional[int]): The distance between neighboring sliding window frames.
             (Default: ``win_length // 4``)
@@ -107,10 +106,13 @@ def istft(stft_matrix,          # type: Tensor
 
     Returns:
         torch.Tensor: Least squares estimation of the original signal of size
-        (batch, signal_length) or (signal_length)
+        (signal_length)
     """
     stft_matrix_dim = stft_matrix.dim()
-    assert 3 <= stft_matrix_dim <= 4, ('Incorrect stft dimension: %d' % (stft_matrix_dim))
+    # Technically this function can accept either (batch, fft_size, n_frames, 2) or
+    # (fft_size, n_frames, 2). But going to temporarily remove batch support (
+    # through adding an assert) to make torchaudio functions consistent.
+    assert stft_matrix_dim == 3, ('Incorrect stft dimension: %d' % (stft_matrix_dim))
 
     if stft_matrix_dim == 3:
         # add a batch dimension

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -255,9 +255,9 @@ def spectrogram(waveform, pad, window, n_fft, hop_length, win_length, power, nor
         n_fft (int): Size of fft
         hop_length (int): Length of hop between STFT windows
         win_length (int): Window size
-        power (int) : Exponent for the magnitude spectrogram,
+        power (int): Exponent for the magnitude spectrogram,
             (must be > 0) e.g., 1 for energy, 2 for power, etc.
-        normalized (bool) : Whether to normalize by magnitude after stft
+        normalized (bool): Whether to normalize by magnitude after stft
 
     Returns:
         torch.Tensor: Channels x frequency x time (c, f, t), where channels
@@ -356,9 +356,9 @@ def create_dct(n_mfcc, n_mels, norm):
     normalized depending on norm.
 
     Args:
-        n_mfcc (int) : Number of mfc coefficients to retain
+        n_mfcc (int): Number of mfc coefficients to retain
         n_mels (int): Number of mel filterbanks
-        norm (Optional[str]) : Norm to use (either 'ortho' or None)
+        norm (Optional[str]): Norm to use (either 'ortho' or None)
 
     Returns:
         torch.Tensor: The transformation matrix, to be right-multiplied to

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -380,14 +380,14 @@ def mu_law_expanding(x_mu, qc):
 
 
 def complex_norm(complex_tensor, power=1.0):
-    """Compute the norm of complex tensor input
+    r"""Compute the norm of complex tensor input.
 
     Args:
         complex_tensor (torch.Tensor): Tensor shape of `(*, complex=2)`
         power (float): Power of the norm. (Default: `1.0`).
 
     Returns:
-        torch.Tensor: power of the normed input tensor, shape of `(*, )`
+        torch.Tensor: Power of the normed input tensor. Shape of `(*, )`
     """
     if power == 1.0:
         return torch.norm(complex_tensor, 2, -1)
@@ -395,24 +395,22 @@ def complex_norm(complex_tensor, power=1.0):
 
 
 def angle(complex_tensor):
-    """
+    r"""
     Args:
         complex_tensor (torch.Tensor): Tensor shape of `(*, complex=2)`
 
     Return:
-        torch.Tensor: Angle of a complex tensor
+        torch.Tensor: Angle of a complex tensor. Shape of `(*, )`
     """
     return torch.atan2(complex_tensor[..., 1], complex_tensor[..., 0])
 
 
 def magphase(complex_tensor, power=1.):
-    """
-    Separate a complex-valued spectrogram with shape (*,2)
-    into its magnitude and phase.
+    r"""Separate a complex-valued spectrogram with shape (*,2) into its magnitude and phase.
 
     Args:
         complex_tensor (torch.Tensor): Tensor shape of `(*, complex=2)`
-        power (float): Power of the norm. (Default: `1.0`).
+        power (float): Power of the norm. (Default: `1.0`)
 
     Returns:
         Tuple[torch.Tensor, torch.Tensor]: The magnitude and phase of the complex_tensor
@@ -423,19 +421,16 @@ def magphase(complex_tensor, power=1.):
 
 
 def phase_vocoder(complex_specgrams, rate, phase_advance):
-    """
-    Phase vocoder. Given a STFT tensor, speed up in time
-    without modifying pitch by a factor of `rate`.
+    r"""Given a STFT tensor, speed up in time without modifying pitch by a
+    factor of `rate`.
 
     Args:
         complex_specgrams (torch.Tensor): Size of (*, c, f, t, complex=2)
-        rate (float): Speed-up factor.
-        phase_advance (torch.Tensor): Expected phase advance in
-            each bin. Size of (f, 1).
+        rate (float): Speed-up factor
+        phase_advance (torch.Tensor): Expected phase advance in each bin. Size of (f, 1)
 
     Returns:
-        complex_specgrams_stretch (torch.Tensor):
-            (*, c, f, ceil(t/rate), complex=2).
+        complex_specgrams_stretch (torch.Tensor): Size of (*, c, f, ceil(t/rate), complex=2)
 
     Example:
         >>> num_freqs, hop_length = 1025, 512

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -42,9 +42,9 @@ def pad_trim(waveform, max_len, fill_value):
 
 # TODO: remove this once https://github.com/pytorch/pytorch/issues/21478 gets solved
 @torch.jit.ignore
-def _stft(input, n_fft, hop_length, win_length, window, center, pad_mode, normalized, onesided):
+def _stft(waveform, n_fft, hop_length, win_length, window, center, pad_mode, normalized, onesided):
     # type: (Tensor, int, Optional[int], Optional[int], Optional[Tensor], bool, str, bool, bool) -> Tensor
-    return torch.stft(input, n_fft, hop_length, win_length, window, center, pad_mode, normalized, onesided)
+    return torch.stft(waveform, n_fft, hop_length, win_length, window, center, pad_mode, normalized, onesided)
 
 
 def istft(stft_matrix,          # type: Tensor

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -92,6 +92,7 @@ def LC2CL(tensor):
     return tensor.transpose(0, 1).contiguous()
 
 
+# TODO: remove this once https://github.com/pytorch/pytorch/issues/21478 gets solved
 @torch.jit.ignore
 def _stft(input, n_fft, hop_length, win_length, window, center, pad_mode, normalized, onesided):
     # type: (Tensor, int, Optional[int], Optional[int], Optional[Tensor], bool, str, bool, bool) -> Tensor

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -384,7 +384,7 @@ def complex_norm(complex_tensor, power=1.0):
 
     Args:
         complex_tensor (torch.Tensor): Tensor shape of `(*, complex=2)`
-        power (float): Power of the norm. Defaults to `1.0`.
+        power (float): Power of the norm. (Default: `1.0`).
 
     Returns:
         torch.Tensor: power of the normed input tensor, shape of `(*, )`
@@ -396,7 +396,11 @@ def complex_norm(complex_tensor, power=1.0):
 
 def angle(complex_tensor):
     """
-    Return angle of a complex tensor with shape (*, 2).
+    Args:
+        complex_tensor (torch.Tensor): Tensor shape of `(*, complex=2)`
+
+    Return:
+        torch.Tensor: Angle of a complex tensor
     """
     return torch.atan2(complex_tensor[..., 1], complex_tensor[..., 0])
 
@@ -405,6 +409,13 @@ def magphase(complex_tensor, power=1.):
     """
     Separate a complex-valued spectrogram with shape (*,2)
     into its magnitude and phase.
+
+    Args:
+        complex_tensor (torch.Tensor): Tensor shape of `(*, complex=2)`
+        power (float): Power of the norm. (Default: `1.0`).
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: The magnitude and phase of the complex_tensor
     """
     mag = complex_norm(complex_tensor, power)
     phase = angle(complex_tensor)

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -4,7 +4,6 @@ import torch
 
 __all__ = [
     'pad_trim',
-    'downmix_mono',
     'istft',
     'spectrogram',
     'spectrogram_to_DB',
@@ -34,25 +33,6 @@ def pad_trim(waveform, max_len, fill_value):
         waveform = torch.nn.functional.pad(waveform, (0, max_len - n), 'constant', fill_value)
     else:
         waveform = waveform[:, :max_len]
-    return waveform
-
-
-@torch.jit.script
-def downmix_mono(waveform):
-    # type: (Tensor) -> Tensor
-    r"""Downmix stereo waveform to mono. Consider using a `SoxEffectsChain` with
-    the `channels` effect instead of this transformation.
-
-    Args:
-        waveform (torch.Tensor): Tensor of audio of size (c, n)
-
-    Returns:
-        torch.Tensor: Tensor that has been downmixed of size (1, n)
-    """
-    if not waveform.is_floating_point():
-        waveform = waveform.to(torch.float32)
-
-    waveform = torch.mean(waveform, 0, True)
     return waveform
 
 

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -329,7 +329,7 @@ def create_dct(n_mfcc, n_mels, norm):
 
 
 @torch.jit.script
-def mu_law_encoding(x, qc):
+def mu_law_encoding(x, quantization_channels):
     # type: (Tensor, int) -> Tensor
     r"""Encode signal based on mu-law companding.  For more info see the
     `Wikipedia Entry <https://en.wikipedia.org/wiki/%CE%9C-law_algorithm>`_
@@ -339,12 +339,12 @@ def mu_law_encoding(x, qc):
 
     Args:
         x (torch.Tensor): Input tensor
-        qc (int): Number of channels (i.e. quantization channels)
+        quantization_channels (int): Number of channels
 
     Returns:
         torch.Tensor: Input after mu-law companding
     """
-    mu = qc - 1.
+    mu = quantization_channels - 1.
     if not x.is_floating_point():
         x = x.to(torch.float)
     mu = torch.tensor(mu, dtype=x.dtype)
@@ -355,7 +355,7 @@ def mu_law_encoding(x, qc):
 
 
 @torch.jit.script
-def mu_law_expanding(x_mu, qc):
+def mu_law_expanding(x_mu, quantization_channels):
     # type: (Tensor, int) -> Tensor
     r"""Decode mu-law encoded signal.  For more info see the
     `Wikipedia Entry <https://en.wikipedia.org/wiki/%CE%9C-law_algorithm>`_
@@ -365,12 +365,12 @@ def mu_law_expanding(x_mu, qc):
 
     Args:
         x_mu (torch.Tensor): Input tensor
-        qc (int): Number of channels (i.e. quantization channels)
+        quantization_channels (int): Number of channels
 
     Returns:
         torch.Tensor: Input after decoding
     """
-    mu = qc - 1.
+    mu = quantization_channels - 1.
     if not x_mu.is_floating_point():
         x_mu = x_mu.to(torch.float)
     mu = torch.tensor(mu, dtype=x_mu.dtype)

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -7,31 +7,6 @@ from . import functional as F
 from .compliance import kaldi
 
 
-class Scale(torch.jit.ScriptModule):
-    r"""Scales tensor by a factor. By default, assuming the input is int32, it
-    will scale the tensor to have values between -1.0 and 1.0.
-
-    Args:
-        factor (float): Factor to scale by. (Default: `float(2**31)`)
-    """
-    __constants__ = ['factor']
-
-    def __init__(self, factor=float(2**31)):
-        super(Scale, self).__init__()
-        self.factor = factor
-
-    @torch.jit.script_method
-    def forward(self, tensor):
-        r"""
-        Args:
-            tensor (torch.Tensor): Tensor input to scale
-
-        Returns:
-            torch.Tensor: Scaled by the scale factor
-        """
-        return F.scale(tensor, self.factor)
-
-
 class PadTrim(torch.jit.ScriptModule):
     r"""Pad/Trim a 2D tensor
 
@@ -75,23 +50,6 @@ class DownmixMono(torch.jit.ScriptModule):
             torch.Tensor: Tensor that has been downmixed of size (1, n)
         """
         return F.downmix_mono(waveform)
-
-
-class LC2CL(torch.jit.ScriptModule):
-    r"""Converts a 2D tensor from (n, c) to (c, n)
-    """
-    def __init__(self):
-        super(LC2CL, self).__init__()
-
-    @torch.jit.script_method
-    def forward(self, tensor):
-        r"""
-        Args:
-            tensor (torch.Tensor): Tensor of audio signal with shape (n, c)
-        Returns:
-            torch.Tensor: Tensor of audio signal with shape (c, n)
-        """
-        return F.LC2CL(tensor)
 
 
 class Spectrogram(torch.jit.ScriptModule):

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -81,9 +81,6 @@ class Spectrogram(torch.jit.ScriptModule):
                              self.win_length, self.power, self.normalized)
 
 
-
-
-
 class MelScale(torch.jit.ScriptModule):
     r"""This turns a normal STFT into a mel frequency STFT, using a conversion
        matrix.  This uses triangular filter banks.

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -60,7 +60,7 @@ class PadTrim(torch.jit.ScriptModule):
 
 class DownmixMono(torch.jit.ScriptModule):
     r"""Downmix stereo waveform to mono.  Consider using a `SoxEffectsChain` with
-       the `channels` effect instead of this transformation.
+    the `channels` effect instead of this transformation.
     """
     def __init__(self):
         super(DownmixMono, self).__init__()
@@ -107,7 +107,7 @@ class Spectrogram(torch.jit.ScriptModule):
             that is applied/multiplied to each frame/window. (Default: `torch.hann_window`)
         power (int) : Exponent for the magnitude spectrogram,
             (must be > 0) e.g., 1 for energy, 2 for power, etc.
-        normalized (bool) : Whether to normalized by magnitude after stft. (Default: `False`)
+        normalized (bool) : Whether to normalize by magnitude after stft. (Default: `False`)
         wkwargs (Dict[..., ...]): Arguments for window function. (Default: `None`)
     """
     __constants__ = ['n_fft', 'win_length', 'hop_length', 'pad', 'power', 'normalized']
@@ -137,7 +137,6 @@ class Spectrogram(torch.jit.ScriptModule):
             torch.Tensor: Channels x frequency x time (c, f, t), where channels
             is unchanged, frequency is `n_fft // 2 + 1` where `n_fft` is the number of
             fourier bins, and time is the number of window hops (n_frames).
-
         """
         return F.spectrogram(waveform, self.pad, self.window, self.n_fft, self.hop_length,
                              self.win_length, self.power, self.normalized)
@@ -151,20 +150,20 @@ class SpectrogramToDB(torch.jit.ScriptModule):
     a full clip.
 
     Args:
-        stype (str): scale of input spectrogram ("power" or "magnitude"). The
+        stype (str): scale of input spectrogram ('power' or 'magnitude'). The
             power being the elementwise square of the magnitude. (Default: 'power')
         top_db (float, optional): minimum negative cut-off in decibels.  A reasonable number
             is 80.
     """
     __constants__ = ['multiplier', 'amin', 'ref_value', 'db_multiplier']
 
-    def __init__(self, stype="power", top_db=None):
+    def __init__(self, stype='power', top_db=None):
         super(SpectrogramToDB, self).__init__()
         self.stype = torch.jit.Attribute(stype, str)
         if top_db is not None and top_db < 0:
             raise ValueError('top_db must be positive value')
         self.top_db = torch.jit.Attribute(top_db, Optional[float])
-        self.multiplier = 10.0 if stype == "power" else 20.0
+        self.multiplier = 10.0 if stype == 'power' else 20.0
         self.amin = 1e-10
         self.ref_value = 1.0
         self.db_multiplier = math.log10(max(self.amin, self.ref_value))
@@ -254,7 +253,7 @@ class MelSpectrogram(torch.jit.ScriptModule):
         wkwargs (Dict[..., ...]): Arguments for window function. (Default: `None`)
 
     Example:
-        >>> waveform, sample_rate = torchaudio.load("test.wav", normalization=True)
+        >>> waveform, sample_rate = torchaudio.load('test.wav', normalization=True)
         >>> mel_specgram = transforms.MelSpectrogram(sample_rate)(waveform)  # (c, n_mels, t)
     """
     __constants__ = ['sample_rate', 'n_fft', 'win_length', 'hop_length', 'pad', 'n_mels', 'f_min']

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -164,9 +164,9 @@ class SpectrogramToDB(torch.jit.ScriptModule):
         if top_db is not None and top_db < 0:
             raise ValueError('top_db must be positive value')
         self.top_db = torch.jit.Attribute(top_db, Optional[float])
-        self.multiplier = 10. if stype == "power" else 20.
+        self.multiplier = 10.0 if stype == "power" else 20.0
         self.amin = 1e-10
-        self.ref_value = 1.
+        self.ref_value = 1.0
         self.db_multiplier = math.log10(max(self.amin, self.ref_value))
 
     @torch.jit.script_method
@@ -204,7 +204,7 @@ class MelScale(torch.jit.ScriptModule):
         self.n_mels = n_mels
         self.sample_rate = sample_rate
         self.f_max = f_max if f_max is not None else float(sample_rate // 2)
-        assert f_min <= f_max, 'Require f_min: %f < f_max: %f' % (f_min, f_max)
+        assert f_min <= self.f_max, 'Require f_min: %f < f_max: %f' % (f_min, self.f_max)
         self.f_min = f_min
         fb = torch.empty(0) if n_stft is None else F.create_fb_matrix(
             n_stft, self.f_min, self.f_max, self.n_mels)
@@ -246,7 +246,7 @@ class MelSpectrogram(torch.jit.ScriptModule):
             Default: `win_length // 2`)
         n_fft (int, optional): Size of fft, creates `n_fft // 2 + 1` bins
         f_min (float): Minimum frequency. (Default: 0.)
-        f_max (float, optional): Maximum frequency. (Default: `sample_rate // 2`)
+        f_max (float, optional): Maximum frequency. (Default: `None`)
         pad (int): Two sided padding of signal. (Default: 0)
         n_mels (int): Number of mel filterbanks. (Default: 128)
         window_fn (Callable[[...], torch.Tensor]): A function to create a window tensor
@@ -274,7 +274,7 @@ class MelSpectrogram(torch.jit.ScriptModule):
                                        hop_length=self.hop_length,
                                        pad=self.pad, window_fn=window_fn, power=2,
                                        normalized=False, wkwargs=wkwargs)
-        self.mel_scale = MelScale(self.n_mels, self.sample_rate, self.f_max, self.f_min)
+        self.mel_scale = MelScale(self.n_mels, self.sample_rate, self.f_min, self.f_max)
 
     @torch.jit.script_method
     def forward(self, waveform):

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -303,11 +303,11 @@ class MuLawEncoding(torch.jit.ScriptModule):
     Args:
         quantization_channels (int): Number of channels. default: 256
     """
-    __constants__ = ['qc']
+    __constants__ = ['quantization_channels']
 
     def __init__(self, quantization_channels=256):
         super(MuLawEncoding, self).__init__()
-        self.qc = quantization_channels
+        self.quantization_channels = quantization_channels
 
     @torch.jit.script_method
     def forward(self, x):
@@ -318,10 +318,7 @@ class MuLawEncoding(torch.jit.ScriptModule):
         Returns:
             x_mu (torch.Tensor): An encoded signal
         """
-        return F.mu_law_encoding(x, self.qc)
-
-    def __repr__(self):
-        return self.__class__.__name__ + '()'
+        return F.mu_law_encoding(x, self.quantization_channels)
 
 
 class MuLawExpanding(torch.jit.ScriptModule):
@@ -334,11 +331,11 @@ class MuLawExpanding(torch.jit.ScriptModule):
     Args:
         quantization_channels (int): Number of channels. default: 256
     """
-    __constants__ = ['qc']
+    __constants__ = ['quantization_channels']
 
     def __init__(self, quantization_channels=256):
         super(MuLawExpanding, self).__init__()
-        self.qc = quantization_channels
+        self.quantization_channels = quantization_channels
 
     @torch.jit.script_method
     def forward(self, x_mu):
@@ -349,10 +346,7 @@ class MuLawExpanding(torch.jit.ScriptModule):
         Returns:
             torch.Tensor: The signal decoded
         """
-        return F.mu_law_expanding(x_mu, self.qc)
-
-    def __repr__(self):
-        return self.__class__.__name__ + '()'
+        return F.mu_law_expanding(x_mu, self.quantization_channels)
 
 
 class Resample(torch.nn.Module):

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -105,9 +105,9 @@ class Spectrogram(torch.jit.ScriptModule):
         pad (int): Two sided padding of signal. (Default: 0)
         window_fn (Callable[[...], torch.Tensor]): A function to create a window tensor
             that is applied/multiplied to each frame/window. (Default: `torch.hann_window`)
-        power (int) : Exponent for the magnitude spectrogram,
+        power (int): Exponent for the magnitude spectrogram,
             (must be > 0) e.g., 1 for energy, 2 for power, etc.
-        normalized (bool) : Whether to normalize by magnitude after stft. (Default: `False`)
+        normalized (bool): Whether to normalize by magnitude after stft. (Default: `False`)
         wkwargs (Dict[..., ...]): Arguments for window function. (Default: `None`)
     """
     __constants__ = ['n_fft', 'win_length', 'hop_length', 'pad', 'power', 'normalized']
@@ -301,11 +301,11 @@ class MFCC(torch.jit.ScriptModule):
     a full clip.
 
     Args:
-        sample_rate (int) : Sample rate of audio signal. (Default: 16000)
-        n_mfcc (int) : Number of mfc coefficients to retain
-        dct_type (int) : type of DCT (discrete cosine transform) to use
-        norm (string, optional) : norm to use
-        log_mels (bool) : whether to use log-mel spectrograms instead of db-scaled
+        sample_rate (int): Sample rate of audio signal. (Default: 16000)
+        n_mfcc (int): Number of mfc coefficients to retain
+        dct_type (int): type of DCT (discrete cosine transform) to use
+        norm (string, optional): norm to use
+        log_mels (bool): whether to use log-mel spectrograms instead of db-scaled
         melkwargs (dict, optional): arguments for MelSpectrogram
     """
     __constants__ = ['sample_rate', 'n_mfcc', 'dct_type', 'top_db', 'log_mels']

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -33,25 +33,6 @@ class PadTrim(torch.jit.ScriptModule):
         return F.pad_trim(waveform, self.max_len, self.fill_value)
 
 
-class DownmixMono(torch.jit.ScriptModule):
-    r"""Downmix stereo waveform to mono.  Consider using a `SoxEffectsChain` with
-    the `channels` effect instead of this transformation.
-    """
-    def __init__(self):
-        super(DownmixMono, self).__init__()
-
-    @torch.jit.script_method
-    def forward(self, waveform):
-        r"""
-        Args:
-            waveform (torch.Tensor): Tensor of audio of size (c, n)
-
-        Returns:
-            torch.Tensor: Tensor that has been downmixed of size (1, n)
-        """
-        return F.downmix_mono(waveform)
-
-
 class Spectrogram(torch.jit.ScriptModule):
     r"""Create a spectrogram from a audio signal
 

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -69,13 +69,12 @@ class DownmixMono(torch.jit.ScriptModule):
     Returns:
         tensor (Tensor) (1, n):
     """
-
     def __init__(self):
         super(DownmixMono, self).__init__()
 
     @torch.jit.script_method
     def forward(self, tensor):
-        return F.downmix_mono(tensor, self.ch_dim)
+        return F.downmix_mono(tensor)
 
 
 class LC2CL(torch.jit.ScriptModule):


### PR DESCRIPTION
### tl;dr Signals will be (channels, time) (c, n). spectrograms will be (channels, freq, time) (c, f, t) and various transformations will be similar format with channel as first dimension and time as last dimension e.g (c, n_mels, t) or (c, n_mfcc, t)

## Removal of Legacy Transforms
-Compose: From https://github.com/pytorch/audio/issues/110, "we wouldn't need it because once things are based on Layers people can simply build a nn.Sequential()."
-Aliases and deprecated modules: SPECTROGRAM, F2M, MEL If we are going to start breaking things in this new release, then it makes sense to do as much as possible so that the future stable versions do not have technical debt
-BLC2CBL: there is no input/output to this library that uses BLC or CBL format (going to keep LC2CL mainly because all the inputs are (c, n) meaning it would be convenient for users to switch this format).

## Channel x Time
The input (some outputs) of all transforms/functions would be (c, n) e.g Spectrogram, MFCC, MelSpectrogram, Resample, etc. This is to be consistent with PyTorch which has channel followed by the number of samples.
This means removing the channel dimension flags that some transforms were using which could accept either (n, c) or (c, n).

## Channel x Frequency x Time
The output of stft is (c, f, t, 2) meaning for each channel, the columns are the fft of a certain window so as we travel horizontally we can see each column (fft) change over time. This matches the output of librosa so we no longer need to transpose in our test comparisions with spectrogram, melscale, and mfcc. Previously it was time x frequency.
![image](https://user-images.githubusercontent.com/10252970/61475204-47e64400-a958-11e9-9b25-c05f85a9ee3c.png)

## DCT and Filterbank matrices
Going to keep them as they are. These matrices should be shaped so that they can be multiplied without a transpose e.g for filterbank (..., n_freqs) x (n_freqs, n_mels) meaning each column is a filterbank and DCT (..., n_mels) x (n_mels, n_mfcc) meaning each column is a cos function

## Misc
Going to keep scale, padtrim, downmixmono as while they are simple, they could be operations that are performed often so it would be convenient to have the code to reduce amount of code the user has to write as well as provides documentation as the name of the transforms/functions communicates the intent clearly