### PR TITLE
fix test_scriptmodule_Resample

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -324,7 +324,7 @@ class Tester(unittest.TestCase):
         sample_rate = 100
         sample_rate_2 = 50
 
-        _test_script_module(transforms.Spectrogram, tensor, sample_rate, sample_rate_2)
+        _test_script_module(transforms.Resample, tensor, sample_rate, sample_rate_2)
 
     def test_batch_Resample(self):
         waveform = torch.randn(2, 2786)


### PR DESCRIPTION
Currently, when calling `test_scriptmodule_Resample` it is testing `transforms.Spectrogram` instead of `transforms.Resample`