### PR TITLE
Revert "Revert "Change Tensor.data<T> to Tensor.data_ptr<T>

### DIFF
--- a/torchaudio/torch_sox.cpp
+++ b/torchaudio/torch_sox.cpp
@@ -37,7 +37,7 @@ int64_t write_audio(SoxDescriptor& fd, at::Tensor tensor) {
   std::vector<sox_sample_t> buffer(tensor.numel());
 
   AT_DISPATCH_ALL_TYPES(tensor.scalar_type(), "write_audio_buffer", [&] {
-    auto* data = tensor.data<scalar_t>();
+    auto* data = tensor.data_ptr<scalar_t>();
     std::copy(data, data + tensor.numel(), buffer.begin());
   });
 
@@ -64,7 +64,7 @@ void read_audio(
   output = output.contiguous();
 
   AT_DISPATCH_ALL_TYPES(output.scalar_type(), "read_audio_buffer", [&] {
-    auto* data = output.data<scalar_t>();
+    auto* data = output.data_ptr<scalar_t>();
     std::copy(buffer.begin(), buffer.begin() + samples_read, data);
   });
 }
@@ -370,7 +370,7 @@ int build_flow_effects(const std::string& file_name,
   const int64_t samples_read = sox_read(input, samples.data(), buffer_size);
   assert(samples_read != nc * ns && samples_read != 0);
   AT_DISPATCH_ALL_TYPES(otensor.scalar_type(), "effects_buffer", [&] {
-    auto* data = otensor.data<scalar_t>();
+    auto* data = otensor.data_ptr<scalar_t>();
     std::copy(samples.begin(), samples.begin() + samples_read, data);
   });
   // free buffer and close mem_read


### PR DESCRIPTION
Re-implement #261 which was reverted in #265.

This reverts commit 962c6b0f7f6efbd17349e4cf2fedfe6d2450aad1.