### PR TITLE
Run nightly workflow only on nightly branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,10 @@ workflows:
           python_version: '3.8'
   nightly:
     jobs:
-      - circleci_consistency
+      - circleci_consistency:
+          filters:
+            branches:
+              only: nightly
       - binary_linux_wheel:
           filters:
             branches:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -276,7 +276,10 @@ workflows:
       {{ unittest_workflows() }}
   nightly:
     jobs:
-      - circleci_consistency
+      - circleci_consistency:
+          filters:
+            branches:
+              only: nightly
       {{ build_workflows(prefix="nightly_", filter_branch="nightly", upload=True) }}
   docker_build:
     triggers:


### PR DESCRIPTION
`circleci_consistency` under `nightly` workflow should run only for `nightly` branch.
The same job runs for PR under `build` workflow. So it's redundant.