### PR TITLE
Remove Python2.7 related code from CircleCI helper function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,15 +24,10 @@ binary_common: &binary_common
     python_version:
       description: "Python version to build against (e.g., 3.8)"
       type: string
-    unicode_abi:
-      description: "Python 2.7 wheel only: whether or not we are cp27mu (default: no)"
-      type: string
-      default: ""
   environment:
     PYTHON_VERSION: << parameters.python_version >>
     BUILD_VERSION: << parameters.build_version >>
     PYTORCH_VERSION: << parameters.pytorch_version >>
-    UNICODE_ABI: << parameters.unicode_abi >>
     CU_VERSION: cpu
 
 smoke_test_common: &smoke_test_common

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -24,15 +24,10 @@ binary_common: &binary_common
     python_version:
       description: "Python version to build against (e.g., 3.8)"
       type: string
-    unicode_abi:
-      description: "Python 2.7 wheel only: whether or not we are cp27mu (default: no)"
-      type: string
-      default: ""
   environment:
     PYTHON_VERSION: << parameters.python_version >>
     BUILD_VERSION: << parameters.build_version >>
     PYTORCH_VERSION: << parameters.pytorch_version >>
-    UNICODE_ABI: << parameters.unicode_abi >>
     CU_VERSION: cpu
 
 smoke_test_common: &smoke_test_common

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -24,24 +24,22 @@ def workflows(prefix='', upload=False, filter_branch=None, indentation=6):
     for btype in ["wheel", "conda"]:
         for os_type in ["linux", "macos"]:
             for python_version in ["3.5", "3.6", "3.7", "3.8"]:
-                for unicode in ([False, True] if btype == "wheel" and python_version == "2.7" else [False]):
-                    w += workflow_pair(btype, os_type, python_version, unicode, filter_branch, prefix, upload)
+                w += workflow_pair(btype, os_type, python_version, filter_branch, prefix, upload)
 
     return indent(indentation, w)
 
 
-def workflow_pair(btype, os_type, python_version, unicode, filter_branch, prefix='', upload=False):
+def workflow_pair(btype, os_type, python_version, filter_branch, prefix='', upload=False):
 
     w = []
-    unicode_suffix = "_unicode" if unicode else ""
-    base_workflow_name = "{prefix}binary_{os_type}_{btype}_py{python_version}{unicode_suffix}".format(
+    base_workflow_name = "{prefix}binary_{os_type}_{btype}_py{python_version}".format(
         prefix=prefix,
         os_type=os_type,
         btype=btype,
         python_version=python_version,
-        unicode_suffix=unicode_suffix)
+    )
 
-    w.append(generate_base_workflow(base_workflow_name, python_version, unicode, filter_branch, os_type, btype))
+    w.append(generate_base_workflow(base_workflow_name, python_version, filter_branch, os_type, btype))
 
     if upload:
 
@@ -56,15 +54,12 @@ def workflow_pair(btype, os_type, python_version, unicode, filter_branch, prefix
     return w
 
 
-def generate_base_workflow(base_workflow_name, python_version, unicode, filter_branch, os_type, btype):
+def generate_base_workflow(base_workflow_name, python_version, filter_branch, os_type, btype):
 
     d = {
         "name": base_workflow_name,
         "python_version": python_version,
     }
-
-    if unicode:
-        d["unicode_abi"] = '1'
 
     if filter_branch:
         d["filters"] = gen_filter_branch_tree(filter_branch)


### PR DESCRIPTION
Remove Python 2.7 related options from regenerate script. This does not change `config.yml` as 2.7 is deprecated.