### PR TITLE
Remove travis unittest jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - env: PYTHON_VERSION="3.6"
-    - env: PYTHON_VERSION="3.7"
-    - env: PYTHON_VERSION="3.8"
-    - env: PYTHON_VERSION="3.6" RUN_FLAKE8="true" SKIP_INSTALL="true" SKIP_TESTS="true"
     - env: PYTHON_VERSION="3.6" RUN_EXAMPLE_TESTS="true" SKIP_TESTS="true"
   allow_failures:
     - env: PYTHON_VERSION="3.6" RUN_EXAMPLE_TESTS="true" SKIP_TESTS="true"


### PR DESCRIPTION
Travis's  running unit test was not configured correctly.
(`python setup.py install` puts the package in `site-packages` directory, but tests are performed on checked out code)
Since unittests and style checks are carried out on Circle CI, running them on Travis is redundant.
Rather than fixing Travis, we should remove them.