### PR TITLE
Add Bass with Biquad

### DIFF
--- a/docs/source/functional.rst
+++ b/docs/source/functional.rst
@@ -113,6 +113,11 @@ Functions to perform common audio operations.
 
 .. autofunction:: treble_biquad
 
+:hidden:`bass_biquad`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: bass_biquad
+
 :hidden:`deemph_biquad`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test/test_sox_compatibility.py
+++ b/test/test_sox_compatibility.py
@@ -289,28 +289,6 @@ class TestFunctionalFiltering(TestCase):
 
     @unittest.skipIf("sox" not in BACKENDS, "sox not available")
     @AudioBackendScope("sox")
-    def test_bass(self):
-        """
-        Test biquad bass filter, compare to SoX implementation
-        """
-
-        central_freq = 1000
-        q = 0.707
-        gain = 30
-
-        noise_filepath = common_utils.get_asset_path('whitenoise.wav')
-        E = torchaudio.sox_effects.SoxEffectsChain()
-        E.set_input_file(noise_filepath)
-        E.append_effect_to_chain("bass", [gain, central_freq, str(q) + 'q'])
-        sox_output_waveform, sr = E.sox_build_flow_effects()
-
-        waveform, sample_rate = torchaudio.load(noise_filepath, normalization=True)
-        output_waveform = F.bass_biquad(waveform, sample_rate, gain, central_freq, q)
-
-        self.assertEqual(output_waveform, sox_output_waveform, atol=1e-4, rtol=1e-5)
-        
-    @unittest.skipIf("sox" not in BACKENDS, "sox not available")
-    @AudioBackendScope("sox")
     def test_deemph(self):
         """
         Test biquad deemph filter, compare to SoX implementation

--- a/test/test_sox_compatibility.py
+++ b/test/test_sox_compatibility.py
@@ -285,8 +285,30 @@ class TestFunctionalFiltering(TestCase):
         waveform, sample_rate = torchaudio.load(noise_filepath, normalization=True)
         output_waveform = F.bass_biquad(waveform, sample_rate, gain, central_freq, q)
 
-        self.assertEqual(output_waveform, sox_output_waveform, atol=1e-4, rtol=1e-5)
+        self.assertEqual(output_waveform, sox_output_waveform, atol=1.5e-4, rtol=1e-5)
 
+    @unittest.skipIf("sox" not in BACKENDS, "sox not available")
+    @AudioBackendScope("sox")
+    def test_bass(self):
+        """
+        Test biquad bass filter, compare to SoX implementation
+        """
+
+        central_freq = 1000
+        q = 0.707
+        gain = 30
+
+        noise_filepath = common_utils.get_asset_path('whitenoise.wav')
+        E = torchaudio.sox_effects.SoxEffectsChain()
+        E.set_input_file(noise_filepath)
+        E.append_effect_to_chain("bass", [gain, central_freq, str(q) + 'q'])
+        sox_output_waveform, sr = E.sox_build_flow_effects()
+
+        waveform, sample_rate = torchaudio.load(noise_filepath, normalization=True)
+        output_waveform = F.bass_biquad(waveform, sample_rate, gain, central_freq, q)
+
+        self.assertEqual(output_waveform, sox_output_waveform, atol=1e-4, rtol=1e-5)
+        
     @unittest.skipIf("sox" not in BACKENDS, "sox not available")
     @AudioBackendScope("sox")
     def test_deemph(self):

--- a/test/test_sox_compatibility.py
+++ b/test/test_sox_compatibility.py
@@ -267,6 +267,28 @@ class TestFunctionalFiltering(TestCase):
 
     @unittest.skipIf("sox" not in BACKENDS, "sox not available")
     @AudioBackendScope("sox")
+    def test_bass(self):
+        """
+        Test biquad bass filter, compare to SoX implementation
+        """
+
+        central_freq = 1000
+        q = 0.707
+        gain = 40
+
+        noise_filepath = common_utils.get_asset_path('whitenoise.wav')
+        E = torchaudio.sox_effects.SoxEffectsChain()
+        E.set_input_file(noise_filepath)
+        E.append_effect_to_chain("bass", [gain, central_freq, str(q) + 'q'])
+        sox_output_waveform, sr = E.sox_build_flow_effects()
+
+        waveform, sample_rate = torchaudio.load(noise_filepath, normalization=True)
+        output_waveform = F.bass_biquad(waveform, sample_rate, gain, central_freq, q)
+
+        self.assertEqual(output_waveform, sox_output_waveform, atol=1e-4, rtol=1e-5)
+
+    @unittest.skipIf("sox" not in BACKENDS, "sox not available")
+    @AudioBackendScope("sox")
     def test_deemph(self):
         """
         Test biquad deemph filter, compare to SoX implementation

--- a/test/torchscript_consistency_impl.py
+++ b/test/torchscript_consistency_impl.py
@@ -366,7 +366,7 @@ class Functional(common_utils.TestBaseMixin):
             return F.treble_biquad(tensor, sample_rate, gain, central_freq, q)
 
         self._assert_consistency(func, waveform)
-        
+
     def test_bass(self):
         if self.dtype == torch.float64:
             raise unittest.SkipTest("This test is known to fail for float64")

--- a/test/torchscript_consistency_impl.py
+++ b/test/torchscript_consistency_impl.py
@@ -366,6 +366,21 @@ class Functional(common_utils.TestBaseMixin):
             return F.treble_biquad(tensor, sample_rate, gain, central_freq, q)
 
         self._assert_consistency(func, waveform)
+        
+    def test_bass(self):
+        if self.dtype == torch.float64:
+            raise unittest.SkipTest("This test is known to fail for float64")
+
+        waveform = common_utils.get_whitenoise(sample_rate=44100)
+
+        def func(tensor):
+            sample_rate = 44100
+            gain = 40.
+            central_freq = 1000.
+            q = 0.707
+            return F.bass_biquad(tensor, sample_rate, gain, central_freq, q)
+
+        self._assert_consistency(func, waveform)
 
     def test_deemph(self):
         if self.dtype == torch.float64:

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -1022,7 +1022,7 @@ def bass_biquad(
     a1 = -2 * ((A - 1) + temp3)
     a2 = (A + 1) + temp2 - temp1
 
-    return biquad(waveform, b0/a0, b1/a0, b2/a0, a0/a0, a1/a0, a2/a0)
+    return biquad(waveform, b0 / a0, b1 / a0, b2 / a0, a0 / a0, a1 / a0, a2 / a0)
 
 
 def deemph_biquad(

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -1022,7 +1022,7 @@ def bass_biquad(
     a1 = -2 * ((A - 1) + temp3)
     a2 = (A + 1) + temp2 - temp1
 
-    return biquad(waveform, b0, b1, b2, a0, a1, a2)
+    return biquad(waveform, b0/a0, b1/a0, b2/a0, a0/a0, a1/a0, a2/a0)
 
 
 def deemph_biquad(


### PR DESCRIPTION
This is a sox dependency reduction task to implement bass (with biquad) filter as #260 using the treble (with biquad) filter as example.