### PR TITLE
Fix lfilter for GPU machine

### DIFF
--- a/test/test_functional_filtering.py
+++ b/test/test_functional_filtering.py
@@ -87,7 +87,7 @@ class TestFunctionalFiltering(unittest.TestCase):
 
         self._test_lfilter(waveform, torch.device("cpu"))
 
-    def test_lfilter_gpu(self):  
+    def test_lfilter_gpu(self):
         if torch.cuda.is_available():
             filepath = os.path.join(self.test_dirpath, "assets", "whitenoise.mp3")
             waveform, _ = torchaudio.load(filepath, normalization=True)

--- a/test/test_functional_filtering.py
+++ b/test/test_functional_filtering.py
@@ -99,7 +99,6 @@ class TestFunctionalFiltering(unittest.TestCase):
             print("skipping GPU test for lfilter because device not available")
             pass
 
-    @unittest.skip
     def test_lowpass(self):
 
         """
@@ -119,7 +118,6 @@ class TestFunctionalFiltering(unittest.TestCase):
 
         assert torch.allclose(sox_output_waveform, output_waveform, atol=1e-4)
 
-    @unittest.skip
     def test_highpass(self):
         """
         Test biquad highpass filter, compare to SoX implementation
@@ -139,7 +137,6 @@ class TestFunctionalFiltering(unittest.TestCase):
         # TBD - this fails at the 1e-4 level, debug why
         assert torch.allclose(sox_output_waveform, output_waveform, atol=1e-3)
 
-    @unittest.skip
     def test_perf_biquad_filtering(self):
 
         fn_sine = os.path.join(self.test_dirpath, "assets", "whitenoise.mp3")

--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -27,7 +27,8 @@ def load(filepath,
          offset=0,
          signalinfo=None,
          encodinginfo=None,
-         filetype=None):
+         filetype=None,
+         device=None):
     r"""Loads an audio file from disk into a tensor
 
     Args:
@@ -50,6 +51,8 @@ def load(filepath,
             audio type cannot be automatically determined. (Default: ``None``)
         filetype (str, optional): A filetype or extension to be set if sox cannot determine it
             automatically. (Default: ``None``)
+        device (torch.device, optional): A device type can be passed in to create output tensor on, otherwise
+            default to CPU
 
     Returns:
         Tuple[torch.Tensor, int]: An output tensor of size `[C x L]` or `[L x C]` where L is the number
@@ -77,7 +80,10 @@ def load(filepath,
     if out is not None:
         check_input(out)
     else:
-        out = torch.FloatTensor()
+        if device is None:
+            out = torch.FloatTensor()
+        else:
+            out = torch.FloatTensor(device=device)
 
     if num_frames < -1:
         raise ValueError("Expected value for num_samples -1 (entire file) or >=0")

--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -50,8 +50,6 @@ def load(filepath,
             audio type cannot be automatically determined. (Default: ``None``)
         filetype (str, optional): A filetype or extension to be set if sox cannot determine it
             automatically. (Default: ``None``)
-        device (torch.device, optional): A device type can be passed in to create output tensor on, otherwise
-            default to CPU
 
     Returns:
         Tuple[torch.Tensor, int]: An output tensor of size `[C x L]` or `[L x C]` where L is the number
@@ -80,7 +78,7 @@ def load(filepath,
         check_input(out)
     else:
         out = torch.FloatTensor()
-        
+
     if num_frames < -1:
         raise ValueError("Expected value for num_samples -1 (entire file) or >=0")
     if offset < 0:

--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -27,8 +27,7 @@ def load(filepath,
          offset=0,
          signalinfo=None,
          encodinginfo=None,
-         filetype=None,
-         device=None):
+         filetype=None):
     r"""Loads an audio file from disk into a tensor
 
     Args:
@@ -80,11 +79,8 @@ def load(filepath,
     if out is not None:
         check_input(out)
     else:
-        if device is None:
-            out = torch.FloatTensor()
-        else:
-            out = torch.FloatTensor(device=device)
-
+        out = torch.FloatTensor()
+        
     if num_frames < -1:
         raise ValueError("Expected value for num_samples -1 (entire file) or >=0")
     if offset < 0:

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -600,7 +600,6 @@ def biquad(waveform, b0, b1, b2, a0, a1, a2):
 
 
 def _dB2Linear(x):
-    import math
     return math.exp(x * math.log(10) / 20.0)
 
 

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -523,7 +523,7 @@ def lfilter(waveform, a_coeffs, b_coeffs):
                                  Must be same size as a_coeffs (pad with 0's as necessary).
 
     Returns:
-        output_waveform (torch.Tensor): Dimension of `(n_channel, n_frames)`.  Output will be clipped to -1 to 1. 
+        output_waveform (torch.Tensor): Dimension of `(n_channel, n_frames)`.  Output will be clipped to -1 to 1.
                                         Will be on the same device as the inputs.
 
     """


### PR DESCRIPTION
I took master and tested on a GPU machine, passing in inputs that are tensors on GPU.  Failed due to internal tensors being created on CPU.

Fixed this, and added testing for GPU path if available.