### PR TITLE
Improve lfilter functional

### DIFF
--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -581,7 +581,6 @@ def lfilter(waveform, a_coeffs, b_coeffs):
 
     # Set up a few other utilities
     a0_repeated = torch.ones(n_channel, dtype=dtype, device=device) * a_coeffs[0]
-    ones = torch.ones(n_channel, n_sample, dtype=dtype, device=device)
 
     for i_sample in range(n_sample):
 
@@ -597,9 +596,7 @@ def lfilter(waveform, a_coeffs, b_coeffs):
 
         padded_output_waveform[:, i_sample + n_order - 1] = o0
 
-    output = torch.min(
-        ones, torch.max(ones * -1, padded_output_waveform[:, (n_order - 1):])
-    )
+    output = torch.clamp(padded_output_waveform[:, (n_order - 1):], min=-1., max=1.)
 
     # unpack batch
     output = output.reshape(shape[:-1] + output.shape[-1:])


### PR DESCRIPTION
I made the following improvements to the `lfilter` functional code.

* use `torch.clamp` instead of `torch.min(..., torch.max(...))`
* remove unneeded creation of various intermediate tensors previously required
* vectorize calculation of windows on padded waveform
* make for-loop calculation more efficient by directly calculating items on the diagonal

For me, this reduced the run time of `test/test_functional_filtering.py` from about 120s to 80s.
