### PR TITLE
Change default value of dither

### DIFF
--- a/torchaudio/compliance/kaldi.py
+++ b/torchaudio/compliance/kaldi.py
@@ -194,7 +194,7 @@ def _subtract_column_mean(tensor, subtract_mean):
 
 
 def spectrogram(
-        waveform, blackman_coeff=0.42, channel=-1, dither=1.0, energy_floor=0.0,
+        waveform, blackman_coeff=0.42, channel=-1, dither=0.0, energy_floor=1.0,
         frame_length=25.0, frame_shift=10.0, min_duration=0.0,
         preemphasis_coefficient=0.97, raw_energy=True, remove_dc_offset=True,
         round_to_power_of_two=True, sample_frequency=16000.0, snip_edges=True,
@@ -429,7 +429,7 @@ def get_mel_banks(num_bins, window_length_padded, sample_freq,
 
 
 def fbank(
-        waveform, blackman_coeff=0.42, channel=-1, dither=1.0, energy_floor=0.0,
+        waveform, blackman_coeff=0.42, channel=-1, dither=0.0, energy_floor=1.0,
         frame_length=25.0, frame_shift=10.0, high_freq=0.0, htk_compat=False, low_freq=20.0,
         min_duration=0.0, num_mel_bins=23, preemphasis_coefficient=0.97, raw_energy=True,
         remove_dc_offset=True, round_to_power_of_two=True, sample_frequency=16000.0,
@@ -547,8 +547,8 @@ def _get_lifter_coeffs(num_ceps, cepstral_lifter):
 
 
 def mfcc(
-        waveform, blackman_coeff=0.42, cepstral_lifter=22.0, channel=-1, dither=1.0,
-        energy_floor=0.0, frame_length=25.0, frame_shift=10.0, high_freq=0.0, htk_compat=False,
+        waveform, blackman_coeff=0.42, cepstral_lifter=22.0, channel=-1, dither=0.0,
+        energy_floor=1.0, frame_length=25.0, frame_shift=10.0, high_freq=0.0, htk_compat=False,
         low_freq=20.0, num_ceps=13, min_duration=0.0, num_mel_bins=23, preemphasis_coefficient=0.97,
         raw_energy=True, remove_dc_offset=True, round_to_power_of_two=True,
         sample_frequency=16000.0, snip_edges=True, subtract_mean=False, use_energy=False,

--- a/torchaudio/compliance/kaldi.py
+++ b/torchaudio/compliance/kaldi.py
@@ -207,10 +207,10 @@ def spectrogram(
         blackman_coeff (float): Constant coefficient for generalized Blackman window. (Default: ``0.42``)
         channel (int): Channel to extract (-1 -> expect mono, 0 -> left, 1 -> right) (Default: ``-1``)
         dither (float): Dithering constant (0.0 means no dither). If you turn this off, you should set
-            the energy_floor option, e.g. to 1.0 or 0.1 (Default: ``1.0``)
+            the energy_floor option, e.g. to 1.0 or 0.1 (Default: ``0.0``)
         energy_floor (float): Floor on energy (absolute, not relative) in Spectrogram computation.  Caution:
             this floor is applied to the zeroth component, representing the total signal energy.  The floor on the
-            individual spectrogram elements is fixed at std::numeric_limits<float>::epsilon(). (Default: ``0.0``)
+            individual spectrogram elements is fixed at std::numeric_limits<float>::epsilon(). (Default: ``1.0``)
         frame_length (float): Frame length in milliseconds (Default: ``25.0``)
         frame_shift (float): Frame shift in milliseconds (Default: ``10.0``)
         min_duration (float): Minimum duration of segments to process (in seconds). (Default: ``0.0``)
@@ -443,10 +443,10 @@ def fbank(
         blackman_coeff (float): Constant coefficient for generalized Blackman window. (Default: ``0.42``)
         channel (int): Channel to extract (-1 -> expect mono, 0 -> left, 1 -> right) (Default: ``-1``)
         dither (float): Dithering constant (0.0 means no dither). If you turn this off, you should set
-            the energy_floor option, e.g. to 1.0 or 0.1 (Default: ``1.0``)
+            the energy_floor option, e.g. to 1.0 or 0.1 (Default: ``0.0``)
         energy_floor (float): Floor on energy (absolute, not relative) in Spectrogram computation.  Caution:
             this floor is applied to the zeroth component, representing the total signal energy.  The floor on the
-            individual spectrogram elements is fixed at std::numeric_limits<float>::epsilon(). (Default: ``0.0``)
+            individual spectrogram elements is fixed at std::numeric_limits<float>::epsilon(). (Default: ``1.0``)
         frame_length (float): Frame length in milliseconds (Default: ``25.0``)
         frame_shift (float): Frame shift in milliseconds (Default: ``10.0``)
         high_freq (float): High cutoff frequency for mel bins (if <= 0, offset from Nyquist) (Default: ``0.0``)
@@ -562,10 +562,10 @@ def mfcc(
         cepstral_lifter (float): Constant that controls scaling of MFCCs (Default: ``22.0``)
         channel (int): Channel to extract (-1 -> expect mono, 0 -> left, 1 -> right) (Default: ``-1``)
         dither (float): Dithering constant (0.0 means no dither). If you turn this off, you should set
-            the energy_floor option, e.g. to 1.0 or 0.1 (Default: ``1.0``)
+            the energy_floor option, e.g. to 1.0 or 0.1 (Default: ``0.0``)
         energy_floor (float): Floor on energy (absolute, not relative) in Spectrogram computation.  Caution:
             this floor is applied to the zeroth component, representing the total signal energy.  The floor on the
-            individual spectrogram elements is fixed at std::numeric_limits<float>::epsilon(). (Default: ``0.0``)
+            individual spectrogram elements is fixed at std::numeric_limits<float>::epsilon(). (Default: ``1.0``)
         frame_length (float): Frame length in milliseconds (Default: ``25.0``)
         frame_shift (float): Frame shift in milliseconds (Default: ``10.0``)
         high_freq (float): High cutoff frequency for mel bins (if <= 0, offset from Nyquist) (Default: ``0.0``)


### PR DESCRIPTION
Following [comment](https://github.com/pytorch/audio/issues/371#issuecomment-594130485), setting `dither` to `0` and setting `energy_floor` to `1.`.

```python
import torchaudio

filename = "audio/test/assets/steam-train-whistle-daniel_simon.mp3"
s, sr = torchaudio.load(filename)

spec1 = torchaudio.compliance.kaldi.spectrogram(s, dither=0., energy_floor=1.)
spec2 = torchaudio.compliance.kaldi.spectrogram(s, dither=1e-6)
print(2*((spec1 - spec2).abs()/(spec1.abs() + spec2.abs())).mean())
# tensor(0.0016)  # Mean absolute percent difference 

spec1 = torchaudio.compliance.kaldi.fbank(s, dither=0., energy_floor=1.)
spec2 = torchaudio.compliance.kaldi.fbank(s, dither=1e-6)
print(2*((spec1 - spec2).abs()/(spec1.abs() + spec2.abs())).mean())
# tensor(4.8548e-05)

spec1 = torchaudio.compliance.kaldi.mfcc(s, dither=0., energy_floor=1.)
spec2 = torchaudio.compliance.kaldi.mfcc(s, dither=1e-6)
print(2*((spec1 - spec2).abs()/(spec1.abs() + spec2.abs())).mean())
# tensor(0.0022)
```

Closes #371