### PR TITLE
Fix Fade device compatibility

### DIFF
--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -6,7 +6,6 @@ from warnings import warn
 
 import torch
 from torch import Tensor
-from torch import device as Device
 from torchaudio import functional as F
 from torchaudio.compliance import kaldi
 

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -725,11 +725,12 @@ class Fade(torch.nn.Module):
         """
         waveform_length = waveform.size()[-1]
         device = waveform.device
-        return self._fade_in(waveform_length, device) * self._fade_out(waveform_length, device) * waveform
+        return self._fade_in(waveform_length).to(device) * \
+            self._fade_out(waveform_length).to(device) * waveform
 
-    def _fade_in(self, waveform_length: int, device: Device) -> Tensor:
-        fade = torch.linspace(0, 1, self.fade_in_len, device=device)
-        ones = torch.ones(waveform_length - self.fade_in_len, device=device)
+    def _fade_in(self, waveform_length: int) -> Tensor:
+        fade = torch.linspace(0, 1, self.fade_in_len)
+        ones = torch.ones(waveform_length - self.fade_in_len)
 
         if self.fade_shape == "linear":
             fade = fade
@@ -748,9 +749,9 @@ class Fade(torch.nn.Module):
 
         return torch.cat((fade, ones)).clamp_(0, 1)
 
-    def _fade_out(self, waveform_length: int, device: Device) -> Tensor:
-        fade = torch.linspace(0, 1, self.fade_out_len, device=device)
-        ones = torch.ones(waveform_length - self.fade_out_len, device=device)
+    def _fade_out(self, waveform_length: int) -> Tensor:
+        fade = torch.linspace(0, 1, self.fade_out_len)
+        ones = torch.ones(waveform_length - self.fade_out_len)
 
         if self.fade_shape == "linear":
             fade = - fade + 1

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -6,6 +6,7 @@ from warnings import warn
 
 import torch
 from torch import Tensor
+from torch import device as Device
 from torchaudio import functional as F
 from torchaudio.compliance import kaldi
 
@@ -726,7 +727,7 @@ class Fade(torch.nn.Module):
         device = waveform.device
         return self._fade_in(waveform_length, device) * self._fade_out(waveform_length, device) * waveform
 
-    def _fade_in(self, waveform_length: int, device: torch.device) -> Tensor:
+    def _fade_in(self, waveform_length: int, device: Device) -> Tensor:
         fade = torch.linspace(0, 1, self.fade_in_len, device=device)
         ones = torch.ones(waveform_length - self.fade_in_len, device=device)
 
@@ -747,7 +748,7 @@ class Fade(torch.nn.Module):
 
         return torch.cat((fade, ones)).clamp_(0, 1)
 
-    def _fade_out(self, waveform_length: int, device: torch.device) -> Tensor:
+    def _fade_out(self, waveform_length: int, device: Device) -> Tensor:
         fade = torch.linspace(0, 1, self.fade_out_len, device=device)
         ones = torch.ones(waveform_length - self.fade_out_len, device=device)
 

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -723,12 +723,12 @@ class Fade(torch.nn.Module):
             Tensor: Tensor of audio of dimension (..., time).
         """
         waveform_length = waveform.size()[-1]
+        device = waveform.device
+        return self._fade_in(waveform_length, device) * self._fade_out(waveform_length, device) * waveform
 
-        return self._fade_in(waveform_length) * self._fade_out(waveform_length) * waveform
-
-    def _fade_in(self, waveform_length: int) -> Tensor:
-        fade = torch.linspace(0, 1, self.fade_in_len)
-        ones = torch.ones(waveform_length - self.fade_in_len)
+    def _fade_in(self, waveform_length: int, device: torch.device) -> Tensor:
+        fade = torch.linspace(0, 1, self.fade_in_len, device=device)
+        ones = torch.ones(waveform_length - self.fade_in_len, device=device)
 
         if self.fade_shape == "linear":
             fade = fade
@@ -747,9 +747,9 @@ class Fade(torch.nn.Module):
 
         return torch.cat((fade, ones)).clamp_(0, 1)
 
-    def _fade_out(self, waveform_length: int) -> Tensor:
-        fade = torch.linspace(0, 1, self.fade_out_len)
-        ones = torch.ones(waveform_length - self.fade_out_len)
+    def _fade_out(self, waveform_length: int, device: torch.device) -> Tensor:
+        fade = torch.linspace(0, 1, self.fade_out_len, device=device)
+        ones = torch.ones(waveform_length - self.fade_out_len, device=device)
 
         if self.fade_shape == "linear":
             fade = - fade + 1


### PR DESCRIPTION
This PR makes `Fade` compatible with device other than CPU. It was generating coefficients on CPU so that when the input Tensor is on CUDA, it failed.