### PR TITLE
Fix smoke test image

### DIFF
--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -25,12 +25,12 @@ RUN apt-get -qq update && apt-get -qq -y install curl bzip2 sox libsox-dev libso
 
 ENV PATH /opt/conda/bin:$PATH
 
-RUN conda create -y --name python3.5 python=3.5
 RUN conda create -y --name python3.6 python=3.6
 RUN conda create -y --name python3.7 python=3.7
+RUN conda create -y --name python3.8 python=3.8
 SHELL [ "/bin/bash", "-c" ]
 RUN echo "source /usr/local/etc/profile.d/conda.sh" >> ~/.bashrc
-RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.5 && conda install -y -c conda-forge sox && conda install -y numpy
 RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.6 && conda install -y -c conda-forge sox && conda install -y numpy
 RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.7 && conda install -y -c conda-forge sox && conda install -y numpy
+RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.8 && conda install -y -c conda-forge sox && conda install -y numpy
 CMD [ "/bin/bash"]


### PR DESCRIPTION
Nightly smoke test is failing for Python 3.8 as conda environment does not exist.