### PR TITLE
Run test against PyTorch nightly on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,13 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - env: PYTHON_VERSION="3.5"
     - env: PYTHON_VERSION="3.6"
     - env: PYTHON_VERSION="3.7"
-    - env: PYTHON_VERSION="3.5" RUN_FLAKE8="true" SKIP_INSTALL="true" SKIP_TESTS="true"
-    - env: PYTHON_VERSION="3.5" RUN_EXAMPLE_TESTS="true" SKIP_TESTS="true"
+    - env: PYTHON_VERSION="3.8"
+    - env: PYTHON_VERSION="3.6" RUN_FLAKE8="true" SKIP_INSTALL="true" SKIP_TESTS="true"
+    - env: PYTHON_VERSION="3.6" RUN_EXAMPLE_TESTS="true" SKIP_TESTS="true"
   allow_failures:
-    - env: PYTHON_VERSION="3.5" RUN_EXAMPLE_TESTS="true" SKIP_TESTS="true"
+    - env: PYTHON_VERSION="3.6" RUN_EXAMPLE_TESTS="true" SKIP_TESTS="true"
 
 addons:
   apt:

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -48,6 +48,7 @@ popd
 source activate testenv
 
  # Install requirements via pip in our conda environment
+conda install -y pytorch cpuonly -c pytorch-nightly
 pip install -r requirements.txt
 
  # Install the following only if running tests

--- a/build_tools/travis/test_script.sh
+++ b/build_tools/travis/test_script.sh
@@ -6,6 +6,7 @@
 set -e
 
 python --version
+python -c 'import torch;print("torch:", torch.__version__)'
 
 run_tests() {
   # find all the test files that match "test*.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=1.2.0
+torch>=1.4.0
 
 # Required for Windows because it's the only available backend
 SoundFile; sys_platform == 'win32'
@@ -18,6 +18,3 @@ scipy
 
 # Unit tests with pytest
 pytest
-
-# Testing only Py3 compat
-backports.tempfile


### PR DESCRIPTION
- Install PyTorch nightly build on CI test.
- Update requirements

**Important version changes**
- Drop Python 3.5 unit test.
- Add Python 3.8 unit test.
- Replace other test (lint and example) being run on 3.5 with 3.6

Unblocks #531 