### PR TITLE
CI Fix: upgrade to torch 1.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - env: PYTHON_VERSION="3.7.3"
+    - env: PYTHON_VERSION="3.7"
     - env: PYTHON_VERSION="3.6"
     # TODO add this back in when there is a pytorch 1.2 for python 3.5
     - env: PYTHON_VERSION="3.5" RUN_FLAKE8="true" SKIP_TESTS="true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - env: PYTHON_VERSION="3.7"
+    - env: PYTHON_VERSION="3.7.3"
     - env: PYTHON_VERSION="3.6"
     # TODO add this back in when there is a pytorch 1.2 for python 3.5
     - env: PYTHON_VERSION="3.5" RUN_FLAKE8="true" SKIP_TESTS="true"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -48,8 +48,8 @@ popd
 source activate testenv
 
  # Install requirements via pip in our conda environment
-which conda
-pip install -vvv -r requirements.txt
+conda install pip
+/home/travis/miniconda3/condabin/conda/pip install -vvv -r requirements.txt
 
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -48,7 +48,7 @@ popd
 source activate testenv
 
  # Install requirements via pip in our conda environment
-pip install -r requirements.txt
+pip install -vvv -r requirements.txt
 
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -48,11 +48,7 @@ popd
 source activate testenv
 
  # Install requirements via pip in our conda environment
-which pip
-which python
-pip --version
-python --version
-
+# conda install pytorch torchvision cpuonly -c pytorch
 python -m pip install -vvv -r requirements.txt
 
  # Install the following only if running tests

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -48,7 +48,11 @@ popd
 source activate testenv
 
  # Install requirements via pip in our conda environment
-python -m pip3 install -vvv -r requirements.txt
+which pip
+python -m pip install -vvv -r requirements.txt
+echo "mello"
+conda install pip
+python -m home/travis/miniconda3/envs/testenv/bin/pip install -vvv -r requirements.txt
 
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -48,7 +48,7 @@ popd
 source activate testenv
 
  # Install requirements via pip in our conda environment
-python -m pip install -vvv -r requirements.txt
+python -m pip3 install -vvv -r requirements.txt
 
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -48,6 +48,7 @@ popd
 source activate testenv
 
  # Install requirements via pip in our conda environment
+python --version
 pip install -vvv -r requirements.txt
 
  # Install the following only if running tests

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -48,8 +48,7 @@ popd
 source activate testenv
 
  # Install requirements via pip in our conda environment
-conda install pip
-/home/travis/miniconda3/envs/testenv/bin/pip install -vvv -r requirements.txt
+python -m pip install -vvv -r requirements.txt
 
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -48,8 +48,8 @@ popd
 source activate testenv
 
  # Install requirements via pip in our conda environment
-conda install pip3
-/home/travis/miniconda3/envs/testenv/bin/pip3 install -vvv -r requirements.txt
+conda install pip
+/home/travis/miniconda3/envs/testenv/bin/pip install -vvv -r requirements.txt
 
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -49,10 +49,11 @@ source activate testenv
 
  # Install requirements via pip in our conda environment
 which pip
+which python
+pip --version
+python --version
+
 python -m pip install -vvv -r requirements.txt
-echo "mello"
-conda install pip
-python -m home/travis/miniconda3/envs/testenv/bin/pip install -vvv -r requirements.txt
 
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -48,8 +48,8 @@ popd
 source activate testenv
 
  # Install requirements via pip in our conda environment
-conda install pip
-/home/travis/miniconda3/envs/testenv/bin/pip install -vvv -r requirements.txt
+conda install pip3
+/home/travis/miniconda3/envs/testenv/bin/pip3 install -vvv -r requirements.txt
 
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -49,7 +49,7 @@ source activate testenv
 
  # Install requirements via pip in our conda environment
 python --version
-pip install -vvv -r requirements.txt
+pip3 install -vvv -r requirements.txt
 
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -48,7 +48,7 @@ popd
 source activate testenv
 
  # Install requirements via pip in our conda environment
-pip -r requirements.txt
+pip install -r requirements.txt
 
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -48,8 +48,8 @@ popd
 source activate testenv
 
  # Install requirements via pip in our conda environment
-python --version
-pip3 install -vvv -r requirements.txt
+which conda
+pip install -vvv -r requirements.txt
 
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -49,7 +49,7 @@ source activate testenv
 
  # Install requirements via pip in our conda environment
 conda install pip
-/home/travis/miniconda3/condabin/conda/envs/$(testenv)/bin/pip install -vvv -r requirements.txt
+/home/travis/miniconda3/condabin/conda/envs/testenv/bin/pip install -vvv -r requirements.txt
 
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -49,7 +49,7 @@ source activate testenv
 
  # Install requirements via pip in our conda environment
 conda install pip
-/home/travis/miniconda3/condabin/conda/pip install -vvv -r requirements.txt
+/home/travis/miniconda3/condabin/conda/envs/$(testenv)/bin/pip install -vvv -r requirements.txt
 
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -49,7 +49,8 @@ source activate testenv
 
  # Install requirements via pip in our conda environment
 conda install pip
-/home/travis/miniconda3/condabin/conda/envs/testenv/bin/pip install -vvv -r requirements.txt
+ls /home/travis/miniconda3/condabin/
+/home/travis/miniconda3/condabin/envs/testenv/bin/pip install -vvv -r requirements.txt
 
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -49,8 +49,7 @@ source activate testenv
 
  # Install requirements via pip in our conda environment
 conda install pip
-ls /home/travis/miniconda3/condabin/
-/home/travis/miniconda3/condabin/envs/testenv/bin/pip install -vvv -r requirements.txt
+/home/travis/miniconda3/envs/testenv/bin/pip install -vvv -r requirements.txt
 
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -52,9 +52,6 @@ pip install -r requirements.txt
 
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then
-    # PyTorch (nightly as 1.1 does not have Optional for type annotations)
-    conda install --yes pytorch-nightly-cpu -c pytorch
-
      # TorchAudio CPP Extensions
     python setup.py install
 fi

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -48,8 +48,7 @@ popd
 source activate testenv
 
  # Install requirements via pip in our conda environment
-# conda install pytorch torchvision cpuonly -c pytorch
-python -m pip install -vvv -r requirements.txt
+pip -r requirements.txt
 
  # Install the following only if running tests
 if [[ "$SKIP_TESTS" != "true" ]]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=1.2.0 -c pytorch
+torch>=1.2.0
 
 # Optional for torchaudio.kaldi_io
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=1.1.0
+torch>=1.2.0
 
 # Optional for torchaudio.kaldi_io
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=1.2.0
+torch>=1.2.0 -c pytorch
 
 # Optional for torchaudio.kaldi_io
 numpy


### PR DESCRIPTION
Upgrading requirements.txt from torch 1.1.0 to 1.2.0

The python 3.7.4 seems to have issue when doing pip install torch 1.2.0 so using to 3.7.3 instead works (https://github.com/ContinuumIO/anaconda-issues/issues/11195). Instead of changing the code, I am going to wait until conda releases their fix.