### PR TITLE
CI Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - env: PYTHON_VERSION="3.5"
+    # TODO add this back in when there is a pytorch 1.2 for python 3.5
+    # - env: PYTHON_VERSION="3.5"
     - env: PYTHON_VERSION="3.6"
     - env: PYTHON_VERSION="3.5" RUN_FLAKE8="true" SKIP_TESTS="true"
 

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -53,7 +53,7 @@ pip install -r requirements.txt
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then
     # PyTorch (nightly as 1.1 does not have Optional for type annotations)
-    conda install --yes pytorch-nightly-cpu -c pytorch
+    conda install --yes pytorch-nightly-cpu>=1.2.0 -c pytorch
 
      # TorchAudio CPP Extensions
     pip install .

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -53,7 +53,7 @@ pip install -r requirements.txt
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then
     # PyTorch (nightly as 1.1 does not have Optional for type annotations)
-    conda install --yes pytorch-nightly-cpu>=1.2.0 -c pytorch
+    conda install --yes pytorch-nightly-cpu -c pytorch
 
      # TorchAudio CPP Extensions
     pip install .


### PR DESCRIPTION
The most recent pytorch with python 3.5 use to be pytorch-nightly-cpu-1.1.0.dev20190516 but it got deleted so the most recent one is pytorch-nightly-cpu-1.1.0.dev20190425. This is too far back which causes the build to break.

The solution is to remove python 3.5 test as the python 3.6 is still good at pytorch-nightly-cpu-1.2.0.dev20190722