### PR TITLE
Revert "Change Tensor.data<T> to Tensor.data_ptr<T> (#261)"

### DIFF
--- a/torchaudio/torch_sox.cpp
+++ b/torchaudio/torch_sox.cpp
@@ -37,7 +37,7 @@ int64_t write_audio(SoxDescriptor& fd, at::Tensor tensor) {
   std::vector<sox_sample_t> buffer(tensor.numel());
 
   AT_DISPATCH_ALL_TYPES(tensor.scalar_type(), "write_audio_buffer", [&] {
-    auto* data = tensor.data_ptr<scalar_t>();
+    auto* data = tensor.data<scalar_t>();
     std::copy(data, data + tensor.numel(), buffer.begin());
   });
 
@@ -64,7 +64,7 @@ void read_audio(
   output = output.contiguous();
 
   AT_DISPATCH_ALL_TYPES(output.scalar_type(), "read_audio_buffer", [&] {
-    auto* data = output.data_ptr<scalar_t>();
+    auto* data = output.data<scalar_t>();
     std::copy(buffer.begin(), buffer.begin() + samples_read, data);
   });
 }
@@ -370,7 +370,7 @@ int build_flow_effects(const std::string& file_name,
   const int64_t samples_read = sox_read(input, samples.data(), buffer_size);
   assert(samples_read != nc * ns && samples_read != 0);
   AT_DISPATCH_ALL_TYPES(otensor.scalar_type(), "effects_buffer", [&] {
-    auto* data = otensor.data_ptr<scalar_t>();
+    auto* data = otensor.data<scalar_t>();
     std::copy(samples.begin(), samples.begin() + samples_read, data);
   });
   // free buffer and close mem_read


### PR DESCRIPTION
Compilation error noticed in #262.

First PR to crash is #261 according to [this](https://travis-ci.org/pytorch/audio/pull_requests). Unknown status from [this](https://travis-ci.org/pytorch/audio/builds).

This reverts commit 860edcdb13e07d017ae0d081d4e2e3034b5e455f.