### PR TITLE
WIP: Make `get_info` torchscript-able

### DIFF
--- a/test/torchscript_consistency_sox_io.py
+++ b/test/torchscript_consistency_sox_io.py
@@ -1,0 +1,26 @@
+"""Test suites for torchscriptability of SoX I/O and its comatibility with Python"""
+from typing import Tuple
+
+import torch
+from torch.testing._internal.common_utils import TestCase
+import torchaudio
+
+import common_utils
+
+SignalInfo = torchaudio._soundfile_backend.SignalInfo
+EncodingInfo = torchaudio._soundfile_backend.EncodingInfo
+
+
+class TestSoxIO(TestCase):
+    """Implements test for `sox` C++ extensions"""
+    def test_get_info(self):
+        def func(path: str) -> Tuple[SignalInfo, EncodingInfo]:
+            return torchaudio._sox_backend.info(path)
+
+        path = common_utils.get_asset_path('sinewave.wav')
+        ts_func = torch.jit.script(func)
+        py_signal_info, py_encoding_info = func(path)
+        ts_signal_info, ts_encoding_info = ts_func(path)
+
+        assert py_signal_info.__dict__ == ts_signal_info.__dict__
+        assert py_encoding_info.__dict__ == ts_encoding_info.__dict__

--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -421,3 +421,27 @@ def _audio_normalization(signal: Tensor, normalization: Union[bool, float, Calla
     elif callable(normalization):
         a = normalization(signal)
         signal /= a
+
+
+def _init_extension():
+    import importlib
+
+    # load the custom_op_library and register the custom ops
+    lib_dir = os.path.dirname(__file__)
+    loader_details = (
+        importlib.machinery.ExtensionFileLoader,
+        importlib.machinery.EXTENSION_SUFFIXES
+    )
+
+    extfinder = importlib.machinery.FileFinder(lib_dir, loader_details)
+    ext_specs = extfinder.find_spec("_torchaudio")
+    if ext_specs is None:
+        raise ImportError("_torchaudio is not found.")
+    # torch.classes.load_library(ext_specs.origin)
+    torch.ops.load_library(ext_specs.origin)
+
+
+_init_extension()
+
+
+del _init_extension

--- a/torchaudio/_soundfile_backend.py
+++ b/torchaudio/_soundfile_backend.py
@@ -27,12 +27,12 @@ class SignalInfo:
 
 class EncodingInfo:
     def __init__(self,
-                 encoding: Any = None,
+                 encoding: Optional[int] = None,
                  bits_per_sample: Optional[int] = None,
                  compression: Optional[float] = None,
-                 reverse_bytes: Any = None,
-                 reverse_nibbles: Any = None,
-                 reverse_bits: Any = None,
+                 reverse_bytes: Optional[int] = None,
+                 reverse_nibbles: Optional[int] = None,
+                 reverse_bits: Optional[int] = None,
                  opposite_endian: Optional[bool] = None) -> None:
         self.encoding = encoding
         self.bits_per_sample = bits_per_sample

--- a/torchaudio/_sox_backend.py
+++ b/torchaudio/_sox_backend.py
@@ -67,6 +67,11 @@ def save(filepath: str, src: Tensor, sample_rate: int, precision: int = 16, chan
 
 def info(filepath: str) -> Tuple[SignalInfo, EncodingInfo]:
     r"""See torchaudio.info"""
-
-    from . import _torchaudio
-    return _torchaudio.get_info(filepath)
+    info_ = torch.ops.torchaudio.sox_get_info(filepath)
+    return (
+        SignalInfo(info_.GetChannels(), info_.GetRate(), info_.GetPrecision(), info_.GetLength()),
+        EncodingInfo(
+            info_.GetEncoding(), info_.GetBPS(), info_.GetCompression(),
+            info_.GetReverseBytes(), info_.GetReverseNibbles(), info_.GetReverseBits(),
+            info_.GetOppositeEndian()),
+    )

--- a/torchaudio/csrc/sox.cpp
+++ b/torchaudio/csrc/sox.cpp
@@ -68,20 +68,6 @@ void read_audio(
 }
 } // namespace
 
-std::tuple<sox_signalinfo_t, sox_encodinginfo_t> get_info(
-    const std::string& file_name
-  ) {
-  SoxDescriptor fd(sox_open_read(
-      file_name.c_str(),
-      /*signal=*/nullptr,
-      /*encoding=*/nullptr,
-      /*filetype=*/nullptr));
-  if (fd.get() == nullptr) {
-    throw std::runtime_error("Error opening audio file");
-  }
-  return std::make_tuple(fd->signal, fd->encoding);
-}
-
 std::vector<std::string> get_effect_names() {
   sox_effect_fn_t const * fns = sox_get_effect_fns();
   std::vector<std::string> sv;
@@ -485,10 +471,6 @@ PYBIND11_MODULE(_torchaudio, m) {
       "write_audio_file",
       &torch::audio::write_audio_file,
       "Writes data from a tensor into an audio file");
-  m.def(
-      "get_info",
-      &torch::audio::get_info,
-      "Gets information about an audio file");
   m.def(
       "get_effect_names",
       &torch::audio::get_effect_names,

--- a/torchaudio/csrc/sox_io.cpp
+++ b/torchaudio/csrc/sox_io.cpp
@@ -1,0 +1,144 @@
+#include "sox.h"
+#include "torch/script.h"
+
+namespace {
+/// Helper struct to safely close the sox_format_t descriptor.
+struct SoxDescriptor {
+  explicit SoxDescriptor(sox_format_t* fd) noexcept : fd_(fd) {}
+  SoxDescriptor(const SoxDescriptor& other) = delete;
+  SoxDescriptor(SoxDescriptor&& other) = delete;
+  SoxDescriptor& operator=(const SoxDescriptor& other) = delete;
+  SoxDescriptor& operator=(SoxDescriptor&& other) = delete;
+  ~SoxDescriptor() {
+    if (fd_ != nullptr) {
+      sox_close(fd_);
+    }
+  }
+  sox_format_t* operator->() noexcept {
+    return fd_;
+  }
+  sox_format_t* get() noexcept {
+    return fd_;
+  }
+
+ private:
+  sox_format_t* fd_;
+};
+
+} // namespace
+
+namespace torchaudio {
+namespace sox_io {
+
+struct SoxAudioInfo : torch::CustomClassHolder {
+  // from sox_signalinfo_t
+  const int64_t channels;
+  const double rate;
+  const int64_t precision;
+  const int64_t length;
+  // from sox_encodinginfo_t
+  const int64_t encoding;
+  const int64_t bits_per_sample;
+  const double compression;
+  const int64_t reverse_bytes;
+  const int64_t reverse_nibbles;
+  const int64_t reverse_bits;
+  const bool opposite_endian;
+
+  explicit SoxAudioInfo(sox_signalinfo_t si, sox_encodinginfo_t ei) noexcept
+      : channels(si.channels),
+        rate(si.rate),
+        precision(si.precision),
+        length(si.length),
+        encoding((int64_t)ei.encoding),
+        bits_per_sample(ei.bits_per_sample),
+        compression(ei.compression),
+        reverse_bytes((int64_t)ei.reverse_bytes),
+        reverse_nibbles((int64_t)ei.reverse_nibbles),
+        reverse_bits((int64_t)ei.reverse_bits),
+        opposite_endian(ei.opposite_endian) {}
+};
+
+static auto registerSoxAudioInfo =
+    torch::class_<SoxAudioInfo>("torchaudio", "SoxAudioInfo")
+        .def(
+            "GetChannels",
+            [](const c10::intrusive_ptr<SoxAudioInfo>& self) -> int64_t {
+              return self->channels;
+            })
+        .def(
+            "GetRate",
+            [](const c10::intrusive_ptr<SoxAudioInfo>& self) -> double {
+              return self->rate;
+            })
+        .def(
+            "GetPrecision",
+            [](const c10::intrusive_ptr<SoxAudioInfo>& self) -> int64_t {
+              return self->precision;
+            })
+        .def(
+            "GetLength",
+            [](const c10::intrusive_ptr<SoxAudioInfo>& self) -> int64_t {
+              return self->length;
+            })
+        .def(
+            "GetEncoding",
+            [](const c10::intrusive_ptr<SoxAudioInfo>& self) -> int64_t {
+              return self->encoding;
+            })
+        .def(
+            "GetBPS",
+            [](const c10::intrusive_ptr<SoxAudioInfo>& self) -> int64_t {
+              return self->bits_per_sample;
+            })
+        .def(
+            "GetCompression",
+            [](const c10::intrusive_ptr<SoxAudioInfo>& self) -> double {
+              return self->compression;
+            })
+        .def(
+            "GetReverseBytes",
+            [](const c10::intrusive_ptr<SoxAudioInfo>& self) -> int64_t {
+              return self->reverse_bytes;
+            })
+        .def(
+            "GetReverseNibbles",
+            [](const c10::intrusive_ptr<SoxAudioInfo>& self) -> int64_t {
+              return self->reverse_nibbles;
+            })
+        .def(
+            "GetReverseBits",
+            [](const c10::intrusive_ptr<SoxAudioInfo>& self) -> int64_t {
+              return self->reverse_bits;
+            })
+        .def(
+            "GetOppositeEndian",
+            [](const c10::intrusive_ptr<SoxAudioInfo>& self) -> bool {
+              return self->opposite_endian;
+            });
+
+/// Reads an audio file from the given `path` and returns a tuple of
+/// sox_signalinfo_t and sox_encodinginfo_t, which contain information about
+/// the audio file such as sample rate, length, bit precision, encoding and
+/// more. Throws `std::runtime_error` if the audio file could not be opened, or
+/// an error occurred during reading of the audio data.
+c10::intrusive_ptr<SoxAudioInfo> get_info(const std::string& file_name) {
+  SoxDescriptor fd(sox_open_read(
+      file_name.c_str(),
+      /*signal=*/nullptr,
+      /*encoding=*/nullptr,
+      /*filetype=*/nullptr));
+  if (fd.get() == nullptr) {
+    throw std::runtime_error("Error opening audio file");
+  }
+  return c10::make_intrusive<SoxAudioInfo>(fd->signal, fd->encoding);
+}
+
+static auto registerGetInfo = torch::RegisterOperators().op(
+    torch::RegisterOperators::options()
+        .schema(
+            "torchaudio::sox_get_info(str path) -> __torch__.torch.classes.torchaudio.SoxAudioInfo info")
+        .catchAllKernel<decltype(get_info), &get_info>());
+
+} // namespace sox_io
+} // namespace torchaudio


### PR DESCRIPTION
Binds `get_info` function via `torchscript` instead of `pybind`.
Introduces the intermediate struct `SoxAudioInfo` that is passed from C++ extension to Python,
This is due to the fact that unlike `pybind11`, `torchscript` does not allow to expose arbitral C struct to Python (`sox_encodinginfo_t` and `sox_signalinfo_t`).

~~This PR is built on / blocked by #625 .~~