### PR TITLE
Fix test backend ImportError

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -76,7 +76,7 @@ def filter_backends_with_mp3(backends):
             with AudioBackendScope(backend):
                 torchaudio.load(test_filepath)
             return True
-        except RuntimeError:
+        except (RuntimeError, ImportError):
             return False
 
     return [backend for backend in backends if supports_mp3(backend)]


### PR DESCRIPTION
Fix the case when the test utility collects available backends, it is not handling `ImportError` and fails.

Resolves #536 