### PR TITLE
Move import _torch_sox inside function calls

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -143,7 +143,7 @@ class Test_LoadSave(unittest.TestCase):
             torchaudio.load(tdir)
 
     def test_3_load_and_save_is_identity(self):
-        for backend in ["sox", "pysoundfile"]:
+        for backend in ["sox", "soundfile"]:
             with self.subTest():
                 with AudioBackendScope(backend):
                     self._test_3_load_and_save_is_identity()

--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 _audio_backend = "sox"
-_audio_backends = ["sox", "pysoundfile"]
+_audio_backends = ["sox", "soundfile"]
 
 
 def set_audio_backend(backend):
@@ -102,7 +102,7 @@ def load(filepath,
 
     if get_audio_backend() == "sox":
         func = _sox_backend.load
-    elif get_audio_backend() == "pysoundfile":
+    elif get_audio_backend() == "soundfile":
         func = _soundfile_backend.load
     else:
         raise ImportError
@@ -152,7 +152,7 @@ def save(filepath, src, sample_rate, precision=16, channels_first=True):
 
     if get_audio_backend() == "sox":
         func = _sox_backend.save
-    elif get_audio_backend() == "pysoundfile":
+    elif get_audio_backend() == "soundfile":
         func = _soundfile_backend.save
     else:
         raise ImportError
@@ -253,7 +253,7 @@ def info(filepath):
 
     if get_audio_backend() == "sox":
         func = _sox_backend.info
-    elif get_audio_backend() == "pysoundfile":
+    elif get_audio_backend() == "soundfile":
         func = _soundfile_backend.info
     else:
         raise ImportError

--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -12,18 +12,19 @@ except ImportError:
 
 
 _audio_backend = "sox"
+_audio_backends = ["sox", "pysoundfile"]
 
 
 def set_audio_backend(backend):
     """
     Specifies the package used to load.
     Args:
-        backend (string): Name of the backend. one of {'sox'}.
-    """
+        backend (string): Name of the backend. One of {}.
+    """.format(_audio_backends)
     global _audio_backend
-    if backend not in ["sox"]:
+    if backend not in _audio_backends:
         raise ValueError(
-            "Invalid backend '{}'. Options are 'sox'.".format(backend)
+            "Invalid backend '{}'. Options are {}.".format(backend, _audio_backends)
         )
     _audio_backend = backend
 

--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os.path
 
 import torch
-import _torch_sox
 
 from torchaudio import transforms, datasets, kaldi_io, sox_effects, compliance
 
@@ -84,6 +83,7 @@ def load(filepath,
     if offset < 0:
         raise ValueError("Expected positive offset value")
 
+    import _torch_sox
     sample_rate = _torch_sox.read_audio_file(filepath,
                                              out,
                                              channels_first,
@@ -203,6 +203,8 @@ def save_encinfo(filepath,
         src = src.transpose(1, 0)
     # save data to file
     src = src.contiguous()
+
+    import _torch_sox
     _torch_sox.write_audio_file(filepath, src, signalinfo, encodinginfo, filetype)
 
 
@@ -220,6 +222,7 @@ def info(filepath):
          >>> si, ei = torchaudio.info('foo.wav')
          >>> rate, channels, encoding = si.rate, si.channels, ei.encoding
      """
+    import _torch_sox
     return _torch_sox.get_info(filepath)
 
 
@@ -242,6 +245,7 @@ def sox_signalinfo_t():
         >>> si.precision = 16
         >>> si.length = 0
     """
+    import _torch_sox
     return _torch_sox.sox_signalinfo_t()
 
 
@@ -274,6 +278,7 @@ def sox_encodinginfo_t():
         >>> ei.opposite_endian = torchaudio.get_sox_bool(0)
 
     """
+    import _torch_sox
     ei = _torch_sox.sox_encodinginfo_t()
     sdo = get_sox_option_t(2)  # sox_default_option
     ei.reverse_bytes = sdo
@@ -292,6 +297,9 @@ def get_sox_encoding_t(i=None):
     Returns:
         sox_encoding_t: A sox_encoding_t type for output encoding
     """
+
+    import _torch_sox
+
     if i is None:
         # one can see all possible values using the .__members__ attribute
         return _torch_sox.sox_encoding_t
@@ -309,6 +317,9 @@ def get_sox_option_t(i=2):
     Returns:
         sox_option_t: A sox_option_t type
     """
+
+    import _torch_sox
+
     if i is None:
         return _torch_sox.sox_option_t
     else:
@@ -326,6 +337,9 @@ def get_sox_bool(i=0):
     Returns:
         sox_bool: A sox_bool type
     """
+
+    import _torch_sox
+
     if i is None:
         return _torch_sox.sox_bool
     else:
@@ -337,6 +351,7 @@ def initialize_sox():
     loading.  Importantly, only run `initialize_sox` once and do not shutdown
     after each effect chain, but rather once you are finished with all effects chains.
     """
+    import _torch_sox
     return _torch_sox.initialize_sox()
 
 
@@ -344,6 +359,7 @@ def shutdown_sox():
     """Showdown sox for effects chain.  Not required for simple loading.  Importantly,
     only call once.  Attempting to re-initialize sox will result in seg faults.
     """
+    import _torch_sox
     return _torch_sox.shutdown_sox()
 
 

--- a/torchaudio/_soundfile_backend.py
+++ b/torchaudio/_soundfile_backend.py
@@ -20,43 +20,11 @@ def load(
     filetype=None,
     **_,
 ):
-    r"""Loads an audio file from disk into a tensor
+    r"""See torchaudio.load"""
 
-    Args:
-        filepath (str or pathlib.Path): Path to audio file
-        out (torch.Tensor, optional): An output tensor to use instead of creating one. (Default: ``None``)
-        normalization (bool, number, or callable, optional): If boolean `True`, then output is divided by `1 << 31`
-            (assumes signed 32-bit audio), and normalizes to `[-1, 1]`.
-            If `number`, then output is divided by that number
-            If `callable`, then the output is passed as a parameter
-            to the given function, then the output is divided by
-            the result. (Default: ``True``)
-        channels_first (bool): Set channels first or length first in result. (Default: ``True``)
-        num_frames (int, optional): Number of frames to load.  0 to load everything after the offset.
-            (Default: ``0``)
-        offset (int, optional): Number of frames from the start of the file to begin data loading.
-            (Default: ``0``)
-        filetype (str, optional): A filetype or extension to be set if not determined automatically.
-            (Default: ``None``)
-
-    Returns:
-        Tuple[torch.Tensor, int]: An output tensor of size `[C x L]` or `[L x C]` where L is the number
-        of audio frames and C is the number of channels. An integer which is the sample rate of the
-        audio (as listed in the metadata of the file)
-
-    Example
-        >>> data, sample_rate = torchaudio.load('foo.mp3')
-        >>> print(data.size())
-        torch.Size([2, 278756])
-        >>> print(sample_rate)
-        44100
-        >>> data_vol_normalized, _ = torchaudio.load('foo.mp3', normalization=lambda x: torch.abs(x).max())
-        >>> print(data_vol_normalized.abs().max())
-        1.
-
-    """
     # stringify if `pathlib.Path` (noop if already `str`)
     filepath = str(filepath)
+
     # check if valid file
     if not os.path.isfile(filepath):
         raise OSError("{} not found or is a directory".format(filepath))
@@ -90,36 +58,17 @@ def load(
 
 
 def save(filepath, src, sample_rate, channels_first=True, **_):
-    r"""Saves a tensor of an audio signal to disk as a standard format like mp3, wav, etc.
+    r"""See torchaudio.save"""
 
-    Args:
-        filepath (str): Path to audio file
-        src (torch.Tensor): An input 2D tensor of shape `[C x L]` or `[L x C]` where L is
-            the number of audio frames, C is the number of channels
-        sample_rate (int): An integer which is the sample rate of the
-            audio (as listed in the metadata of the file)
-    """
     if channels_first:
         src = src.t()
 
     import soundfile
-
     return soundfile.write(filepath, src, sample_rate)
 
 
 def info(filepath, **_):
-    r"""Gets metadata from an audio file without loading the signal.
+    r"""See torchaudio.info"""
 
-     Args:
-        filepath (str): Path to audio file
-
-     Returns:
-        Object with information about a SoundFile
-
-     Example
-         >>> si, ei = torchaudio.info('foo.wav')
-         >>> rate, channels, encoding = si.rate, si.channels, ei.encoding
-     """
     import soundfile
-
     return soundfile.info(filepath)

--- a/torchaudio/_soundfile_backend.py
+++ b/torchaudio/_soundfile_backend.py
@@ -1,0 +1,125 @@
+import os
+
+import torch
+
+
+def check_input(src):
+    if not torch.is_tensor(src):
+        raise TypeError("Expected a tensor, got %s" % type(src))
+    if src.is_cuda:
+        raise TypeError("Expected a CPU based tensor, got %s" % type(src))
+
+
+def load(
+    filepath,
+    out=None,
+    normalization=True,
+    channels_first=True,
+    num_frames=0,
+    offset=0,
+    filetype=None,
+    **_,
+):
+    r"""Loads an audio file from disk into a tensor
+
+    Args:
+        filepath (str or pathlib.Path): Path to audio file
+        out (torch.Tensor, optional): An output tensor to use instead of creating one. (Default: ``None``)
+        normalization (bool, number, or callable, optional): If boolean `True`, then output is divided by `1 << 31`
+            (assumes signed 32-bit audio), and normalizes to `[-1, 1]`.
+            If `number`, then output is divided by that number
+            If `callable`, then the output is passed as a parameter
+            to the given function, then the output is divided by
+            the result. (Default: ``True``)
+        channels_first (bool): Set channels first or length first in result. (Default: ``True``)
+        num_frames (int, optional): Number of frames to load.  0 to load everything after the offset.
+            (Default: ``0``)
+        offset (int, optional): Number of frames from the start of the file to begin data loading.
+            (Default: ``0``)
+        filetype (str, optional): A filetype or extension to be set if not determined automatically.
+            (Default: ``None``)
+
+    Returns:
+        Tuple[torch.Tensor, int]: An output tensor of size `[C x L]` or `[L x C]` where L is the number
+        of audio frames and C is the number of channels. An integer which is the sample rate of the
+        audio (as listed in the metadata of the file)
+
+    Example
+        >>> data, sample_rate = torchaudio.load('foo.mp3')
+        >>> print(data.size())
+        torch.Size([2, 278756])
+        >>> print(sample_rate)
+        44100
+        >>> data_vol_normalized, _ = torchaudio.load('foo.mp3', normalization=lambda x: torch.abs(x).max())
+        >>> print(data_vol_normalized.abs().max())
+        1.
+
+    """
+    # stringify if `pathlib.Path` (noop if already `str`)
+    filepath = str(filepath)
+    # check if valid file
+    if not os.path.isfile(filepath):
+        raise OSError("{} not found or is a directory".format(filepath))
+
+    if num_frames < -1:
+        raise ValueError("Expected value for num_samples -1 (entire file) or >=0")
+    if num_frames == 0:
+        num_frames = -1
+    if offset < 0:
+        raise ValueError("Expected positive offset value")
+
+    import soundfile
+
+    # initialize output tensor
+    # TODO remove pysoundfile and call directly soundfile to avoid going through numpy
+    if out is not None:
+        check_input(out)
+        _, sample_rate = soundfile.read(
+            filepath, frames=num_frames, start=offset, always_2d=True, out=out
+        )
+    else:
+        out, sample_rate = soundfile.read(
+            filepath, frames=num_frames, start=offset, always_2d=True
+        )
+        out = torch.tensor(out).t()
+
+    # normalize if needed
+    # _audio_normalization(out, normalization)
+
+    return out, sample_rate
+
+
+def save(filepath, src, sample_rate, channels_first=True, **_):
+    r"""Saves a tensor of an audio signal to disk as a standard format like mp3, wav, etc.
+
+    Args:
+        filepath (str): Path to audio file
+        src (torch.Tensor): An input 2D tensor of shape `[C x L]` or `[L x C]` where L is
+            the number of audio frames, C is the number of channels
+        sample_rate (int): An integer which is the sample rate of the
+            audio (as listed in the metadata of the file)
+    """
+    if channels_first:
+        src = src.t()
+
+    import soundfile
+
+    return soundfile.write(filepath, src, sample_rate)
+
+
+def info(filepath, **_):
+    r"""Gets metadata from an audio file without loading the signal.
+
+     Args:
+        filepath (str): Path to audio file
+
+     Returns:
+        Object with information about a SoundFile
+
+     Example
+         >>> si, ei = torchaudio.info('foo.wav')
+         >>> rate, channels, encoding = si.rate, si.channels, ei.encoding
+     """
+    import soundfile
+
+    return soundfile.info(filepath)

--- a/torchaudio/_sox_backend.py
+++ b/torchaudio/_sox_backend.py
@@ -1,0 +1,130 @@
+import os.path
+
+import torch
+
+import torchaudio
+
+
+def load(filepath,
+         out=None,
+         normalization=True,
+         channels_first=True,
+         num_frames=0,
+         offset=0,
+         signalinfo=None,
+         encodinginfo=None,
+         filetype=None,
+         **_):
+    r"""Loads an audio file from disk into a tensor
+
+    Args:
+        filepath (str or pathlib.Path): Path to audio file
+        out (torch.Tensor, optional): An output tensor to use instead of creating one. (Default: ``None``)
+        normalization (bool, number, or callable, optional): If boolean `True`, then output is divided by `1 << 31`
+            (assumes signed 32-bit audio), and normalizes to `[-1, 1]`.
+            If `number`, then output is divided by that number
+            If `callable`, then the output is passed as a parameter
+            to the given function, then the output is divided by
+            the result. (Default: ``True``)
+        channels_first (bool): Set channels first or length first in result. (Default: ``True``)
+        num_frames (int, optional): Number of frames to load.  0 to load everything after the offset.
+            (Default: ``0``)
+        offset (int, optional): Number of frames from the start of the file to begin data loading.
+            (Default: ``0``)
+        signalinfo (sox_signalinfo_t, optional): A sox_signalinfo_t type, which could be helpful if the
+            audio type cannot be automatically determined. (Default: ``None``)
+        encodinginfo (sox_encodinginfo_t, optional): A sox_encodinginfo_t type, which could be set if the
+            audio type cannot be automatically determined. (Default: ``None``)
+        filetype (str, optional): A filetype or extension to be set if sox cannot determine it
+            automatically. (Default: ``None``)
+
+    Returns:
+        Tuple[torch.Tensor, int]: An output tensor of size `[C x L]` or `[L x C]` where L is the number
+        of audio frames and C is the number of channels. An integer which is the sample rate of the
+        audio (as listed in the metadata of the file)
+
+    Example
+        >>> data, sample_rate = torchaudio.load('foo.mp3')
+        >>> print(data.size())
+        torch.Size([2, 278756])
+        >>> print(sample_rate)
+        44100
+        >>> data_vol_normalized, _ = torchaudio.load('foo.mp3', normalization=lambda x: torch.abs(x).max())
+        >>> print(data_vol_normalized.abs().max())
+        1.
+
+    """
+    # stringify if `pathlib.Path` (noop if already `str`)
+    filepath = str(filepath)
+    # check if valid file
+    if not os.path.isfile(filepath):
+        raise OSError("{} not found or is a directory".format(filepath))
+
+    # initialize output tensor
+    if out is not None:
+        torchaudio.check_input(out)
+    else:
+        out = torch.FloatTensor()
+
+    if num_frames < -1:
+        raise ValueError("Expected value for num_samples -1 (entire file) or >=0")
+    if offset < 0:
+        raise ValueError("Expected positive offset value")
+
+    import _torch_sox
+    sample_rate = _torch_sox.read_audio_file(
+        filepath,
+        out,
+        channels_first,
+        num_frames,
+        offset,
+        signalinfo,
+        encodinginfo,
+        filetype
+    )
+
+    # normalize if needed
+    torchaudio._audio_normalization(out, normalization)
+
+    return out, sample_rate
+
+
+def save(filepath, src, sample_rate, precision=16, channels_first=True, **_):
+    r"""Convenience function for `save_encinfo`.
+
+    Args:
+        filepath (str): Path to audio file
+        src (torch.Tensor): An input 2D tensor of shape `[C x L]` or `[L x C]` where L is
+            the number of audio frames, C is the number of channels
+        sample_rate (int): An integer which is the sample rate of the
+            audio (as listed in the metadata of the file)
+        precision (int): Bit precision (Default: ``16``)
+        channels_first (bool): Set channels first or length first in result. (
+            Default: ``True``)
+    """
+    si = torchaudio.sox_signalinfo_t()
+    ch_idx = 0 if channels_first else 1
+    si.rate = sample_rate
+    si.channels = 1 if src.dim() == 1 else src.size(ch_idx)
+    si.length = src.numel()
+    si.precision = precision
+    return torchaudio.save_encinfo(filepath, src, channels_first, si)
+
+
+def info(filepath, **_):
+    r"""Gets metadata from an audio file without loading the signal.
+
+     Args:
+        filepath (str): Path to audio file
+
+     Returns:
+        Tuple[sox_signalinfo_t, sox_encodinginfo_t]: A si (sox_signalinfo_t) signal
+        info as a python object. An ei (sox_encodinginfo_t) encoding info
+
+     Example
+         >>> si, ei = torchaudio.info('foo.wav')
+         >>> rate, channels, encoding = si.rate, si.channels, ei.encoding
+     """
+
+    import _torch_sox
+    return _torch_sox.get_info(filepath)

--- a/torchaudio/_sox_backend.py
+++ b/torchaudio/_sox_backend.py
@@ -15,45 +15,8 @@ def load(filepath,
          encodinginfo=None,
          filetype=None,
          **_):
-    r"""Loads an audio file from disk into a tensor
+    r"""See torchaudio.load"""
 
-    Args:
-        filepath (str or pathlib.Path): Path to audio file
-        out (torch.Tensor, optional): An output tensor to use instead of creating one. (Default: ``None``)
-        normalization (bool, number, or callable, optional): If boolean `True`, then output is divided by `1 << 31`
-            (assumes signed 32-bit audio), and normalizes to `[-1, 1]`.
-            If `number`, then output is divided by that number
-            If `callable`, then the output is passed as a parameter
-            to the given function, then the output is divided by
-            the result. (Default: ``True``)
-        channels_first (bool): Set channels first or length first in result. (Default: ``True``)
-        num_frames (int, optional): Number of frames to load.  0 to load everything after the offset.
-            (Default: ``0``)
-        offset (int, optional): Number of frames from the start of the file to begin data loading.
-            (Default: ``0``)
-        signalinfo (sox_signalinfo_t, optional): A sox_signalinfo_t type, which could be helpful if the
-            audio type cannot be automatically determined. (Default: ``None``)
-        encodinginfo (sox_encodinginfo_t, optional): A sox_encodinginfo_t type, which could be set if the
-            audio type cannot be automatically determined. (Default: ``None``)
-        filetype (str, optional): A filetype or extension to be set if sox cannot determine it
-            automatically. (Default: ``None``)
-
-    Returns:
-        Tuple[torch.Tensor, int]: An output tensor of size `[C x L]` or `[L x C]` where L is the number
-        of audio frames and C is the number of channels. An integer which is the sample rate of the
-        audio (as listed in the metadata of the file)
-
-    Example
-        >>> data, sample_rate = torchaudio.load('foo.mp3')
-        >>> print(data.size())
-        torch.Size([2, 278756])
-        >>> print(sample_rate)
-        44100
-        >>> data_vol_normalized, _ = torchaudio.load('foo.mp3', normalization=lambda x: torch.abs(x).max())
-        >>> print(data_vol_normalized.abs().max())
-        1.
-
-    """
     # stringify if `pathlib.Path` (noop if already `str`)
     filepath = str(filepath)
     # check if valid file
@@ -90,18 +53,8 @@ def load(filepath,
 
 
 def save(filepath, src, sample_rate, precision=16, channels_first=True, **_):
-    r"""Convenience function for `save_encinfo`.
+    r"""See torchaudio.save"""
 
-    Args:
-        filepath (str): Path to audio file
-        src (torch.Tensor): An input 2D tensor of shape `[C x L]` or `[L x C]` where L is
-            the number of audio frames, C is the number of channels
-        sample_rate (int): An integer which is the sample rate of the
-            audio (as listed in the metadata of the file)
-        precision (int): Bit precision (Default: ``16``)
-        channels_first (bool): Set channels first or length first in result. (
-            Default: ``True``)
-    """
     si = torchaudio.sox_signalinfo_t()
     ch_idx = 0 if channels_first else 1
     si.rate = sample_rate
@@ -112,19 +65,7 @@ def save(filepath, src, sample_rate, precision=16, channels_first=True, **_):
 
 
 def info(filepath, **_):
-    r"""Gets metadata from an audio file without loading the signal.
-
-     Args:
-        filepath (str): Path to audio file
-
-     Returns:
-        Tuple[sox_signalinfo_t, sox_encodinginfo_t]: A si (sox_signalinfo_t) signal
-        info as a python object. An ei (sox_encodinginfo_t) encoding info
-
-     Example
-         >>> si, ei = torchaudio.info('foo.wav')
-         >>> rate, channels, encoding = si.rate, si.channels, ei.encoding
-     """
+    r"""See torchaudio.info"""
 
     import _torch_sox
     return _torch_sox.get_info(filepath)

--- a/torchaudio/sox_effects.py
+++ b/torchaudio/sox_effects.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import torch
-import _torch_sox
 
 import torchaudio
 
@@ -13,6 +12,7 @@ def effect_names():
     Example
         >>> EFFECT_NAMES = torchaudio.sox_effects.effect_names()
     """
+    import _torch_sox
     return _torch_sox.get_effect_names()
 
 
@@ -23,6 +23,7 @@ def SoxEffect():
         SoxEffect: An object with the following attributes: ename (str) which is the
         name of effect, and eopts (List[str]) which is a list of effect options.
     """
+    import _torch_sox
     return _torch_sox.SoxEffect()
 
 
@@ -130,6 +131,8 @@ class SoxEffectsChain(object):
             self.chain.append(e)
 
         # print("effect options:", [x.eopts for x in self.chain])
+
+        import _torch_sox
         sr = _torch_sox.build_flow_effects(self.input_file,
                                            out,
                                            self.channels_first,

--- a/torchaudio/sox_effects.py
+++ b/torchaudio/sox_effects.py
@@ -12,6 +12,10 @@ def effect_names():
     Example
         >>> EFFECT_NAMES = torchaudio.sox_effects.effect_names()
     """
+
+    if torchaudio.get_audio_backend() != "sox":
+        raise ImportError
+
     import _torch_sox
     return _torch_sox.get_effect_names()
 
@@ -23,6 +27,10 @@ def SoxEffect():
         SoxEffect: An object with the following attributes: ename (str) which is the
         name of effect, and eopts (List[str]) which is a list of effect options.
     """
+
+    if torchaudio.get_audio_backend() != "sox":
+        raise ImportError
+
     import _torch_sox
     return _torch_sox.SoxEffect()
 
@@ -131,6 +139,9 @@ class SoxEffectsChain(object):
             self.chain.append(e)
 
         # print("effect options:", [x.eopts for x in self.chain])
+
+        if torchaudio.get_audio_backend() != "sox":
+            raise ImportError
 
         import _torch_sox
         sr = _torch_sox.build_flow_effects(self.input_file,

--- a/torchaudio/sox_effects.py
+++ b/torchaudio/sox_effects.py
@@ -80,7 +80,6 @@ class SoxEffectsChain(object):
 
     """
 
-    EFFECTS_AVAILABLE = set(effect_names())
     EFFECTS_UNIMPLEMENTED = set(["spectrogram", "splice", "noiseprof", "fir"])
 
     def __init__(self, normalization=True, channels_first=True, out_siginfo=None, out_encinfo=None, filetype="raw"):
@@ -92,6 +91,9 @@ class SoxEffectsChain(object):
         self.filetype = filetype
         self.normalization = normalization
         self.channels_first = channels_first
+
+        # Define in __init__ to avoid calling at import time
+        self.EFFECTS_AVAILABLE = set(effect_names())
 
     def append_effect_to_chain(self, ename, eargs=None):
         r"""Append effect to a sox effects chain.


### PR DESCRIPTION
Import sox only when sox is used at runtime, e.g. sox_effects or loading files, from #355. As noted [here](https://github.com/pytorch/audio/pull/355#discussion_r353811539), repeated imports of `_torch_sox` do seem to properly hit cache.