### PR TITLE
Ignore pycharm and OSX files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,12 @@ ENV/
 # Rope project settings
 .ropeproject
 
+# PyCharm project settings
+.idea
+
+# OSX dir files
+.DS_Store
+
 # mkdocs documentation
 /site
 


### PR DESCRIPTION
Ignore files generate by Pycharm and OSX files

- This will make easier to manage commits