### PR TITLE
Fix log10 for float32

### DIFF
--- a/test/test_batch_consistency.py
+++ b/test/test_batch_consistency.py
@@ -216,7 +216,7 @@ class TestTransforms(unittest.TestCase):
 
         # Batch then transform
         computed = torchaudio.transforms.MFCC()(waveform.repeat(3, 1, 1))
-        torch.testing.assert_allclose(computed, expected, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_allclose(computed, expected, atol=1e-4, rtol=1e-5)
 
     def test_batch_TimeStretch(self):
         test_filepath = common_utils.get_asset_path('steam-train-whistle-daniel_simon.wav')

--- a/test/test_batch_consistency.py
+++ b/test/test_batch_consistency.py
@@ -216,7 +216,7 @@ class TestTransforms(unittest.TestCase):
 
         # Batch then transform
         computed = torchaudio.transforms.MFCC()(waveform.repeat(3, 1, 1))
-        torch.testing.assert_allclose(computed, expected, atol=1e-4, rtol=1e-5)
+        torch.testing.assert_allclose(computed, expected, atol=1e-5, rtol=1e-5)
 
     def test_batch_TimeStretch(self):
         test_filepath = common_utils.get_asset_path('steam-train-whistle-daniel_simon.wav')

--- a/test/test_librosa_compatibility.py
+++ b/test/test_librosa_compatibility.py
@@ -244,7 +244,7 @@ class TestTransforms(_LibrosaMixin, unittest.TestCase):
         _test_compatibilities(**kwargs)
 
     # NOTE: Test passes offline, but fails on TravisCI (and CircleCI), see #372.
-    @unittest.skipIf('CI' in os.environ, 'Test is known to fail on CI')
+    # @unittest.skipIf('CI' in os.environ, 'Test is known to fail on CI')
     def test_basics3(self):
         kwargs = {
             'n_fft': 200,

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -392,7 +392,9 @@ def amplitude_to_DB(
     Returns:
         Tensor: Output tensor in decibel scale
     """
-    x_db = multiplier * torch.log10(torch.clamp(x, min=amin))
+    # casting to float64 is necessary because log10 behaves differently for
+    # different processors when the argument is float32
+    x_db = multiplier * torch.log10(torch.clamp(x, min=amin).to(torch.float64))
     x_db -= multiplier * db_multiplier
 
     if top_db is not None:

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -395,13 +395,13 @@ def amplitude_to_DB(
     # casting to float64 is necessary because log10 behaves differently for
     # different processors when the argument is float32. Make sure the result
     # is a tensor of the original type.
-    x_db = multiplier * torch.log10(torch.clamp(x, min=amin).to(torch.float64)).to(x.dtype)
+    x_db = multiplier * torch.log10(torch.clamp(x, min=amin).to(torch.float64))
     x_db -= multiplier * db_multiplier
 
     if top_db is not None:
         x_db = x_db.clamp(min=x_db.max().item() - top_db)
 
-    return x_db
+    return x_db.to(x.dtype)
 
 
 def DB_to_amplitude(

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -393,8 +393,9 @@ def amplitude_to_DB(
         Tensor: Output tensor in decibel scale
     """
     # casting to float64 is necessary because log10 behaves differently for
-    # different processors when the argument is float32
-    x_db = multiplier * torch.log10(torch.clamp(x, min=amin).to(torch.float64))
+    # different processors when the argument is float32. Make sure the result
+    # is a tensor of the original type.
+    x_db = multiplier * torch.log10(torch.clamp(x, min=amin).to(torch.float64)).to(x.dtype)
     x_db -= multiplier * db_multiplier
 
     if top_db is not None:


### PR DESCRIPTION
Changed the log10 code to execute all the computations in float64 and change back to the original tensor at the end of the function.