### PR TITLE
Define proper logger for module

### DIFF
--- a/torchaudio/datasets/utils.py
+++ b/torchaudio/datasets/utils.py
@@ -17,6 +17,8 @@ import urllib.request
 from torch.utils.data import Dataset
 from torch.utils.model_zoo import tqdm
 
+_LG = logging.getLogger(__name__)
+
 
 def unicode_csv_reader(unicode_csv_data: TextIOWrapper, **kwargs: Any) -> Any:
     r"""Since the standard csv library does not handle unicode in Python 2, we need a wrapper.
@@ -214,14 +216,14 @@ def extract_archive(from_path: str, to_path: Optional[str] = None, overwrite: bo
 
     try:
         with tarfile.open(from_path, "r") as tar:
-            logging.info("Opened tar file {}.".format(from_path))
+            _LG.info("Opened tar file %s.", from_path)
             files = []
             for file_ in tar:  # type: Any
                 file_path = os.path.join(to_path, file_.name)
                 if file_.isfile():
                     files.append(file_path)
                     if os.path.exists(file_path):
-                        logging.info("{} already extracted.".format(file_path))
+                        _LG.info("%s already extracted.", file_path)
                         if not overwrite:
                             continue
                 tar.extract(file_, to_path)
@@ -231,12 +233,12 @@ def extract_archive(from_path: str, to_path: Optional[str] = None, overwrite: bo
 
     try:
         with zipfile.ZipFile(from_path, "r") as zfile:
-            logging.info("Opened zip file {}.".format(from_path))
+            _LG.info("Opened zip file %s.", from_path)
             files = zfile.namelist()
             for file_ in files:
                 file_path = os.path.join(to_path, file_)
                 if os.path.exists(file_path):
-                    logging.info("{} already extracted.".format(file_path))
+                    _LG.info("%s already extracted.", file_path)
                     if not overwrite:
                         continue
                 zfile.extract(file_, to_path)


### PR DESCRIPTION
`logging.info` writes to the root logger, which should be reserved for application logging, and it makes hard for users to filter `torchaudio`.
Also, it is recommended to let logging module string substitution only when the log is actually emitted.