### PR TITLE
Implementation of RandomCrop for audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ to use and feel like a natural extension.
     - [Kaldi (ark/scp)](http://pytorch.org/audio/kaldi_io.html)
 - [Dataloaders for common audio datasets (VCTK, YesNo)](http://pytorch.org/audio/datasets.html)
 - Common audio transforms
-    - [Spectrogram, AmplitudeToDB, MelScale, MelSpectrogram, MFCC, MuLawEncoding, MuLawDecoding, Resample](http://pytorch.org/audio/transforms.html)
+    - [Spectrogram, AmplitudeToDB, MelScale, MelSpectrogram, MFCC, MuLawEncoding, MuLawDecoding, Resample, RandomCrop](http://pytorch.org/audio/transforms.html)
 - Compliance interfaces: Run code using PyTorch that align with other libraries
     - [Kaldi: spectrogram, fbank, mfcc, resample_waveform](https://pytorch.org/audio/compliance.kaldi.html)
 
@@ -143,6 +143,7 @@ Transforms expect and return the following dimensions.
 * `MuLawEncode`: (channel, time) -> (channel, time)
 * `MuLawDecode`: (channel, time) -> (channel, time)
 * `Resample`: (channel, time) -> (channel, time)
+* `RandomCrop`: (channel, time) -> (channel, time)
 
 Complex numbers are supported via tensors of dimension (..., 2), and torchaudio provides `complex_norm` and `angle` to convert such a tensor into its magnitude and phase. Here, and in the documentation, we use an ellipsis "..." as a placeholder for the rest of the dimensions of a tensor, e.g. optional batching and channel dimensions.
 

--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -72,6 +72,13 @@ Transforms are common audio transforms. They can be chained together using :clas
 
   .. automethod:: forward
 
+:hidden:`RandomCrop`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: RandomCrop
+
+  .. automethod:: forward
+
 :hidden:`ComplexNorm`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -445,7 +445,6 @@ class Tester(unittest.TestCase):
         _test_script_module(transforms.TimeMasking, tensor, time_mask_param=30, iid_masks=False)
 
     def test_random_crop_size(self):
-        import numpy as np
         input_path = os.path.join(self.test_dirpath, 'assets', 'sinewave.wav')
         waveform, sample_rate = torchaudio.load(input_path)
         length = 2
@@ -453,6 +452,14 @@ class Tester(unittest.TestCase):
         random_cropper = torchaudio.transforms.RandomCrop(length=length, freq=sample_rate)
         # Test waveform size is correct
         self.assertTrue(random_cropper(waveform).shape == torch.Size([channels, length * sample_rate]))
+
+    def test_random_crop_content(self):
+        import numpy as np
+        input_path = os.path.join(self.test_dirpath, 'assets', 'sinewave.wav')
+        waveform, sample_rate = torchaudio.load(input_path)
+        length = 2
+        channels, total_samples = waveform.shape[0], waveform.shape[1]
+        random_cropper = torchaudio.transforms.RandomCrop(length=length, freq=sample_rate)
         # Test waveform is subset of the original waveform
         self.assertTrue(
             np.sum(np.isin(waveform, random_cropper(waveform), assume_unique=True)) >= length * sample_rate * channels)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -444,13 +444,13 @@ class Tester(unittest.TestCase):
         tensor = torch.rand((10, 2, 50, 10, 2))
         _test_script_module(transforms.TimeMasking, tensor, time_mask_param=30, iid_masks=False)
 
-    def test_random_cropping_size(self):
+    def test_random_crop_size(self):
         import numpy as np
         input_path = os.path.join(self.test_dirpath, 'assets', 'sinewave.wav')
         waveform, sample_rate = torchaudio.load(input_path)
         length = 2
         channels, total_samples = waveform.shape[0], waveform.shape[1]
-        random_cropper = torchaudio.transforms.RandomCropping(length=length, freq=sample_rate)
+        random_cropper = torchaudio.transforms.RandomCrop(length=length, freq=sample_rate)
         # Test waveform size is correct
         self.assertTrue(random_cropper(waveform).shape == torch.Size([channels, length * sample_rate]))
         # Test waveform is subset of the original waveform

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -590,7 +590,7 @@ class TimeMasking(_AxisMasking):
         super(TimeMasking, self).__init__(time_mask_param, 2, iid_masks)
 
 
-class RandomCropping(torch.nn.Module):
+class RandomCrop(torch.nn.Module):
     r"""Crop the given Audio at a random location with fixed length
 
     Args:
@@ -606,7 +606,7 @@ class RandomCropping(torch.nn.Module):
     __constants__ = ['constant', 'reflect', 'replicate', 'circular']
 
     def __init__(self, length=1, freq=16000, padding_mode='constant', fill=0):
-        super(RandomCropping, self).__init__()
+        super(RandomCrop, self).__init__()
         # Check Correctness
         if length <= 0:
             raise ValueError(f"Audio length cannot be less than equal to 0")


### PR DESCRIPTION
Similar to `RandomCrop` in torchvision. This implementation is for audio given a tensor.
I would've used `RandomCrop` in torchvision, however, it only takes PIL Image instead of a Tensor.
More on it in #416 