### PR TITLE
Use older numpy for python 2.7

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -50,6 +50,14 @@ source activate testenv
  # Install requirements via pip in our conda environment
 pip install -r requirements.txt
 
+ # TODO Remove python version check once python 2.7 is deprecated
+ver=$(python -c"import sys; print(sys.version_info.major)")
+if [ $ver -eq 2 ]; then
+    pip install numpy=1.10
+else
+    pip install numpy
+fi
+
  # Install the following only if running tests
 if [[ "$SKIP_INSTALL" != "true" ]]; then
      # TorchAudio CPP Extensions

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -53,7 +53,7 @@ pip install -r requirements.txt
  # TODO Remove python version check once python 2.7 is deprecated
 ver=$(python -c"import sys; print(sys.version_info.major)")
 if [ $ver -eq 2 ]; then
-    pip install numpy=1.10
+    pip install 'numpy==1.10'
 else
     pip install numpy
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch>=1.2.0
 
 # Optional for torchaudio.kaldi_io
-numpy
+# numpy  # TODO add back when python 2.7 is deprecated
 kaldi_io
 
 # Required for tests only:


### PR DESCRIPTION
Conda builds for torchaudio have been failing recently. This may be due to numpy having dropped python 2.7 support in recent versions.