### PR TITLE
Update smoke test docker image and tag new images latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ binary_common: &binary_common
 smoke_test_common: &smoke_test_common
   <<: *binary_common
   docker:
-    - image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/torchaudio/smoke_test:d26af7d0-8458-face-book-84239b5c75c0
+    - image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/torchaudio/smoke_test:56c846a5-acaa-41a7-92f5-46ec66186c61
       aws_auth:
         aws_access_key_id: ${ECR_AWS_ACCESS_KEY}
         aws_secret_access_key: ${ECR_AWS_SECRET_ACCESS_KEY}
@@ -264,7 +264,9 @@ jobs:
             eval $(aws ecr get-login --region us-east-1 --no-include-email)
             set -x
             docker tag ${image_name}:${CIRCLE_WORKFLOW_ID} 308535385114.dkr.ecr.us-east-1.amazonaws.com/${image_name}:${CIRCLE_WORKFLOW_ID}
+            docker tag ${image_name}:${CIRCLE_WORKFLOW_ID} 308535385114.dkr.ecr.us-east-1.amazonaws.com/${image_name}:latest
             docker push 308535385114.dkr.ecr.us-east-1.amazonaws.com/${image_name}:${CIRCLE_WORKFLOW_ID}
+            docker push 308535385114.dkr.ecr.us-east-1.amazonaws.com/${image_name}:latest
 
   unittest_linux_cpu:
     <<: *binary_common

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -43,7 +43,7 @@ binary_common: &binary_common
 smoke_test_common: &smoke_test_common
   <<: *binary_common
   docker:
-    - image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/torchaudio/smoke_test:d26af7d0-8458-face-book-84239b5c75c0
+    - image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/torchaudio/smoke_test:56c846a5-acaa-41a7-92f5-46ec66186c61
       aws_auth:
         aws_access_key_id: ${ECR_AWS_ACCESS_KEY}
         aws_secret_access_key: ${ECR_AWS_SECRET_ACCESS_KEY}
@@ -264,7 +264,9 @@ jobs:
             eval $(aws ecr get-login --region us-east-1 --no-include-email)
             set -x
             docker tag ${image_name}:${CIRCLE_WORKFLOW_ID} 308535385114.dkr.ecr.us-east-1.amazonaws.com/${image_name}:${CIRCLE_WORKFLOW_ID}
+            docker tag ${image_name}:${CIRCLE_WORKFLOW_ID} 308535385114.dkr.ecr.us-east-1.amazonaws.com/${image_name}:latest
             docker push 308535385114.dkr.ecr.us-east-1.amazonaws.com/${image_name}:${CIRCLE_WORKFLOW_ID}
+            docker push 308535385114.dkr.ecr.us-east-1.amazonaws.com/${image_name}:latest
 
   unittest_linux_cpu:
     <<: *binary_common


### PR DESCRIPTION
1. Docker image used for smoke test is old (No Python 3.8). Updating this to the latest one. build [here](https://app.circleci.com/pipelines/github/pytorch/audio/1763/workflows/56c846a5-acaa-41a7-92f5-46ec66186c61/jobs/44484)
2. Add `latest` tag to the newly built docker so that later we can always use `latest` version and we do not have to update docker image tag manually.