### PR TITLE
Reduce tolerance for MFCC

### DIFF
--- a/test/test_batch_consistency.py
+++ b/test/test_batch_consistency.py
@@ -207,7 +207,6 @@ class TestTransforms(unittest.TestCase):
         computed = torchaudio.transforms.MelSpectrogram()(waveform.repeat(3, 1, 1))
         torch.testing.assert_allclose(computed, expected)
 
-    @unittest.skipIf(platform.system() == "Windows", "Test is known to fail on Windows.")
     def test_batch_mfcc(self):
         test_filepath = common_utils.get_asset_path('steam-train-whistle-daniel_simon.wav')
         waveform, _ = torchaudio.load(test_filepath)
@@ -217,7 +216,7 @@ class TestTransforms(unittest.TestCase):
 
         # Batch then transform
         computed = torchaudio.transforms.MFCC()(waveform.repeat(3, 1, 1))
-        torch.testing.assert_allclose(computed, expected, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_allclose(computed, expected, atol=1e-4, rtol=1e-5)
 
     def test_batch_TimeStretch(self):
         test_filepath = common_utils.get_asset_path('steam-train-whistle-daniel_simon.wav')


### PR DESCRIPTION
`test_batch_mfcc` fails not only on Windows but also on [GPU linux machine](https://app.circleci.com/pipelines/github/pytorch/audio/1628/workflows/9c945119-bd14-40a4-9813-6d1f0fd764bc/jobs/41720).

I suspect this is resulted from the different version of CPU architecture ( `amd64-6_85` vs GPU `amd64-6_79` Windows `amd64-1_`) but cannot be sure. 

Looking at the error rate, more than 99.9% of elements are within the range of `1e-5` so I think it's safe to reduce it to `1e-4` so that Windows and GPU can pass this test.