### PR TITLE
Split CUDA and CPU tests of `torchscript_consistency`

### DIFF
--- a/test/torchscript_consistency_cpu_test.py
+++ b/test/torchscript_consistency_cpu_test.py
@@ -1,0 +1,5 @@
+from common_utils import define_test_suites
+from torchscript_consistency_impl import Functional, Transforms
+
+
+define_test_suites(globals(), [Functional, Transforms], devices=['cpu'])

--- a/test/torchscript_consistency_cuda_test.py
+++ b/test/torchscript_consistency_cuda_test.py
@@ -1,0 +1,5 @@
+from common_utils import define_test_suites
+from torchscript_consistency_impl import Functional, Transforms
+
+
+define_test_suites(globals(), [Functional, Transforms], devices=['cuda'])

--- a/test/torchscript_consistency_impl.py
+++ b/test/torchscript_consistency_impl.py
@@ -608,6 +608,3 @@ class Transforms(common_utils.TestBaseMixin):
         filepath = common_utils.get_asset_path("vad-go-mono-32000.wav")
         waveform, sample_rate = torchaudio.load(filepath)
         self._assert_consistency(T.Vad(sample_rate=sample_rate), waveform)
-
-
-common_utils.define_test_suites(globals(), [Functional, Transforms])


### PR DESCRIPTION
Currently there is no CUDA device for regular FB's infra, where `torchaudio`'s tests are ran.
Skipping these tests consistently raises a flag so we decided to split the tests into runnable and not-runnable on file-level.