### PR TITLE
Run unit test on CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,14 +243,14 @@ jobs:
       - restore_cache:
 
           keys:
-            - env-v1-{{ arch }}-<< parameters.python_version >>-{{ checksum "./packaging/build_from_source.sh" }}-{{ checksum ".circleci/unittest/environment.yml" }}
+            - env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum "./packaging/build_from_source.sh" }}-{{ checksum ".circleci/unittest/environment.yml" }}
 
       - run:
           name: Setup
           command: .circleci/unittest/setup_env.sh
       - save_cache:
 
-          key: env-v1-{{ arch }}-<< parameters.python_version >>-{{ checksum "./packaging/build_from_source.sh" }}-{{ checksum ".circleci/unittest/environment.yml" }}
+          key: env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum "./packaging/build_from_source.sh" }}-{{ checksum ".circleci/unittest/environment.yml" }}
 
           paths:
             - conda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,6 +233,20 @@ jobs:
             docker tag ${image_name}:${CIRCLE_WORKFLOW_ID} 308535385114.dkr.ecr.us-east-1.amazonaws.com/${image_name}:${CIRCLE_WORKFLOW_ID}
             docker push 308535385114.dkr.ecr.us-east-1.amazonaws.com/${image_name}:${CIRCLE_WORKFLOW_ID}
 
+  unittest_linux:
+    <<: *binary_common
+    docker:
+      - image: "pytorch/manylinux-cuda100"
+    resource_class: 2xlarge+
+    steps:
+      - checkout
+      - run:
+          name: Setup environment
+          command: .circleci/unittest/setup_env.sh
+      - run:
+          name: Run test
+          command: .circleci/unittest/run_test.sh
+
 workflows:
   build:
     jobs:
@@ -276,7 +290,17 @@ workflows:
       - binary_win_conda:
           name: torchaudio_win_py3.6
           python_version: "3.6"
-
+  unittest:
+    jobs:
+      - unittest_linux:
+          name: unittest_linux_py3.6
+          python_version: '3.6'
+      - unittest_linux:
+          name: unittest_linux_py3.7
+          python_version: '3.7'
+      - unittest_linux:
+          name: unittest_linux_py3.8
+          python_version: '3.8'
   nightly:
     jobs:
       - circleci_consistency

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,9 +240,25 @@ jobs:
     resource_class: 2xlarge+
     steps:
       - checkout
+      - restore_cache:
+
+          keys:
+            - env-v1-{{ arch }}-<< parameters.python_version >>-{{ checksum "./packaging/build_from_source.sh" }}-{{ checksum ".circleci/unittest/environment.yml" }}
+
       - run:
-          name: Setup environment
+          name: Setup
           command: .circleci/unittest/setup_env.sh
+      - save_cache:
+
+          key: env-v1-{{ arch }}-<< parameters.python_version >>-{{ checksum "./packaging/build_from_source.sh" }}-{{ checksum ".circleci/unittest/environment.yml" }}
+
+          paths:
+            - conda
+            - env
+            - third_party
+      - run:
+          name: Installation
+          command: .circleci/unittest/install.sh
       - run:
           name: Run test
           command: .circleci/unittest/run_test.sh

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -243,14 +243,14 @@ jobs:
       - restore_cache:
           {% raw %}
           keys:
-            - env-v1-{{ arch }}-<< parameters.python_version >>-{{ checksum "./packaging/build_from_source.sh" }}-{{ checksum ".circleci/unittest/environment.yml" }}
+            - env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum "./packaging/build_from_source.sh" }}-{{ checksum ".circleci/unittest/environment.yml" }}
           {% endraw %}
       - run:
           name: Setup
           command: .circleci/unittest/setup_env.sh
       - save_cache:
           {% raw %}
-          key: env-v1-{{ arch }}-<< parameters.python_version >>-{{ checksum "./packaging/build_from_source.sh" }}-{{ checksum ".circleci/unittest/environment.yml" }}
+          key: env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum "./packaging/build_from_source.sh" }}-{{ checksum ".circleci/unittest/environment.yml" }}
 	  {% endraw %}
           paths:
             - conda

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -233,6 +233,20 @@ jobs:
             docker tag ${image_name}:${CIRCLE_WORKFLOW_ID} 308535385114.dkr.ecr.us-east-1.amazonaws.com/${image_name}:${CIRCLE_WORKFLOW_ID}
             docker push 308535385114.dkr.ecr.us-east-1.amazonaws.com/${image_name}:${CIRCLE_WORKFLOW_ID}
 
+  unittest_linux:
+    <<: *binary_common
+    docker:
+      - image: "pytorch/manylinux-cuda100"
+    resource_class: 2xlarge+
+    steps:
+      - checkout
+      - run:
+          name: Setup environment
+          command: .circleci/unittest/setup_env.sh
+      - run:
+          name: Run test
+          command: .circleci/unittest/run_test.sh
+
 workflows:
   build:
     jobs:
@@ -241,7 +255,9 @@ workflows:
       - binary_win_conda:
           name: torchaudio_win_py3.6
           python_version: "3.6"
-
+  unittest:
+    jobs:
+      {{ unittest_workflows() }}
   nightly:
     jobs:
       - circleci_consistency

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -251,7 +251,7 @@ jobs:
       - save_cache:
           {% raw %}
           key: env-v1-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum "./packaging/build_from_source.sh" }}-{{ checksum ".circleci/unittest/environment.yml" }}
-	  {% endraw %}
+          {% endraw %}
           paths:
             - conda
             - env

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -237,7 +237,7 @@ workflows:
   build:
     jobs:
       - circleci_consistency
-      {{ workflows() }}
+      {{ build_workflows() }}
       - binary_win_conda:
           name: torchaudio_win_py3.6
           python_version: "3.6"
@@ -245,7 +245,7 @@ workflows:
   nightly:
     jobs:
       - circleci_consistency
-      {{ workflows(prefix="nightly_", filter_branch="nightly", upload=True) }}
+      {{ build_workflows(prefix="nightly_", filter_branch="nightly", upload=True) }}
   docker_build:
     triggers:
       - schedule:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -240,9 +240,25 @@ jobs:
     resource_class: 2xlarge+
     steps:
       - checkout
+      - restore_cache:
+          {% raw %}
+          keys:
+            - env-v1-{{ arch }}-<< parameters.python_version >>-{{ checksum "./packaging/build_from_source.sh" }}-{{ checksum ".circleci/unittest/environment.yml" }}
+          {% endraw %}
       - run:
-          name: Setup environment
+          name: Setup
           command: .circleci/unittest/setup_env.sh
+      - save_cache:
+          {% raw %}
+          key: env-v1-{{ arch }}-<< parameters.python_version >>-{{ checksum "./packaging/build_from_source.sh" }}-{{ checksum ".circleci/unittest/environment.yml" }}
+	  {% endraw %}
+          paths:
+            - conda
+            - env
+            - third_party
+      - run:
+          name: Installation
+          command: .circleci/unittest/install.sh
       - run:
           name: Run test
           command: .circleci/unittest/run_test.sh

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -19,17 +19,20 @@ import yaml
 import os.path
 
 
+PYTHON_VERSIONS = ["3.6", "3.7", "3.8"]
+
+
 def build_workflows(prefix='', upload=False, filter_branch=None, indentation=6):
     w = []
     for btype in ["wheel", "conda"]:
         for os_type in ["linux", "macos"]:
-            for python_version in ["3.6", "3.7", "3.8"]:
-                w += workflow_pair(btype, os_type, python_version, filter_branch, prefix, upload)
+            for python_version in PYTHON_VERSIONS:
+                w += build_workflow_pair(btype, os_type, python_version, filter_branch, prefix, upload)
 
     return indent(indentation, w)
 
 
-def workflow_pair(btype, os_type, python_version, filter_branch, prefix='', upload=False):
+def build_workflow_pair(btype, os_type, python_version, filter_branch, prefix='', upload=False):
 
     w = []
     base_workflow_name = "{prefix}binary_{os_type}_{btype}_py{python_version}".format(
@@ -107,6 +110,19 @@ def indent(indentation, data_list):
     return ("\n" + " " * indentation).join(yaml.dump(data_list).splitlines())
 
 
+def unittest_workflows(indentation=6):
+    w = []
+    for os_type in ["linux"]:
+        for python_version in PYTHON_VERSIONS:
+            w.append({
+                f"unittest_{os_type}": {
+                    "name": f"unittest_{os_type}_py{python_version}",
+                    "python_version": python_version,
+                }
+            })
+    return indent(indentation, w)
+
+
 if __name__ == "__main__":
     d = os.path.dirname(__file__)
     env = jinja2.Environment(
@@ -116,4 +132,7 @@ if __name__ == "__main__":
     )
 
     with open(os.path.join(d, 'config.yml'), 'w') as f:
-        f.write(env.get_template('config.yml.in').render(build_workflows=build_workflows))
+        f.write(env.get_template('config.yml.in').render(
+            build_workflows=build_workflows,
+            unittest_workflows=unittest_workflows,
+        ))

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -19,7 +19,7 @@ import yaml
 import os.path
 
 
-def workflows(prefix='', upload=False, filter_branch=None, indentation=6):
+def build_workflows(prefix='', upload=False, filter_branch=None, indentation=6):
     w = []
     for btype in ["wheel", "conda"]:
         for os_type in ["linux", "macos"]:
@@ -116,4 +116,4 @@ if __name__ == "__main__":
     )
 
     with open(os.path.join(d, 'config.yml'), 'w') as f:
-        f.write(env.get_template('config.yml.in').render(workflows=workflows))
+        f.write(env.get_template('config.yml.in').render(build_workflows=build_workflows))

--- a/.circleci/unittest/environment.yml
+++ b/.circleci/unittest/environment.yml
@@ -1,10 +1,7 @@
 channels:
-  - pytorch-nightly
   - conda-forge
   - defaults
 dependencies:
-  - pytorch
-  - cpuonly
   - flake8
   - numpy
   - pytest
@@ -13,4 +10,3 @@ dependencies:
   - pip:
     - kaldi-io
     - scipy
-    - soundfile

--- a/.circleci/unittest/environment.yml
+++ b/.circleci/unittest/environment.yml
@@ -1,0 +1,16 @@
+channels:
+  - pytorch-nightly
+  - conda-forge
+  - defaults
+dependencies:
+  - pytorch
+  - cpuonly
+  - flake8
+  - numpy
+  - pytest
+  - librosa
+  - pip
+  - pip:
+    - kaldi-io
+    - scipy
+    - soundfile

--- a/.circleci/unittest/install.sh
+++ b/.circleci/unittest/install.sh
@@ -8,7 +8,7 @@ set -e
 eval "$(./conda/bin/conda shell.bash hook)"
 conda activate ./env
 
-printf "* Installing PyTorch Nightly"
+printf "* Installing PyTorch nightly build"
 conda install -c pytorch-nightly pytorch cpuonly
 
 printf "* Setting up torchaudio\n"

--- a/.circleci/unittest/install.sh
+++ b/.circleci/unittest/install.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+unset PYTORCH_VERSION
+# For unittest, nightly PyTorch is used, and we do not want to fixiate on the version
+
+set -e
+
+eval "$(./conda/bin/conda shell.bash hook)"
+conda activate ./env
+
+printf "* Installing PyTorch Nightly"
+conda install -c pytorch-nightly pytorch cpuonly
+
+printf "* Setting up torchaudio\n"
+IS_CONDA=true python setup.py develop

--- a/.circleci/unittest/run_test.sh
+++ b/.circleci/unittest/run_test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+conda_location="${HOME}/miniconda3"
+root_dir="$(git rev-parse --show-toplevel)"
+
+eval "$(${conda_location}/bin/conda shell.bash hook)"
+conda activate ./env
+
+python -m torch.utils.collect_env
+pytest -v test

--- a/.circleci/unittest/run_test.sh
+++ b/.circleci/unittest/run_test.sh
@@ -2,10 +2,7 @@
 
 set -e
 
-conda_location="${HOME}/miniconda3"
-root_dir="$(git rev-parse --show-toplevel)"
-
-eval "$(${conda_location}/bin/conda shell.bash hook)"
+eval "$(./conda/bin/conda shell.bash hook)"
 conda activate ./env
 
 python -m torch.utils.collect_env

--- a/.circleci/unittest/setup_env.sh
+++ b/.circleci/unittest/setup_env.sh
@@ -1,30 +1,38 @@
 #!/usr/bin/env bash
 
 # This script is for setting up environment for running unit test on CircleCI.
+# To speed up the CI time, the result of environment is cached.
+# PyTorch is not included here, so that it won't be cached.
 
 set -e
 
-unset PYTORCH_VERSION
-# For unittest, nightly PyTorch is used, and we do not want to fixiate on the version
-
-conda_location="${HOME}/miniconda3"
-root_dir="$(git rev-parse --show-toplevel)"
 this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+root_dir="$(git rev-parse --show-toplevel)"
+conda_dir="${root_dir}/conda"
+env_dir="${root_dir}/env"
 
 cd "${root_dir}"
 
-printf "* Installing conda\n"
-wget -O miniconda.sh http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-bash ./miniconda.sh -b -f -p "${conda_location}"
-eval "$(${conda_location}/bin/conda shell.bash hook)"
-conda init
+# 1. Install conda at ./conda
+if [ ! -d "${conda_dir}" ]; then
+    printf "* Installing conda\n"
+    wget -O miniconda.sh http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+    bash ./miniconda.sh -b -f -p "${conda_dir}"
+fi
+printf "* Checking conda update\n"
+eval "$(${conda_dir}/bin/conda shell.bash hook)"
 conda update -n base -c defaults conda
 
-printf "* Creating a test environment\n"
-conda create --prefix ./env -y python="$PYTHON_VERSION"
-source activate ./env
+# 2. Create test environment at ./env
+if [ ! -d "${env_dir}" ]; then
+    printf "* Creating a test environment\n"
+    conda create --prefix "${env_dir}" -y python="$PYTHON_VERSION"
+fi
+conda activate "${env_dir}"
 conda env update --file "${this_dir}/environment.yml" --prune
 
-printf "* Setting up torchaudio\n"
-./packaging/build_from_source.sh "$PWD"
-IS_CONDA=true python setup.py develop
+# 3. Build codecs at ./third_party
+if [ ! -d "./third_party" ]; then
+    printf "* Building Codecs"
+    ./packaging/build_from_source.sh "$PWD"
+fi

--- a/.circleci/unittest/setup_env.sh
+++ b/.circleci/unittest/setup_env.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# This script is for setting up environment for running unit test on CircleCI.
+
+set -e
+
+unset PYTORCH_VERSION
+# For unittest, nightly PyTorch is used, and we do not want to fixiate on the version
+
+conda_location="${HOME}/miniconda3"
+root_dir="$(git rev-parse --show-toplevel)"
+this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cd "${root_dir}"
+
+printf "* Installing conda\n"
+wget -O miniconda.sh http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+bash ./miniconda.sh -b -f -p "${conda_location}"
+eval "$(${conda_location}/bin/conda shell.bash hook)"
+conda init
+conda update -n base -c defaults conda
+
+printf "* Creating a test environment\n"
+conda create --prefix ./env -y python="$PYTHON_VERSION"
+source activate ./env
+conda env update --file "${this_dir}/environment.yml" --prune
+
+printf "* Setting up torchaudio\n"
+./packaging/build_from_source.sh "$PWD"
+IS_CONDA=true python setup.py develop

--- a/.circleci/unittest/setup_env.sh
+++ b/.circleci/unittest/setup_env.sh
@@ -28,6 +28,7 @@ if [ ! -d "${env_dir}" ]; then
     printf "* Creating a test environment\n"
     conda create --prefix "${env_dir}" -y python="$PYTHON_VERSION"
 fi
+printf "* Installing dependencies (except PyTorch)\n"
 conda activate "${env_dir}"
 conda env update --file "${this_dir}/environment.yml" --prune
 

--- a/test/test_librosa_compatibility.py
+++ b/test/test_librosa_compatibility.py
@@ -243,8 +243,8 @@ class TestTransforms(_LibrosaMixin, unittest.TestCase):
         }
         _test_compatibilities(**kwargs)
 
-    # NOTE: Test passes offline, but fails on TravisCI, see #372.
-    @unittest.skipIf('CI ' in os.environ, 'Test is known to fail on CI')
+    # NOTE: Test passes offline, but fails on TravisCI (and CircleCI), see #372.
+    @unittest.skipIf('CI' in os.environ, 'Test is known to fail on CI')
     def test_basics3(self):
         kwargs = {
             'n_fft': 200,

--- a/test/test_librosa_compatibility.py
+++ b/test/test_librosa_compatibility.py
@@ -244,9 +244,7 @@ class TestTransforms(_LibrosaMixin, unittest.TestCase):
         _test_compatibilities(**kwargs)
 
     # NOTE: Test passes offline, but fails on TravisCI, see #372.
-    @unittest.skipIf(
-        os.environ.get('CI') == 'true' and os.environ.get('TRAVIS') == 'true',
-        'Test is known to fail on TravisCI')
+    @unittest.skipIf('CI ' in os.environ('CI'), 'Test is known to fail on CI')
     def test_basics3(self):
         kwargs = {
             'n_fft': 200,

--- a/test/test_librosa_compatibility.py
+++ b/test/test_librosa_compatibility.py
@@ -244,7 +244,7 @@ class TestTransforms(_LibrosaMixin, unittest.TestCase):
         _test_compatibilities(**kwargs)
 
     # NOTE: Test passes offline, but fails on TravisCI, see #372.
-    @unittest.skipIf('CI ' in os.environ('CI'), 'Test is known to fail on CI')
+    @unittest.skipIf('CI ' in os.environ, 'Test is known to fail on CI')
     def test_basics3(self):
         kwargs = {
             'n_fft': 200,


### PR DESCRIPTION
This PR adds unit test on Circle CI.

These tests are added as a new workflow so that binary build and unit tests are independent each other.
