### PR TITLE
Data points remain tuples

### DIFF
--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -15,11 +15,11 @@ class TestDatasets(unittest.TestCase):
     path = os.path.join(test_dirpath, "assets")
 
     def test_yesno(self):
-        data = YESNO(self.path, return_dict=True)
+        data = YESNO(self.path)
         data[0]
 
     def test_vctk(self):
-        data = VCTK(self.path, return_dict=True)
+        data = VCTK(self.path)
         data[0]
 
     def test_librispeech(self):

--- a/torchaudio/datasets/commonvoice.py
+++ b/torchaudio/datasets/commonvoice.py
@@ -36,8 +36,8 @@ def load_commonvoice_item(line, header, path, folder_audio):
 class COMMONVOICE(Dataset):
     """
     Create a Dataset for CommonVoice. Each item is a tuple of the form:
-    (waveform, sample_rate, dict)
-    where dict is a dictionary built from the tsv file with the following keys:
+    (waveform, sample_rate, dictionary)
+    where dictionary is a dictionary built from the tsv file with the following keys:
     client_id, path, sentence, up_votes, down_votes, age, gender, accent.
     """
 

--- a/torchaudio/datasets/commonvoice.py
+++ b/torchaudio/datasets/commonvoice.py
@@ -1,9 +1,9 @@
 import os
 
-import torchaudio
 from torch.utils.data import Dataset
-from torchaudio.datasets.utils import (download_url, extract_archive,
-                                       unicode_csv_reader)
+
+import torchaudio
+from torchaudio.datasets.utils import download_url, extract_archive, unicode_csv_reader
 
 # Default TSV should be one of
 # dev.tsv
@@ -17,24 +17,28 @@ URL = "english"
 TSV = "train.tsv"
 
 
-def load_commonvoice_item(line, path, folder_audio):
+def load_commonvoice_item(line, header, path, folder_audio):
     # Each line as the following data:
     # client_id, path, sentence, up_votes, down_votes, age, gender, accent
+
+    assert header[1] == "path"
     fileid = line[1]
 
     filename = os.path.join(path, folder_audio, fileid)
 
     waveform, sample_rate = torchaudio.load(filename)
 
-    return(waveform, sample_rate, *line)
+    dic = dict(zip(header, line))
+
+    return waveform, sample_rate, dic
 
 
 class COMMONVOICE(Dataset):
     """
     Create a Dataset for CommonVoice. Each item is a tuple of the form:
-    (waveform, sample_rate, client_id, path, sentence,
-        up_votes, down_votes, age, gender, accent)
-    following the format of the tsv-files.
+    (waveform, sample_rate, dict)
+    where dict is a dictionary built from the tsv file with the following keys:
+    client_id, path, sentence, up_votes, down_votes, age, gender, accent.
     """
 
     _ext_txt = ".txt"
@@ -104,7 +108,7 @@ class COMMONVOICE(Dataset):
 
     def __getitem__(self, n):
         line = self._walker[n]
-        return load_commonvoice_item(line, self._path, self._folder_audio)
+        return load_commonvoice_item(line, self._header, self._path, self._folder_audio)
 
     def __len__(self):
         return len(self._walker)

--- a/torchaudio/datasets/librispeech.py
+++ b/torchaudio/datasets/librispeech.py
@@ -29,13 +29,14 @@ def load_librispeech_item(fileid, path, ext_audio, ext_txt):
     waveform, sample_rate = torchaudio.load(file_audio)
 
     # Load text
-    for line in open(file_text):
-        fileid_text, content = line.strip().split(" ", 1)
-        if fileid_audio == fileid_text:
-            break
-    else:
-        # Translation not found
-        raise FileNotFoundError("Translation not found for " + fileid_audio)
+    with open(file_text) as ft:
+        for line in ft:
+            fileid_text, content = line.strip().split(" ", 1)
+            if fileid_audio == fileid_text:
+                break
+        else:
+            # Translation not found
+            raise FileNotFoundError("Translation not found for " + fileid_audio)
 
     return {
         "speaker_id": speaker,

--- a/torchaudio/datasets/librispeech.py
+++ b/torchaudio/datasets/librispeech.py
@@ -1,8 +1,7 @@
 import os
 
-from torch.utils.data import Dataset
-
 import torchaudio
+from torch.utils.data import Dataset
 from torchaudio.datasets.utils import (
     download_url,
     extract_archive,
@@ -16,14 +15,14 @@ FOLDER_IN_ARCHIVE = "LibriSpeech"
 
 def load_librispeech_item(fileid, path, ext_audio, ext_txt):
 
-    speaker, chapter, utterance = fileid.split("-")
+    speaker_id, chapter_id, utterance_id = fileid.split("-")
 
-    file_text = speaker + "-" + chapter + ext_txt
-    file_text = os.path.join(path, speaker, chapter, file_text)
+    file_text = speaker_id + "-" + chapter_id + ext_txt
+    file_text = os.path.join(path, speaker_id, chapter_id, file_text)
 
-    fileid_audio = speaker + "-" + chapter + "-" + utterance
+    fileid_audio = speaker_id + "-" + chapter_id + "-" + utterance_id
     file_audio = fileid_audio + ext_audio
-    file_audio = os.path.join(path, speaker, chapter, file_audio)
+    file_audio = os.path.join(path, speaker_id, chapter_id, file_audio)
 
     # Load audio
     waveform, sample_rate = torchaudio.load(file_audio)
@@ -31,24 +30,28 @@ def load_librispeech_item(fileid, path, ext_audio, ext_txt):
     # Load text
     with open(file_text) as ft:
         for line in ft:
-            fileid_text, content = line.strip().split(" ", 1)
+            fileid_text, utterance = line.strip().split(" ", 1)
             if fileid_audio == fileid_text:
                 break
         else:
             # Translation not found
             raise FileNotFoundError("Translation not found for " + fileid_audio)
 
-    return {
-        "speaker_id": speaker,
-        "chapter_id": chapter,
-        "utterance_id": utterance,
-        "utterance": content,
-        "waveform": waveform,
-        "sample_rate": sample_rate,
-    }
+    return (
+        waveform,
+        sample_rate,
+        utterance,
+        int(speaker_id),
+        int(chapter_id),
+        int(utterance_id),
+    )
 
 
 class LIBRISPEECH(Dataset):
+    """
+    Create a Dataset for LibriSpeech. Each item is a tuple of the form:
+    waveform, sample_rate, utterance, speaker_id, chapter_id, utterance_id
+    """
 
     _ext_txt = ".trans.txt"
     _ext_audio = ".flac"


### PR DESCRIPTION
Since this is what has been most used in domains, we keep tuples as the item to return for now.

for CommonVoice:
```
    # dictionary with keys:
    # client_id, path, sentence, up_votes, down_votes, age, gender, accent
    return waveform, sample_rate, dictionary
```
for LibriSpeech:
```
    return (
        waveform,
        sample_rate,
        utterance,
        int(speaker_id),
        int(chapter_id),
        int(utterance_id),
    )
```
for VCTK:
```
    return waveform, sample_rate, utterance, speaker_id, utterance_id
```
for YesNo:
```
    # labels = [int(c), ...]
    return waveform, sample_rate, labels
```

CC #303 