### PR TITLE
Introduce common utility for defining test matrix for device/dtype

### DIFF
--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -9,10 +9,7 @@ import pytest
 import common_utils
 
 
-class _LfilterMixin:
-    device = None
-    dtype = None
-
+class Lfilter(common_utils.TestBaseMixin):
     def test_simple(self):
         """
         Create a very basic signal,
@@ -33,25 +30,12 @@ class _LfilterMixin:
         b_coeffs = torch.tensor([1, 0], dtype=self.dtype, device=self.device)
         a_coeffs = torch.tensor([1, -0.95], dtype=self.dtype, device=self.device)
         output_signal = F.lfilter(input_signal, a_coeffs, b_coeffs, clamp=True)
-        self.assertTrue(output_signal.max() <= 1)
+        assert output_signal.max() <= 1
         output_signal = F.lfilter(input_signal, a_coeffs, b_coeffs, clamp=False)
-        self.assertTrue(output_signal.max() > 1)
+        assert output_signal.max() > 1
 
 
-class TestLfilterFloat32CPU(_LfilterMixin, unittest.TestCase):
-    device = torch.device('cpu')
-    dtype = torch.float32
-
-
-class TestLfilterFloat64CPU(_LfilterMixin, unittest.TestCase):
-    device = torch.device('cpu')
-    dtype = torch.float64
-
-
-@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
-class TestLfilterFloat32CUDA(_LfilterMixin, unittest.TestCase):
-    device = torch.device('cuda')
-    dtype = torch.float32
+common_utils.define_test_suites(globals(), [Lfilter])
 
 
 class TestComputeDeltas(unittest.TestCase):

--- a/test/test_kaldi_compatibility.py
+++ b/test/test_kaldi_compatibility.py
@@ -90,6 +90,7 @@ class TestFunctional:
             'vtln_low': 1445,
             'vtln_warp': 1.0000,
             'window_type': 'hamming',
+
         }
         wave_file = common_utils.get_asset_path('kaldi_file.wav')
         result = torchaudio.compliance.kaldi.fbank(torchaudio.load_wav(wave_file)[0], **kwargs)

--- a/test/test_kaldi_compatibility.py
+++ b/test/test_kaldi_compatibility.py
@@ -90,7 +90,6 @@ class TestFunctional:
             'vtln_low': 1445,
             'vtln_warp': 1.0000,
             'window_type': 'hamming',
-
         }
         wave_file = common_utils.get_asset_path('kaldi_file.wav')
         result = torchaudio.compliance.kaldi.fbank(torchaudio.load_wav(wave_file)[0], **kwargs)

--- a/test/test_torchscript_consistency.py
+++ b/test/test_torchscript_consistency.py
@@ -30,7 +30,7 @@ def _assert_transforms_consistency(transform, tensor):
 class Functional(common_utils.TestBaseMixin):
     """Implements test for `functinoal` modul that are performed for different devices"""
     def _assert_consistency(self, func, tensor, shape_only=False):
-        tensor = tensor.to(self.device).to(self.dtype)
+        tensor = tensor.to(device=self.device, dtype=self.dtype)
         return _assert_functional_consistency(func, tensor, shape_only=shape_only)
 
     def test_spectrogram(self):
@@ -488,8 +488,8 @@ class Functional(common_utils.TestBaseMixin):
 class Transforms(common_utils.TestBaseMixin):
     """Implements test for Transforms that are performed for different devices"""
     def _assert_consistency(self, transform, tensor):
-        tensor = tensor.to(self.device).to(self.dtype)
-        transform = transform.to(self.device).to(self.dtype)
+        tensor = tensor.to(device=self.device, dtype=self.dtype)
+        transform = transform.to(device=self.device, dtype=self.dtype)
         _assert_transforms_consistency(transform, tensor)
 
     def test_Spectrogram(self):

--- a/test/test_torchscript_consistency.py
+++ b/test/test_torchscript_consistency.py
@@ -1,5 +1,6 @@
 """Test suites for jit-ability and its numerical compatibility"""
 import unittest
+import pytest
 
 import torch
 import torchaudio
@@ -207,6 +208,9 @@ class Functional(common_utils.TestBaseMixin):
         self._assert_consistency(func, tensor, shape_only=True)
 
     def test_lfilter(self):
+        if self.dtype == torch.float64:
+            pytest.xfail("This test is known to fail for float64")
+
         filepath = common_utils.get_asset_path('whitenoise.wav')
         waveform, _ = torchaudio.load(filepath, normalization=True)
 
@@ -248,6 +252,9 @@ class Functional(common_utils.TestBaseMixin):
         self._assert_consistency(func, waveform)
 
     def test_lowpass(self):
+        if self.dtype == torch.float64:
+            pytest.xfail("This test is known to fail for float64")
+
         filepath = common_utils.get_asset_path('whitenoise.wav')
         waveform, _ = torchaudio.load(filepath, normalization=True)
 
@@ -259,6 +266,9 @@ class Functional(common_utils.TestBaseMixin):
         self._assert_consistency(func, waveform)
 
     def test_highpass(self):
+        if self.dtype == torch.float64:
+            pytest.xfail("This test is known to fail for float64")
+
         filepath = common_utils.get_asset_path('whitenoise.wav')
         waveform, _ = torchaudio.load(filepath, normalization=True)
 
@@ -270,6 +280,9 @@ class Functional(common_utils.TestBaseMixin):
         self._assert_consistency(func, waveform)
 
     def test_allpass(self):
+        if self.dtype == torch.float64:
+            pytest.xfail("This test is known to fail for float64")
+
         filepath = common_utils.get_asset_path('whitenoise.wav')
         waveform, _ = torchaudio.load(filepath, normalization=True)
 
@@ -282,6 +295,9 @@ class Functional(common_utils.TestBaseMixin):
         self._assert_consistency(func, waveform)
 
     def test_bandpass_with_csg(self):
+        if self.dtype == torch.float64:
+            pytest.xfail("This test is known to fail for float64")
+
         filepath = common_utils.get_asset_path("whitenoise.wav")
         waveform, _ = torchaudio.load(filepath, normalization=True)
 
@@ -294,7 +310,10 @@ class Functional(common_utils.TestBaseMixin):
 
         self._assert_consistency(func, waveform)
 
-    def test_bandpass_withou_csg(self):
+    def test_bandpass_without_csg(self):
+        if self.dtype == torch.float64:
+            pytest.xfail("This test is known to fail for float64")
+
         filepath = common_utils.get_asset_path("whitenoise.wav")
         waveform, _ = torchaudio.load(filepath, normalization=True)
 
@@ -308,6 +327,9 @@ class Functional(common_utils.TestBaseMixin):
         self._assert_consistency(func, waveform)
 
     def test_bandreject(self):
+        if self.dtype == torch.float64:
+            pytest.xfail("This test is known to fail for float64")
+
         filepath = common_utils.get_asset_path("whitenoise.wav")
         waveform, _ = torchaudio.load(filepath, normalization=True)
 
@@ -320,6 +342,9 @@ class Functional(common_utils.TestBaseMixin):
         self._assert_consistency(func, waveform)
 
     def test_band_with_noise(self):
+        if self.dtype == torch.float64:
+            pytest.xfail("This test is known to fail for float64")
+
         filepath = common_utils.get_asset_path("whitenoise.wav")
         waveform, _ = torchaudio.load(filepath, normalization=True)
 
@@ -333,6 +358,9 @@ class Functional(common_utils.TestBaseMixin):
         self._assert_consistency(func, waveform)
 
     def test_band_without_noise(self):
+        if self.dtype == torch.float64:
+            pytest.xfail("This test is known to fail for float64")
+
         filepath = common_utils.get_asset_path("whitenoise.wav")
         waveform, _ = torchaudio.load(filepath, normalization=True)
 
@@ -346,6 +374,9 @@ class Functional(common_utils.TestBaseMixin):
         self._assert_consistency(func, waveform)
 
     def test_treble(self):
+        if self.dtype == torch.float64:
+            pytest.xfail("This test is known to fail for float64")
+
         filepath = common_utils.get_asset_path("whitenoise.wav")
         waveform, _ = torchaudio.load(filepath, normalization=True)
 
@@ -359,6 +390,9 @@ class Functional(common_utils.TestBaseMixin):
         self._assert_consistency(func, waveform)
 
     def test_deemph(self):
+        if self.dtype == torch.float64:
+            pytest.xfail("This test is known to fail for float64")
+
         filepath = common_utils.get_asset_path("whitenoise.wav")
         waveform, _ = torchaudio.load(filepath, normalization=True)
 
@@ -369,6 +403,9 @@ class Functional(common_utils.TestBaseMixin):
         self._assert_consistency(func, waveform)
 
     def test_riaa(self):
+        if self.dtype == torch.float64:
+            pytest.xfail("This test is known to fail for float64")
+
         filepath = common_utils.get_asset_path("whitenoise.wav")
         waveform, _ = torchaudio.load(filepath, normalization=True)
 
@@ -379,6 +416,9 @@ class Functional(common_utils.TestBaseMixin):
         self._assert_consistency(func, waveform)
 
     def test_equalizer(self):
+        if self.dtype == torch.float64:
+            pytest.xfail("This test is known to fail for float64")
+
         filepath = common_utils.get_asset_path("whitenoise.wav")
         waveform, _ = torchaudio.load(filepath, normalization=True)
 
@@ -392,6 +432,9 @@ class Functional(common_utils.TestBaseMixin):
         self._assert_consistency(func, waveform)
 
     def test_perf_biquad_filtering(self):
+        if self.dtype == torch.float64:
+            pytest.xfail("This test is known to fail for float64")
+
         filepath = common_utils.get_asset_path("whitenoise.wav")
         waveform, _ = torchaudio.load(filepath, normalization=True)
 

--- a/test/test_torchscript_consistency.py
+++ b/test/test_torchscript_consistency.py
@@ -618,7 +618,3 @@ class Transforms(common_utils.TestBaseMixin):
 
 
 common_utils.define_test_suites(globals(), [Functional, Transforms])
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/torchaudio/compliance/kaldi.py
+++ b/torchaudio/compliance/kaldi.py
@@ -890,6 +890,8 @@ def resample_waveform(waveform: Tensor,
     Returns:
         Tensor: The waveform at the new frequency
     """
+    device, dtype = waveform.device, waveform.dtype
+
     assert waveform.dim() == 2
     assert orig_freq > 0.0 and new_freq > 0.0
 
@@ -905,7 +907,7 @@ def resample_waveform(waveform: Tensor,
     window_width = lowpass_filter_width / (2.0 * lowpass_cutoff)
     first_indices, weights = _get_LR_indices_and_weights(orig_freq, new_freq, output_samples_in_unit,
                                                          window_width, lowpass_cutoff, lowpass_filter_width)
-    weights = weights.to(waveform.device)  # TODO Create weights on device directly
+    weights = weights.to(device=device, dtype=dtype)  # TODO Create weights on device directly
 
     assert first_indices.dim() == 1
     # TODO figure a better way to do this. conv1d reaches every element i*stride + padding
@@ -918,9 +920,9 @@ def resample_waveform(waveform: Tensor,
     window_size = weights.size(1)
     tot_output_samp = _get_num_LR_output_samples(wave_len, orig_freq, new_freq)
     output = torch.zeros((num_channels, tot_output_samp),
-                         device=waveform.device)
+                         device=device, dtype=dtype)
     # eye size: (num_channels, num_channels, 1)
-    eye = torch.eye(num_channels, device=waveform.device).unsqueeze(2)
+    eye = torch.eye(num_channels, device=device, dtype=dtype).unsqueeze(2)
     for i in range(first_indices.size(0)):
         wave_to_conv = waveform
         first_index = int(first_indices[i].item())


### PR DESCRIPTION
To work on #613, I added a helper function which simplifies the logic to generate test suites for different device, which also extends it to dtype.
As a result, torchscript consistency test is performed on (cpu, cuda) x (float32, float64) matrix. (float64 is newly added)

1. This revealed that some transforms (`Resample`) is not compatible with float64, which is fixed in this PR.
1. Interestingly `lfilter` does not yield consistent result among Python and torchscript only when `float64`.
    I looked at it but do not have an immediate fix so I marked them as expected to fail.