### PR TITLE
CPP extension for overdrive effect in functional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,14 @@ else:
             extra_compile_args=eca,
             extra_objects=extra_objects,
             extra_link_args=ela),
+        CppExtension(
+            '_torch_overdrive',
+            ['torchaudio/torch_overdrive.cpp'],
+            libraries=libraries,
+            include_dirs=include_dirs,
+            extra_compile_args=eca,
+            extra_objects=extra_objects,
+            extra_link_args=ela),
     ]
 
 setup(

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple
 
 import torch
 from torch import Tensor
+from _torch_overdrive import  _overdrive_float
 
 __all__ = [
     "istft",
@@ -1287,10 +1288,7 @@ def overdrive(
     output_waveform = torch.zeros_like(waveform, dtype=dtype, device=device)
 
     # TODO: Implement a torch CPP extension
-    for i in range(waveform.shape[-1]):
-        last_out = temp[:, i] - last_in + 0.995 * last_out
-        last_in = temp[:, i]
-        output_waveform[:, i] = waveform[:, i] * 0.5 + last_out * 0.75
+    _overdrive_float(waveform,temp,last_in,last_out,output_waveform)
 
     return output_waveform.clamp(min=-1, max=1).view(actual_shape)
 

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple
 
 import torch
 from torch import Tensor
-from _torch_overdrive import  _overdrive_float
+from _torch_overdrive import _overdrive_helper
 
 __all__ = [
     "istft",
@@ -1288,7 +1288,7 @@ def overdrive(
     output_waveform = torch.zeros_like(waveform, dtype=dtype, device=device)
 
     # TODO: Implement a torch CPP extension
-    _overdrive_float(waveform,temp,last_in,last_out,output_waveform)
+    _overdrive_helper(waveform, temp, last_in, last_out, output_waveform)
 
     return output_waveform.clamp(min=-1, max=1).view(actual_shape)
 

--- a/torchaudio/torch_overdrive.cpp
+++ b/torchaudio/torch_overdrive.cpp
@@ -1,0 +1,56 @@
+#include <torch/extension.h>
+// TBD - for CUDA support #include <ATen/cuda/CUDAContext.h>
+// TBD - Compile on CUDA
+
+namespace torch {
+namespace audio {
+
+
+  template <typename T>
+  void _overdrive_float(
+    at::Tensor & waveform,
+    at::Tensor & temp,
+    at::Tensor & last_in,
+    at::Tensor & last_out,
+    at::Tensor & output_waveform
+  ) {
+    int64_t n_frames = waveform.size(1);
+    int64_t n_channels = waveform.size(0);
+    // Create CPU accessors for fast access
+    // https://pytorch.org/cppdocs/notes/tensor_basics.html
+    auto waveform_accessor = waveform.accessor<T, 2>();
+    auto temp_accessor = temp.accessor<T, 2>();
+    auto last_in_accessor = last_in.accessor<T, 1>();
+    auto last_out_accessor = last_out.accessor<T, 1>();
+    auto output_waveform_accessor = output_waveform.accessor<T, 2>();
+
+    for (int64_t i_channel = 0; i_channel < n_channels; ++i_channel) {
+
+        for (int64_t i_frame = 0; i_frame < n_frames; ++i_frame) {
+        last_out_accessor[i_channel] = temp_accessor[i_channel][i_frame] - last_in_accessor[i_channel] + 0.995 * last_out_accessor[i_channel];
+        last_in_accessor[i_channel] = temp_accessor[i_channel][i_frame];
+        output_waveform_accessor[i_channel][i_frame]= waveform_accessor[i_channel][i_frame] * 0.5 + last_out_accessor[i_channel] * 0.75;
+        }
+    }
+    /*
+    for (int64_t i_frame = 0; i_frame < n_frames; ++i_frame) {
+
+      last_out = temp.slice(1,i_frame,i_frame+1) - last_in + 0.995 * last_out;
+      last_in = temp.slice(1,i_frame,i_frame+1);
+      output_waveform.slice(1,i_frame,i_frame+1) = waveform.slice(1,i_frame,i_frame+1) * 0.5 + last_out * 0.75;
+
+      }
+    */
+
+  }
+
+}  // namespace audio
+}  // namespace torch
+
+
+PYBIND11_MODULE(_torch_overdrive, m) {
+  m.def(
+      "_overdrive_float",
+      &torch::audio::_overdrive_float<float>,
+      "Executes difference equation with tensor");
+}

--- a/torchaudio/torch_overdrive.cpp
+++ b/torchaudio/torch_overdrive.cpp
@@ -1,46 +1,51 @@
 #include <torch/extension.h>
-// TBD - for CUDA support #include <ATen/cuda/CUDAContext.h>
-// TBD - Compile on CUDA
 
 namespace torch {
 namespace audio {
 
 
-  template <typename T>
-  void _overdrive_float(
+  template <typename scalar_t>
+  void overdrive_cpu_kernel(
+    at::TensorAccessor<scalar_t, 2>  waveform_accessor,
+    at::TensorAccessor<scalar_t, 2>  temp_accessor,
+    at::TensorAccessor<scalar_t, 1>  last_in_accessor,
+    at::TensorAccessor<scalar_t, 1>  last_out_accessor,
+    at::TensorAccessor<scalar_t, 2>  output_waveform_accessor
+  ) {
+    int64_t n_frames = waveform_accessor.size(1);
+    int64_t n_channels = waveform_accessor.size(0);
+
+    for (int64_t i_channel = 0; i_channel < n_channels; ++i_channel) {
+
+        for (int64_t i_frame = 0; i_frame < n_frames; ++i_frame) {
+
+        last_out_accessor[i_channel] = temp_accessor[i_channel][i_frame] - last_in_accessor[i_channel] + 0.995 * last_out_accessor[i_channel];
+        last_in_accessor[i_channel] = temp_accessor[i_channel][i_frame];
+        output_waveform_accessor[i_channel][i_frame]= waveform_accessor[i_channel][i_frame] * 0.5 + last_out_accessor[i_channel] * 0.75;
+
+        }
+    }
+
+  }
+
+
+  void _overdrive_helper_cpu(
     at::Tensor & waveform,
     at::Tensor & temp,
     at::Tensor & last_in,
     at::Tensor & last_out,
     at::Tensor & output_waveform
   ) {
-    int64_t n_frames = waveform.size(1);
-    int64_t n_channels = waveform.size(0);
-    // Create CPU accessors for fast access
-    // https://pytorch.org/cppdocs/notes/tensor_basics.html
-    auto waveform_accessor = waveform.accessor<T, 2>();
-    auto temp_accessor = temp.accessor<T, 2>();
-    auto last_in_accessor = last_in.accessor<T, 1>();
-    auto last_out_accessor = last_out.accessor<T, 1>();
-    auto output_waveform_accessor = output_waveform.accessor<T, 2>();
 
-    for (int64_t i_channel = 0; i_channel < n_channels; ++i_channel) {
 
-        for (int64_t i_frame = 0; i_frame < n_frames; ++i_frame) {
-        last_out_accessor[i_channel] = temp_accessor[i_channel][i_frame] - last_in_accessor[i_channel] + 0.995 * last_out_accessor[i_channel];
-        last_in_accessor[i_channel] = temp_accessor[i_channel][i_frame];
-        output_waveform_accessor[i_channel][i_frame]= waveform_accessor[i_channel][i_frame] * 0.5 + last_out_accessor[i_channel] * 0.75;
-        }
-    }
-    /*
-    for (int64_t i_frame = 0; i_frame < n_frames; ++i_frame) {
-
-      last_out = temp.slice(1,i_frame,i_frame+1) - last_in + 0.995 * last_out;
-      last_in = temp.slice(1,i_frame,i_frame+1);
-      output_waveform.slice(1,i_frame,i_frame+1) = waveform.slice(1,i_frame,i_frame+1) * 0.5 + last_out * 0.75;
-
-      }
-    */
+    AT_DISPATCH_FLOATING_TYPES(waveform.scalar_type(),"overdrive_cpu",([&]{
+      overdrive_cpu_kernel<scalar_t>(
+      waveform.accessor<scalar_t, 2>(),
+      temp.accessor<scalar_t, 2>(),
+      last_in.accessor<scalar_t, 1>(),
+      last_out.accessor<scalar_t, 1>(),
+      output_waveform.accessor<scalar_t, 2>());
+    } ));
 
   }
 
@@ -50,7 +55,6 @@ namespace audio {
 
 PYBIND11_MODULE(_torch_overdrive, m) {
   m.def(
-      "_overdrive_float",
-      &torch::audio::_overdrive_float<float>,
-      "Executes difference equation with tensor");
+      "_overdrive_helper",&torch::audio::_overdrive_helper_cpu,
+      "Executes loop for overdrive effect");
 }

--- a/torchaudio/torch_overdrive.cpp
+++ b/torchaudio/torch_overdrive.cpp
@@ -3,58 +3,50 @@
 namespace torch {
 namespace audio {
 
+template <typename scalar_t>
+void overdrive_cpu_kernel(
+    at::TensorAccessor<scalar_t, 2> waveform_accessor,
+    at::TensorAccessor<scalar_t, 2> temp_accessor,
+    at::TensorAccessor<scalar_t, 1> last_in_accessor,
+    at::TensorAccessor<scalar_t, 1> last_out_accessor,
+    at::TensorAccessor<scalar_t, 2> output_waveform_accessor) {
+  int64_t n_frames = waveform_accessor.size(1);
+  int64_t n_channels = waveform_accessor.size(0);
 
-  template <typename scalar_t>
-  void overdrive_cpu_kernel(
-    at::TensorAccessor<scalar_t, 2>  waveform_accessor,
-    at::TensorAccessor<scalar_t, 2>  temp_accessor,
-    at::TensorAccessor<scalar_t, 1>  last_in_accessor,
-    at::TensorAccessor<scalar_t, 1>  last_out_accessor,
-    at::TensorAccessor<scalar_t, 2>  output_waveform_accessor
-  ) {
-    int64_t n_frames = waveform_accessor.size(1);
-    int64_t n_channels = waveform_accessor.size(0);
-
-    for (int64_t i_channel = 0; i_channel < n_channels; ++i_channel) {
-
-        for (int64_t i_frame = 0; i_frame < n_frames; ++i_frame) {
-
-        last_out_accessor[i_channel] = temp_accessor[i_channel][i_frame] - last_in_accessor[i_channel] + 0.995 * last_out_accessor[i_channel];
-        last_in_accessor[i_channel] = temp_accessor[i_channel][i_frame];
-        output_waveform_accessor[i_channel][i_frame]= waveform_accessor[i_channel][i_frame] * 0.5 + last_out_accessor[i_channel] * 0.75;
-
-        }
+  for (int64_t i_channel = 0; i_channel < n_channels; ++i_channel) {
+    for (int64_t i_frame = 0; i_frame < n_frames; ++i_frame) {
+      last_out_accessor[i_channel] = temp_accessor[i_channel][i_frame] -
+          last_in_accessor[i_channel] + 0.995 * last_out_accessor[i_channel];
+      last_in_accessor[i_channel] = temp_accessor[i_channel][i_frame];
+      output_waveform_accessor[i_channel][i_frame] =
+          waveform_accessor[i_channel][i_frame] * 0.5 +
+          last_out_accessor[i_channel] * 0.75;
     }
-
   }
+}
 
+void _overdrive_helper_cpu(
+    at::Tensor& waveform,
+    at::Tensor& temp,
+    at::Tensor& last_in,
+    at::Tensor& last_out,
+    at::Tensor& output_waveform) {
+  AT_DISPATCH_FLOATING_TYPES(waveform.scalar_type(), "overdrive_cpu", ([&] {
+                               overdrive_cpu_kernel<scalar_t>(
+                                   waveform.accessor<scalar_t, 2>(),
+                                   temp.accessor<scalar_t, 2>(),
+                                   last_in.accessor<scalar_t, 1>(),
+                                   last_out.accessor<scalar_t, 1>(),
+                                   output_waveform.accessor<scalar_t, 2>());
+                             }));
+}
 
-  void _overdrive_helper_cpu(
-    at::Tensor & waveform,
-    at::Tensor & temp,
-    at::Tensor & last_in,
-    at::Tensor & last_out,
-    at::Tensor & output_waveform
-  ) {
-
-
-    AT_DISPATCH_FLOATING_TYPES(waveform.scalar_type(),"overdrive_cpu",([&]{
-      overdrive_cpu_kernel<scalar_t>(
-      waveform.accessor<scalar_t, 2>(),
-      temp.accessor<scalar_t, 2>(),
-      last_in.accessor<scalar_t, 1>(),
-      last_out.accessor<scalar_t, 1>(),
-      output_waveform.accessor<scalar_t, 2>());
-    } ));
-
-  }
-
-}  // namespace audio
-}  // namespace torch
-
+} // namespace audio
+} // namespace torch
 
 PYBIND11_MODULE(_torch_overdrive, m) {
   m.def(
-      "_overdrive_helper",&torch::audio::_overdrive_helper_cpu,
-      "Executes loop for overdrive effect");
+      "_overdrive_helper",
+      &torch::audio::_overdrive_helper_cpu,
+      "Executes helper loop for overdrive effect");
 }


### PR DESCRIPTION
Hi ,

I  have tried implementing existing fucntional ```overdrive``` using cpp as the python version is slow compared to Sox version . ( #260 ( Reducing dependency in Sox) )
Though cpp version is slight slower than sox version . It is much better compated to python version 

- comparing Sox with new overdrive(with cpp ext )
<img width="612" alt="Screenshot 2020-04-24 at 7 52 00 PM" src="https://user-images.githubusercontent.com/12258823/80223735-4f184c00-8666-11ea-9bc4-231183879dfa.png">


- old python overdrive effect took 80000 ms
<img width="573" alt="Screenshot 2020-04-24 at 8 28 46 PM" src="https://user-images.githubusercontent.com/12258823/80226712-57728600-866a-11ea-84f2-7d6260e2fb8f.png">

Almost >700X speed compared to python implementation

- sox comapatibilty - passed
- batch test - passed
- Torch script - not passed . I think  cpp extension cannot be converted to torch script
```
$ python test/test_torchscript_consistency.py
.............................E.....sssssssssssssssssssssssssssssssssss................ssssssssssssssss
======================================================================
ERROR: test_overdrive (__main__.TestFunctionalCPU)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_torchscript_consistency.py", line 474, in test_overdrive
    self._assert_consistency(func, waveform)
  File "test/test_torchscript_consistency.py", line 38, in _assert_consistency
    return _assert_functional_consistency(func, tensor, self.device, shape_only=shape_only)
  File "test/test_torchscript_consistency.py", line 14, in _assert_functional_consistency
    ts_func = torch.jit.script(func)
  File "/Users/ka387861/pytorch/torch/jit/__init__.py", line 1296, in script
    fn = torch._C._jit_script_compile(qualified_name, ast, _rcb, get_default_args(obj))
  File "/Users/ka387861/pytorch/torch/jit/_recursive.py", line 559, in try_compile_fn
    return torch.jit.script(fn, _rcb=rcb)
  File "/Users/ka387861/pytorch/torch/jit/__init__.py", line 1296, in script
    fn = torch._C._jit_script_compile(qualified_name, ast, _rcb, get_default_args(obj))
RuntimeError: 
Python builtin <built-in method _overdrive_helper of PyCapsule object at 0x143fe2270> is currently not supported in Torchscript:
  File "/Users/ka387861/audio/torchaudio/functional.py", line 1291

    # TODO: Implement a torch CPP extension
    _overdrive_helper(waveform, temp, last_in, last_out, output_waveform)
    ~~~~~~~~~~~~~~~~~ <--- HERE

    return output_waveform.clamp(min=-1, max=1).view(actual_shape)
'overdrive' is being compiled since it was called from 'func'
  File "test/test_torchscript_consistency.py", line 472
            gain = 30.
            colour = 50.
            return F.overdrive(tensor, gain, colour)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE


----------------------------------------------------------------------
Ran 102 tests in 1839.777s

FAILED (errors=1, skipped=51)
```


- should we create a new folder to organize cpp codes in torchaudio  ?
   - Cuda kernels and cpp files for other functions might clutter the torchaudio folder
- Planning to write a cuda kernel , but i am getting some weird errors when running existing torch script test on remote GPU docker 
ENV : pytorch - 1.4 , CUDA 10 , Multi GPU 

Below is a part of the log 
```
======================================================================
ERROR: test_Spectrogram (__main__.TestTransformsCUDA)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_torchscript_consistency.py", line 486, in test_Spectrogram
    self._assert_consistency(T.Spectrogram(), tensor)
  File "test/test_torchscript_consistency.py", line 482, in _assert_consistency
    _assert_transforms_consistency(transform, tensor, self.device)
  File "test/test_torchscript_consistency.py", line 27, in _assert_transforms_consistency
    ts_transform = torch.jit.script(transform)
  File "/miniconda/envs/python36/lib/python3.6/site-packages/torch/jit/__init__.py", line 1255, in script
    return torch.jit._recursive.recursive_script(obj)
  File "/miniconda/envs/python36/lib/python3.6/site-packages/torch/jit/_recursive.py", line 534, in recursive_script
    return create_script_module(nn_module, infer_methods_to_compile(nn_module))
  File "/miniconda/envs/python36/lib/python3.6/site-packages/torch/jit/_recursive.py", line 296, in create_script_module
    return create_script_module_impl(nn_module, concrete_type, cpp_module, stubs)
  File "/miniconda/envs/python36/lib/python3.6/site-packages/torch/jit/_recursive.py", line 340, in create_script_module_impl
    create_methods_from_stubs(concrete_type, stubs)
  File "/miniconda/envs/python36/lib/python3.6/site-packages/torch/jit/_recursive.py", line 259, in create_methods_from_stubs
    concrete_type._create_methods(defs, rcbs, defaults)
RuntimeError: Can't redefine method: forward on class: __torch__.torchaudio.transforms.Spectrogram (addMethod at /opt/conda/conda-bld/pytorch_1579027003190/work/torch/csrc/jit/script/class_type.cpp:73)
frame #0: c10::Error::Error(c10::SourceLocation, std::string const&) + 0x47 (0x7f55078ed627 in /miniconda/envs/python36/lib/python3.6/site-packages/torch/lib/libc10.so)
frame #1: c10::ClassType::addMethod(torch::jit::Function*) + 0x1d9 (0x7f550d426f69 in /miniconda/envs/python36/lib/python3.6/site-packages/torch/lib/libtorch.so)
frame #2: torch::jit::script::CompilationUnit::define(c10::optional<c10::QualifiedName> const&, torch::jit::script::Def const&, std::shared_ptr<torch::jit::script::Resolver> const&, torch::jit::script::Self const*, std::unordered_map<std::string, torch::jit::Function*, std::hash<std::string>, std::equal_to<std::string>, std::allocator<std::pair<std::string const, torch::jit::Function*> > > const&, bool) const + 0x6d7 (0x7f550d3b3f47 in /miniconda/envs/python36/lib/python3.6/site-packages/torch/lib/libtorch.so)
frame #3: torch::jit::script::CompilationUnit::define(c10::optional<c10::QualifiedName> const&, std::vector<torch::jit::script::Def, std::allocator<torch::jit::script::Def> > const&, std::vector<std::shared_ptr<torch::jit::script::Resolver>, std::allocator<std::shared_ptr<torch::jit::script::Resolver> > > const&, torch::jit::script::Self const*, bool) + 0x17d (0x7f550d3b468d in /miniconda/envs/python36/lib/python3.6/site-packages/torch/lib/libtorch.so)
frame #4: <unknown function> + 0x7897af (0x7f5538dd57af in /miniconda/envs/python36/lib/python3.6/site-packages/torch/lib/libtorch_python.so)
frame #5: <unknown function> + 0x28c076 (0x7f55388d8076 in /miniconda/envs/python36/lib/python3.6/site-packages/torch/lib/libtorch_python.so)
<omitting python frames>


======================================================================
FAIL: test_TimeStretch (__main__.TestTransformsCUDA)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_torchscript_consistency.py", line 533, in test_TimeStretch
    tensor,
  File "test/test_torchscript_consistency.py", line 482, in _assert_consistency
    _assert_transforms_consistency(transform, tensor, self.device)
  File "test/test_torchscript_consistency.py", line 30, in _assert_transforms_consistency
    torch.testing.assert_allclose(ts_output, output)
  File "/miniconda/envs/python36/lib/python3.6/site-packages/torch/testing/__init__.py", line 59, in assert_allclose
    count - 1, 100 * count / actual.numel()))
AssertionError: Not within tolerance rtol=0.0001 atol=1e-05 at input[7, 0, 254, 5, 0] (-0.030245909467339516 vs. -0.029713068157434464) and 101 other locations (0.00%)

----------------------------------------------------------------------
Ran 102 tests in 254.452s

FAILED (failures=1, errors=14, skipped=2)
```
Any idea of this  error above "Can't redefine method: forward on class"

@mthrok or @vincentqb  could review these changes 
