### PR TITLE
Rename SpectrogramToDB to AmplitudeToDB

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -78,11 +78,11 @@ class Test_JIT(unittest.TestCase):
 
         self._test_script_module(spec_f, transforms.MelScale)
 
-    def test_torchscript_spectrogram_to_DB(self):
+    def test_torchscript_amplitude_to_DB(self):
         @torch.jit.script
         def jit_method(spec, multiplier, amin, db_multiplier, top_db):
             # type: (Tensor, float, float, float, Optional[float]) -> Tensor
-            return F.spectrogram_to_DB(spec, multiplier, amin, db_multiplier, top_db)
+            return F.amplitude_to_DB(spec, multiplier, amin, db_multiplier, top_db)
 
         spec = torch.rand((6, 201))
         multiplier = 10.
@@ -91,15 +91,15 @@ class Test_JIT(unittest.TestCase):
         top_db = 80.
 
         jit_out = jit_method(spec, multiplier, amin, db_multiplier, top_db)
-        py_out = F.spectrogram_to_DB(spec, multiplier, amin, db_multiplier, top_db)
+        py_out = F.amplitude_to_DB(spec, multiplier, amin, db_multiplier, top_db)
 
         self.assertTrue(torch.allclose(jit_out, py_out))
 
     @unittest.skipIf(not RUN_CUDA, "no CUDA")
-    def test_scriptmodule_SpectrogramToDB(self):
+    def test_scriptmodule_AmplitudeToDB(self):
         spec = torch.rand((6, 201), device="cuda")
 
-        self._test_script_module(spec, transforms.SpectrogramToDB)
+        self._test_script_module(spec, transforms.AmplitudeToDB)
 
     def test_torchscript_create_dct(self):
         @torch.jit.script

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -52,7 +52,7 @@ class Tester(unittest.TestCase):
 
     def test_mel2(self):
         top_db = 80.
-        s2db = transforms.SpectrogramToDB('power', top_db)
+        s2db = transforms.AmplitudeToDB('power', top_db)
 
         waveform = self.waveform.clone()  # (1, 16000)
         waveform_scaled = self.scale(waveform)  # (1, 16000)
@@ -155,7 +155,7 @@ class Tester(unittest.TestCase):
             self.assertTrue(torch.allclose(torch_mel.type(librosa_mel_tensor.dtype), librosa_mel_tensor, atol=5e-3))
 
             # test s2db
-            db_transform = torchaudio.transforms.SpectrogramToDB('power', 80.)
+            db_transform = torchaudio.transforms.AmplitudeToDB('power', 80.)
             db_torch = db_transform(spect_transform(sound)).squeeze().cpu()
             db_librosa = librosa.core.spectrum.power_to_db(out_librosa)
             self.assertTrue(torch.allclose(db_torch, torch.from_numpy(db_librosa), atol=5e-3))

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -231,7 +231,7 @@ def amplitude_to_DB(x, multiplier, amin, db_multiplier, top_db=None):
 
     if top_db is not None:
         new_x_db_max = torch.tensor(float(x_db.max()) - top_db,
-                                       dtype=x_db.dtype, device=x_db.device)
+                                    dtype=x_db.dtype, device=x_db.device)
         x_db = torch.max(x_db, new_x_db_max)
 
     return x_db

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -5,7 +5,7 @@ import torch
 __all__ = [
     'istft',
     'spectrogram',
-    'spectrogram_to_DB',
+    'amplitude_to_DB',
     'create_fb_matrix',
     'create_dct',
     'mu_law_encoding',
@@ -207,18 +207,18 @@ def spectrogram(waveform, pad, window, n_fft, hop_length, win_length, power, nor
 
 
 @torch.jit.script
-def spectrogram_to_DB(specgram, multiplier, amin, db_multiplier, top_db=None):
+def amplitude_to_DB(x, multiplier, amin, db_multiplier, top_db=None):
     # type: (Tensor, float, float, float, Optional[float]) -> Tensor
-    r"""Turns a spectrogram from the power/amplitude scale to the decibel scale.
+    r"""Turns a tensor from the power/amplitude scale to the decibel scale.
 
-    This output depends on the maximum value in the input spectrogram, and so
+    This output depends on the maximum value in the input tensor, and so
     may return different values for an audio clip split into snippets vs. a
     a full clip.
 
     Args:
-        specgram (torch.Tensor): Normal STFT of size (c, f, t)
+        x (torch.Tensor): Input tensor before being converted to decibel scale
         multiplier (float): Use 10. for power and 20. for amplitude
-        amin (float): Number to clamp specgram
+        amin (float): Number to clamp ``x``
         db_multiplier (float): Log10(max(reference value and amin))
         top_db (Optional[float]): Minimum negative cut-off in decibels. A reasonable number
             is 80.
@@ -226,15 +226,15 @@ def spectrogram_to_DB(specgram, multiplier, amin, db_multiplier, top_db=None):
     Returns:
         torch.Tensor: Spectrogram in DB of size (c, f, t)
     """
-    specgram_db = multiplier * torch.log10(torch.clamp(specgram, min=amin))
-    specgram_db -= multiplier * db_multiplier
+    x_db = multiplier * torch.log10(torch.clamp(x, min=amin))
+    x_db -= multiplier * db_multiplier
 
     if top_db is not None:
-        new_spec_db_max = torch.tensor(float(specgram_db.max()) - top_db,
-                                       dtype=specgram_db.dtype, device=specgram_db.device)
-        specgram_db = torch.max(specgram_db, new_spec_db_max)
+        new_x_db_max = torch.tensor(float(x_db.max()) - top_db,
+                                       dtype=x_db.dtype, device=x_db.device)
+        x_db = torch.max(x_db, new_x_db_max)
 
-    return specgram_db
+    return x_db
 
 
 @torch.jit.script

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -224,7 +224,7 @@ def amplitude_to_DB(x, multiplier, amin, db_multiplier, top_db=None):
             is 80.
 
     Returns:
-        torch.Tensor: Spectrogram in DB of size (c, f, t)
+        torch.Tensor: Output tensor in decibel scale
     """
     x_db = multiplier * torch.log10(torch.clamp(x, min=amin))
     x_db -= multiplier * db_multiplier


### PR DESCRIPTION
We want to keep SpectrogramToDB's implementation of toDB mainly cause it is used in the computation for MelSpectrogram, MFCC. However, it is more generic and can be applied to any tensor (not just spectrograms).