### PR TITLE
Resume download

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,5 @@ pytest
 
 # Testing only Py3 compat
 backports.tempfile
+
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,3 @@ pytest
 
 # Testing only Py3 compat
 backports.tempfile
-
-requests

--- a/torchaudio/datasets/utils.py
+++ b/torchaudio/datasets/utils.py
@@ -202,7 +202,7 @@ def validate_file(filepath, hash_value, hash_type="sha256"):
     Args:
         filepath (str): File to read.
         hash_value (str): Hash for url.
-        hash_type (str): Hash type.
+        hash_type (str): Hash type, among "sha256" and "md5".
     """
 
     if hash_type == "sha256":

--- a/torchaudio/datasets/utils.py
+++ b/torchaudio/datasets/utils.py
@@ -104,7 +104,7 @@ def stream_url(url, start_byte=None, block_size=32 * 1024, progress_bar=True):
             pbar.update(len(chunk))
 
 
-def download_single_url(
+def download_url(
     url,
     download_folder,
     filename=None,
@@ -162,38 +162,6 @@ def download_single_url(
                 filepath
             )
         )
-
-
-def download_url(urls, *args, max_workers=5, **kwargs):
-    """Download urls to disk. The other arguments are passed to download_single_url.
-
-    Args:
-        urls (str or List[str]): List of urls.
-        max_workers (int): Maximum number of workers.
-    """
-
-    if isinstance(urls, str):
-        return download_single_url(urls, *args, **kwargs)
-
-    # Turn arguments into lists
-    args = list(args)
-    for i, item in enumerate(args):
-        if not isinstance(item, list):
-            args[i] = [item] * len(urls)
-    args = list(zip(*args))
-
-    # Turn keyword arguments into lists
-    for key, value in kwargs.items():
-        if not isinstance(value, list):
-            kwargs[key] = [value] * len(urls)
-    kwargs = [dict(zip(kwargs.keys(), values)) for values in zip(*(kwargs.values()))]
-
-    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = [
-            executor.submit(download_single_url, url, *arg, **kwarg)
-            for url, arg, kwarg in zip(urls, args, kwargs)
-        ]
-        return concurrent.futures.as_completed(futures)
 
 
 def validate_file(filepath, hash_value, hash_type="sha256"):

--- a/torchaudio/datasets/utils.py
+++ b/torchaudio/datasets/utils.py
@@ -1,6 +1,6 @@
+import concurrent.futures
 import csv
 import errno
-import gzip
 import hashlib
 import logging
 import os
@@ -12,7 +12,6 @@ from queue import Queue
 
 import six
 import torch
-import torchaudio
 from six.moves import urllib
 from torch.utils.data import Dataset
 from torch.utils.model_zoo import tqdm
@@ -81,7 +80,7 @@ def stream_url(url, start_byte=None, block_size=32 * 1024, progress_bar=True):
     req = urllib.request.Request(url, method="HEAD")
     url_size = int(urllib.request.urlopen(req).info().get("Content-Length", -1))
     if url_size == start_byte:
-        raise StopIteration
+        return
 
     req = urllib.request.Request(url)
     if start_byte:
@@ -105,7 +104,7 @@ def stream_url(url, start_byte=None, block_size=32 * 1024, progress_bar=True):
             pbar.update(len(chunk))
 
 
-def download_url(
+def download_single_url(
     url,
     download_folder,
     filename=None,
@@ -147,12 +146,11 @@ def download_url(
     if hash_value and local_size == int(req_info.get("Content-Length", -1)):
         if validate_file(filepath, hash_value, hash_type):
             return
-        else:
-            raise RuntimeError(
-                "The hash of {} does not match. Delete the file manually and retry.".format(
-                    filepath
-                )
+        raise RuntimeError(
+            "The hash of {} does not match. Delete the file manually and retry.".format(
+                filepath
             )
+        )
 
     with open(filepath, mode) as fpointer:
         for chunk in stream_url(url, start_byte=local_size, progress_bar=progress_bar):
@@ -164,6 +162,38 @@ def download_url(
                 filepath
             )
         )
+
+
+def download_url(urls, *args, max_workers=5, **kwargs):
+    """Download urls to disk. The other arguments are passed to download_single_url.
+
+    Args:
+        urls (str or List[str]): List of urls.
+        max_workers (int): Maximum number of workers.
+    """
+
+    if isinstance(urls, str):
+        return download_single_url(urls, *args, **kwargs)
+
+    # Turn arguments into lists
+    args = list(args)
+    for i, item in enumerate(args):
+        if not isinstance(item, list):
+            args[i] = [item] * len(urls)
+    args = list(zip(*args))
+
+    # Turn keyword arguments into lists
+    for key, value in kwargs.items():
+        if not isinstance(value, list):
+            kwargs[key] = [value] * len(urls)
+    kwargs = [dict(zip(kwargs.keys(), values)) for values in zip(*(kwargs.values()))]
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [
+            executor.submit(download_single_url, url, *arg, **kwarg)
+            for url, arg, kwarg in zip(urls, args, kwargs)
+        ]
+        return concurrent.futures.as_completed(futures)
 
 
 def validate_file(filepath, hash_value, hash_type="sha256"):

--- a/torchaudio/datasets/utils.py
+++ b/torchaudio/datasets/utils.py
@@ -159,31 +159,31 @@ def download_url(
             fpointer.write(chunk)
 
 
-def validate_download_url(filepath, hash_value, hash_type="sha256"):
+def validate_file(filepath, hash_value, hash_type="sha256"):
     """Validate a given file with its hash.
 
     Args:
-        url (str): Url.
-        download_folder (str): Folder to download file.
+        filepath (str): File to read.
         hash_value (str): Hash for url.
         hash_type (str): Hash type.
     """
 
     if hash_type == "sha256":
-        sha = hashlib.sha256()
+        hash_func = hashlib.sha256()
     elif hash_type == "md5":
-        sha = hashlib.md5()
+        hash_func = hashlib.md5()
     else:
         raise ValueError
 
     with open(filepath, "rb") as f:
         while True:
-            chunk = f.read(1000 * 1000)  # 1MB so that memory is not exhausted
+            # Read by chunk to avoid filling memory
+            chunk = f.read(1024 ** 2)
             if not chunk:
                 break
-            sha.update(chunk)
+            hash_func.update(chunk)
 
-    return sha.hexdigest() == hash_value
+    return hash_func.hexdigest() == hash_value
 
 
 def extract_archive(from_path, to_path=None, overwrite=False):

--- a/torchaudio/datasets/utils.py
+++ b/torchaudio/datasets/utils.py
@@ -135,7 +135,7 @@ def download_single_url(
     if resume and os.path.exists(filepath):
         mode = "ab"
         local_size = os.path.getsize(filepath)
-    elif resume and os.path.exists(filepath):
+    elif not resume and os.path.exists(filepath):
         raise RuntimeError(
             "{} already exists. Delete the file manually and retry.".format(filepath)
         )

--- a/torchaudio/datasets/utils.py
+++ b/torchaudio/datasets/utils.py
@@ -1,4 +1,3 @@
-import concurrent.futures
 import csv
 import errno
 import hashlib

--- a/torchaudio/datasets/utils.py
+++ b/torchaudio/datasets/utils.py
@@ -120,7 +120,7 @@ def download_single_url(
         download_folder (str): Folder to download file.
         filename (str): Name of downloaded file. If None, it is inferred from the url.
         hash_value (str): Hash for url.
-        hash_type (str): Hash type.
+        hash_type (str): Hash type, among "sha256" and "md5".
         progress_bar (bool): Display a progress bar.
         resume (bool): Enable resuming download.
     """


### PR DESCRIPTION
This adds resume to download function, and a validate function with md5 or sha256, from pytorch/pytorch#24915.

Following [this](https://tobiasraabe.github.io/blog/how-to-download-files-with-python.html), it was tested using:
```python
    def test_download_url(self):

        url = "http://www.patentsview.org/data/20171226/botanic.tsv.zip"
        hash_url = "94c642405619b20ecaf657b30e84bab787320649e751ed6ac629c0be613ded44"

        download_folder = "."
        download_url(url, download_folder)
        validate_download_url(url, download_folder, hash_url)
```
Do we have a url we can use to test? I'm leaning toward not having a test like this that would ping a url with every batch of test.

See 
* [another example](https://gist.github.com/mjohnsullivan/9322154#file-download-py-L32).
* [using keep alive](https://stackoverflow.com/questions/25239650/python-requests-speed-up-using-keep-alive)