### PR TITLE
Add overdrive to functional

### DIFF
--- a/docs/source/functional.rst
+++ b/docs/source/functional.rst
@@ -133,6 +133,11 @@ Functions to perform common audio operations.
 
 .. autofunction:: dcshift
 
+:hidden:`overdrive`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: overdrive
+
 :hidden:`mask_along_axis`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test/test_batch_consistency.py
+++ b/test/test_batch_consistency.py
@@ -72,6 +72,10 @@ class TestFunctional(unittest.TestCase):
         waveform = torch.rand(2, 100) - 0.5
         _test_batch(F.dcshift, waveform, shift=0.5, limiter_gain=0.05)
 
+    def test_overdrive(self):
+        waveform = torch.rand(2, 100) - 0.5
+        _test_batch(F.overdrive, waveform, gain=45, colour=30)
+
 
 class TestTransforms(unittest.TestCase):
     """Test suite for classes defined in `transforms` module"""

--- a/test/test_sox_compatibility.py
+++ b/test/test_sox_compatibility.py
@@ -357,6 +357,25 @@ class TestFunctionalFiltering(unittest.TestCase):
 
     @unittest.skipIf("sox" not in BACKENDS, "sox not available")
     @AudioBackendScope("sox")
+    def test_overdrive(self):
+        """
+        Test overdrive effect, compare to SoX implementation
+        """
+        gain = 30
+        colour = 40
+        noise_filepath = common_utils.get_asset_path('whitenoise.wav')
+        E = torchaudio.sox_effects.SoxEffectsChain()
+        E.set_input_file(noise_filepath)
+        E.append_effect_to_chain("overdrive", [gain, colour])
+        sox_output_waveform, sr = E.sox_build_flow_effects()
+
+        waveform, _ = torchaudio.load(noise_filepath, normalization=True)
+        output_waveform = F.overdrive(waveform, gain, colour)
+
+        torch.testing.assert_allclose(output_waveform, sox_output_waveform, atol=1e-4, rtol=1e-5)
+
+    @unittest.skipIf("sox" not in BACKENDS, "sox not available")
+    @AudioBackendScope("sox")
     def test_equalizer(self):
         """
         Test biquad peaking equalizer filter, compare to SoX implementation

--- a/test/test_torchscript_consistency.py
+++ b/test/test_torchscript_consistency.py
@@ -462,6 +462,17 @@ class _FunctionalTestMixin:
 
         self._assert_consistency(func, waveform)
 
+    def test_overdrive(self):
+        filepath = common_utils.get_asset_path("whitenoise.wav")
+        waveform, _ = torchaudio.load(filepath, normalization=True)
+
+        def func(tensor):
+            gain = 30.
+            colour = 50.
+            return F.overdrive(tensor, gain, colour)
+
+        self._assert_consistency(func, waveform)
+
 
 class _TransformsTestMixin:
     """Implements test for Transforms that are performed for different devices"""

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -1268,17 +1268,17 @@ def overdrive(
 
     gain = _dB2Linear(gain)
     colour = colour / 200
-    last_in = torch.zeros(waveform.shape[0],waveform.shape[1])
-    last_out = torch.zeros(waveform.shape[0],waveform.shape[1])
+    last_in = torch.zeros(waveform.shape[0], waveform.shape[1])
+    last_out = torch.zeros(waveform.shape[0], waveform.shape[1])
 
     temp = waveform * gain + colour
 
     mask1 = temp < -1
     temp[mask1] = temp[mask1] * 0 - 2 / 3
-    #Above redundant multiplcation to accomadate torchscript issue
+    # Above redundant multiplcation to accomadate torchscript issue
 
     mask2 = temp > 1
-    temp[mask2] =  temp[mask2] * 0 + 2 / 3
+    temp[mask2] = temp[mask2] * 0 + 2 / 3
 
     mask3 = (~mask1 & ~mask2)
     temp[mask3] = temp[mask3] - (temp[mask3]**3) * (1. / 3)

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -1268,16 +1268,17 @@ def overdrive(
 
     gain = _dB2Linear(gain)
     colour = colour / 200
-    last_in = 0.
-    last_out = 0.
+    last_in = torch.zeros(waveform.shape[0],waveform.shape[1])
+    last_out = torch.zeros(waveform.shape[0],waveform.shape[1])
 
     temp = waveform * gain + colour
 
     mask1 = temp < -1
-    temp[mask1] = waveform[mask1] * 0 + (-2 / 3)
+    temp[mask1] = temp[mask1] * 0 + 2 / 3
+    #Above redundant multiplcation to accomadate torchscript issue
 
     mask2 = temp > 1
-    temp[mask2] = waveform[mask2] * 0 + (2 / 3)
+    temp[mask2] =  temp[mask2] * 0 - 2 / 3
 
     mask3 = (~mask1 & ~mask2)
     temp[mask3] = temp[mask3] - (temp[mask3]**3) * (1. / 3)

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -1274,11 +1274,11 @@ def overdrive(
     temp = waveform * gain + colour
 
     mask1 = temp < -1
-    temp[mask1] = temp[mask1] * 0 + 2 / 3
+    temp[mask1] = temp[mask1] * 0 - 2 / 3
     #Above redundant multiplcation to accomadate torchscript issue
 
     mask2 = temp > 1
-    temp[mask2] =  temp[mask2] * 0 - 2 / 3
+    temp[mask2] =  temp[mask2] * 0 + 2 / 3
 
     mask3 = (~mask1 & ~mask2)
     temp[mask3] = temp[mask3] - (temp[mask3]**3) * (1. / 3)


### PR DESCRIPTION
Hi ,
Regarding the issue #260 ( Reducing dependency in Sox)
Implemented ```overdrive``` function in functional.py

   

-  function.rst - updated with new fucntion

  

-   test_sox_compatibility.py - Added a test for overdrive . Tests passed

```
...................gain: can't reclaim headroom
.
----------------------------------------------------------------------
Ran 20 tests in 509.658s

OK
```

  
-   test_torchscript_consistency.py - added test . Test passed

```
...................................sssssssssssssssssssssssssssssssssss................ssssssssssssssss
----------------------------------------------------------------------
Ran 102 tests in 1400.141s

OK (skipped=51)
````

-  test_batch_consistency.py - added test for overdrive . Test for overdrive passed, but 
existing batch_mfcc  failed
```
...............F..
======================================================================
FAIL: test_batch_mfcc (__main__.TestTransforms)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_batch_consistency.py", line 201, in test_batch_mfcc
    torch.testing.assert_allclose(computed, expected, atol=1e-5, rtol=1e-5)
  File "/Users/ka387861/pytorch/torch/testing/__init__.py", line 59, in assert_allclose
    count - 1, 100 * count / actual.numel()))
AssertionError: Not within tolerance rtol=1e-05 atol=1e-05 at input[2, 0, 2, 1384] (0.5488258004188538 vs. 0.5488020181655884) and 8 other locations (0.00%)

----------------------------------------------------------------------
Ran 18 tests in 185.586s
```

For making the torch script test work i added a redundant operation . 
Comment mentioning that is present in code.

@vincentqb could you please review these changes