### PR TITLE
istft: torch.eye dtype conforms to stft_matrix.

### DIFF
--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -137,7 +137,7 @@ def istft(stft_matrix,          # type: Tensor
     # each column of a channel is a frame which needs to be overlap added at the right place
     ytmp = ytmp.transpose(1, 2)  # size (channel, n_fft, n_frames)
 
-    eye = torch.eye(n_fft, requires_grad=False,
+    eye = torch.eye(n_fft, requires_grad=False, dtype=ytmp.dtype,
                     device=device, dtype=dtype).unsqueeze(1)  # size (n_fft, 1, n_fft)
 
     # this does overlap add where the frames of ytmp are added such that the i'th frame of


### PR DESCRIPTION
In `torchaudio.functional.istft`, `eye = torch.eye` should manually be typecast to that of `stft_matrix` or `ytmp`, because otherwise, when `stft_matrix`/`ytmp` is `torch.float64`, `eye` still defaults to `torch.float32` and causes a `RuntimeError: expected scalar type Double but found Float`