### PR TITLE
Apply tweaks required for running test in fbcode

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,10 @@
+def _init_fb_ctypes():
+    # Initiaization required only in facebook infrastructure to use soundfile
+    import libfb.py.ctypesmonkeypatch
+    libfb.py.ctypesmonkeypatch.install()
+
+
+try:
+    _init_fb_ctypes()
+except Exception:
+    pass

--- a/test/kaldi_compatibility_cpu_test.py
+++ b/test/kaldi_compatibility_cpu_test.py
@@ -1,5 +1,5 @@
-import common_utils
-from kaldi_compatibility_impl import Kaldi
+from . import common_utils
+from .kaldi_compatibility_impl import Kaldi
 
 
 common_utils.define_test_suites(globals(), [Kaldi], devices=['cpu'])

--- a/test/kaldi_compatibility_cuda_test.py
+++ b/test/kaldi_compatibility_cuda_test.py
@@ -1,5 +1,5 @@
-import common_utils
-from kaldi_compatibility_impl import Kaldi
+from . import common_utils
+from .kaldi_compatibility_impl import Kaldi
 
 
 common_utils.define_test_suites(globals(), [Kaldi], devices=['cuda'])

--- a/test/kaldi_compatibility_impl.py
+++ b/test/kaldi_compatibility_impl.py
@@ -8,7 +8,7 @@ import torch
 import torchaudio.functional as F
 import torchaudio.compliance.kaldi
 
-import common_utils
+from . import common_utils
 
 
 def _not_available(cmd):

--- a/test/test_batch_consistency.py
+++ b/test/test_batch_consistency.py
@@ -6,7 +6,7 @@ from torch.testing._internal.common_utils import TestCase
 import torchaudio
 import torchaudio.functional as F
 
-import common_utils
+from . import common_utils
 
 
 class TestFunctional(TestCase):

--- a/test/test_compliance_kaldi.py
+++ b/test/test_compliance_kaldi.py
@@ -1,13 +1,13 @@
 import math
 import os
-import compliance.utils
 import torch
 import torchaudio
 import torchaudio.compliance.kaldi as kaldi
 import unittest
 
-import common_utils
-from common_utils import AudioBackendScope, BACKENDS
+from . import common_utils
+from .compliance import utils as compliance_utils
+from .common_utils import AudioBackendScope, BACKENDS
 
 
 def extract_window(window, wave, f, frame_length, frame_shift, snip_edges):
@@ -50,7 +50,7 @@ class Test_Kaldi(unittest.TestCase):
     test_filepath = common_utils.get_asset_path('kaldi_file.wav')
     test_8000_filepath = common_utils.get_asset_path('kaldi_file_8000.wav')
     kaldi_output_dir = common_utils.get_asset_path('kaldi')
-    test_filepaths = {prefix: [] for prefix in compliance.utils.TEST_PREFIX}
+    test_filepaths = {prefix: [] for prefix in compliance_utils.TEST_PREFIX}
 
     # separating test files by their types (e.g 'spec', 'fbank', etc.)
     for f in os.listdir(kaldi_output_dir):
@@ -151,7 +151,7 @@ class Test_Kaldi(unittest.TestCase):
             args = f.split('-')
             args[-1] = os.path.splitext(args[-1])[0]
             assert len(args) == expected_num_args, 'invalid test kaldi file name'
-            args = [compliance.utils.parse(arg) for arg in args]
+            args = [compliance_utils.parse(arg) for arg in args]
 
             output = get_output_fn(sound, args)
 

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -3,8 +3,8 @@ import unittest
 import torchaudio
 from torch.utils.data import Dataset, DataLoader
 
-import common_utils
-from common_utils import AudioBackendScope, BACKENDS
+from . import common_utils
+from .common_utils import AudioBackendScope, BACKENDS
 
 
 class TORCHAUDIODS(Dataset):

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -8,7 +8,7 @@ from torchaudio.datasets.vctk import VCTK
 from torchaudio.datasets.yesno import YESNO
 from torchaudio.datasets.ljspeech import LJSPEECH
 
-import common_utils
+from . import common_utils
 
 
 class TestDatasets(unittest.TestCase):

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -6,7 +6,7 @@ import torchaudio
 import torchaudio.functional as F
 import pytest
 
-import common_utils
+from . import common_utils
 
 
 class Lfilter(common_utils.TestBaseMixin):

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -3,7 +3,7 @@ import torch
 import torchaudio
 import math
 import os
-from common_utils import AudioBackendScope, BACKENDS, BACKENDS_MP3, create_temp_assets_dir
+from .common_utils import AudioBackendScope, BACKENDS, BACKENDS_MP3, create_temp_assets_dir
 
 
 class Test_LoadSave(unittest.TestCase):

--- a/test/test_kaldi_io.py
+++ b/test/test_kaldi_io.py
@@ -3,7 +3,7 @@ import unittest
 import torch
 import torchaudio.kaldi_io as kio
 
-import common_utils
+from . import common_utils
 
 
 class Test_KaldiIO(unittest.TestCase):

--- a/test/test_librosa_compatibility.py
+++ b/test/test_librosa_compatibility.py
@@ -1,6 +1,7 @@
 """Test suites for numerical compatibility with librosa"""
 import os
 import unittest
+from distutils.version import StrictVersion
 
 import torch
 from torch.testing._internal.common_utils import TestCase
@@ -15,7 +16,7 @@ if IMPORT_LIBROSA:
 
 import pytest
 
-import common_utils
+from . import common_utils
 
 
 @unittest.skipIf(not IMPORT_LIBROSA, "Librosa not available")
@@ -74,6 +75,8 @@ class TestFunctional(TestCase):
         self._test_create_fb(n_mels=56, fmin=800.0, fmax=900.0)
         self._test_create_fb(n_mels=56, fmin=1900.0, fmax=900.0)
         self._test_create_fb(n_mels=10, fmin=1900.0, fmax=900.0)
+        if StrictVersion(librosa.__version__) < StrictVersion("0.7.2"):
+            return
         self._test_create_fb(n_mels=128, sample_rate=44100, norm="slaney")
         self._test_create_fb(n_mels=128, fmin=2000.0, fmax=5000.0, norm="slaney")
         self._test_create_fb(n_mels=56, fmin=100.0, fmax=9000.0, norm="slaney")

--- a/test/test_sox_compatibility.py
+++ b/test/test_sox_compatibility.py
@@ -6,8 +6,8 @@ import torchaudio
 import torchaudio.functional as F
 import torchaudio.transforms as T
 
-import common_utils
-from common_utils import AudioBackendScope, BACKENDS
+from . import common_utils
+from .common_utils import AudioBackendScope, BACKENDS
 
 
 class TestFunctionalFiltering(TestCase):

--- a/test/test_sox_effects.py
+++ b/test/test_sox_effects.py
@@ -3,8 +3,8 @@ import torch
 import torchaudio
 import math
 
-import common_utils
-from common_utils import AudioBackendScope, BACKENDS
+from . import common_utils
+from .common_utils import AudioBackendScope, BACKENDS
 
 
 class Test_SoxEffectsChain(unittest.TestCase):

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -7,7 +7,7 @@ import torchaudio
 import torchaudio.transforms as transforms
 import torchaudio.functional as F
 
-import common_utils
+from . import common_utils
 
 
 class Tester(TestCase):

--- a/test/torchscript_consistency_cpu_test.py
+++ b/test/torchscript_consistency_cpu_test.py
@@ -1,5 +1,5 @@
-from common_utils import define_test_suites
-from torchscript_consistency_impl import Functional, Transforms
+from .common_utils import define_test_suites
+from .torchscript_consistency_impl import Functional, Transforms
 
 
 define_test_suites(globals(), [Functional, Transforms], devices=['cpu'])

--- a/test/torchscript_consistency_cuda_test.py
+++ b/test/torchscript_consistency_cuda_test.py
@@ -1,5 +1,5 @@
-from common_utils import define_test_suites
-from torchscript_consistency_impl import Functional, Transforms
+from .common_utils import define_test_suites
+from .torchscript_consistency_impl import Functional, Transforms
 
 
 define_test_suites(globals(), [Functional, Transforms], devices=['cuda'])

--- a/test/torchscript_consistency_impl.py
+++ b/test/torchscript_consistency_impl.py
@@ -6,7 +6,7 @@ import torchaudio
 import torchaudio.functional as F
 import torchaudio.transforms as T
 
-import common_utils
+from . import common_utils
 
 
 class Functional(common_utils.TestBaseMixin):


### PR DESCRIPTION
This PR contains
 - changes to tweak for test import (relative import and addition of `__init__.py`)
 - Initialization required to use soundfile in fb infrastructure. This is harmless in other locations, yet `__init__.py` was the best place to put so I included it in public facing code base.