### PR TITLE
[0.5.0] Test against RC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,11 +15,11 @@ binary_common: &binary_common
     build_version:
       description: "version number of release binary; by default, build a nightly"
       type: string
-      default: ""
+      default: "0.5.0"
     pytorch_version:
       description: "PyTorch version to build against; by default, use a nightly"
       type: string
-      default: ""
+      default: "1.5.0"
     # Don't edit these
     python_version:
       description: "Python version to build against (e.g., 3.8)"

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -15,11 +15,11 @@ binary_common: &binary_common
     build_version:
       description: "version number of release binary; by default, build a nightly"
       type: string
-      default: ""
+      default: "0.5.0"
     pytorch_version:
       description: "PyTorch version to build against; by default, use a nightly"
       type: string
-      default: ""
+      default: "1.5.0"
     # Don't edit these
     python_version:
       description: "Python version to build against (e.g., 3.8)"

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -170,6 +170,7 @@ setup_pip_pytorch_version() {
     fi
   else
     pip_install "torch==$PYTORCH_VERSION$PYTORCH_VERSION_SUFFIX" \
+      -f https://download.pytorch.org/whl/torch_test.html \
       -f https://download.pytorch.org/whl/torch_stable.html \
       -f https://download.pytorch.org/whl/nightly/torch_nightly.html
   fi
@@ -181,10 +182,10 @@ setup_pip_pytorch_version() {
 # You MUST have populated PYTORCH_VERSION_SUFFIX before hand.
 setup_conda_pytorch_constraint() {
   if [[ -z "$PYTORCH_VERSION" ]]; then
-    export CONDA_CHANNEL_FLAGS="-c pytorch-nightly"
-    export PYTORCH_VERSION="$(conda search --json 'pytorch[channel=pytorch-nightly]' | python -c "import sys, json, re; print(re.sub(r'\\+.*$', '', json.load(sys.stdin)['pytorch'][-1]['version']))")"
+    export CONDA_CHANNEL_FLAGS="-c pytorch-test"
+    export PYTORCH_VERSION="$(conda search --json 'pytorch[channel=pytorch-test]' | python -c "import sys, json, re; print(re.sub(r'\\+.*$', '', json.load(sys.stdin)['pytorch'][-1]['version']))")"
   else
-    export CONDA_CHANNEL_FLAGS="-c pytorch -c pytorch-nightly"
+    export CONDA_CHANNEL_FLAGS="-c pytorch-test -c pytorch -c pytorch-nightly"
   fi
   if [[ "$CU_VERSION" == cpu ]]; then
     export CONDA_PYTORCH_BUILD_CONSTRAINT="- pytorch==$PYTORCH_VERSION${PYTORCH_VERSION_SUFFIX}"

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -170,7 +170,7 @@ setup_pip_pytorch_version() {
     fi
   else
     pip_install "torch==$PYTORCH_VERSION$PYTORCH_VERSION_SUFFIX" \
-      -f https://download.pytorch.org/whl/torch_test.html \
+      -f https://download.pytorch.org/whl/test/torch_test.html \
       -f https://download.pytorch.org/whl/torch_stable.html \
       -f https://download.pytorch.org/whl/nightly/torch_nightly.html
   fi


### PR DESCRIPTION
Bump version to 0.5.0. Before merging:
- [ ] set back channels to pytorch from pytorch-test used for pre-release testing

cc #354 #546  pytorch/vision#2011