### PR TITLE
dither jit test

### DIFF
--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -29,6 +29,11 @@ __all__ = [
 ]
 
 
+# TODO: remove once https://github.com/pytorch/pytorch/issues/32358#issuecomment-576909755 is resolved
+def _bartlett_window(x: int):
+    return torch.bartlett_window(x, dtype=torch.float)
+
+
 # TODO: remove this once https://github.com/pytorch/pytorch/issues/21478 gets solved
 @torch.jit.ignore
 def _stft(
@@ -1051,7 +1056,7 @@ def _apply_probability_distribution(waveform, density_function="TPDF"):
 
         signal_scaled_dis = signal_scaled + gaussian
     else:
-        TPDF = torch.bartlett_window(time_size + 1)
+        TPDF = _bartlett_window(time_size + 1)
         TPDF = TPDF.repeat((channel_size + 1), 1)
         signal_scaled_dis = signal_scaled + TPDF
 

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -29,11 +29,6 @@ __all__ = [
 ]
 
 
-# TODO: remove once https://github.com/pytorch/pytorch/issues/32358#issuecomment-576909755 is resolved
-def _bartlett_window(x: int):
-    return torch.bartlett_window(x, dtype=torch.float)
-
-
 # TODO: remove this once https://github.com/pytorch/pytorch/issues/21478 gets solved
 @torch.jit.ignore
 def _stft(
@@ -1056,7 +1051,8 @@ def _apply_probability_distribution(waveform, density_function="TPDF"):
 
         signal_scaled_dis = signal_scaled + gaussian
     else:
-        TPDF = _bartlett_window(time_size + 1)
+        # dtype needed for https://github.com/pytorch/pytorch/issues/32358
+        TPDF = torch.bartlett_window(time_size + 1, dtype=torch.float)
         TPDF = TPDF.repeat((channel_size + 1), 1)
         signal_scaled_dis = signal_scaled + TPDF
 


### PR DESCRIPTION
[Test](https://travis-ci.org/pytorch/audio/jobs/638411105) falling on master:

```
======================================================================
ERROR: test_torchscript_dither (__main__.TestFunctional)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_functional.py", line 641, in test_torchscript_dither
    _test_torchscript_functional_shape(F.dither, tensor)
  File "test/test_functional.py", line 23, in _test_torchscript_functional_shape
    jit_out = jit_method(*args, **kwargs)
RuntimeError: result type Float can't be cast to the desired output type Long
The above operation failed in interpreter.
Traceback (most recent call last):
  File "/Users/vincentqb/anaconda3/envs/audio-built/lib/python3.7/site-packages/torchaudio-0.5.0a0+2c49528-py3.7-macosx-10.9-x86_64.egg/torchaudio/functional.py", line 1055
        signal_scaled_dis = signal_scaled + gaussian
    else:
        TPDF = torch.bartlett_window(int(time_size + 1))
               ~~~~~~~~~~~~~~~~~~~~~ <--- HERE
        TPDF = TPDF.repeat((channel_size + 1), 1)
        signal_scaled_dis = signal_scaled + TPDF


----------------------------------------------------------------------
```