### PR TITLE
Stop build binary for Python3.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,9 +238,6 @@ workflows:
     jobs:
       - circleci_consistency
       - binary_linux_wheel:
-          name: binary_linux_wheel_py3.5
-          python_version: '3.5'
-      - binary_linux_wheel:
           name: binary_linux_wheel_py3.6
           python_version: '3.6'
       - binary_linux_wheel:
@@ -249,9 +246,6 @@ workflows:
       - binary_linux_wheel:
           name: binary_linux_wheel_py3.8
           python_version: '3.8'
-      - binary_macos_wheel:
-          name: binary_macos_wheel_py3.5
-          python_version: '3.5'
       - binary_macos_wheel:
           name: binary_macos_wheel_py3.6
           python_version: '3.6'
@@ -262,9 +256,6 @@ workflows:
           name: binary_macos_wheel_py3.8
           python_version: '3.8'
       - binary_linux_conda:
-          name: binary_linux_conda_py3.5
-          python_version: '3.5'
-      - binary_linux_conda:
           name: binary_linux_conda_py3.6
           python_version: '3.6'
       - binary_linux_conda:
@@ -273,9 +264,6 @@ workflows:
       - binary_linux_conda:
           name: binary_linux_conda_py3.8
           python_version: '3.8'
-      - binary_macos_conda:
-          name: binary_macos_conda_py3.5
-          python_version: '3.5'
       - binary_macos_conda:
           name: binary_macos_conda_py3.6
           python_version: '3.6'
@@ -292,28 +280,6 @@ workflows:
   nightly:
     jobs:
       - circleci_consistency
-      - binary_linux_wheel:
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py3.5
-          python_version: '3.5'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py3.5_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.5
-      - smoke_test_linux_pip:
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py3.5_smoke_test_pip
-          python_version: '3.5'
-          requires:
-          - nightly_binary_linux_wheel_py3.5_upload
       - binary_linux_wheel:
           filters:
             branches:
@@ -384,20 +350,6 @@ workflows:
           filters:
             branches:
               only: nightly
-          name: nightly_binary_macos_wheel_py3.5
-          python_version: '3.5'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_macos_wheel_py3.5_upload
-          requires:
-          - nightly_binary_macos_wheel_py3.5
-      - binary_macos_wheel:
-          filters:
-            branches:
-              only: nightly
           name: nightly_binary_macos_wheel_py3.6
           python_version: '3.6'
       - binary_wheel_upload:
@@ -436,28 +388,6 @@ workflows:
           name: nightly_binary_macos_wheel_py3.8_upload
           requires:
           - nightly_binary_macos_wheel_py3.8
-      - binary_linux_conda:
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_conda_py3.5
-          python_version: '3.5'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_conda_py3.5_upload
-          requires:
-          - nightly_binary_linux_conda_py3.5
-      - smoke_test_linux_conda:
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_conda_py3.5_smoke_test_conda
-          python_version: '3.5'
-          requires:
-          - nightly_binary_linux_conda_py3.5_upload
       - binary_linux_conda:
           filters:
             branches:
@@ -524,20 +454,6 @@ workflows:
           python_version: '3.8'
           requires:
           - nightly_binary_linux_conda_py3.8_upload
-      - binary_macos_conda:
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_macos_conda_py3.5
-          python_version: '3.5'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_macos_conda_py3.5_upload
-          requires:
-          - nightly_binary_macos_conda_py3.5
       - binary_macos_conda:
           filters:
             branches:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -23,7 +23,7 @@ def workflows(prefix='', upload=False, filter_branch=None, indentation=6):
     w = []
     for btype in ["wheel", "conda"]:
         for os_type in ["linux", "macos"]:
-            for python_version in ["3.5", "3.6", "3.7", "3.8"]:
+            for python_version in ["3.6", "3.7", "3.8"]:
                 w += workflow_pair(btype, os_type, python_version, filter_branch, prefix, upload)
 
     return indent(indentation, w)


### PR DESCRIPTION
PyTorch master has dropped support for Python 3.5 but torch audio is still building binary for Python 3.5.
Not sure if intended. Can you advise? @seemethere @soumith @ezyang 