### PR TITLE
Recommend conda installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ Installation
 
 ### Binaries
 
+To install the latest version using anaconda, run:
+```
+conda install -c pytorch torchaudio
+```
+
 To install the latest pip wheels, run:
 
 ```


### PR DESCRIPTION
As done on pytorch.org, let's mention conda as the first way to install torchaudio.