### PR TITLE
standardizing n_*

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Quick Usage
 
 ```python
 import torchaudio
-sound, sample_rate = torchaudio.load('foo.mp3')
-torchaudio.save('foo_save.mp3', sound, sample_rate) # saves tensor to file
+waveform, sample_rate = torchaudio.load('foo.mp3')  # load tensor from file
+torchaudio.save('foo_save.mp3', waveform, sample_rate)  # save tensor to file
 ```
 
 API Reference
@@ -118,7 +118,7 @@ dimension (channel, time)")
 * `win_length`: the length of the STFT window
 * `window_fn`: for functions that creates windows e.g. `torch.hann_window`
 
-Transforms expect the following dimensions.
+Transforms expect and return the following dimensions.
 
 * `Spectrogram`: (channel, time) -> (channel, freq, time)
 * `AmplitudeToDB`: (channel, freq, time) -> (channel, freq, time)

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -62,7 +62,7 @@ class Spectrogram(torch.jit.ScriptModule):
         Returns:
             torch.Tensor: Dimension (channel, freq, time), where channel
             is unchanged, freq is ``n_fft // 2 + 1`` where ``n_fft`` is the number of
-            Fourier bins, and time is the number of window hops (n_frames).
+            Fourier bins, and time is the number of window hops (n_frame).
         """
         return F.spectrogram(waveform, self.pad, self.window, self.n_fft, self.hop_length,
                              self.win_length, self.power, self.normalized)
@@ -409,9 +409,9 @@ class ComputeDeltas(torch.jit.ScriptModule):
     def forward(self, specgram):
         r"""
         Args:
-            specgram (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)
+            specgram (torch.Tensor): Tensor of audio of dimension (channel, freq, time)
 
         Returns:
-            deltas (torch.Tensor): Tensor of audio of dimension (channel, n_mfcc, time)
+            deltas (torch.Tensor): Tensor of audio of dimension (channel, freq, time)
         """
         return F.compute_deltas(specgram, win_length=self.win_length, mode=self.mode)


### PR DESCRIPTION
We want to clarify the naming of `n_*` variables, initiated by #293. Documentation of standardization in [README](https://github.com/pytorch/audio/blob/master/README.md).