### PR TITLE
Complex STFT transform from spectrogram

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -313,6 +313,20 @@ class Tester(unittest.TestCase):
         computed = transform(specgram)
         self.assertTrue(computed.shape == specgram.shape, (computed.shape, specgram.shape))
 
+    def test_batch_spectrogram(self):
+        waveform, sample_rate = torchaudio.load(self.test_filepath)  # (2, 278756), 44100
+
+        # Single then transform then batch
+        expected = transforms.Spectrogram()(waveform).unsqueeze(0).repeat(3,1,1,1)
+
+        # Batch then transform
+        waveform = waveform.unsqueeze(0).repeat(3,1,1)
+        computed = transforms.Spectrogram()(waveform)
+
+        # shape = (3, 2, 201, 1394)
+        self.assertTrue(computed.shape == expected.shape, (computed.shape, expected.shape))
+        self.assertTrue(torch.allclose(computed, expected))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -314,16 +314,14 @@ class Tester(unittest.TestCase):
         self.assertTrue(computed.shape == specgram.shape, (computed.shape, specgram.shape))
 
     def test_batch_spectrogram(self):
-        waveform, sample_rate = torchaudio.load(self.test_filepath)  # (2, 278756), 44100
+        waveform, sample_rate = torchaudio.load(self.test_filepath)
 
         # Single then transform then batch
-        expected = Transform()(waveform).unsqueeze(0).repeat(3, 1, 1, 1)
+        expected = transforms.Spectrogram()(waveform).repeat(3, 1, 1, 1)
 
         # Batch then transform
-        waveform = waveform.unsqueeze(0).repeat(3, 1, 1)
-        computed = transforms.Spectrogram()(waveform)
+        computed = transforms.Spectrogram()(waveform.repeat(3, 1, 1))
 
-        # shape = (3, 2, 201, 1394)
         self.assertTrue(computed.shape == expected.shape, (computed.shape, expected.shape))
         self.assertTrue(torch.allclose(computed, expected))
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -317,10 +317,10 @@ class Tester(unittest.TestCase):
         waveform, sample_rate = torchaudio.load(self.test_filepath)  # (2, 278756), 44100
 
         # Single then transform then batch
-        expected = transforms.Spectrogram()(waveform).unsqueeze(0).repeat(3,1,1,1)
+        expected = Transform()(waveform).unsqueeze(0).repeat(3, 1, 1, 1)
 
         # Batch then transform
-        waveform = waveform.unsqueeze(0).repeat(3,1,1)
+        waveform = waveform.unsqueeze(0).repeat(3, 1, 1)
         computed = transforms.Spectrogram()(waveform)
 
         # shape = (3, 2, 201, 1394)

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -241,7 +241,6 @@ def spectrogram(
         is unchanged, freq is ``n_fft // 2 + 1`` and ``n_fft`` is the number of
         Fourier bins, and time is the number of window hops (n_frame).
     """
-    assert waveform.dim() == 2
 
     if pad > 0:
         # TODO add "with torch.no_grad():" back when JIT supports it

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -221,7 +221,8 @@ def spectrogram(
     r"""
     spectrogram(waveform, pad, window, n_fft, hop_length, win_length, power, normalized)
 
-    Create a spectrogram from a raw audio signal.
+    Create a spectrogram or a batch of spectrograms from a raw audio signal.
+    The spectrogram can be either magnitude-only or complex.
 
     Args:
         waveform (torch.Tensor): Tensor of audio of dimension (*, channel, time)
@@ -232,7 +233,7 @@ def spectrogram(
         win_length (int): Window size
         power (int): Exponent for the magnitude spectrogram,
             (must be > 0) e.g., 1 for energy, 2 for power, etc.
-            If None, then the complex spectrum is returned.
+            If None, then the complex spectrum is returned instead.
         normalized (bool): Whether to normalize by magnitude after stft
 
     Returns:

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -548,36 +548,6 @@ def phase_vocoder(complex_specgrams, rate, phase_advance):
 
 
 @torch.jit.script
-def stft(waveform, pad, window, n_fft, hop_length, win_length):
-    # type: (Tensor, int, Tensor, int, int, int) -> Tensor
-    r"""Create a spectrogram from a raw audio signal.
-
-    Args:
-        waveform (torch.Tensor): Tensor of audio of dimension (channel, time)
-        pad (int): Two sided padding of signal
-        window (torch.Tensor): Window tensor that is applied/multiplied to each frame/window
-        n_fft (int): Size of FFT
-        hop_length (int): Length of hop between STFT windows
-        win_length (int): Window size
-
-    Returns:
-        torch.Tensor: Dimension (channel, freq, time), where channel
-        is unchanged, freq is ``n_fft // 2 + 1`` where ``n_fft`` is the number of
-        Fourier bins, and time is the number of window hops (n_frames).
-    """
-    assert waveform.dim() == 2
-
-    if pad > 0:
-        # TODO add "with torch.no_grad():" back when JIT supports it
-        waveform = torch.nn.functional.pad(waveform, (pad, pad), "constant")
-
-    # default values are consistent with librosa.core.spectrum._spectrogram
-    spec_f = _stft(waveform, n_fft, hop_length, win_length, window,
-                   True, 'reflect', False, True)
-    return spec_f
-
-
-@torch.jit.script
 def lfilter(waveform, a_coeffs, b_coeffs):
     # type: (Tensor, Tensor, Tensor) -> Tensor
     r"""

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -225,7 +225,7 @@ def spectrogram(
     Create a spectrogram from a raw audio signal.
 
     Args:
-        waveform (torch.Tensor): Tensor of audio of dimension (channel, time)
+        waveform (torch.Tensor): Tensor of audio of dimension ([batch,] channel, time)
         pad (int): Two sided padding of signal
         window (torch.Tensor): Window tensor that is applied/multiplied to each frame/window
         n_fft (int): Size of FFT
@@ -237,7 +237,7 @@ def spectrogram(
         normalized (bool): Whether to normalize by magnitude after stft
 
     Returns:
-        torch.Tensor: Dimension (channel, freq, time), where channel
+        torch.Tensor: Dimension ([batch,] channel, freq, time), where channel
         is unchanged, freq is ``n_fft // 2 + 1`` and ``n_fft`` is the number of
         Fourier bins, and time is the number of window hops (n_frame).
     """
@@ -262,6 +262,7 @@ def spectrogram(
         spec_f /= window.pow(2).sum().sqrt()
     if power is not None:
         spec_f = spec_f.pow(power).sum(-1)  # get power of "complex" tensor
+
     return spec_f
 
 

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -96,8 +96,7 @@ def istft(
 
     Args:
         stft_matrix (torch.Tensor): Output of stft where each row of a channel is a frequency and each
-            column is a window. it has a size of either (channel, fft_size, n_frame, 2) or (
-            fft_size, n_frame, 2)
+            column is a window. it has a size of either (*, fft_size, n_frame, 2)
         n_fft (int): Size of Fourier transform
         hop_length (Optional[int]): The distance between neighboring sliding window frames.
             (Default: ``win_length // 4``)
@@ -225,7 +224,7 @@ def spectrogram(
     Create a spectrogram from a raw audio signal.
 
     Args:
-        waveform (torch.Tensor): Tensor of audio of dimension ([batch,] channel, time)
+        waveform (torch.Tensor): Tensor of audio of dimension (*, channel, time)
         pad (int): Two sided padding of signal
         window (torch.Tensor): Window tensor that is applied/multiplied to each frame/window
         n_fft (int): Size of FFT
@@ -237,7 +236,7 @@ def spectrogram(
         normalized (bool): Whether to normalize by magnitude after stft
 
     Returns:
-        torch.Tensor: Dimension ([batch,] channel, freq, time), where channel
+        torch.Tensor: Dimension (*, channel, freq, time), where channel
         is unchanged, freq is ``n_fft // 2 + 1`` and ``n_fft`` is the number of
         Fourier bins, and time is the number of window hops (n_frame).
     """

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -96,7 +96,7 @@ def istft(
 
     Args:
         stft_matrix (torch.Tensor): Output of stft where each row of a channel is a frequency and each
-            column is a window. it has a size of either (*, fft_size, n_frame, 2)
+            column is a window. it has a size of either (..., fft_size, n_frame, 2)
         n_fft (int): Size of Fourier transform
         hop_length (Optional[int]): The distance between neighboring sliding window frames.
             (Default: ``win_length // 4``)
@@ -225,7 +225,7 @@ def spectrogram(
     The spectrogram can be either magnitude-only or complex.
 
     Args:
-        waveform (torch.Tensor): Tensor of audio of dimension (*, channel, time)
+        waveform (torch.Tensor): Tensor of audio of dimension (..., channel, time)
         pad (int): Two sided padding of signal
         window (torch.Tensor): Window tensor that is applied/multiplied to each frame/window
         n_fft (int): Size of FFT
@@ -237,7 +237,7 @@ def spectrogram(
         normalized (bool): Whether to normalize by magnitude after stft
 
     Returns:
-        torch.Tensor: Dimension (*, channel, freq, time), where channel
+        torch.Tensor: Dimension (..., channel, freq, time), where channel
         is unchanged, freq is ``n_fft // 2 + 1`` and ``n_fft`` is the number of
         Fourier bins, and time is the number of window hops (n_frame).
     """
@@ -440,11 +440,11 @@ def complex_norm(complex_tensor, power=1.0):
     r"""Compute the norm of complex tensor input.
 
     Args:
-        complex_tensor (torch.Tensor): Tensor shape of `(*, complex=2)`
+        complex_tensor (torch.Tensor): Tensor shape of `(..., complex=2)`
         power (float): Power of the norm. (Default: `1.0`).
 
     Returns:
-        torch.Tensor: Power of the normed input tensor. Shape of `(*, )`
+        torch.Tensor: Power of the normed input tensor. Shape of `(..., )`
     """
     if power == 1.0:
         return torch.norm(complex_tensor, 2, -1)
@@ -457,10 +457,10 @@ def angle(complex_tensor):
     r"""Compute the angle of complex tensor input.
 
     Args:
-        complex_tensor (torch.Tensor): Tensor shape of `(*, complex=2)`
+        complex_tensor (torch.Tensor): Tensor shape of `(..., complex=2)`
 
     Return:
-        torch.Tensor: Angle of a complex tensor. Shape of `(*, )`
+        torch.Tensor: Angle of a complex tensor. Shape of `(..., )`
     """
     return torch.atan2(complex_tensor[..., 1], complex_tensor[..., 0])
 
@@ -468,10 +468,10 @@ def angle(complex_tensor):
 @torch.jit.script
 def magphase(complex_tensor, power=1.0):
     # type: (Tensor, float) -> Tuple[Tensor, Tensor]
-    r"""Separate a complex-valued spectrogram with shape `(*, 2)` into its magnitude and phase.
+    r"""Separate a complex-valued spectrogram with shape `(..., 2)` into its magnitude and phase.
 
     Args:
-        complex_tensor (torch.Tensor): Tensor shape of `(*, complex=2)`
+        complex_tensor (torch.Tensor): Tensor shape of `(..., complex=2)`
         power (float): Power of the norm. (Default: `1.0`)
 
     Returns:

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -16,7 +16,6 @@ __all__ = [
     'MuLawEncoding',
     'MuLawDecoding',
     'Resample',
-    'STFT',
     'ComplexNorm'
 ]
 
@@ -367,51 +366,6 @@ class Resample(torch.nn.Module):
             return kaldi.resample_waveform(waveform, self.orig_freq, self.new_freq)
 
         raise ValueError('Invalid resampling method: %s' % (self.resampling_method))
-
-
-class STFT(torch.jit.ScriptModule):
-    r"""Create a complex stft from a audio signal
-
-    Args:
-        n_fft (int, optional): Size of FFT, creates ``n_fft // 2 + 1`` bins
-        win_length (int): Window size. (Default: ``n_fft``)
-        hop_length (int, optional): Length of hop between STFT windows. (
-            Default: ``win_length // 2``)
-        pad (int): Two sided padding of signal. (Default: ``0``)
-        window_fn (Callable[[...], torch.Tensor]): A function to create a window tensor
-            that is applied/multiplied to each frame/window. (Default: ``torch.hann_window``)
-        wkwargs (Dict[..., ...]): Arguments for window function. (Default: ``None``)
-    """
-    __constants__ = ['n_fft', 'win_length', 'hop_length', 'pad']
-
-    def __init__(self, n_fft=400, win_length=None, hop_length=None,
-                 pad=0, window_fn=torch.hann_window, wkwargs=None):
-        super(STFT, self).__init__()
-        self.n_fft = n_fft
-        # number of FFT bins. the returned STFT result will have n_fft // 2 + 1
-        # number of frequecies due to onesided=True in torch.stft
-        self.win_length = win_length if win_length is not None else n_fft
-        self.hop_length = hop_length if hop_length is not None else self.win_length // 2
-        window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
-        self.window = torch.jit.Attribute(window, torch.Tensor)
-        self.pad = pad
-
-    @torch.jit.script_method
-    def forward(self, waveform):
-        r"""
-        Args:
-            waveform (torch.Tensor): Tensor of audio of dimension (*, channel, time)
-
-        Returns:
-            torch.Tensor: Dimension (*, channel, freq, time, complex=2), where channel
-            is unchanged, freq is ``n_fft // 2 + 1`` where ``n_fft`` is the number of
-            Fourier bins, and time is the number of window hops (n_frames).
-        """
-        shape = waveform.size()
-        waveform = waveform.reshape(-1, shape[-1])
-        complex_specgrams = F.stft(waveform, self.pad, self.window, self.n_fft, self.hop_length, self.win_length)
-
-        return complex_specgrams.reshape(shape[:-1] + complex_specgrams.shape[-3:])
 
 
 class ComplexNorm(torch.jit.ScriptModule):


### PR DESCRIPTION
We offer a layer that applies complex STFT without the power/normalization done in spectrogram. However, we do not want to overload the name "STFT" existing in pytorch, as done in the original proposal in [the proposal](https://github.com/pytorch/audio/pull/327/commits/008791c06a7ea187056f1ee48072ec37705c9148) from #285.

@ksanjeevan -- thoughts?

CC @ksanjeevan @keunwoochoi @cpuhrsch