### PR TITLE
Only initialize sox once and never shutdown in test

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -84,3 +84,14 @@ def filter_backends_with_mp3(backends):
 
 
 BACKENDS_MP3 = filter_backends_with_mp3(BACKENDS)
+
+
+_IS_SOX_INITIALIZED = False
+
+
+def initialize_sox():
+    """Initialize sox backend only if it has not yet."""
+    global _IS_SOX_INITIALIZED
+    if not _IS_SOX_INITIALIZED:
+        torchaudio.initialize_sox()
+        _IS_SOX_INITIALIZED = True

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -7,9 +7,7 @@ import common_utils
 from common_utils import AudioBackendScope, BACKENDS
 
 
-@unittest.skipIf("sox" not in BACKENDS, "sox not available")
 class TORCHAUDIODS(Dataset):
-
     def __init__(self):
         sound_files = ["sinewave.wav", "steam-train-whistle-daniel_simon.mp3"]
         self.data = [common_utils.get_asset_path(fn) for fn in sound_files]
@@ -34,11 +32,7 @@ class TORCHAUDIODS(Dataset):
 class Test_DataLoader(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        torchaudio.initialize_sox()
-
-    @classmethod
-    def tearDownClass(cls):
-        torchaudio.shutdown_sox()
+        common_utils.initialize_sox()
 
     def test_1(self):
         expected_size = (2, 1, 16000)
@@ -46,6 +40,7 @@ class Test_DataLoader(unittest.TestCase):
         dl = DataLoader(ds, batch_size=2)
         for x in dl:
             self.assertTrue(x.size() == expected_size)
+
 
 if __name__ == '__main__':
     with AudioBackendScope("sox"):

--- a/test/test_sox_effects.py
+++ b/test/test_sox_effects.py
@@ -13,11 +13,7 @@ class Test_SoxEffectsChain(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        torchaudio.initialize_sox()
-
-    @classmethod
-    def tearDownClass(cls):
-        torchaudio.shutdown_sox()
+        common_utils.initialize_sox()
 
     def test_single_channel(self):
         fn_sine = common_utils.get_asset_path("sinewave.wav")


### PR DESCRIPTION
Fixes #533 by only initializing SoX once on-demand in test.

*NB* This does not affect the way tests are ran in CI.