### PR TITLE
Call torch.stft directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,13 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - env: PYTHON_VERSION="3.5"
     - env: PYTHON_VERSION="3.6"
     - env: PYTHON_VERSION="3.7"
-    - env: PYTHON_VERSION="3.5" RUN_FLAKE8="true" SKIP_INSTALL="true" SKIP_TESTS="true"
-    - env: PYTHON_VERSION="3.5" RUN_EXAMPLE_TESTS="true" SKIP_TESTS="true"
+    - env: PYTHON_VERSION="3.8"
+    - env: PYTHON_VERSION="3.6" RUN_FLAKE8="true" SKIP_INSTALL="true" SKIP_TESTS="true"
+    - env: PYTHON_VERSION="3.6" RUN_EXAMPLE_TESTS="true" SKIP_TESTS="true"
   allow_failures:
-    - env: PYTHON_VERSION="3.5" RUN_EXAMPLE_TESTS="true" SKIP_TESTS="true"
+    - env: PYTHON_VERSION="3.6" RUN_EXAMPLE_TESTS="true" SKIP_TESTS="true"
 
 addons:
   apt:

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -48,6 +48,7 @@ popd
 source activate testenv
 
  # Install requirements via pip in our conda environment
+conda install -y pytorch cpuonly -c pytorch-nightly
 pip install -r requirements.txt
 
  # Install the following only if running tests

--- a/build_tools/travis/test_script.sh
+++ b/build_tools/travis/test_script.sh
@@ -6,6 +6,7 @@
 set -e
 
 python --version
+python -c 'import torch;print("torch:", torch.__version__)'
 
 run_tests() {
   # find all the test files that match "test*.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=1.2.0
+torch>=1.4.0
 
 # Required for Windows because it's the only available backend
 SoundFile; sys_platform == 'win32'
@@ -18,6 +18,3 @@ scipy
 
 # Unit tests with pytest
 pytest
-
-# Testing only Py3 compat
-backports.tempfile

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -36,32 +36,6 @@ __all__ = [
 ]
 
 
-# TODO: remove this once https://github.com/pytorch/pytorch/issues/21478 gets solved
-@torch.jit.ignore
-def _stft(
-        waveform: Tensor,
-        n_fft: int,
-        hop_length: Optional[int],
-        win_length: Optional[int],
-        window: Optional[Tensor],
-        center: bool,
-        pad_mode: str,
-        normalized: bool,
-        onesided: bool
-) -> Tensor:
-    return torch.stft(
-        waveform,
-        n_fft,
-        hop_length,
-        win_length,
-        window,
-        center,
-        pad_mode,
-        normalized,
-        onesided,
-    )
-
-
 def istft(
         stft_matrix: Tensor,
         n_fft: int,
@@ -265,7 +239,7 @@ def spectrogram(
     waveform = waveform.view(-1, shape[-1])
 
     # default values are consistent with librosa.core.spectrum._spectrogram
-    spec_f = _stft(
+    spec_f = torch.stft(
         waveform, n_fft, hop_length, win_length, window, True, "reflect", False, True
     )
 
@@ -365,8 +339,8 @@ def griffinlim(
                         length=length).float()
 
         # Rebuild the spectrogram
-        rebuilt = _stft(inverse, n_fft, hop_length, win_length, window,
-                        True, 'reflect', False, True)
+        rebuilt = torch.stft(inverse, n_fft, hop_length, win_length, window,
+                             True, 'reflect', False, True)
 
         # Update our phase estimates
         angles = rebuilt - tprev.mul_(momentum / (1 + momentum))


### PR DESCRIPTION
Found the note

`# TODO: remove this once https://github.com/pytorch/pytorch/issues/21478 gets solved`

And the issue is resolved and we should not need to wrap `torch.stft` anymore.