### PR TITLE
Apply 'nightly' branch filter to binary uploads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,6 +324,9 @@ workflows:
           python_version: '3.5'
       - binary_wheel_upload:
           context: org-member
+          filters:
+            branches:
+              only: nightly
           name: nightly_binary_linux_wheel_py3.5_upload
           requires:
           - nightly_binary_linux_wheel_py3.5
@@ -343,6 +346,9 @@ workflows:
           python_version: '3.6'
       - binary_wheel_upload:
           context: org-member
+          filters:
+            branches:
+              only: nightly
           name: nightly_binary_linux_wheel_py3.6_upload
           requires:
           - nightly_binary_linux_wheel_py3.6
@@ -362,6 +368,9 @@ workflows:
           python_version: '3.7'
       - binary_wheel_upload:
           context: org-member
+          filters:
+            branches:
+              only: nightly
           name: nightly_binary_linux_wheel_py3.7_upload
           requires:
           - nightly_binary_linux_wheel_py3.7
@@ -466,6 +475,9 @@ workflows:
           python_version: '3.5'
       - binary_conda_upload:
           context: org-member
+          filters:
+            branches:
+              only: nightly
           name: nightly_binary_linux_conda_py3.5_upload
           requires:
           - nightly_binary_linux_conda_py3.5
@@ -485,6 +497,9 @@ workflows:
           python_version: '3.6'
       - binary_conda_upload:
           context: org-member
+          filters:
+            branches:
+              only: nightly
           name: nightly_binary_linux_conda_py3.6_upload
           requires:
           - nightly_binary_linux_conda_py3.6
@@ -504,6 +519,9 @@ workflows:
           python_version: '3.7'
       - binary_conda_upload:
           context: org-member
+          filters:
+            branches:
+              only: nightly
           name: nightly_binary_linux_conda_py3.7_upload
           requires:
           - nightly_binary_linux_conda_py3.7

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -47,10 +47,7 @@ def workflow_pair(btype, os_type, python_version, unicode, filter_branch, prefix
 
         is_py3_linux = os_type == 'linux' and not python_version.startswith("2.")
 
-        # XXX This logic is suspect...
-        upload_job_filter_branch = not is_py3_linux and filter_branch
-
-        w.append(generate_upload_workflow(base_workflow_name, upload_job_filter_branch, btype))
+        w.append(generate_upload_workflow(base_workflow_name, filter_branch, btype))
 
         if filter_branch == 'nightly' and is_py3_linux:
             pydistro = 'pip' if btype == 'wheel' else 'conda'


### PR DESCRIPTION
This drops a special case in the native-Python code generation logic that was put in place to emulate old codegen behavior that was originally a bug (see [original comment](https://github.com/pytorch/audio/pull/378#discussion_r361589458)).