### PR TITLE
Put SignalInfo, EncodingInfo in common module

### DIFF
--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -19,7 +19,8 @@ from torchaudio._backend import (
     get_audio_backend,
     set_audio_backend,
 )
-from torchaudio._soundfile_backend import SignalInfo, EncodingInfo
+from torchaudio.backend_common import SignalInfo, EncodingInfo
+
 
 try:
     from .version import __version__, git_version  # noqa: F401

--- a/torchaudio/_soundfile_backend.py
+++ b/torchaudio/_soundfile_backend.py
@@ -1,8 +1,10 @@
 import os
-from typing import Any, Optional, Tuple, Union
+from typing import Optional, Tuple
 
 import torch
 from torch import Tensor
+
+from .backend_common import SignalInfo, EncodingInfo
 
 _subtype_to_precision = {
     'PCM_S8': 8,
@@ -11,36 +13,6 @@ _subtype_to_precision = {
     'PCM_32': 32,
     'PCM_U8': 8
 }
-
-
-class SignalInfo:
-    def __init__(self,
-                 channels: Optional[int] = None,
-                 rate: Optional[float] = None,
-                 precision: Optional[int] = None,
-                 length: Optional[int] = None) -> None:
-        self.channels = channels
-        self.rate = rate
-        self.precision = precision
-        self.length = length
-
-
-class EncodingInfo:
-    def __init__(self,
-                 encoding: Any = None,
-                 bits_per_sample: Optional[int] = None,
-                 compression: Optional[float] = None,
-                 reverse_bytes: Any = None,
-                 reverse_nibbles: Any = None,
-                 reverse_bits: Any = None,
-                 opposite_endian: Optional[bool] = None) -> None:
-        self.encoding = encoding
-        self.bits_per_sample = bits_per_sample
-        self.compression = compression
-        self.reverse_bytes = reverse_bytes
-        self.reverse_nibbles = reverse_nibbles
-        self.reverse_bits = reverse_bits
-        self.opposite_endian = opposite_endian
 
 
 def check_input(src: Tensor) -> None:

--- a/torchaudio/_sox_backend.py
+++ b/torchaudio/_sox_backend.py
@@ -4,7 +4,8 @@ from typing import Optional, Tuple
 import torch
 from torch import Tensor
 import torchaudio
-from torchaudio._soundfile_backend import SignalInfo, EncodingInfo
+
+from .backend_common import SignalInfo, EncodingInfo
 
 
 def load(filepath: str,

--- a/torchaudio/backend_common.py
+++ b/torchaudio/backend_common.py
@@ -1,0 +1,31 @@
+from typing import Any, Optional
+
+
+class SignalInfo:
+    def __init__(self,
+                 channels: Optional[int] = None,
+                 rate: Optional[float] = None,
+                 precision: Optional[int] = None,
+                 length: Optional[int] = None) -> None:
+        self.channels = channels
+        self.rate = rate
+        self.precision = precision
+        self.length = length
+
+
+class EncodingInfo:
+    def __init__(self,
+                 encoding: Any = None,
+                 bits_per_sample: Optional[int] = None,
+                 compression: Optional[float] = None,
+                 reverse_bytes: Any = None,
+                 reverse_nibbles: Any = None,
+                 reverse_bits: Any = None,
+                 opposite_endian: Optional[bool] = None) -> None:
+        self.encoding = encoding
+        self.bits_per_sample = bits_per_sample
+        self.compression = compression
+        self.reverse_bytes = reverse_bytes
+        self.reverse_nibbles = reverse_nibbles
+        self.reverse_bits = reverse_bits
+        self.opposite_endian = opposite_endian


### PR DESCRIPTION
SignalInfo, EncodingInfo are used across backends but were defined in soundfile backend and
imported from there in sox backend, which gives an impression that sox backend depends on sounds file backend.

This PR fixes this by moving these to a common module.