### PR TITLE
Add bandpass and bandreject to functional

### DIFF
--- a/test/test_functional_filtering.py
+++ b/test/test_functional_filtering.py
@@ -168,6 +168,68 @@ class TestFunctionalFiltering(unittest.TestCase):
         assert torch.allclose(sox_output_waveform, output_waveform, atol=1e-4)
         _test_torchscript_functional(F.allpass_biquad, waveform, sample_rate, CENTRAL_FREQ, Q)
 
+    def test_bandpass_with_csg(self):
+        """
+        Test biquad bandpass filter, compare to SoX implementation
+        """
+
+        CENTRAL_FREQ = 1000
+        Q = 0.707
+        USE_CSG = True
+
+        noise_filepath = os.path.join(self.test_dirpath, "assets", "whitenoise.mp3")
+        E = torchaudio.sox_effects.SoxEffectsChain()
+        E.set_input_file(noise_filepath)
+        E.append_effect_to_chain("bandpass", ["-c", CENTRAL_FREQ, str(Q) + 'q'])
+        sox_output_waveform, sr = E.sox_build_flow_effects()
+
+        waveform, sample_rate = torchaudio.load(noise_filepath, normalization=True)
+        output_waveform = F.bandpass_biquad(waveform, sample_rate, CENTRAL_FREQ, Q, USE_CSG)
+
+        assert torch.allclose(sox_output_waveform, output_waveform, atol=1e-4)
+        _test_torchscript_functional(F.bandpass_biquad, waveform, sample_rate, CENTRAL_FREQ, Q, USE_CSG)
+
+    def test_bandpass_without_csg(self):
+        """
+        Test biquad bandpass filter, compare to SoX implementation
+        """
+
+        CENTRAL_FREQ = 1000
+        Q = 0.707
+        USE_CSG = False
+
+        noise_filepath = os.path.join(self.test_dirpath, "assets", "whitenoise.mp3")
+        E = torchaudio.sox_effects.SoxEffectsChain()
+        E.set_input_file(noise_filepath)
+        E.append_effect_to_chain("bandpass", [CENTRAL_FREQ, str(Q) + 'q'])
+        sox_output_waveform, sr = E.sox_build_flow_effects()
+
+        waveform, sample_rate = torchaudio.load(noise_filepath, normalization=True)
+        output_waveform = F.bandpass_biquad(waveform, sample_rate, CENTRAL_FREQ, Q, USE_CSG)
+
+        assert torch.allclose(sox_output_waveform, output_waveform, atol=1e-4)
+        _test_torchscript_functional(F.bandpass_biquad, waveform, sample_rate, CENTRAL_FREQ, Q, USE_CSG)
+
+    def test_bandreject(self):
+        """
+        Test biquad bandreject filter, compare to SoX implementation
+        """
+
+        CENTRAL_FREQ = 1000
+        Q = 0.707
+
+        noise_filepath = os.path.join(self.test_dirpath, "assets", "whitenoise.mp3")
+        E = torchaudio.sox_effects.SoxEffectsChain()
+        E.set_input_file(noise_filepath)
+        E.append_effect_to_chain("bandreject", [CENTRAL_FREQ, str(Q) + 'q'])
+        sox_output_waveform, sr = E.sox_build_flow_effects()
+
+        waveform, sample_rate = torchaudio.load(noise_filepath, normalization=True)
+        output_waveform = F.bandreject_biquad(waveform, sample_rate, CENTRAL_FREQ, Q)
+
+        assert torch.allclose(sox_output_waveform, output_waveform, atol=1e-4)
+        _test_torchscript_functional(F.bandreject_biquad, waveform, sample_rate, CENTRAL_FREQ, Q)
+
     def test_equalizer(self):
         """
         Test biquad peaking equalizer filter, compare to SoX implementation

--- a/test/test_functional_filtering.py
+++ b/test/test_functional_filtering.py
@@ -175,7 +175,7 @@ class TestFunctionalFiltering(unittest.TestCase):
 
         CENTRAL_FREQ = 1000
         Q = 0.707
-        USE_CSG = True
+        CONST_SKIRT_GAIN = True
 
         noise_filepath = os.path.join(self.test_dirpath, "assets", "whitenoise.mp3")
         E = torchaudio.sox_effects.SoxEffectsChain()
@@ -184,10 +184,10 @@ class TestFunctionalFiltering(unittest.TestCase):
         sox_output_waveform, sr = E.sox_build_flow_effects()
 
         waveform, sample_rate = torchaudio.load(noise_filepath, normalization=True)
-        output_waveform = F.bandpass_biquad(waveform, sample_rate, CENTRAL_FREQ, Q, USE_CSG)
+        output_waveform = F.bandpass_biquad(waveform, sample_rate, CENTRAL_FREQ, Q, CONST_SKIRT_GAIN)
 
         assert torch.allclose(sox_output_waveform, output_waveform, atol=1e-4)
-        _test_torchscript_functional(F.bandpass_biquad, waveform, sample_rate, CENTRAL_FREQ, Q, USE_CSG)
+        _test_torchscript_functional(F.bandpass_biquad, waveform, sample_rate, CENTRAL_FREQ, Q, CONST_SKIRT_GAIN)
 
     def test_bandpass_without_csg(self):
         """
@@ -196,7 +196,7 @@ class TestFunctionalFiltering(unittest.TestCase):
 
         CENTRAL_FREQ = 1000
         Q = 0.707
-        USE_CSG = False
+        CONST_SKIRT_GAIN = False
 
         noise_filepath = os.path.join(self.test_dirpath, "assets", "whitenoise.mp3")
         E = torchaudio.sox_effects.SoxEffectsChain()
@@ -205,10 +205,10 @@ class TestFunctionalFiltering(unittest.TestCase):
         sox_output_waveform, sr = E.sox_build_flow_effects()
 
         waveform, sample_rate = torchaudio.load(noise_filepath, normalization=True)
-        output_waveform = F.bandpass_biquad(waveform, sample_rate, CENTRAL_FREQ, Q, USE_CSG)
+        output_waveform = F.bandpass_biquad(waveform, sample_rate, CENTRAL_FREQ, Q, CONST_SKIRT_GAIN)
 
         assert torch.allclose(sox_output_waveform, output_waveform, atol=1e-4)
-        _test_torchscript_functional(F.bandpass_biquad, waveform, sample_rate, CENTRAL_FREQ, Q, USE_CSG)
+        _test_torchscript_functional(F.bandpass_biquad, waveform, sample_rate, CENTRAL_FREQ, Q, CONST_SKIRT_GAIN)
 
     def test_bandreject(self):
         """

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -23,6 +23,7 @@ __all__ = [
     "lowpass_biquad",
     "highpass_biquad",
     "allpass_biquad",
+    "bandpass_biquad",
     "equalizer_biquad",
     "biquad",
     'mask_along_axis',
@@ -818,6 +819,35 @@ def allpass_biquad(waveform, sample_rate, central_freq, Q=0.707):
     b0 = 1 - alpha
     b1 = -2 * math.cos(w0)
     b2 = 1 + alpha
+    a0 = 1 + alpha
+    a1 = -2 * math.cos(w0)
+    a2 = 1 - alpha
+    return biquad(waveform, b0, b1, b2, a0, a1, a2)
+
+
+def bandpass_biquad(waveform, sample_rate, central_freq, Q=0.707):
+    # type: (Tensor, int, float, float) -> Tensor
+    r"""Design two-pole band-pass filter.  Similar to SoX implementation.
+
+    Args:
+        waveform(torch.Tensor): audio waveform of dimension of `(..., time)`
+        sample_rate (int): sampling rate of the waveform, e.g. 44100 (Hz)
+        central_freq (float): central frequency (in Hz)
+        q_factor (float): https://en.wikipedia.org/wiki/Q_factor
+
+    Returns:
+        output_waveform (torch.Tensor): Dimension of `(..., time)`
+
+    References:
+        http://sox.sourceforge.net/sox.html
+        https://www.w3.org/2011/audio/audio-eq-cookbook.html#APF
+    """
+    w0 = 2 * math.pi * central_freq / sample_rate
+    alpha = math.sin(w0) / 2 / Q
+
+    b0 = math.sin(w0) / 2
+    b1 = 0
+    b2 = -math.sin(w0) / 2
     a0 = 1 + alpha
     a1 = -2 * math.cos(w0)
     a2 = 1 - alpha

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -826,7 +826,7 @@ def allpass_biquad(waveform, sample_rate, central_freq, Q=0.707):
     return biquad(waveform, b0, b1, b2, a0, a1, a2)
 
 
-def bandpass_biquad(waveform, sample_rate, central_freq, Q=0.707, use_csg=False):
+def bandpass_biquad(waveform, sample_rate, central_freq, Q=0.707, const_skirt_gain=False):
     # type: (Tensor, int, float, float, bool) -> Tensor
     r"""Design two-pole band-pass filter.  Similar to SoX implementation.
 
@@ -835,8 +835,8 @@ def bandpass_biquad(waveform, sample_rate, central_freq, Q=0.707, use_csg=False)
         sample_rate (int): sampling rate of the waveform, e.g. 44100 (Hz)
         central_freq (float): central frequency (in Hz)
         q_factor (float): https://en.wikipedia.org/wiki/Q_factor
-        use_csg (bool) : When True : uses a constant skirt gain (peak gain = Q)
-                        When False(default): uses a constant 0dB peak gain.
+        const_skirt_gain (bool) : If ``True``, uses a constant skirt gain (peak gain = Q).
+            If ``False``, uses a constant 0dB peak gain. (Default: ``False``)
 
     Returns:
         output_waveform (torch.Tensor): Dimension of `(..., time)`
@@ -848,7 +848,7 @@ def bandpass_biquad(waveform, sample_rate, central_freq, Q=0.707, use_csg=False)
     w0 = 2 * math.pi * central_freq / sample_rate
     alpha = math.sin(w0) / 2 / Q
 
-    temp = math.sin(w0) / 2 if use_csg else alpha
+    temp = math.sin(w0) / 2 if const_skirt_gain else alpha
     b0 = temp
     b1 = 0.
     b2 = -temp


### PR DESCRIPTION
Hi ,

Checked this issue #260 ( Reducing dependency in Sox) 
Went throught Sox source code and implemented below functions along the lines of existing allpass function in functional.py

- ```bandpass_biquad``` 

- ```bandreject_biquad```   

Add test cases for both ```bandpass_biquad``` and ```bandreject_biquad``` to test_functional_filtering.py

All tests in test_functional_filtering.py passed
Output of test_functional_filtering.py
```
.........skipping GPU test for lfilter_basic because device not available
.skipping GPU test for lfilter because device not available
...
----------------------------------------------------------------------
Ran 13 tests in 1422.882s

OK
```
