### PR TITLE
Compute deltas

### DIFF
--- a/test/test_compliance_kaldi.py
+++ b/test/test_compliance_kaldi.py
@@ -319,15 +319,6 @@ class Test_Kaldi(unittest.TestCase):
             single_channel_sampled = kaldi.resample_waveform(single_channel, sample_rate, sample_rate // 2)
             self.assertTrue(torch.allclose(multi_sound_sampled[i, :], single_channel_sampled, rtol=1e-4))
 
-    def test_compute_deltas(self):
-        channel = 13
-        n_mfcc = channel * 3
-        time = 1021
-        win_length = 7
-        order = 1
-        specgram = torch.randn(channel, n_mfcc, time)
-        computed = kaldi.add_deltas(specgram, win_length=win_length, order=order)
-        self.assertTrue(computed.shape == specgram.shape, (computed.shape, specgram.shape))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_compliance_kaldi.py
+++ b/test/test_compliance_kaldi.py
@@ -319,5 +319,15 @@ class Test_Kaldi(unittest.TestCase):
             single_channel_sampled = kaldi.resample_waveform(single_channel, sample_rate, sample_rate // 2)
             self.assertTrue(torch.allclose(multi_sound_sampled[i, :], single_channel_sampled, rtol=1e-4))
 
+    def test_compute_deltas(self):
+        channel = 13
+        n_mfcc = channel * 3
+        time = 1021
+        window = 7
+        order = 1
+        specgram = torch.randn(channel, n_mfcc, time)
+        computed = kaldi.add_deltas(specgram, window=window, order=order)
+        self.assertTrue(computed.shape == specgram.shape, (computed.shape, specgram.shape))
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_compliance_kaldi.py
+++ b/test/test_compliance_kaldi.py
@@ -323,10 +323,10 @@ class Test_Kaldi(unittest.TestCase):
         channel = 13
         n_mfcc = channel * 3
         time = 1021
-        window = 7
+        win_length = 7
         order = 1
         specgram = torch.randn(channel, n_mfcc, time)
-        computed = kaldi.add_deltas(specgram, window=window, order=order)
+        computed = kaldi.add_deltas(specgram, win_length=win_length, order=order)
         self.assertTrue(computed.shape == specgram.shape, (computed.shape, specgram.shape))
 
 if __name__ == '__main__':

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -193,23 +193,23 @@ class TestFunctional(unittest.TestCase):
 
 
 class TestDeltas(unittest.TestCase):
-    waveform = torch.tensor([1., 2., 3., 4.]).unsqueeze(0)
+    specgram = torch.tensor([1., 2., 3., 4.])
 
-    def _test(self, waveform, expected, n_diff=1, atol=1e-6, rtol=1e-8):
-        computed = F.compute_deltas(waveform, n_diff=1)
+    def _test(self, specgram, expected, n_diff=1, atol=1e-6, rtol=1e-8):
+        computed = F.compute_deltas(specgram, n_diff=1)
         self.assertTrue(computed.shape == expected.shape, (computed.shape, expected.shape))
         self.assertTrue(torch.allclose(computed, expected, atol=atol, rtol=rtol))
 
     def test_onechannel(self):
-        waveform = self.waveform
-        expected = torch.tensor([[1.0, 1.0, 1.0, -1.5]])
-        self._test(waveform, expected)
+        specgram = self.specgram.unsqueeze(0).unsqueeze(0)
+        expected = torch.tensor([[[1.0, 1.0, 1.0, -1.5]]])
+        self._test(specgram, expected)
 
     def test_twochannel(self):
-        waveform = torch.cat([self.waveform, self.waveform], dim=0)
-        expected = torch.tensor([[1.0, 1.0, 1.0, -1.5],
-                                 [1.0, 1.0, 1.0, -1.5]])
-        self._test(waveform, expected)
+        specgram = self.specgram.repeat(1, 2, 1)
+        expected = torch.tensor([[[1.0, 1.0, 1.0, -1.5],
+                                  [1.0, 1.0, 1.0, -1.5]]])
+        self._test(specgram, expected)
 
 
 def _num_stft_bins(signal_len, fft_len, hop_length, pad):

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -192,6 +192,26 @@ class TestFunctional(unittest.TestCase):
         self._test_istft_of_sine(amplitude=99, L=10, n=7)
 
 
+class TestDeltas(unittest.TestCase):
+    waveform = torch.tensor([1.,2.,3.,4.]).unsqueeze(0)
+
+    def _test(self, waveform, expected, n_diff=1, atol=1e-6, rtol=1e-8):
+        computed = F.compute_deltas(waveform, n_diff=1)
+        self.assertTrue(computed.shape == expected.shape, (computed.shape, expected.shape))
+        self.assertTrue(torch.allclose(computed, expected, atol=atol, rtol=rtol))
+
+    def test_onechannel(self):
+        waveform = self.waveform
+        expected = torch.tensor([[ 1.0,  1.0,  1.0, -1.5]])
+        self._test(waveform, expected)
+
+    def test_twochannel(self):
+        waveform = torch.cat([self.waveform, self.waveform], dim=0)
+        expected = torch.tensor([[ 1.0,  1.0,  1.0, -1.5],
+                                [ 1.,  1.0,  1.0, -1.5]])
+        self._test(waveform, expected)
+
+
 def _num_stft_bins(signal_len, fft_len, hop_length, pad):
     return (signal_len + 2 * pad - fft_len + hop_length) // hop_length
 

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -40,7 +40,7 @@ class TestFunctional(unittest.TestCase):
         channel = 13
         n_mfcc = channel * 3
         time = 1021
-        win_length = 2*7+1
+        win_length = 2 * 7 + 1
         specgram = torch.randn(channel, n_mfcc, time)
         computed = F.compute_deltas(specgram, win_length=win_length)
         self.assertTrue(computed.shape == specgram.shape, (computed.shape, specgram.shape))

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -211,6 +211,14 @@ class TestDeltas(unittest.TestCase):
                                   [1.0, 1.0, 1.0, -1.5]]])
         self._test(specgram, expected)
 
+    def test_randn(self):
+        channel = 13
+        n_mfcc = channel * 3
+        time = 1021
+        specgram = torch.randn(channel, n_mfcc, time)
+        computed = F.compute_deltas(specgram, n_diff=7)
+        self.assertTrue(computed.shape == specgram.shape, (computed.shape, specgram.shape))
+
 
 def _num_stft_bins(signal_len, fft_len, hop_length, pad):
     return (signal_len + 2 * pad - fft_len + hop_length) // hop_length

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -21,7 +21,7 @@ class TestFunctional(unittest.TestCase):
     specgram = torch.tensor([1., 2., 3., 4.])
 
     def _test_compute_deltas(self, specgram, expected, win_length=3, atol=1e-6, rtol=1e-8):
-        computed = F.compute_deltas(specgram, win_length=3)
+        computed = F.compute_deltas(specgram, win_length=win_length)
         self.assertTrue(computed.shape == expected.shape, (computed.shape, expected.shape))
         torch.testing.assert_allclose(computed, expected, atol=atol, rtol=rtol)
 

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -18,6 +18,32 @@ if IMPORT_LIBROSA:
 class TestFunctional(unittest.TestCase):
     data_sizes = [(2, 20), (3, 15), (4, 10)]
     number_of_trials = 100
+    specgram = torch.tensor([1., 2., 3., 4.])
+
+    def _test_compute_deltas(self, specgram, expected, win_length=3, atol=1e-6, rtol=1e-8):
+        computed = F.compute_deltas(specgram, win_length=3)
+        self.assertTrue(computed.shape == expected.shape, (computed.shape, expected.shape))
+        torch.testing.assert_allclose(computed, expected, atol=atol, rtol=rtol)
+
+    def test_compute_deltas_onechannel(self):
+        specgram = self.specgram.unsqueeze(0).unsqueeze(0)
+        expected = torch.tensor([[[0.5, 1.0, 1.0, 0.5]]])
+        self._test_compute_deltas(specgram, expected)
+
+    def test_compute_deltas_twochannel(self):
+        specgram = self.specgram.repeat(1, 2, 1)
+        expected = torch.tensor([[[0.5, 1.0, 1.0, 0.5],
+                                  [0.5, 1.0, 1.0, 0.5]]])
+        self._test_compute_deltas(specgram, expected)
+
+    def test_compute_deltas_randn(self):
+        channel = 13
+        n_mfcc = channel * 3
+        time = 1021
+        win_length = 2*7+1
+        specgram = torch.randn(channel, n_mfcc, time)
+        computed = F.compute_deltas(specgram, win_length=win_length)
+        self.assertTrue(computed.shape == specgram.shape, (computed.shape, specgram.shape))
 
     def _compare_estimate(self, sound, estimate, atol=1e-6, rtol=1e-8):
         # trim sound for case when constructed signal is shorter than original
@@ -190,35 +216,6 @@ class TestFunctional(unittest.TestCase):
         self._test_istft_of_sine(amplitude=145, L=8, n=5)
         self._test_istft_of_sine(amplitude=80, L=9, n=6)
         self._test_istft_of_sine(amplitude=99, L=10, n=7)
-
-
-class TestDeltas(unittest.TestCase):
-    specgram = torch.tensor([1., 2., 3., 4.])
-
-    def _test(self, specgram, expected, window=1, atol=1e-6, rtol=1e-8):
-        computed = F.compute_deltas(specgram, window=1)
-        self.assertTrue(computed.shape == expected.shape, (computed.shape, expected.shape))
-        self.assertTrue(torch.allclose(computed, expected, atol=atol, rtol=rtol))
-
-    def test_onechannel(self):
-        specgram = self.specgram.unsqueeze(0).unsqueeze(0)
-        expected = torch.tensor([[[0.5, 1.0, 1.0, 0.5]]])
-        self._test(specgram, expected)
-
-    def test_twochannel(self):
-        specgram = self.specgram.repeat(1, 2, 1)
-        expected = torch.tensor([[[0.5, 1.0, 1.0, 0.5],
-                                  [0.5, 1.0, 1.0, 0.5]]])
-        self._test(specgram, expected)
-
-    def test_randn(self):
-        channel = 13
-        n_mfcc = channel * 3
-        time = 1021
-        window = 7
-        specgram = torch.randn(channel, n_mfcc, time)
-        computed = F.compute_deltas(specgram, window=window)
-        self.assertTrue(computed.shape == specgram.shape, (computed.shape, specgram.shape))
 
 
 def _num_stft_bins(signal_len, fft_len, hop_length, pad):

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -215,8 +215,9 @@ class TestDeltas(unittest.TestCase):
         channel = 13
         n_mfcc = channel * 3
         time = 1021
+        window = 7
         specgram = torch.randn(channel, n_mfcc, time)
-        computed = F.compute_deltas(specgram, window=7)
+        computed = F.compute_deltas(specgram, window=window)
         self.assertTrue(computed.shape == specgram.shape, (computed.shape, specgram.shape))
 
 

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -195,20 +195,20 @@ class TestFunctional(unittest.TestCase):
 class TestDeltas(unittest.TestCase):
     specgram = torch.tensor([1., 2., 3., 4.])
 
-    def _test(self, specgram, expected, n_diff=1, atol=1e-6, rtol=1e-8):
-        computed = F.compute_deltas(specgram, n_diff=1)
+    def _test(self, specgram, expected, window=1, atol=1e-6, rtol=1e-8):
+        computed = F.compute_deltas(specgram, window=1)
         self.assertTrue(computed.shape == expected.shape, (computed.shape, expected.shape))
         self.assertTrue(torch.allclose(computed, expected, atol=atol, rtol=rtol))
 
     def test_onechannel(self):
         specgram = self.specgram.unsqueeze(0).unsqueeze(0)
-        expected = torch.tensor([[[1.0, 1.0, 1.0, -1.5]]])
+        expected = torch.tensor([[[0.5, 1.0, 1.0, 0.5]]])
         self._test(specgram, expected)
 
     def test_twochannel(self):
         specgram = self.specgram.repeat(1, 2, 1)
-        expected = torch.tensor([[[1.0, 1.0, 1.0, -1.5],
-                                  [1.0, 1.0, 1.0, -1.5]]])
+        expected = torch.tensor([[[0.5, 1.0, 1.0, 0.5],
+                                  [0.5, 1.0, 1.0, 0.5]]])
         self._test(specgram, expected)
 
     def test_randn(self):
@@ -216,7 +216,7 @@ class TestDeltas(unittest.TestCase):
         n_mfcc = channel * 3
         time = 1021
         specgram = torch.randn(channel, n_mfcc, time)
-        computed = F.compute_deltas(specgram, n_diff=7)
+        computed = F.compute_deltas(specgram, window=7)
         self.assertTrue(computed.shape == specgram.shape, (computed.shape, specgram.shape))
 
 

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -193,7 +193,7 @@ class TestFunctional(unittest.TestCase):
 
 
 class TestDeltas(unittest.TestCase):
-    waveform = torch.tensor([1.,2.,3.,4.]).unsqueeze(0)
+    waveform = torch.tensor([1., 2., 3., 4.]).unsqueeze(0)
 
     def _test(self, waveform, expected, n_diff=1, atol=1e-6, rtol=1e-8):
         computed = F.compute_deltas(waveform, n_diff=1)
@@ -202,13 +202,13 @@ class TestDeltas(unittest.TestCase):
 
     def test_onechannel(self):
         waveform = self.waveform
-        expected = torch.tensor([[ 1.0,  1.0,  1.0, -1.5]])
+        expected = torch.tensor([[1.0, 1.0, 1.0, -1.5]])
         self._test(waveform, expected)
 
     def test_twochannel(self):
         waveform = torch.cat([self.waveform, self.waveform], dim=0)
-        expected = torch.tensor([[ 1.0,  1.0,  1.0, -1.5],
-                                [ 1.,  1.0,  1.0, -1.5]])
+        expected = torch.tensor([[1.0, 1.0, 1.0, -1.5],
+                                 [1.0, 1.0, 1.0, -1.5]])
         self._test(waveform, expected)
 
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -291,5 +291,6 @@ class Tester(unittest.TestCase):
         computed = transform(specgram)
         self.assertTrue(computed.shape == specgram.shape, (computed.shape, specgram.shape))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -285,9 +285,17 @@ class Tester(unittest.TestCase):
         channel = 13
         n_mfcc = channel * 3
         time = 1021
-        window = 7
+        win_length = 2 * 7 + 1
         specgram = torch.randn(channel, n_mfcc, time)
-        transform = transforms.ComputeDeltas(window=window)
+        transform = transforms.ComputeDeltas(win_length=win_length)
+        computed = transform(specgram)
+        self.assertTrue(computed.shape == specgram.shape, (computed.shape, specgram.shape))
+
+    def test_compute_deltas_twochannel(self):
+        specgram = torch.tensor([1., 2., 3., 4.]).repeat(1, 2, 1)
+        expected = torch.tensor([[[0.5, 1.0, 1.0, 0.5],
+                                  [0.5, 1.0, 1.0, 0.5]]])
+        transform = transforms.ComputeDeltas()
         computed = transform(specgram)
         self.assertTrue(computed.shape == specgram.shape, (computed.shape, specgram.shape))
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -4,8 +4,9 @@ import os
 
 import torch
 import torchaudio
-from torchaudio.common_utils import IMPORT_LIBROSA, IMPORT_SCIPY
 import torchaudio.transforms as transforms
+import torchaudio.functional as F
+from torchaudio.common_utils import IMPORT_LIBROSA, IMPORT_SCIPY
 import unittest
 import common_utils
 
@@ -290,6 +291,19 @@ class Tester(unittest.TestCase):
         transform = transforms.ComputeDeltas(win_length=win_length)
         computed = transform(specgram)
         self.assertTrue(computed.shape == specgram.shape, (computed.shape, specgram.shape))
+
+    def test_compute_deltas_transform_same_as_functional(self, atol=1e-6, rtol=1e-8):
+        channel = 13
+        n_mfcc = channel * 3
+        time = 1021
+        win_length = 2 * 7 + 1
+        specgram = torch.randn(channel, n_mfcc, time)
+
+        transform = transforms.ComputeDeltas(win_length=win_length)
+        computed_transform = transform(specgram)
+
+        computed_functional = F.compute_deltas(specgram, win_length=win_length)
+        torch.testing.assert_allclose(computed_functional, computed_transform, atol=atol, rtol=rtol)
 
     def test_compute_deltas_twochannel(self):
         specgram = torch.tensor([1., 2., 3., 4.]).repeat(1, 2, 1)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -281,5 +281,15 @@ class Tester(unittest.TestCase):
         # we expect the downsampled signal to have half as many samples
         self.assertTrue(down_sampled.size(-1) == waveform.size(-1) // 2)
 
+    def test_compute_deltas(self):
+        channel = 13
+        n_mfcc = channel * 3
+        time = 1021
+        window = 7
+        specgram = torch.randn(channel, n_mfcc, time)
+        transform = transforms.ComputeDeltas(window=window)
+        computed = transform(specgram)
+        self.assertTrue(computed.shape == specgram.shape, (computed.shape, specgram.shape))
+
 if __name__ == '__main__':
     unittest.main()

--- a/torchaudio/compliance/kaldi.py
+++ b/torchaudio/compliance/kaldi.py
@@ -866,20 +866,3 @@ def resample_waveform(waveform, orig_freq, new_freq, lowpass_filter_width=6):
         output += dilated_conv_wave
 
     return output
-
-
-def add_deltas(specgram, order=1, win_length=2):
-    r"""Compute delta coefficients of given order of a spectogram.
-
-    Args:
-        specgram (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)
-        order (int): A nonzero order of difference
-        win_length (int): The window length used for computing delta.
-
-    Returns:
-        deltas (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)
-    """
-    deltas = specgram
-    for _ in range(order):
-        deltas = torchaudio.functional.compute_deltas(deltas, win_length=win_length)
-    return deltas

--- a/torchaudio/compliance/kaldi.py
+++ b/torchaudio/compliance/kaldi.py
@@ -866,3 +866,20 @@ def resample_waveform(waveform, orig_freq, new_freq, lowpass_filter_width=6):
         output += dilated_conv_wave
 
     return output
+
+
+def add_deltas(specgram, order=1, window=2):
+    r"""Compute delta coefficients of given order of a spectogram.
+
+    Args:
+        specgram (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)
+        order (int): A nonzero order of difference
+        window (int): A nonzero number of differences to use in computing delta
+
+    Returns:
+        deltas (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)
+    """
+    deltas = specgram
+    for _ in range(order):
+        deltas = torchaudio.functional.compute_deltas(deltas, window=window)
+    return deltas

--- a/torchaudio/compliance/kaldi.py
+++ b/torchaudio/compliance/kaldi.py
@@ -868,18 +868,18 @@ def resample_waveform(waveform, orig_freq, new_freq, lowpass_filter_width=6):
     return output
 
 
-def add_deltas(specgram, order=1, window=2):
+def add_deltas(specgram, order=1, win_length=2):
     r"""Compute delta coefficients of given order of a spectogram.
 
     Args:
         specgram (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)
         order (int): A nonzero order of difference
-        window (int): A nonzero number of differences to use in computing delta
+        win_length (int): The window length used for computing delta.
 
     Returns:
         deltas (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)
     """
     deltas = specgram
     for _ in range(order):
-        deltas = torchaudio.functional.compute_deltas(deltas, window=window)
+        deltas = torchaudio.functional.compute_deltas(deltas, win_length=win_length)
     return deltas

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -689,5 +689,5 @@ def compute_deltas(specgram, n_diff=2):
         .repeat(specgram.shape[1], specgram.shape[0], 1)
     )
     return torch.nn.functional.conv1d(
-        specgram, kernel, padding=n_diff, groups=specgram.shape[1]//specgram.shape[0]
+        specgram, kernel, padding=n_diff, groups=specgram.shape[1] // specgram.shape[0]
     ) / denom

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -658,11 +658,11 @@ def compute_deltas(specgram, n_diff=2):
     r"""Compute delta coefficients of a spectogram.
 
     Args:
-        specgram (torch.Tensor): Tensor of audio of dimension (channel, time)
-        n_diff (int): Number of differences to consider
+        specgram (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)
+        n_diff (int): Number of differences to use in computing delta
 
     Returns:
-        deltas (torch.Tensor): Tensor of audio of dimension (channel, time)
+        deltas (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)
 
     Example
         >>> specgram = torch.randn(1, 40, 1000)
@@ -670,6 +670,7 @@ def compute_deltas(specgram, n_diff=2):
     """
 
     assert specgram.dim() == 3
+    assert not specgram.shape[1] % specgram.shape[0]
 
     # twice sum of integer squared
     denom = n_diff * (n_diff + 1) * (2 * n_diff + 1) / 3
@@ -680,5 +681,5 @@ def compute_deltas(specgram, n_diff=2):
         .repeat(specgram.shape[1], specgram.shape[0], 1)
     )
     return torch.nn.functional.conv1d(
-        specgram, kernel, padding=n_diff, groups=specgram.shape[1]
+        specgram, kernel, padding=n_diff, groups=specgram.shape[1]//specgram.shape[0]
     ) / denom

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -665,7 +665,7 @@ def compute_deltas(specgram, n_diff=2):
         deltas (torch.Tensor): Tensor of audio of dimension (channel, time)
 
     Example
-        >>> specgram = torch.randn(2, 100)
+        >>> specgram = torch.randn(1, 40, 1000)
         >>> deltas = compute_deltas(specgram)
     """
 

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -669,7 +669,7 @@ def compute_deltas(specgram, win_length=5):
 
     Args:
         specgram (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)
-        win_length (int): A nonzero number of differences to use in computing delta
+        win_length (int): The window length used for computing delta.
 
     Returns:
         deltas (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -655,7 +655,14 @@ def lowpass_biquad(waveform, sample_rate, cutoff_freq, Q=0.707):
 
 
 def compute_deltas(specgram, n_diff=2):
-    r"""Compute delta coefficients of a spectogram.
+    r"""Compute delta coefficients of a spectogram:
+
+    .. math::
+        d_t = \frac{\sum_{n=1}^{N} n (c_{t+n} - c_{t-n})}{2 \sum_{n=1}^N n^2}
+
+    where :math:`d_t` is the deltas at time :math:`t`,
+    :math:`N` is n_diff,
+    :math:`c_t` are the spectogram coeffcients at time :math:`t`,
 
     Args:
         specgram (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)
@@ -671,6 +678,7 @@ def compute_deltas(specgram, n_diff=2):
 
     assert specgram.dim() == 3
     assert not specgram.shape[1] % specgram.shape[0]
+    assert n_diff > 0
 
     # twice sum of integer squared
     denom = n_diff * (n_diff + 1) * (2 * n_diff + 1) / 3

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -655,8 +655,8 @@ def lowpass_biquad(waveform, sample_rate, cutoff_freq, Q=0.707):
     return biquad(waveform, b0, b1, b2, a0, a1, a2)
 
 
-def compute_deltas(specgram, win_length=5):
-    # type: (Tensor, int) -> Tensor
+def compute_deltas(specgram, win_length=5, mode="replicate"):
+    # type: (Tensor, int, string) -> Tensor
     r"""Compute delta coefficients of a spectrogram:
 
     .. math::
@@ -666,11 +666,10 @@ def compute_deltas(specgram, win_length=5):
     :math:`c_t` is the spectrogram coeffcients at time :math:`t`,
     :math:`N` is (`win_length`-1)//2.
 
-    The behavior at the edges is to replicate the boundaries.
-
     Args:
         specgram (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)
-        win_length (int): The window length used for computing delta.
+        win_length (int): The window length used for computing delta
+        mode (string): Mode parameter passed to padding
 
     Returns:
         deltas (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)
@@ -690,7 +689,7 @@ def compute_deltas(specgram, win_length=5):
     # twice sum of integer squared
     denom = n * (n + 1) * (2 * n + 1) / 3
 
-    specgram = torch.nn.functional.pad(specgram, (n, n), mode='replicate')
+    specgram = torch.nn.functional.pad(specgram, (n, n), mode=mode)
 
     kernel = (
         torch

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -657,7 +657,7 @@ def lowpass_biquad(waveform, sample_rate, cutoff_freq, Q=0.707):
 
 def compute_deltas(specgram, win_length=5, mode="replicate"):
     # type: (Tensor, int, str) -> Tensor
-    r"""Compute delta coefficients of a spectrogram:
+    r"""Compute delta coefficients of a tensor, usually a spectrogram:
 
     .. math::
         d_t = \frac{\sum_{n=1}^{\text{N}} n (c_{t+n} - c_{t-n})}{2 \sum_{n=1}^{\text{N} n^2}

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -20,6 +20,7 @@ __all__ = [
     "biquad",
 ]
 
+
 # TODO: remove this once https://github.com/pytorch/pytorch/issues/21478 gets solved
 @torch.jit.ignore
 def _stft(
@@ -656,13 +657,13 @@ def lowpass_biquad(waveform, sample_rate, cutoff_freq, Q=0.707):
 
 def compute_deltas(specgram, win_length=5):
     # type: (Tensor, int) -> Tensor
-    r"""Compute delta coefficients of a spectogram:
+    r"""Compute delta coefficients of a spectrogram:
 
     .. math::
         d_t = \frac{\sum_{n=1}^{\text{N}} n (c_{t+n} - c_{t-n})}{2 \sum_{n=1}^{\text{N} n^2}
 
     where :math:`d_t` is the deltas at time :math:`t`,
-    :math:`c_t` is the spectogram coeffcients at time :math:`t`,
+    :math:`c_t` is the spectrogram coeffcients at time :math:`t`,
     :math:`N` is (`win_length`-1)//2.
 
     The behavior at the edges is to replicate the boundaries.

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -655,6 +655,7 @@ def lowpass_biquad(waveform, sample_rate, cutoff_freq, Q=0.707):
 
 
 def compute_deltas(specgram, window=2):
+    # type: (Tensor, int) -> Tensor
     r"""Compute delta coefficients of a spectogram:
 
     .. math::
@@ -690,7 +691,7 @@ def compute_deltas(specgram, window=2):
 
     kernel = (
         torch
-        .tensor(range(-window, window + 1, 1), device=specgram.device, dtype=specgram.dtype)
+        .arange(-window, window + 1, 1, device=specgram.device, dtype=specgram.dtype)
         .repeat(specgram.shape[1], specgram.shape[0], 1)
     )
 

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -656,7 +656,7 @@ def lowpass_biquad(waveform, sample_rate, cutoff_freq, Q=0.707):
 
 
 def compute_deltas(specgram, win_length=5, mode="replicate"):
-    # type: (Tensor, int, string) -> Tensor
+    # type: (Tensor, int, str) -> Tensor
     r"""Compute delta coefficients of a spectrogram:
 
     .. math::
@@ -669,7 +669,7 @@ def compute_deltas(specgram, win_length=5, mode="replicate"):
     Args:
         specgram (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)
         win_length (int): The window length used for computing delta
-        mode (string): Mode parameter passed to padding
+        mode (str): Mode parameter passed to padding
 
     Returns:
         deltas (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -673,7 +673,7 @@ def compute_deltas(waveform, n_diff=2):
 
     kernel = (
         torch
-        .tensor(range(-n_diff, n_diff+1, 1), device=waveform.device, dtype=waveform.dtype)
+        .tensor(range(-n_diff, n_diff + 1, 1), device=waveform.device, dtype=waveform.dtype)
         .repeat(waveform.shape[0], 1)
         .unsqueeze(1)
     )
@@ -681,7 +681,7 @@ def compute_deltas(waveform, n_diff=2):
     deltas = torch.nn.functional.conv1d(waveform, kernel, padding=n_diff, groups=waveform.shape[1])
 
     # twice sum of integer squared
-    denom = n_diff * (n_diff+1) * (2*n_diff+1) / 3
+    denom = n_diff * (n_diff + 1) * (2 * n_diff + 1) / 3
 
     deltas /= denom
     return deltas.squeeze(0)

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -661,12 +661,12 @@ def compute_deltas(specgram, n_diff=2):
         d_t = \frac{\sum_{n=1}^{N} n (c_{t+n} - c_{t-n})}{2 \sum_{n=1}^N n^2}
 
     where :math:`d_t` is the deltas at time :math:`t`,
-    :math:`N` is n_diff,
-    :math:`c_t` are the spectogram coeffcients at time :math:`t`,
+    :math:`c_t` is the spectogram coeffcients at time :math:`t`,
+    :math:`N` is n_diff.
 
     Args:
         specgram (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)
-        n_diff (int): Number of differences to use in computing delta
+        n_diff (int): A nonzero number of differences to use in computing delta
 
     Returns:
         deltas (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)
@@ -676,9 +676,9 @@ def compute_deltas(specgram, n_diff=2):
         >>> deltas = compute_deltas(specgram)
     """
 
+    assert n_diff > 0
     assert specgram.dim() == 3
     assert not specgram.shape[1] % specgram.shape[0]
-    assert n_diff > 0
 
     # twice sum of integer squared
     denom = n_diff * (n_diff + 1) * (2 * n_diff + 1) / 3

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -368,7 +368,7 @@ class Resample(torch.nn.Module):
 
 
 class ComputeDeltas(torch.jit.ScriptModule):
-    r"""Compute delta coefficients of a spectogram.
+    r"""Compute delta coefficients of a spectrogram.
 
     See `torchaudio.functional.compute_deltas` for more details.
 

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -368,25 +368,18 @@ class Resample(torch.nn.Module):
 
 
 class ComputeDeltas(torch.jit.ScriptModule):
-    r"""Compute delta coefficients of a spectogram:
+    r"""Compute delta coefficients of a spectogram.
 
-    .. math::
-        d_t = \frac{\sum_{n=1}^{\text{window}} n (c_{t+n} - c_{t-n})}{2 \sum_{n=1}^{\text{window} n^2}
-
-    where :math:`d_t` is the deltas at time :math:`t`,
-    :math:`c_t` is the spectogram coeffcients at time :math:`t`,
-    `window` is the parameter given to the function (the actual window size is 2*window+1).
-
-    The behavior at the edges is to replicate the boundaries.
+    See `torchaudio.functional.compute_deltas` for more details.
 
     Args:
-        window (int): A nonzero number of differences to use in computing delta
+        win_length (int): The window length used for computing delta
     """
-    __constants__ = ['window']
+    __constants__ = ['win_length']
 
-    def __init__(self, window=2):
+    def __init__(self, win_length=5):
         super(ComputeDeltas, self).__init__()
-        self.window = window
+        self.win_length = win_length
 
     @torch.jit.script_method
     def forward(self, specgram):
@@ -397,4 +390,4 @@ class ComputeDeltas(torch.jit.ScriptModule):
         Returns:
             deltas (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)
         """
-        return F.compute_deltas(specgram, window=self.window)
+        return F.compute_deltas(specgram, win_length=self.win_length)

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -375,11 +375,12 @@ class ComputeDeltas(torch.jit.ScriptModule):
     Args:
         win_length (int): The window length used for computing delta.
     """
-    __constants__ = ['win_length']
+    __constants__ = ['win_length', 'mode']
 
-    def __init__(self, win_length=5):
+    def __init__(self, win_length=5, mode="replicate"):
         super(ComputeDeltas, self).__init__()
         self.win_length = win_length
+        self.mode = mode
 
     @torch.jit.script_method
     def forward(self, specgram):
@@ -390,4 +391,4 @@ class ComputeDeltas(torch.jit.ScriptModule):
         Returns:
             deltas (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)
         """
-        return F.compute_deltas(specgram, win_length=self.win_length)
+        return F.compute_deltas(specgram, win_length=self.win_length, mode=self.mode)

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -373,7 +373,7 @@ class ComputeDeltas(torch.jit.ScriptModule):
     See `torchaudio.functional.compute_deltas` for more details.
 
     Args:
-        win_length (int): The window length used for computing delta
+        win_length (int): The window length used for computing delta.
     """
     __constants__ = ['win_length']
 

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -368,19 +368,19 @@ class Resample(torch.nn.Module):
 
 
 class ComputeDeltas(torch.jit.ScriptModule):
-    r"""Compute delta coefficients of a spectrogram.
+    r"""Compute delta coefficients of a tensor, usually a spectrogram.
 
     See `torchaudio.functional.compute_deltas` for more details.
 
     Args:
         win_length (int): The window length used for computing delta.
     """
-    __constants__ = ['win_length', 'mode']
+    __constants__ = ['win_length']
 
     def __init__(self, win_length=5, mode="replicate"):
         super(ComputeDeltas, self).__init__()
         self.win_length = win_length
-        self.mode = mode
+        self.mode = torch.jit.Attribute(mode, str)
 
     @torch.jit.script_method
     def forward(self, specgram):


### PR DESCRIPTION
This PR adds a functional/transform/compliance to compute the deltas of MFCC features, see also [here](http://practicalcryptography.com/miscellaneous/machine-learning/guide-mel-frequency-cepstral-coefficients-mfccs/#deltas-and-delta-deltas).
* The effect at the boundary follows Kaldi's convention of replicating the values (see [here](https://kaldi-asr.org/doc/feature-functions_8h_source.html)).
* To compute the deltas-deltas, simply compute the deltas on the deltas (though Kaldi has a `order` parameter to compute higher order deltas). The compliance interface loops over the order to computer higher order differences.
* This function simply returns the deltas. Kaldi instead appends them to the set of available features, see [here](https://github.com/kaldi-asr/kaldi/blob/master/src/featbin/add-deltas.cc)

To do:
- [ ] ~~Add a test comparing with Kaldi's add_deltas. (leaving off this PR)~~

CC @cpuhrsch @mravanelli