### PR TITLE
packaging: Install correct version of pytorch for pip

### DIFF
--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -168,7 +168,7 @@ setup_pip_pytorch_version() {
       export PYTORCH_VERSION="$(pip show torch | grep ^Version: | sed 's/Version:  *//')"
     fi
   else
-    pip_install "torch==$PYTORCH_VERSION$CUDA_SUFFIX" \
+    pip_install "torch==$PYTORCH_VERSION$PYTORCH_VERSION_SUFFIX" \
       -f https://download.pytorch.org/whl/torch_stable.html \
       -f https://download.pytorch.org/whl/nightly/torch_nightly.html
   fi
@@ -177,7 +177,7 @@ setup_pip_pytorch_version() {
 # Fill PYTORCH_VERSION with the latest conda nightly version, and
 # CONDA_CHANNEL_FLAGS with appropriate flags to retrieve these versions
 #
-# You MUST have populated CUDA_SUFFIX before hand.
+# You MUST have populated PYTORCH_VERSION_SUFFIX before hand.
 setup_conda_pytorch_constraint() {
   if [[ -z "$PYTORCH_VERSION" ]]; then
     export CONDA_CHANNEL_FLAGS="-c pytorch-nightly"


### PR DESCRIPTION
CUDA_SUFFIX was still being used here when it should've been swapped out
for PYTORCH_VERSION_SUFFIX, which is what's being used for conda below.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>