### PR TITLE
Fix `undefined reference` errors (#666)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,21 @@ python setup.py install
 MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ python setup.py install
 ```
 
+If while building from within an anaconda environment you come across errors similar to the following:
+
+
+```
+../bin/ld: console.c:(.text+0xc1): undefined reference to `tgetnum'
+```
+
+Install `ncurses` from `conda-forge` before running `python setup.py install`:
+
+```
+# Install ncurses from conda-forge
+conda install -c conda-forge ncurses
+```
+
+
 Quick Usage
 -----------
 

--- a/build_tools/setup_helpers/build_third_party_helper.sh
+++ b/build_tools/setup_helpers/build_third_party_helper.sh
@@ -77,7 +77,7 @@ build_lame() {
         if [ ! -f Makefile ]; then
             ./configure ${CONFIG_OPTS} \
                         --disable-shared --enable-static --prefix="${install_dir}" CFLAGS=-fPIC CXXFLAGS=-fPIC \
-                        --with-pic --disable-debug --disable-dependency-tracking --enable-nasm
+                        LIBS=-ltinfo --with-pic --disable-debug --disable-dependency-tracking --enable-nasm
         fi
         make ${MAKE_OPTS} > make.log 2>&1
         make ${MAKE_OPTS} install

--- a/build_tools/setup_helpers/build_third_party_helper.sh
+++ b/build_tools/setup_helpers/build_third_party_helper.sh
@@ -77,7 +77,7 @@ build_lame() {
         if [ ! -f Makefile ]; then
             ./configure ${CONFIG_OPTS} \
                         --disable-shared --enable-static --prefix="${install_dir}" CFLAGS=-fPIC CXXFLAGS=-fPIC \
-                        LIBS=-ltinfo --with-pic --disable-debug --disable-dependency-tracking --enable-nasm
+                        --with-pic --disable-debug --disable-dependency-tracking --enable-nasm
         fi
         make ${MAKE_OPTS} > make.log 2>&1
         make ${MAKE_OPTS} install


### PR DESCRIPTION
There was an issue when building from source in an Anaconda environment under `Arch Linux` where building `liblame` would fail with `undefined reference` errors related to the `ncurses` library (`tgetstr`, `tgetnum`, `tgetent`). This PR allows `liblame` to build under this specific setting.