### PR TITLE
Add test transform and functional AmplitudeToDB

### DIFF
--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -573,7 +573,6 @@ class TestFunctional(unittest.TestCase):
         _test_torchscript_functional(F.create_fb_matrix, n_stft, f_min, f_max, n_mels, sample_rate)
 
     def test_torchscript_amplitude_to_DB(self):
-
         spec = torch.rand((6, 201))
         multiplier = 10.0
         amin = 1e-10
@@ -581,6 +580,34 @@ class TestFunctional(unittest.TestCase):
         top_db = 80.0
 
         _test_torchscript_functional(F.amplitude_to_DB, spec, multiplier, amin, db_multiplier, top_db)
+
+    @unittest.skipIf(not IMPORT_LIBROSA, 'Librosa not available')
+    def test_amplitude_to_DB(self):
+        spec = torch.rand((6, 201))
+
+        amin = 1e-10
+        db_multiplier = 0.0
+        top_db = 80.0
+
+        # Power to DB
+        multiplier = 10.0
+
+        ta_out = F.amplitude_to_DB(spec, multiplier, amin, db_multiplier, top_db)
+        lr_out = librosa.core.power_to_db(spec.numpy())
+        lr_out = torch.from_numpy(lr_out).unsqueeze(0)
+
+        self.assertTrue(torch.allclose(ta_out, lr_out, atol=5e-5))
+
+        # Amplitude to DB
+        multiplier = 20.0
+
+        ta_out = F.amplitude_to_DB(spec, multiplier, amin, db_multiplier, top_db)
+        lr_out = librosa.core.amplitude_to_db(spec.numpy())
+        lr_out = torch.from_numpy(lr_out).unsqueeze(0)
+
+        self.assertTrue(torch.allclose(ta_out, lr_out, atol=5e-5))
+
+
 
     def test_torchscript_create_dct(self):
 

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -607,8 +607,6 @@ class TestFunctional(unittest.TestCase):
 
         self.assertTrue(torch.allclose(ta_out, lr_out, atol=5e-5))
 
-
-
     def test_torchscript_create_dct(self):
 
         n_mfcc = 40

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -256,11 +256,13 @@ class Tester(unittest.TestCase):
             db_librosa = librosa.core.spectrum.power_to_db(out_librosa)
             self.assertTrue(torch.allclose(db_torch, torch.from_numpy(db_librosa), atol=5e-3))
 
-            # test s2db
             db_transform_mag = torchaudio.transforms.AmplitudeToDB('magnitude', 80.)
             db_torch_mag = db_transform_mag(spect_transform(sound)).squeeze().cpu()
             db_librosa_mag = librosa.core.spectrum.amplitude_to_db(out_librosa)
             self.assertTrue(torch.allclose(db_torch_mag, torch.from_numpy(db_librosa_mag), atol=5e-3))
+
+            db_torch_mag = db_transform_mag(torch.sqrt(spect_transform(sound))).squeeze().cpu()
+            self.assertTrue(torch.allclose(db_torch_mag, db_torch, atol=5e-3))
 
             db_torch = db_transform(melspect_transform(sound)).squeeze().cpu()
             db_librosa = librosa.core.spectrum.power_to_db(librosa_mel)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -101,23 +101,6 @@ class Tester(unittest.TestCase):
         self.assertTrue(computed.shape == expected.shape, (computed.shape, expected.shape))
         self.assertTrue(torch.allclose(computed, expected))
 
-    def test_AmplitudeToDB(self):
-        spec = torch.rand((6, 201))
-
-        # Power to DB
-        ta_out = transforms.AmplitudeToDB(stype='power', top_db=80)(spec)
-        lr_out = librosa.core.power_to_db(spec.numpy())
-        lr_out = torch.from_numpy(lr_out).unsqueeze(0)
-
-        self.assertTrue(torch.allclose(ta_out, lr_out, atol=5e-5))
-
-        # Amplitude to DB
-        ta_out =transforms.AmplitudeToDB(stype='magnitude', top_db=80)(spec)
-        lr_out = librosa.core.amplitude_to_db(spec.numpy())
-        lr_out = torch.from_numpy(lr_out).unsqueeze(0)
-
-        self.assertTrue(torch.allclose(ta_out, lr_out, atol=5e-5))
-
     def test_scriptmodule_MelScale(self):
         spec_f = torch.rand((1, 6, 201))
         _test_script_module(transforms.MelScale, spec_f)
@@ -272,6 +255,12 @@ class Tester(unittest.TestCase):
             db_torch = db_transform(spect_transform(sound)).squeeze().cpu()
             db_librosa = librosa.core.spectrum.power_to_db(out_librosa)
             self.assertTrue(torch.allclose(db_torch, torch.from_numpy(db_librosa), atol=5e-3))
+
+            # test s2db
+            db_transform_mag = torchaudio.transforms.AmplitudeToDB('magnitude', 80.)
+            db_torch_mag = db_transform_mag(spect_transform(sound)).squeeze().cpu()
+            db_librosa_mag = librosa.core.spectrum.amplitude_to_db(out_librosa)
+            self.assertTrue(torch.allclose(db_torch_mag, torch.from_numpy(db_librosa_mag), atol=5e-3))
 
             db_torch = db_transform(melspect_transform(sound)).squeeze().cpu()
             db_librosa = librosa.core.spectrum.power_to_db(librosa_mel)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -90,13 +90,13 @@ class Tester(unittest.TestCase):
         _test_script_module(transforms.AmplitudeToDB, spec)
 
     def test_batch_AmplitudeToDB(self):
-        waveform, sample_rate = torchaudio.load(self.test_filepath)
+        spec = torch.rand((6, 201))
 
         # Single then transform then batch
-        expected = transforms.AmplitudeToDB()(waveform).repeat(3, 1, 1)
+        expected = transforms.AmplitudeToDB()(spec).repeat(3, 1, 1)
 
         # Batch then transform
-        computed = transforms.AmplitudeToDB()(waveform.repeat(3, 1, 1))
+        computed = transforms.AmplitudeToDB()(spec.repeat(3, 1, 1))
 
         self.assertTrue(computed.shape == expected.shape, (computed.shape, expected.shape))
         self.assertTrue(torch.allclose(computed, expected))

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -101,6 +101,17 @@ class Tester(unittest.TestCase):
         self.assertTrue(computed.shape == expected.shape, (computed.shape, expected.shape))
         self.assertTrue(torch.allclose(computed, expected))
 
+    def test_AmplitudeToDB(self):
+        waveform, sample_rate = torchaudio.load(self.test_filepath)
+
+        mag_to_db_transform = transforms.AmplitudeToDB('magnitude', 80.)
+        power_to_db_transform = transforms.AmplitudeToDB('power', 80.)
+
+        mag_to_db_torch = mag_to_db_transform(torch.abs(waveform))
+        power_to_db_torch = power_to_db_transform(torch.pow(waveform, 2))
+
+        self.assertTrue(torch.allclose(mag_to_db_torch, power_to_db_torch))
+
     def test_scriptmodule_MelScale(self):
         spec_f = torch.rand((1, 6, 201))
         _test_script_module(transforms.MelScale, spec_f)
@@ -251,24 +262,20 @@ class Tester(unittest.TestCase):
             self.assertTrue(torch.allclose(torch_mel.type(librosa_mel_tensor.dtype), librosa_mel_tensor, atol=5e-3))
 
             # test s2db
-            db_transform = torchaudio.transforms.AmplitudeToDB('power', 80.)
-            db_torch = db_transform(spect_transform(sound)).squeeze().cpu()
-            db_librosa = librosa.core.spectrum.power_to_db(out_librosa)
-            self.assertTrue(torch.allclose(db_torch, torch.from_numpy(db_librosa), atol=5e-3))
+            power_to_db_transform = torchaudio.transforms.AmplitudeToDB('power', 80.)
+            power_to_db_torch = power_to_db_transform(spect_transform(sound)).squeeze().cpu()
+            power_to_db_librosa = librosa.core.spectrum.power_to_db(out_librosa)
+            self.assertTrue(torch.allclose(power_to_db_torch, torch.from_numpy(power_to_db_librosa), atol=5e-3))
 
-            db_transform_mag = torchaudio.transforms.AmplitudeToDB('magnitude', 80.)
-            db_torch_mag = db_transform_mag(spect_transform(sound)).squeeze().cpu()
-            db_librosa_mag = librosa.core.spectrum.amplitude_to_db(out_librosa)
-            self.assertTrue(torch.allclose(db_torch_mag, torch.from_numpy(db_librosa_mag), atol=5e-3))
+            mag_to_db_transform = torchaudio.transforms.AmplitudeToDB('magnitude', 80.)
+            mag_to_db_torch = mag_to_db_transform(torch.abs(sound)).squeeze().cpu()
+            mag_to_db_librosa = librosa.core.spectrum.amplitude_to_db(sound_librosa)
+            self.assertTrue(torch.allclose(mag_to_db_torch, torch.from_numpy(mag_to_db_librosa), atol=5e-3))
 
-            db_torch_mag = db_transform_mag(torch.sqrt(spect_transform(sound))).squeeze().cpu()
-            self.assertTrue(torch.allclose(db_torch_mag, db_torch, atol=5e-3))
-
-            db_torch = db_transform(melspect_transform(sound)).squeeze().cpu()
+            power_to_db_torch = power_to_db_transform(melspect_transform(sound)).squeeze().cpu()
             db_librosa = librosa.core.spectrum.power_to_db(librosa_mel)
             db_librosa_tensor = torch.from_numpy(db_librosa)
-
-            self.assertTrue(torch.allclose(db_torch.type(db_librosa_tensor.dtype), db_librosa_tensor, atol=5e-3))
+            self.assertTrue(torch.allclose(power_to_db_torch.type(db_librosa_tensor.dtype), db_librosa_tensor, atol=5e-3))
 
             # test MFCC
             melkwargs = {'hop_length': hop_length, 'n_fft': n_fft}

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -270,12 +270,16 @@ class Tester(unittest.TestCase):
             mag_to_db_transform = torchaudio.transforms.AmplitudeToDB('magnitude', 80.)
             mag_to_db_torch = mag_to_db_transform(torch.abs(sound)).squeeze().cpu()
             mag_to_db_librosa = librosa.core.spectrum.amplitude_to_db(sound_librosa)
-            self.assertTrue(torch.allclose(mag_to_db_torch, torch.from_numpy(mag_to_db_librosa), atol=5e-3))
+            self.assertTrue(
+                torch.allclose(mag_to_db_torch, torch.from_numpy(mag_to_db_librosa), atol=5e-3)
+            )
 
             power_to_db_torch = power_to_db_transform(melspect_transform(sound)).squeeze().cpu()
             db_librosa = librosa.core.spectrum.power_to_db(librosa_mel)
             db_librosa_tensor = torch.from_numpy(db_librosa)
-            self.assertTrue(torch.allclose(power_to_db_torch.type(db_librosa_tensor.dtype), db_librosa_tensor, atol=5e-3))
+            self.assertTrue(
+                torch.allclose(power_to_db_torch.type(db_librosa_tensor.dtype), db_librosa_tensor, atol=5e-3)
+            )
 
             # test MFCC
             melkwargs = {'hop_length': hop_length, 'n_fft': n_fft}


### PR DESCRIPTION
- Compare results from `functional.AmplitudeToDB` with librosa corresponding functions
- Add batch test to `transform.AmplitudeToDB`
- Add to `test_librosa_consistency` test for magnitude