### PR TITLE
Fix Mypy Variable Typing

### DIFF
--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -339,7 +339,7 @@ def get_sox_bool(i: int = 0) -> Any:
         return _torch_sox.sox_bool(i)
 
 
-_SOX_INITIALIZED = False
+_SOX_INITIALIZED: Optional[bool] = False
 # This variable has a micro lifecycle. (False -> True -> None)
 # False: Not initialized
 # True: Initialized


### PR DESCRIPTION
Mypy detected `_SOX_INITIALIZED` merely as `bool`, however, can be `None` as well