### PR TITLE
Suggested changes to speed up phaser

### DIFF
--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -1268,7 +1268,6 @@ def phaser(
     delay_pos = 0
     mod_pos = 0
 
-    # TODO: Autograd support?
     output_waveform_pre_gain_list = []
     waveform = waveform * gain_in
     delay_buf = delay_buf * decay
@@ -1284,9 +1283,7 @@ def phaser(
         delay_buf_list[delay_pos] = temp * decay
         output_waveform_pre_gain_list.append(temp)
 
-    # TODO: Modify test to check that dtype and device are as expected
     output_waveform = torch.stack(output_waveform_pre_gain_list, dim=1).to(dtype=dtype, device=device)
-    # TODO: Autograd support?
     output_waveform.mul_(gain_out)
 
     return output_waveform.clamp(min=-1, max=1).view(actual_shape)

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -1269,7 +1269,7 @@ def phaser(
     mod_pos = 0
 
     # TODO: Autograd support?
-    output_waveform_pre_gain_list = [] #torch.zeros_like(waveform.transpose(0, 1), dtype=dtype, device=device)
+    output_waveform_pre_gain_list = []
     waveform = waveform * gain_in
     delay_buf = delay_buf * decay
     waveform_list = [waveform[:, i] for i in range(waveform.size(1))]

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -1270,7 +1270,9 @@ def phaser(
 
     # TODO: Autograd support?
     output_waveform_pre_gain_list = [] #torch.zeros_like(waveform.transpose(0, 1), dtype=dtype, device=device)
-    waveform_list = [waveform[:, i] * gain_in for i in range(waveform.size(1))]
+    waveform = waveform * gain_in
+    delay_buf = delay_buf * decay
+    waveform_list = [waveform[:, i] for i in range(waveform.size(1))]
     delay_buf_list = [delay_buf[:, i] for i in range(delay_buf.size(1))]
     mod_buf_list = [mod_buf[i] for i in range(mod_buf.size(0))]
 
@@ -1278,15 +1280,12 @@ def phaser(
         idx = int((delay_pos + mod_buf_list[mod_pos]) % delay_buf_len)
         mod_pos = (mod_pos + 1) % mod_buf_len
         delay_pos = (delay_pos + 1) % delay_buf_len
-        delay_buf_list[delay_pos] = (waveform_list[i]) + (delay_buf_list[idx] * decay)
-        output_waveform_pre_gain_list.append(delay_buf_list[delay_pos])
+        temp = (waveform_list[i]) + (delay_buf_list[idx])
+        delay_buf_list[delay_pos] = temp * decay
+        output_waveform_pre_gain_list.append(temp)
 
-    # TODO: Test that output dtype and device are as expected
-    output_waveform = torch.zeros_like(waveform.transpose(0, 1), dtype=dtype, device=device)
-    for i in range(waveform.shape[-1]):
-        output_waveform[i] = output_waveform_pre_gain_list[i]
-    # TODO: This is much more efficient
-    # output_waveform = torch.tensor(output_waveform_pre_gain_list, dtype=dtype, device=device)
+    # TODO: Modify test to check that dtype and device are as expected
+    output_waveform = torch.stack(output_waveform_pre_gain_list).to(dtype=dtype, device=device)
     # TODO: Autograd support?
     output_waveform.mul_(gain_out)
 

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -1285,7 +1285,7 @@ def phaser(
         output_waveform_pre_gain_list.append(temp)
 
     # TODO: Modify test to check that dtype and device are as expected
-    output_waveform = torch.stack(output_waveform_pre_gain_list).to(dtype=dtype, device=device)
+    output_waveform = torch.stack(output_waveform_pre_gain_list, dim=1).to(dtype=dtype, device=device)
     # TODO: Autograd support?
     output_waveform.mul_(gain_out)
 


### PR DESCRIPTION
master: 
```
$ python test/test_sox_compatibility.py TestFunctionalFiltering.test_phaser_sine
Fail to import hypothesis in common_utils, tests are not derandomized
.
----------------------------------------------------------------------
Ran 1 test in 9.838s

$ python test/test_batch_consistency.py TestFunctional.test_phaser
Fail to import hypothesis in common_utils, tests are not derandomized
.
----------------------------------------------------------------------
Ran 1 test in 46.989s

OK


```

fastephaser1:
```
$ python test/test_sox_compatibility.py TestFunctionalFiltering.test_phaser_sine
Fail to import hypothesis in common_utils, tests are not derandomized
.
----------------------------------------------------------------------
Ran 1 test in 5.924s

OK

$ python test/test_batch_consistency.py TestFunctional.test_phaser
.
----------------------------------------------------------------------
Ran 1 test in 23.584s

OK

```

on

```$ lscpu
Architecture:        x86_64
CPU op-mode(s):      32-bit, 64-bit
Byte Order:          Little Endian
Address sizes:       39 bits physical, 48 bits virtual
CPU(s):              6
On-line CPU(s) list: 0-5
Thread(s) per core:  1
Core(s) per socket:  6
Socket(s):           1
NUMA node(s):        1
Vendor ID:           GenuineIntel
CPU family:          6
Model:               158
Model name:          Intel(R) Core(TM) i5-9600K CPU @ 3.70GHz
Stepping:            13
CPU MHz:             800.161
CPU max MHz:         4600.0000
CPU min MHz:         800.0000
BogoMIPS:            7392.00
Virtualization:      VT-x
L1d cache:           32K
L1i cache:           32K
L2 cache:            256K
L3 cache:            9216K
NUMA node0 CPU(s):   0-5
Flags:               fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d arch_capabilities
```

We can increase resolution as we see fit. For now little is done here.


Potential followup work:
- Does this patch increase memory footprint due to additional lists (might need explicit calls to ```del```)?
- How does this behave on GPU?