### PR TITLE
.circleci: Remove if block, wasn't doing anything

### DIFF
--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -244,7 +244,6 @@ jobs:
 
 workflows:
   build:
-{%- if True %}
     jobs:
       - circleci_consistency
       {{ workflows() }}
@@ -253,7 +252,6 @@ workflows:
           python_version: "3.6"
 
   nightly:
-{%- endif %}
     jobs:
       - circleci_consistency
       {{ workflows(prefix="nightly_", filter_branch="nightly", upload=True) }}


### PR DESCRIPTION
With the introduction of the `filter_branch` parameter to the `workflows`
function we no longer have a need to have this if block anymore per
@ezyang's assessment.

NOTE: `regenerate.py` was re-ran but had no effect.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>