### PR TITLE
Make torchaudio work on Python 2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,11 @@ cache:
 matrix:
   fast_finish: true
   include:
-    # TODO add this back in when there is a pytorch 1.2 for python 3.5
-    # - env: PYTHON_VERSION="3.5"
+    - env: PYTHON_VERSION="3.7"
     - env: PYTHON_VERSION="3.6"
+    # TODO add this back in when there is a pytorch 1.2 for python 3.5
     - env: PYTHON_VERSION="3.5" RUN_FLAKE8="true" SKIP_TESTS="true"
+    - env: PYTHON_VERSION="2.7"
 
 addons:
   apt:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,6 @@ scipy
 
 # Unit tests with pytest
 pytest
+
+# Testing only Py3 compat
+backports.tempfile

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 from shutil import copytree
-import tempfile
+import backports.tempfile as tempfile
 import torch
 
 TEST_DIR_PATH = os.path.dirname(os.path.realpath(__file__))

--- a/test/compliance/generate_fbank_data.py
+++ b/test/compliance/generate_fbank_data.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import argparse
 import logging
 import os

--- a/test/compliance/generate_test_stft_data.py
+++ b/test/compliance/generate_test_stft_data.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import argparse
 import logging
 import os

--- a/test/compliance/utils.py
+++ b/test/compliance/utils.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import random
 import torchaudio
 

--- a/test/test.py
+++ b/test/test.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 import common_utils
 import torch

--- a/test/test_compliance_kaldi.py
+++ b/test/test_compliance_kaldi.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import math
 import os
 import common_utils

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 import common_utils
 import torch

--- a/test/test_datasets_vctk.py
+++ b/test/test_datasets_vctk.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 
 import torch

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import math
 
 import torch
@@ -195,14 +196,17 @@ def _num_stft_bins(signal_len, fft_len, hop_length, pad):
     return (signal_len + 2 * pad - fft_len + hop_length) // hop_length
 
 
-@pytest.mark.parametrize('rate', [0.5, 1.01, 1.3])
 @pytest.mark.parametrize('complex_specgrams', [
     torch.randn(1, 2, 1025, 400, 2),
     torch.randn(1, 1025, 400, 2)
 ])
+@pytest.mark.parametrize('rate', [0.5, 1.01, 1.3])
 @pytest.mark.parametrize('hop_length', [256])
-@unittest.skipIf(not IMPORT_LIBROSA, 'Librosa is not available')
 def test_phase_vocoder(complex_specgrams, rate, hop_length):
+
+    # Using a decorator here causes parametrize to fail on Python 2
+    if not IMPORT_LIBROSA:
+        raise unittest.SkipTest('Librosa is not available')
 
     # Due to cummulative sum, numerical error in using torch.float32 will
     # result in bottom right values of the stretched sectrogram to not

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import absolute_import, division, print_function, unicode_literals
 import torch
 import torchaudio.functional as F
 import torchaudio.transforms as transforms

--- a/test/test_kaldi_io.py
+++ b/test/test_kaldi_io.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import torch
 import torchaudio.kaldi_io as kio

--- a/test/test_sox_effects.py
+++ b/test/test_sox_effects.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 import common_utils
 import torch

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import math
 import os
 

--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os.path
 
 import torch

--- a/torchaudio/_docs.py
+++ b/torchaudio/_docs.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import torchaudio
 
 

--- a/torchaudio/common_utils.py
+++ b/torchaudio/common_utils.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import sys
 
 PY3 = sys.version_info > (3, 0)

--- a/torchaudio/compliance/kaldi.py
+++ b/torchaudio/compliance/kaldi.py
@@ -1,4 +1,6 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import math
+import fractions
 import random
 import torch
 
@@ -600,7 +602,7 @@ def _get_LR_indices_and_weights(orig_freq, new_freq, output_samples_in_unit, win
 
 
 def _lcm(a, b):
-    return abs(a * b) // math.gcd(a, b)
+    return abs(a * b) // fractions.gcd(a, b)
 
 
 def _get_num_LR_output_samples(input_num_samp, samp_rate_in, samp_rate_out):
@@ -675,7 +677,7 @@ def resample_waveform(waveform, orig_freq, new_freq, lowpass_filter_width=6):
 
     assert lowpass_cutoff * 2 <= min_freq
 
-    base_freq = math.gcd(int(orig_freq), int(new_freq))
+    base_freq = fractions.gcd(int(orig_freq), int(new_freq))
     input_samples_in_unit = int(orig_freq) // base_freq
     output_samples_in_unit = int(new_freq) // base_freq
 

--- a/torchaudio/datasets/vctk.py
+++ b/torchaudio/datasets/vctk.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import torch.utils.data as data
 import os
 import os.path

--- a/torchaudio/datasets/yesno.py
+++ b/torchaudio/datasets/yesno.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import torch.utils.data as data
 import os
 import os.path

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import absolute_import, division, print_function, unicode_literals
 import math
 import torch
 

--- a/torchaudio/kaldi_io.py
+++ b/torchaudio/kaldi_io.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 # To use this file, the dependency (https://github.com/vesis84/kaldi-io-for-python)
 # needs to be installed. This is a light wrapper around kaldi_io that returns
 # torch.Tensors.

--- a/torchaudio/sox_effects.py
+++ b/torchaudio/sox_effects.py
@@ -1,4 +1,4 @@
-from __future__ import division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import torch
 import _torch_sox
 

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -1,4 +1,4 @@
-from __future__ import division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 from warnings import warn
 import math
 import torch


### PR DESCRIPTION
- Apply `__future__` imports uniformly (future division is the biggy, but absolute
  imports mattered too)
- Hotfix use of tempfile.TemporaryDirectory using a BC library (DO NOT
  add this library as a dependency to torchaudio; it's only for testing)
- Replace math.gcd with fractions.gcd
- Fix a weird pytest collection bug involving parametrized tests
- Turn on Python 2 and Python 3.7 in Travis.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>