### PR TITLE
Packaging improvements for nightlies

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,22 @@ Installation
 
 ### Binaries
 
-To install pip wheels of 0.2.0, select the appropriate pip wheel for
-your version of Python:
+To install the latest pip wheels, run:
 
 ```
-# Wheels for Python 2 are NOT supported
+pip install torchaudio -f https://download.pytorch.org/whl/torch_stable.html
+```
 
-# Python 3.5
-pip3 install http://download.pytorch.org/whl/torchaudio-0.2-cp35-cp35m-linux_x86_64.whl
+(If you do not have torch already installed, this will default to installing
+torch from PyPI. If you need a different torch configuration, preinstall torch
+before running this command.)
 
-# Python 3.6
-pip3 install http://download.pytorch.org/whl/torchaudio-0.2-cp36-cp36m-linux_x86_64.whl
+At the moment, there is no automated nightly build process, but we occasionally
+build nightlies based on PyTorch nightlies by hand following the instructions in
+[build_tools/packaging](build_tools/packaging).  To install the latest nightly, run:
 
-# Python 3.7
-pip3 install http://download.pytorch.org/whl/torchaudio-0.2-cp37-cp37m-linux_x86_64.whl
+```
+pip install torchaudio_nightly -f https://download.pytorch.org/whl/nightly/torch_nightly.html
 ```
 
 ### From Source

--- a/build_tools/packaging/wheel/build_from_source.sh
+++ b/build_tools/packaging/wheel/build_from_source.sh
@@ -28,6 +28,8 @@ popd
 
 # build mad, statically
 pushd libmad-0.15.1b
+# See https://stackoverflow.com/a/12864879/23845
+sed -i 's#-march=i486##' configure
 ./configure --disable-shared --enable-static --prefix="$PREFIX/audio/third_party/mad" CFLAGS=-fPIC CXXFLAGS=-fPIC \
     --with-pic --disable-debug --disable-dependency-tracking
 make -s -j && make install

--- a/build_tools/packaging/wheel/build_from_source.sh
+++ b/build_tools/packaging/wheel/build_from_source.sh
@@ -29,7 +29,7 @@ popd
 # build mad, statically
 pushd libmad-0.15.1b
 # See https://stackoverflow.com/a/12864879/23845
-sed -i 's#-march=i486##' configure
+sed -i.bak 's/-march=i486//' configure
 ./configure --disable-shared --enable-static --prefix="$PREFIX/audio/third_party/mad" CFLAGS=-fPIC CXXFLAGS=-fPIC \
     --with-pic --disable-debug --disable-dependency-tracking
 make -s -j && make install

--- a/build_tools/packaging/wheel/build_from_source.sh
+++ b/build_tools/packaging/wheel/build_from_source.sh
@@ -36,10 +36,13 @@ make -s -j && make install
 popd
 
 # build sox, statically
+# --without-png makes OS X build less hazardous; somehow the build
+# finds png and enables it.  We don't want it; we'd need to package
+# it statically if we do.
 pushd sox-14.4.2
 ./configure --disable-shared --enable-static --prefix="$PREFIX/audio/third_party/sox" \
     LDFLAGS="-L$PREFIX/audio/third_party/lame/lib -L$PREFIX/audio/third_party/flac/lib -L$PREFIX/audio/third_party/mad/lib" \
     CPPFLAGS="-I$PREFIX/audio/third_party/lame/include -I$PREFIX/audio/third_party/flac/include -I$PREFIX/audio/third_party/mad/include" \
-    --with-lame --with-flac --with-mad --without-oggvorbis --without-oss --without-sndfile CFLAGS=-fPIC CXXFLAGS=-fPIC --with-pic --disable-debug --disable-dependency-tracking
+    --with-lame --with-flac --with-mad --without-png --without-oggvorbis --without-oss --without-sndfile CFLAGS=-fPIC CXXFLAGS=-fPIC --with-pic --disable-debug --disable-dependency-tracking
 make -s -j && make install
 popd

--- a/build_tools/packaging/wheel/osx_wheel.sh
+++ b/build_tools/packaging/wheel/osx_wheel.sh
@@ -2,6 +2,10 @@
 
 set -ex
 
+if [[ ":$PATH:" == *"conda"* ]]; then
+    echo "existing anaconda install in PATH, remove it and run script"
+    exit 1
+fi
 # download and activate anaconda
 rm -rf ~/minconda_wheel_env_tmp
 wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh && \

--- a/build_tools/packaging/wheel/osx_wheel.sh
+++ b/build_tools/packaging/wheel/osx_wheel.sh
@@ -2,10 +2,6 @@
 
 set -ex
 
-if [[ ":$PATH:" == *"conda"* ]]; then
-    echo "existing anaconda install in PATH, remove it and run script"
-    exit 1
-fi
 # download and activate anaconda
 rm -rf ~/minconda_wheel_env_tmp
 wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh && \

--- a/build_tools/packaging/wheel/osx_wheel.sh
+++ b/build_tools/packaging/wheel/osx_wheel.sh
@@ -44,14 +44,12 @@ do
     conda activate $env_name
 
     export TORCHAUDIO_PYTORCH_DEPENDENCY_NAME=torch_nightly
-    pip install torch_nightly -f https://download.pytorch.org/whl/nightly/torch_nightly.html
+    pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
     # NB: OS X builds don't have local package qualifiers
     export TORCHAUDIO_PYTORCH_DEPENDENCY_VERSION="$(pip show torch_nightly | grep ^Version: | sed 's/Version: \+//')"
     echo "Building against ${TORCHAUDIO_PYTORCH_DEPENDENCY_VERSION}"
 
-     # install torchaudio dependencies
-    pip install -r requirements.txt
-
+    pip install numpy future
     IS_WHEEL=1 python setup.py clean
     IS_WHEEL=1 python setup.py bdist_wheel
     mkdir -p $OUT_DIR

--- a/build_tools/packaging/wheel/osx_wheel.sh
+++ b/build_tools/packaging/wheel/osx_wheel.sh
@@ -42,7 +42,8 @@ do
     export TORCHAUDIO_PYTORCH_DEPENDENCY_NAME=torch_nightly
     pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
     # NB: OS X builds don't have local package qualifiers
-    export TORCHAUDIO_PYTORCH_DEPENDENCY_VERSION="$(pip show torch_nightly | grep ^Version: | sed 's/Version: \+//')"
+    # NB: Don't use \+ here, it's not portable
+    export TORCHAUDIO_PYTORCH_DEPENDENCY_VERSION="$(pip show torch_nightly | grep ^Version: | sed 's/Version:  *//')"
     echo "Building against ${TORCHAUDIO_PYTORCH_DEPENDENCY_VERSION}"
 
     pip install numpy future


### PR DESCRIPTION
- Instructions for how to install stable and master binaries,
  without hardcoding wheel filenames
- Turn on Python 2 build (numba is only needed for testing)
- Make builds a little more hermetic
- Prefer building against nightly CPU-only torch build
- Don't install all of requirements.txt, it's not necessary

Signed-off-by: Edward Z. Yang <ezyang@fb.com>