### PR TITLE
Python 2 deprecation  - Replace package six with python3 versions

### DIFF
--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN conda create -y --name python3.6 python=3.6
 RUN conda create -y --name python3.7 python=3.7
 SHELL [ "/bin/bash", "-c" ]
 RUN echo "source /usr/local/etc/profile.d/conda.sh" >> ~/.bashrc
-RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.5 && conda install -y -c conda-forge sox && conda install -y numpy six
+RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.5 && conda install -y -c conda-forge sox && conda install -y numpy
 RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.6 && conda install -y -c conda-forge sox && conda install -y numpy
 RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.7 && conda install -y -c conda-forge sox && conda install -y numpy
 CMD [ "/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ build nightlies based on PyTorch nightlies by hand following the instructions in
 
 ```
 pip install numpy
-pip install future # only on python 2.7
-pip install six    # only on python 3.5
 pip install torchaudio_nightly -f https://download.pytorch.org/whl/nightly/torch_nightly.html
 ```
 

--- a/examples/interactive_asr/vad.py
+++ b/examples/interactive_asr/vad.py
@@ -21,7 +21,7 @@ from collections import deque
 
 import numpy as np
 import torch
-from six.moves import queue
+import queue
 
 import librosa
 import pyaudio

--- a/torchaudio/datasets/utils.py
+++ b/torchaudio/datasets/utils.py
@@ -9,9 +9,8 @@ import threading
 import zipfile
 from queue import Queue
 
-import six
 import torch
-from six.moves import urllib
+import urllib
 from torch.utils.data import Dataset
 from torch.utils.model_zoo import tqdm
 
@@ -41,21 +40,8 @@ def unicode_csv_reader(unicode_csv_data, **kwargs):
             maxInt = int(maxInt / 10)
     csv.field_size_limit(maxInt)
 
-    if six.PY2:
-        # Implementation borrowed from docs:
-        # https://docs.python.org/3.0/library/csv.html#examples
-        def utf_8_encoder(unicode_csv_data):
-            for line in unicode_csv_data:
-                yield line.encode('utf-8')
-
-        # csv.py doesn't do Unicode; encode temporarily as UTF-8:
-        csv_reader = csv.reader(utf_8_encoder(unicode_csv_data), **kwargs)
-        for row in csv_reader:
-            # decode UTF-8 back to Unicode, cell by cell:
-            yield [cell.decode("utf-8") for cell in row]
-    else:
-        for line in csv.reader(unicode_csv_data, **kwargs):
-            yield line
+    for line in csv.reader(unicode_csv_data, **kwargs):
+        yield line
 
 
 def makedir_exist_ok(dirpath):


### PR DESCRIPTION
Hey , Regarding the Issue (#477  )
I have replaced the package ```six``` with python 3 equivalents 
and changed readme and docker file which has reference to  package ```six``` installation

@vincentqb  could you review these changes
