### PR TITLE
Adding normalized=True options to MelScale and MelSpectrogram modules

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -330,7 +330,6 @@ class Tester(unittest.TestCase):
         _test_librosa_consistency_helper(**kwargs4)
         _test_librosa_consistency_helper(**kwargs5)
 
-
     def test_scriptmodule_Resample(self):
         tensor = torch.rand((2, 1000))
         sample_rate = 100

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -396,8 +396,8 @@ def amplitude_to_DB(x, multiplier, amin, db_multiplier, top_db=None):
     return x_db
 
 
-def create_fb_matrix(n_freqs, f_min, f_max, n_mels, sample_rate):
-    # type: (int, float, float, int, int) -> Tensor
+def create_fb_matrix(n_freqs, f_min, f_max, n_mels, sample_rate, normalized):
+    # type: (int, float, float, int, int, bool) -> Tensor
     r"""Create a frequency bin conversion matrix.
 
     Args:
@@ -406,6 +406,7 @@ def create_fb_matrix(n_freqs, f_min, f_max, n_mels, sample_rate):
         f_max (float): Maximum frequency (Hz)
         n_mels (int): Number of mel filterbanks
         sample_rate (int): Sample rate of the audio waveform
+        normalized (bool): Divide the triangular mel weights by the width of mel band if True
 
     Returns:
         torch.Tensor: Triangular filter banks (fb matrix) of size (``n_freqs``, ``n_mels``)
@@ -435,6 +436,11 @@ def create_fb_matrix(n_freqs, f_min, f_max, n_mels, sample_rate):
     down_slopes = (-1.0 * slopes[:, :-2]) / f_diff[:-1]  # (n_freqs, n_mels)
     up_slopes = slopes[:, 2:] / f_diff[1:]  # (n_freqs, n_mels)
     fb = torch.max(zero, torch.min(down_slopes, up_slopes))
+
+    if normalized:
+        widths = 2.0 / (f_pts[2:] - f_pts[:-2])  # (n_mels)
+        fb *= widths
+
     return fb
 
 

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -396,7 +396,7 @@ def amplitude_to_DB(x, multiplier, amin, db_multiplier, top_db=None):
     return x_db
 
 
-def create_fb_matrix(n_freqs, f_min, f_max, n_mels, sample_rate, normalized):
+def create_fb_matrix(n_freqs, f_min, f_max, n_mels, sample_rate, normalized=False):
     # type: (int, float, float, int, int, bool) -> Tensor
     r"""Create a frequency bin conversion matrix.
 
@@ -406,7 +406,7 @@ def create_fb_matrix(n_freqs, f_min, f_max, n_mels, sample_rate, normalized):
         f_max (float): Maximum frequency (Hz)
         n_mels (int): Number of mel filterbanks
         sample_rate (int): Sample rate of the audio waveform
-        normalized (bool): Divide the triangular mel weights by the width of mel band if True
+        normalized (bool, optional): area-normalize the FB, so that each filter has equal area
 
     Returns:
         torch.Tensor: Triangular filter banks (fb matrix) of size (``n_freqs``, ``n_mels``)


### PR DESCRIPTION
This allows area normalization for Mel spectrogram (See #287 ), where the filterbank 

In the same issue I also mentioned adding the Slaney mel frequencies in addition to HTK ones, but as the Slaney scale is quite cumbersome (manually connect the linear and logarithmic pieces), I'm not sure if the maintainers thinks it's worth adding it at the moment. So adding the area normalization only for now. 

One caveat might be that the namining might be confusing since `normalized` is also used in the `Spectrogram` module, but I couldn't come up with better choice. Other sensible choices for naming include `normalization=None | "area"` or `area_normalize=False | True`, and I am happy to change the naming to either.

For the test, I've added one more case in the librosa consistency checks. CR appreciated!