### PR TITLE
MelSpectrogram: Use given n_fft to initialize fb immediately

### DIFF
--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -199,7 +199,7 @@ class MelSpectrogram(torch.jit.ScriptModule):
                                        hop_length=self.hop_length,
                                        pad=self.pad, window_fn=window_fn, power=2,
                                        normalized=False, wkwargs=wkwargs)
-        self.mel_scale = MelScale(self.n_mels, self.sample_rate, self.f_min, self.f_max)
+        self.mel_scale = MelScale(self.n_mels, self.sample_rate, self.f_min, self.f_max, self.n_fft // 2 + 1)
 
     @torch.jit.script_method
     def forward(self, waveform):


### PR DESCRIPTION
In the issue https://github.com/pytorch/audio/issues/245, it was determined that for MelSpectrogram the transform already knows how many bins the stft will have and thus can initialize the fb matrix without needing to infer the dimensions of its first input.
The benefit of initializing the fb matrix immediately as opposed to lazy load when given a first input is that loading and saving from state dict (`load_state_dict`) will not throw an error as the tensor sizes match