### PR TITLE
Reorder transforms.py and functional.py + add __all__

### DIFF
--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -5,8 +5,8 @@ import torch
 __all__ = [
     'istft',
     'spectrogram',
-    'create_fb_matrix',
     'spectrogram_to_DB',
+    'create_fb_matrix',
     'create_dct',
     'mu_law_encoding',
     'mu_law_decoding',
@@ -207,6 +207,37 @@ def spectrogram(waveform, pad, window, n_fft, hop_length, win_length, power, nor
 
 
 @torch.jit.script
+def spectrogram_to_DB(specgram, multiplier, amin, db_multiplier, top_db=None):
+    # type: (Tensor, float, float, float, Optional[float]) -> Tensor
+    r"""Turns a spectrogram from the power/amplitude scale to the decibel scale.
+
+    This output depends on the maximum value in the input spectrogram, and so
+    may return different values for an audio clip split into snippets vs. a
+    a full clip.
+
+    Args:
+        specgram (torch.Tensor): Normal STFT of size (c, f, t)
+        multiplier (float): Use 10. for power and 20. for amplitude
+        amin (float): Number to clamp specgram
+        db_multiplier (float): Log10(max(reference value and amin))
+        top_db (Optional[float]): Minimum negative cut-off in decibels. A reasonable number
+            is 80.
+
+    Returns:
+        torch.Tensor: Spectrogram in DB of size (c, f, t)
+    """
+    specgram_db = multiplier * torch.log10(torch.clamp(specgram, min=amin))
+    specgram_db -= multiplier * db_multiplier
+
+    if top_db is not None:
+        new_spec_db_max = torch.tensor(float(specgram_db.max()) - top_db,
+                                       dtype=specgram_db.dtype, device=specgram_db.device)
+        specgram_db = torch.max(specgram_db, new_spec_db_max)
+
+    return specgram_db
+
+
+@torch.jit.script
 def create_fb_matrix(n_freqs, f_min, f_max, n_mels):
     # type: (int, float, float, int) -> Tensor
     r""" Create a frequency bin conversion matrix.
@@ -242,37 +273,6 @@ def create_fb_matrix(n_freqs, f_min, f_max, n_mels):
     up_slopes = slopes[:, 2:] / f_diff[1:]  # (n_freqs, n_mels)
     fb = torch.max(zero, torch.min(down_slopes, up_slopes))
     return fb
-
-
-@torch.jit.script
-def spectrogram_to_DB(specgram, multiplier, amin, db_multiplier, top_db=None):
-    # type: (Tensor, float, float, float, Optional[float]) -> Tensor
-    r"""Turns a spectrogram from the power/amplitude scale to the decibel scale.
-
-    This output depends on the maximum value in the input spectrogram, and so
-    may return different values for an audio clip split into snippets vs. a
-    a full clip.
-
-    Args:
-        specgram (torch.Tensor): Normal STFT of size (c, f, t)
-        multiplier (float): Use 10. for power and 20. for amplitude
-        amin (float): Number to clamp specgram
-        db_multiplier (float): Log10(max(reference value and amin))
-        top_db (Optional[float]): Minimum negative cut-off in decibels. A reasonable number
-            is 80.
-
-    Returns:
-        torch.Tensor: Spectrogram in DB of size (c, f, t)
-    """
-    specgram_db = multiplier * torch.log10(torch.clamp(specgram, min=amin))
-    specgram_db -= multiplier * db_multiplier
-
-    if top_db is not None:
-        new_spec_db_max = torch.tensor(float(specgram_db.max()) - top_db,
-                                       dtype=specgram_db.dtype, device=specgram_db.device)
-        specgram_db = torch.max(specgram_db, new_spec_db_max)
-
-    return specgram_db
 
 
 @torch.jit.script


### PR DESCRIPTION
In transforms.py
-Adding \_\_all\_\_ to show all layers/transforms
-Moving `SpectrogramToDB` to be beside `Spectrogram`
-Moving `MelSpectrogram` to be beside `MelScale`. Also since `MFCC` is an operation on top of `MelSpectrogram`, it makes sense to have it after `MelSpectrogram`

In functional.py
-Moving `spectrogram_to_DB` to be beside `spectrogram` (This also allows `create_fb_matrix` and `create_dct` to be beside each other)