### PR TITLE
Module GPU test fixes

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -82,7 +82,7 @@ class Tester(unittest.TestCase):
         self.assertTrue(waveform_exp.min() >= -1. and waveform_exp.max() <= 1.)
 
     def test_scriptmodule_AmplitudeToDB(self):
-        spec = torch.rand((6, 201))
+        spec = torch.rand((1, 201, 6))
         _test_script_module(transforms.AmplitudeToDB, spec)
 
     def test_scriptmodule_MelScale(self):

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -82,7 +82,7 @@ class Tester(unittest.TestCase):
         self.assertTrue(waveform_exp.min() >= -1. and waveform_exp.max() <= 1.)
 
     def test_scriptmodule_AmplitudeToDB(self):
-        spec = torch.rand((1, 201, 6))
+        spec = torch.rand((6, 201))
         _test_script_module(transforms.AmplitudeToDB, spec)
 
     def test_scriptmodule_MelScale(self):

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -51,7 +51,7 @@ class Spectrogram(torch.nn.Module):
         self.win_length = win_length if win_length is not None else n_fft
         self.hop_length = hop_length if hop_length is not None else self.win_length // 2
         window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
-        self.window = window
+        self.register_buffer('window', window)
         self.pad = pad
         self.power = power
         self.normalized = normalized
@@ -136,7 +136,7 @@ class MelScale(torch.nn.Module):
 
         fb = torch.empty(0) if n_stft is None else F.create_fb_matrix(
             n_stft, self.f_min, self.f_max, self.n_mels, self.sample_rate)
-        self.fb = fb
+        self.register_buffer('fb', fb)
 
     def forward(self, specgram):
         r"""
@@ -260,7 +260,7 @@ class MFCC(torch.nn.Module):
         if self.n_mfcc > self.MelSpectrogram.n_mels:
             raise ValueError('Cannot select more MFCC coefficients than # mel bins')
         dct_mat = F.create_dct(self.n_mfcc, self.MelSpectrogram.n_mels, self.norm)
-        self.dct_mat = dct_mat
+        self.register_buffer('dct_mat', dct_mat)
         self.log_mels = log_mels
 
     def forward(self, waveform):


### PR DESCRIPTION
Tensors initialized but not registered as buffers during module instantiation do not move when the module is moved to another device. This fix registers such tensors as buffers so that they are automatically moved when the module moves.