### PR TITLE
Fix #236 Length Inaccurate for Multi-Channel

### DIFF
--- a/torchaudio/torch_sox.cpp
+++ b/torchaudio/torch_sox.cpp
@@ -120,7 +120,7 @@ int read_audio_file(
 
   const int number_of_channels = fd->signal.channels;
   const int sample_rate = fd->signal.rate;
-  const int64_t total_length = fd->signal.length;
+  const int64_t total_length = fd->signal.length/fd->signal.channels;
 
   // multiply offset and number of frames by number of channels
   offset *= number_of_channels;


### PR DESCRIPTION
https://github.com/pytorch/audio/issues/236

I believe this will fix the issue assuming that everybody agrees with me that length should be the length of a single channel.