### PR TITLE
Add mypy Config File

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+allow_redefinition = True
+disallow_untyped_defs = False
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,3 @@
 [mypy]
 allow_redefinition = True
-disallow_untyped_defs = False
 ignore_missing_imports = True


### PR DESCRIPTION
In order to start using Mypy full potential, we must start fixing the issues that he might throw.
Relates to #477

As a starter I add the following definitions to the config file:

allow_redefinition: True
`Allows variables to be redefined with an arbitrary type, as long as the redefinition is in the same block and nesting level as the original definition.`
ignore_missing_imports: True
`Suppresses error messages about imports that cannot be resolved.`