### PR TITLE
Add contrast to functional

### DIFF
--- a/docs/source/functional.rst
+++ b/docs/source/functional.rst
@@ -93,6 +93,41 @@ Functions to perform common audio operations.
 
 .. autofunction:: equalizer_biquad
 
+:hidden:`bandpass_biquad`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: bandpass_biquad
+
+:hidden:`bandreject_biquad`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: bandreject_biquad
+
+:hidden:`band_biquad`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: band_biquad
+
+:hidden:`treble_biquad`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: treble_biquad
+
+:hidden:`deemph_biquad`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: deemph_biquad
+
+:hidden:`riaa_biquad`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: riaa_biquad
+
+:hidden:`contrast`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: contrast
+
 :hidden:`mask_along_axis`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test/test_batch_consistency.py
+++ b/test/test_batch_consistency.py
@@ -65,6 +65,18 @@ class TestFunctional(unittest.TestCase):
         ])
         _test_batch(F.istft, stft, n_fft=4, length=4)
 
+    def test_contrast(self):
+        filenames = [
+            'steam-train-whistle-daniel_simon.wav',  # 2ch 44100Hz
+            # Files from https://www.mediacollege.com/audio/tone/download/
+            '100Hz_44100Hz_16bit_05sec.wav',  # 1ch
+            '440Hz_44100Hz_16bit_05sec.wav',  # 1ch
+        ]
+        for filename in filenames:
+            filepath = common_utils.get_asset_path(filename)
+            waveform, sample_rate = torchaudio.load(filepath)
+            _test_batch(F.contrast, waveform, enhancement_amount=80.)
+
 
 class TestTransforms(unittest.TestCase):
     """Test suite for classes defined in `transforms` module"""

--- a/test/test_batch_consistency.py
+++ b/test/test_batch_consistency.py
@@ -66,16 +66,8 @@ class TestFunctional(unittest.TestCase):
         _test_batch(F.istft, stft, n_fft=4, length=4)
 
     def test_contrast(self):
-        filenames = [
-            'steam-train-whistle-daniel_simon.wav',  # 2ch 44100Hz
-            # Files from https://www.mediacollege.com/audio/tone/download/
-            '100Hz_44100Hz_16bit_05sec.wav',  # 1ch
-            '440Hz_44100Hz_16bit_05sec.wav',  # 1ch
-        ]
-        for filename in filenames:
-            filepath = common_utils.get_asset_path(filename)
-            waveform, sample_rate = torchaudio.load(filepath)
-            _test_batch(F.contrast, waveform, enhancement_amount=80.)
+        waveform = torch.rand(2, 100) - 0.5
+        _test_batch(F.contrast, waveform, enhancement_amount=80.)
 
 
 class TestTransforms(unittest.TestCase):

--- a/test/test_sox_compatibility.py
+++ b/test/test_sox_compatibility.py
@@ -302,6 +302,24 @@ class TestFunctionalFiltering(unittest.TestCase):
 
     @unittest.skipIf("sox" not in BACKENDS, "sox not available")
     @AudioBackendScope("sox")
+    def test_contrast(self):
+        """
+        Test contrast effect, compare to SoX implementation
+        """
+        ENHANCEMENT_AMOUNT = 80.
+        noise_filepath = common_utils.get_asset_path('whitenoise.wav')
+        E = torchaudio.sox_effects.SoxEffectsChain()
+        E.set_input_file(noise_filepath)
+        E.append_effect_to_chain("contrast", [ENHANCEMENT_AMOUNT])
+        sox_output_waveform, sr = E.sox_build_flow_effects()
+
+        waveform, sample_rate = torchaudio.load(noise_filepath, normalization=True)
+        output_waveform = F.contrast(waveform, ENHANCEMENT_AMOUNT)
+
+        torch.testing.assert_allclose(output_waveform, sox_output_waveform, atol=1e-4, rtol=1e-5)
+
+    @unittest.skipIf("sox" not in BACKENDS, "sox not available")
+    @AudioBackendScope("sox")
     def test_equalizer(self):
         """
         Test biquad peaking equalizer filter, compare to SoX implementation

--- a/test/test_sox_compatibility.py
+++ b/test/test_sox_compatibility.py
@@ -306,15 +306,15 @@ class TestFunctionalFiltering(unittest.TestCase):
         """
         Test contrast effect, compare to SoX implementation
         """
-        ENHANCEMENT_AMOUNT = 80.
+        enhancement_amount = 80.
         noise_filepath = common_utils.get_asset_path('whitenoise.wav')
         E = torchaudio.sox_effects.SoxEffectsChain()
         E.set_input_file(noise_filepath)
-        E.append_effect_to_chain("contrast", [ENHANCEMENT_AMOUNT])
+        E.append_effect_to_chain("contrast", [enhancement_amount])
         sox_output_waveform, sr = E.sox_build_flow_effects()
 
         waveform, sample_rate = torchaudio.load(noise_filepath, normalization=True)
-        output_waveform = F.contrast(waveform, ENHANCEMENT_AMOUNT)
+        output_waveform = F.contrast(waveform, enhancement_amount)
 
         torch.testing.assert_allclose(output_waveform, sox_output_waveform, atol=1e-4, rtol=1e-5)
 

--- a/test/test_torchscript_consistency.py
+++ b/test/test_torchscript_consistency.py
@@ -406,6 +406,16 @@ class _FunctionalTestMixin:
 
         self._assert_consistency(func, waveform)
 
+    def test_contrast(self):
+        filepath = common_utils.get_asset_path("whitenoise.wav")
+        waveform, _ = torchaudio.load(filepath, normalization=True)
+
+        def func(tensor):
+            enhancement_amount = 80.
+            return F.contrast(tensor, enhancement_amount)
+
+        self._assert_consistency(func, waveform)
+
 
 class _TransformsTestMixin:
     """Implements test for Transforms that are performed for different devices"""

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -31,6 +31,7 @@ __all__ = [
     "deemph_biquad",
     "riaa_biquad",
     "biquad",
+    "contrast",
     'mask_along_axis',
     'mask_along_axis_iid'
 ]
@@ -1158,6 +1159,38 @@ def riaa_biquad(
     b2 *= g
 
     return biquad(waveform, b0, b1, b2, a0, a1, a2)
+
+
+def contrast(
+        waveform: Tensor,
+        enhancement_amount: float = 75.
+) -> Tensor:
+    r"""Apply contrast effect.  Similar to SoX implementation.
+    Comparable with compression, this effect modifies an audio signal to make it sound louder
+
+    Args:
+        waveform (Tensor): audio waveform of dimension of `(..., time)`
+        enhancement_amount (float): controls the amount of the enhancement
+            Allowed range of values for enhancement_amount : 0-100
+            Note that enhancement_amount = 0 still gives a significant contrast enhancement
+
+    Returns:
+        Tensor: Waveform of dimension of `(..., time)`
+
+    References:
+        http://sox.sourceforge.net/sox.html
+    """
+
+    if (enhancement_amount < 0 or enhancement_amount > 100):
+        raise ValueError("Allowed range of values for enhancement_amount : 0-100")
+
+    contrast = enhancement_amount / 750.
+
+    temp1 = waveform * (math.pi / 2)
+    temp2 = contrast * torch.sin(temp1 * 4)
+    output_waveform = torch.sin(temp1 + temp2)
+
+    return output_waveform
 
 
 def mask_along_axis_iid(

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -1181,7 +1181,7 @@ def contrast(
         http://sox.sourceforge.net/sox.html
     """
 
-    if (enhancement_amount < 0 or enhancement_amount > 100):
+    if not 0 <= enhancement_amount <= 100:
         raise ValueError("Allowed range of values for enhancement_amount : 0-100")
 
     contrast = enhancement_amount / 750.


### PR DESCRIPTION
Hi ,

Regarding the issue #260 ( Reducing dependency in Sox)
Implemented below function in functional.py
 - contrast

Added a test case  to test_sox_compatibility.py

All tests in test_sox_compatibility.py passed on CPU.

```
................gain: can't reclaim headroom
.
----------------------------------------------------------------------
Ran 17 tests in 501.774s

OK
```
@vincentqb could you please review changes