### PR TITLE
Dataset disclaimer

### DIFF
--- a/torchaudio/datasets/README.md
+++ b/torchaudio/datasets/README.md
@@ -1,0 +1,5 @@
+# Disclaimers
+
+This is a utility library that downloads and prepares public datasets. We do not host or distribute these datasets, vouch for their quality or fairness, or claim that you have license to use the dataset. It is your responsibility to determine whether you have permission to use the dataset under the dataset's license.
+
+If you're a dataset owner and wish to update any part of it (description, citation, etc.), or do not want your dataset to be included in this library, please get in touch through a GitHub issue. Thanks for your contribution to the ML community!


### PR DESCRIPTION
As done in [tensorflow](https://github.com/tensorflow/datasets#disclaimers) and mentioned in pytorch/pytorch#24865, let's add a dataset disclaimer. We could merge this in the main readme, but I added it in the datasets folder to avoid making the main readme too long.