### PR TITLE
Fix several errors in tests run by Travis

### DIFF
--- a/torchaudio/datasets/utils.py
+++ b/torchaudio/datasets/utils.py
@@ -42,6 +42,12 @@ def unicode_csv_reader(unicode_csv_data, **kwargs):
     csv.field_size_limit(maxInt)
 
     if six.PY2:
+        # Implementation borrowed from docs:
+        # https://docs.python.org/3.0/library/csv.html#examples
+        def utf_8_encoder(unicode_csv_data):
+            for line in unicode_csv_data:
+                yield line.encode('utf-8')
+
         # csv.py doesn't do Unicode; encode temporarily as UTF-8:
         csv_reader = csv.reader(utf_8_encoder(unicode_csv_data), **kwargs)
         for row in csv_reader:

--- a/torchaudio/datasets/utils.py
+++ b/torchaudio/datasets/utils.py
@@ -344,6 +344,10 @@ class _ThreadedIterator(threading.Thread):
             raise StopIteration
         return next_item
 
+    # Required for Python 2.7 compatibility
+    def next(self):
+        return self.__next__()
+
 
 def bg_iterator(iterable, maxsize):
     return _ThreadedIterator(iterable, maxsize=maxsize)

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import math

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -1095,12 +1095,12 @@ def _compute_nccf(waveform, sample_rate, frame_time, freq_low):
     EPSILON = 10 ** (-9)
 
     # Number of lags to check
-    lags = math.ceil(sample_rate / freq_low)
+    lags = int(math.ceil(sample_rate / freq_low))
 
     frame_size = int(math.ceil(sample_rate * frame_time))
 
     waveform_length = waveform.size()[-1]
-    num_of_frames = math.ceil(waveform_length / frame_size)
+    num_of_frames = int(math.ceil(waveform_length / frame_size))
 
     p = lags + num_of_frames * frame_size - waveform_length
     waveform = torch.nn.functional.pad(waveform, (0, p))

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -1149,7 +1149,7 @@ def _find_max_per_frame(nccf, sample_rate, freq_high):
     to the first half of lags, then the latter is taken.
     """
 
-    lag_min = math.ceil(sample_rate / freq_high)
+    lag_min = int(math.ceil(sample_rate / freq_high))
 
     # Find near enough max that is smallest
 

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 from warnings import warn
 import math


### PR DESCRIPTION
Fixes the following Travis build errors:
```
E     File "torchaudio/transforms.py", line 82
E   SyntaxError: Non-ASCII character '\xc3' in file torchaudio/transforms.py on line 83, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```
and
```
        if six.PY2:
            # csv.py doesn't do Unicode; encode temporarily as UTF-8:
>           csv_reader = csv.reader(utf_8_encoder(unicode_csv_data), **kwargs)
E           NameError: global name 'utf_8_encoder' is not defined
torchaudio/datasets/utils.py:46: NameError
```
and

```
    def test_commonvoice_bg(self):
        path = os.path.join(self.path, "commonvoice")
        data = COMMONVOICE(path, "train.tsv", "tatar")
        data = bg_iterator(data, 5)
>       for d in data:
E       TypeError: iter() returned non-iterator of type '_ThreadedIterator'
```
and
```
E           TypeError: constant_pad_nd(): argument 'pad' must be tuple of ints, but found element of type float at pos 2
```

I couldn't yet fix *all* the problems with the Python 2 tests, as the current blocker is that [`.subTest()` is new as of Python 3.4](https://python.readthedocs.io/en/latest/library/unittest.html#unittest.TestCase.subTest):

```
__________________________ Test_LoadSave.test_1_save ___________________________
self = <test.Test_LoadSave testMethod=test_1_save>
    def test_1_save(self):
        for backend in ["sox"]:
>           with self.subTest():
E           AttributeError: 'Test_LoadSave' object has no attribute 'subTest'
test/test.py:33: AttributeError
```