### PR TITLE
Make test scripts runnable without being modules.

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -1,5 +1,5 @@
 import unittest
-import test.common_utils
+import common_utils
 import torch
 import torchaudio
 import math
@@ -7,7 +7,7 @@ import os
 
 
 class Test_LoadSave(unittest.TestCase):
-    test_dirpath, test_dir = test.common_utils.create_temp_assets_dir()
+    test_dirpath, test_dir = common_utils.create_temp_assets_dir()
     test_filepath = os.path.join(test_dirpath, "assets",
                                  "steam-train-whistle-daniel_simon.mp3")
 

--- a/test/test_compliance_kaldi.py
+++ b/test/test_compliance_kaldi.py
@@ -1,7 +1,7 @@
 import math
 import os
-import test.common_utils
-import test.compliance.utils
+import common_utils
+import compliance.utils
 import torch
 import torchaudio
 import torchaudio.compliance.kaldi as kaldi
@@ -45,11 +45,11 @@ def extract_window(window, wave, f, frame_length, frame_shift, snip_edges):
 
 
 class Test_Kaldi(unittest.TestCase):
-    test_dirpath, test_dir = test.common_utils.create_temp_assets_dir()
+    test_dirpath, test_dir = common_utils.create_temp_assets_dir()
     test_filepath = os.path.join(test_dirpath, 'assets', 'kaldi_file.wav')
     test_8000_filepath = os.path.join(test_dirpath, 'assets', 'kaldi_file_8000.wav')
     kaldi_output_dir = os.path.join(test_dirpath, 'assets', 'kaldi')
-    test_filepaths = {prefix: [] for prefix in test.compliance.utils.TEST_PREFIX}
+    test_filepaths = {prefix: [] for prefix in compliance.utils.TEST_PREFIX}
 
     # separating test files by their types (e.g 'spec', 'fbank', etc.)
     for f in os.listdir(kaldi_output_dir):
@@ -151,7 +151,7 @@ class Test_Kaldi(unittest.TestCase):
             args = f.split('-')
             args[-1] = os.path.splitext(args[-1])[0]
             assert len(args) == expected_num_args, 'invalid test kaldi file name'
-            args = [test.compliance.utils.parse(arg) for arg in args]
+            args = [compliance.utils.parse(arg) for arg in args]
 
             output = get_output_fn(sound, args)
 

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1,5 +1,5 @@
 import unittest
-import test.common_utils
+import common_utils
 import torch
 import torch.nn as nn
 from torch.utils.data import Dataset, DataLoader
@@ -10,7 +10,7 @@ import os
 
 class TORCHAUDIODS(Dataset):
 
-    test_dirpath, test_dir = test.common_utils.create_temp_assets_dir()
+    test_dirpath, test_dir = common_utils.create_temp_assets_dir()
 
     def __init__(self):
         self.asset_dirpath = os.path.join(self.test_dirpath, "assets")

--- a/test/test_datasets_vctk.py
+++ b/test/test_datasets_vctk.py
@@ -3,13 +3,13 @@ import os
 import torch
 import torchaudio
 import unittest
-import test.common_utils
+import common_utils
 import torchaudio.datasets.vctk as vctk
 
 
 class TestVCTK(unittest.TestCase):
     def setUp(self):
-        self.test_dirpath, self.test_dir = test.common_utils.create_temp_assets_dir()
+        self.test_dirpath, self.test_dir = common_utils.create_temp_assets_dir()
 
     def get_full_path(self, file):
         return os.path.join(self.test_dirpath, 'assets', file)

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -5,7 +5,7 @@ import torchaudio
 import torchaudio.functional as F
 import pytest
 import unittest
-import test.common_utils
+import common_utils
 
 from torchaudio.common_utils import IMPORT_LIBROSA
 
@@ -30,7 +30,7 @@ class TestFunctional(unittest.TestCase):
         # operation to check whether we can reconstruct signal
         for data_size in self.data_sizes:
             for i in range(self.number_of_trials):
-                sound = test.common_utils.random_float_tensor(i, data_size)
+                sound = common_utils.random_float_tensor(i, data_size)
 
                 stft = torch.stft(sound, **kwargs)
                 estimate = torchaudio.functional.istft(stft, length=sound.size(1), **kwargs)

--- a/test/test_kaldi_io.py
+++ b/test/test_kaldi_io.py
@@ -2,13 +2,13 @@ import os
 import torch
 import torchaudio.kaldi_io as kio
 import unittest
-import test.common_utils
+import common_utils
 
 
 class Test_KaldiIO(unittest.TestCase):
     data1 = [[1, 2, 3], [11, 12, 13], [21, 22, 23]]
     data2 = [[31, 32, 33], [41, 42, 43], [51, 52, 53]]
-    test_dirpath, test_dir = test.common_utils.create_temp_assets_dir()
+    test_dirpath, test_dir = common_utils.create_temp_assets_dir()
 
     def _test_helper(self, file_name, expected_data, fn, expected_dtype):
         """ Takes a file_name to the input data and a function fn to extract the

--- a/test/test_legacy.py
+++ b/test/test_legacy.py
@@ -1,5 +1,5 @@
 import unittest
-import test.common_utils
+import common_utils
 import torch
 import torchaudio
 from torchaudio.legacy import save, load
@@ -8,7 +8,7 @@ import os
 
 
 class Test_LoadSave(unittest.TestCase):
-    test_dirpath, test_dir = test.common_utils.create_temp_assets_dir()
+    test_dirpath, test_dir = common_utils.create_temp_assets_dir()
     test_filepath = os.path.join(test_dirpath, "assets",
                                  "steam-train-whistle-daniel_simon.mp3")
 

--- a/test/test_sox_effects.py
+++ b/test/test_sox_effects.py
@@ -1,5 +1,5 @@
 import unittest
-import test.common_utils
+import common_utils
 import torch
 import torchaudio
 import math
@@ -7,7 +7,7 @@ import os
 
 
 class Test_SoxEffectsChain(unittest.TestCase):
-    test_dirpath, test_dir = test.common_utils.create_temp_assets_dir()
+    test_dirpath, test_dir = common_utils.create_temp_assets_dir()
     test_filepath = os.path.join(test_dirpath, "assets",
                                  "steam-train-whistle-daniel_simon.mp3")
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -7,7 +7,7 @@ import torchaudio
 from torchaudio.common_utils import IMPORT_LIBROSA, IMPORT_SCIPY
 import torchaudio.transforms as transforms
 import unittest
-import test.common_utils
+import common_utils
 
 if IMPORT_LIBROSA:
     import librosa
@@ -26,7 +26,7 @@ class Tester(unittest.TestCase):
     waveform.unsqueeze_(0)  # (1, 64000)
     waveform = (waveform * volume * 2**31).long()
     # file for stereo stft test
-    test_dirpath, test_dir = test.common_utils.create_temp_assets_dir()
+    test_dirpath, test_dir = common_utils.create_temp_assets_dir()
     test_filepath = os.path.join(test_dirpath, 'assets',
                                  'steam-train-whistle-daniel_simon.mp3')
 


### PR DESCRIPTION
This makes it easier to test against an installed wheel, as the
torchaudio folder is no longer preferentially picked up when
you run a test module.

I had to move all tests in subfolders into the top level test
directory to make this work, since you can't access .. modules
without mucking around with sys.path (which I don't want to do.)

NB: this BREAKS the syntax where you can run a test by
saying `python -m test.test`.  Instead, do `python test/test.py`
or use the pytest runner.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>