### PR TITLE
Remove scale to interval from #319

### DIFF
--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -379,13 +379,6 @@ class TestFunctional(unittest.TestCase):
 
         self.assertTrue(torch.allclose(waveform_gain, sox_gain_waveform, atol=1e-04))
 
-    def test_scale_to_interval(self):
-        scaled = 5.5  # [-5.5, 5.5]
-        waveform_scaled = F._scale_to_interval(self.waveform_train, scaled)
-
-        self.assertTrue(torch.max(waveform_scaled) <= scaled)
-        self.assertTrue(torch.min(waveform_scaled) >= -scaled)
-
     def test_dither(self):
         waveform_dithered = F.dither(self.waveform_train)
         waveform_dithered_noiseshaped = F.dither(self.waveform_train, noise_shaping=True)
@@ -581,12 +574,6 @@ def test_phase_vocoder(complex_specgrams, rate, hop_length):
         gainDB = 2.0
 
         _test_torchscript_functional(F.gain, tensor, gainDB)
-
-    def test_torchscript_scale_to_interval(self):
-        tensor = torch.rand((1, 1000))
-        scaled = 3.5
-
-        _test_torchscript_functional(F._scale_to_interval, tensor, scaled)
 
     def test_torchscript_dither(self):
         tensor = torch.rand((1, 1000))

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -877,27 +877,6 @@ def gain(waveform, gain_db=1.0):
     return waveform * ratio
 
 
-def _scale_to_interval(waveform, interval_max=1.0):
-    # type: (Tensor, float) -> Tensor
-    r"""Scale the waveform to the interval [-interval_max, interval_max] across all dimensions.
-
-    Args:
-       waveform (torch.Tensor): Tensor of audio of dimension (channel, time).
-       interval_max (float): The bounds of the interval, where the float indicates
-           the upper bound and the negative of the float indicates the lower
-           bound (Default: `1.0`).
-           Example: interval=1.0 -> [-1.0, 1.0]
-
-    Returns:
-       torch.Tensor: the whole waveform scaled to interval.
-    """
-    abs_max = torch.max(torch.abs(waveform))
-    ratio = abs_max / interval_max
-    waveform /= ratio
-
-    return waveform
-
-
 def _add_noise_shaping(dithered_waveform, waveform):
     r"""Noise shaping is calculated by error:
     error[n] = dithered[n] - original[n]


### PR DESCRIPTION
Since this `_scale_to_interval` is private and not used internally, we don't need to keep it until we decide to add it back.