### PR TITLE
Use environment variable for switching SoX dep

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -20,4 +20,4 @@ printf "Installing PyTorch with %s\n" "${cudatoolkit}"
 conda install -y -c pytorch-nightly pytorch "${cudatoolkit}"
 
 printf "* Installing torchaudio\n"
-python setup.py develop
+BUILD_SOX= python setup.py develop

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -20,4 +20,4 @@ printf "Installing PyTorch with %s\n" "${cudatoolkit}"
 conda install -y -c pytorch-nightly pytorch "${cudatoolkit}"
 
 printf "* Installing torchaudio\n"
-BUILD_SOX= python setup.py develop
+BUILD_SOX=1 python setup.py develop

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -20,4 +20,4 @@ printf "Installing PyTorch with %s\n" "${cudatoolkit}"
 conda install -y -c pytorch-nightly pytorch "${cudatoolkit}"
 
 printf "* Installing torchaudio\n"
-IS_CONDA=true python setup.py develop
+python setup.py develop

--- a/README.md
+++ b/README.md
@@ -113,7 +113,18 @@ BUILD_SOX= python setup.py install
 BUILD_SOX= MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ python setup.py install
 ```
 
+This is known to work on a few major Linux distributions such as Ubuntu and CentOS 7 and macOS.
+If you try this on a new system and found a solution to make it work, feel free to share it by opening and issue.
+
 #### Troubleshooting:
+
+<Details><Summary>checking build system type... ./config.guess: unable to guess system type</Summary>
+
+Since the configuration file for codecs are old, they cannot correctly detect the new environments, such as Jetson Aarch. You need to replace the `config.guess` file in `./third_party/tmp/lame-3.99.5/config.guess` and/or `./third_party/tmp/libmad-0.15.1b/config.guess` with [the latest one](https://github.com/gcc-mirror/gcc/blob/master/config.guess).
+
+See also: [#658](https://github.com/pytorch/audio/issues/658)
+
+</Details>
 
 <Details><Summary>Undefined reference to `tgetnum' when using `BUILD_SOX`</Summary>
 
@@ -129,6 +140,9 @@ Install `ncurses` from `conda-forge` before running `python setup.py install`:
 # Install ncurses from conda-forge
 conda install -c conda-forge ncurses
 ```
+
+See also: [#666](https://github.com/pytorch/audio/issues/666)
+
 </Details>
 
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ to use and feel like a natural extension.
 Dependencies
 ------------
 * pytorch (nightly version needed for development)
-* libsox v14.3.2 or above (only when building from source. not required for binary installation)
+* libsox v14.3.2 or above (only required when building from source)
 * [optional] vesis84/kaldi-io-for-python commit cb46cb1f44318a5d04d4941cf39084c5b021241e or above
 
 Installation
@@ -113,10 +113,10 @@ BUILD_SOX= python setup.py install
 BUILD_SOX= MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ python setup.py install
 ```
 
-This is known to work on a few major Linux distributions such as Ubuntu and CentOS 7 and macOS.
+This is known to work on linux and unix distributions such as Ubuntu and CentOS 7 and macOS.
 If you try this on a new system and found a solution to make it work, feel free to share it by opening and issue.
 
-#### Troubleshooting:
+#### Troubleshooting
 
 <Details><Summary>checking build system type... ./config.guess: unable to guess system type</Summary>
 
@@ -140,8 +140,6 @@ Install `ncurses` from `conda-forge` before running `python setup.py install`:
 # Install ncurses from conda-forge
 conda install -c conda-forge ncurses
 ```
-
-See also: [#666](https://github.com/pytorch/audio/issues/666)
 
 </Details>
 

--- a/README.md
+++ b/README.md
@@ -27,29 +27,16 @@ to use and feel like a natural extension.
 Dependencies
 ------------
 * pytorch (nightly version needed for development)
-* libsox v14.3.2 or above
+* libsox v14.3.2 or above (only when building from source. not required for binary installation)
 * [optional] vesis84/kaldi-io-for-python commit cb46cb1f44318a5d04d4941cf39084c5b021241e or above
-
-Quick install on
-OSX (Homebrew):
-```bash
-brew install sox
-```
-Linux (Ubuntu):
-```bash
-sudo apt-get install sox libsox-dev libsox-fmt-all
-```
-Anaconda
-```bash
-conda install -c conda-forge sox
-```
 
 Installation
 ------------
 
-### Binaries
+### Binary Distibutions
 
 To install the latest version using anaconda, run:
+
 ```
 conda install -c pytorch torchaudio
 ```
@@ -64,26 +51,48 @@ pip install torchaudio -f https://download.pytorch.org/whl/torch_stable.html
 torch from PyPI. If you need a different torch configuration, preinstall torch
 before running this command.)
 
-At the moment, there is no automated nightly build process, but we occasionally
-build nightlies based on PyTorch nightlies by hand following the instructions in
-[packaging](packaging).  To install the latest nightly via pip, run:
+### Nightly build
+
+Note that nightly build is build on PyTorch's nightly build. Therefore, you need to install the latest PyTorch when you use nightly build of torchaudio.
+
+**pip**
 
 ```
 pip install numpy
 pip install --pre torchaudio -f https://download.pytorch.org/whl/nightly/torch_nightly.html
 ```
 
-To install the latest nightly via conda, run:
+**conda**
 
 ```
 conda install -y -c pytorch-nightly torchaudio
 ```
 
-
 ### From Source
 
 If your system configuration is not among the supported configurations
-above, you can build from source.
+above, you can build torchaudio from source.
+
+This will require libsox v14.3.2 or above.
+
+<Details><Summary>Click here for the examples on how to install SoX</Summary>
+
+OSX (Homebrew):
+```bash
+brew install sox
+```
+
+Linux (Ubuntu):
+```bash
+sudo apt-get install sox libsox-dev libsox-fmt-all
+```
+
+Anaconda
+```bash
+conda install -c conda-forge sox
+```
+
+</Details>
 
 ```bash
 # Linux
@@ -93,8 +102,22 @@ python setup.py install
 MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ python setup.py install
 ```
 
-If while building from within an anaconda environment you come across errors similar to the following:
+Alternatively, the build process can build SoX (and codecs such as libmad, lame and flac) statically and torchaudio can link them, by defining `BUILD_SOX` environment variable.
+The build process will fetch and build SoX, liblame, libmad, flac before building extension.
 
+```bash
+# Linux
+BUILD_SOX= python setup.py install
+
+# OSX
+BUILD_SOX= MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ python setup.py install
+```
+
+#### Troubleshooting:
+
+<Details><Summary>Undefined reference to `tgetnum' when using `BUILD_SOX`</Summary>
+
+If while building from within an anaconda environment you come across errors similar to the following:
 
 ```
 ../bin/ld: console.c:(.text+0xc1): undefined reference to `tgetnum'
@@ -106,6 +129,7 @@ Install `ncurses` from `conda-forge` before running `python setup.py install`:
 # Install ncurses from conda-forge
 conda install -c conda-forge ncurses
 ```
+</Details>
 
 
 Quick Usage

--- a/README.md
+++ b/README.md
@@ -102,15 +102,15 @@ python setup.py install
 MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ python setup.py install
 ```
 
-Alternatively, the build process can build SoX (and codecs such as libmad, lame and flac) statically and torchaudio can link them, by defining `BUILD_SOX` environment variable.
+Alternatively, the build process can build SoX (and codecs such as libmad, lame and flac) statically and torchaudio can link them, by setting environment variable `BUILD_SOX=1`.
 The build process will fetch and build SoX, liblame, libmad, flac before building extension.
 
 ```bash
 # Linux
-BUILD_SOX= python setup.py install
+BUILD_SOX=1 python setup.py install
 
 # OSX
-BUILD_SOX= MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ python setup.py install
+BUILD_SOX=1 MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ python setup.py install
 ```
 
 This is known to work on linux and unix distributions such as Ubuntu and CentOS 7 and macOS.

--- a/build_tools/setup_helpers/extension.py
+++ b/build_tools/setup_helpers/extension.py
@@ -19,7 +19,17 @@ _CSRC_DIR = _ROOT_DIR / 'torchaudio' / 'csrc'
 _TP_BASE_DIR = _ROOT_DIR / 'third_party'
 _TP_INSTALL_DIR = _TP_BASE_DIR / 'build'
 
-_BUILD_SOX = 'BUILD_SOX' in os.environ
+
+def _get_build_sox():
+    val = os.environ.get('BUILD_SOX', '0')
+    if val in ['1', 'true', 'TRUE', 'on', 'ON', 'yes', 'YES']:
+        return True
+    if val not in ['0', 'false', 'FALSE', 'off', 'OFF', 'no', 'NO']:
+        print(f'Unexpected value environment variable `BUILD_SOX={val}`.')
+    return False
+
+
+_BUILD_SOX = _get_build_sox()
 
 
 def _get_eca(debug):

--- a/build_tools/setup_helpers/extension.py
+++ b/build_tools/setup_helpers/extension.py
@@ -22,10 +22,14 @@ _TP_INSTALL_DIR = _TP_BASE_DIR / 'build'
 
 def _get_build_sox():
     val = os.environ.get('BUILD_SOX', '0')
-    if val in ['1', 'true', 'TRUE', 'on', 'ON', 'yes', 'YES']:
+    trues = ['1', 'true', 'TRUE', 'on', 'ON', 'yes', 'YES']
+    falses = ['0', 'false', 'FALSE', 'off', 'OFF', 'no', 'NO']
+    if val in trues:
         return True
-    if val not in ['0', 'false', 'FALSE', 'off', 'OFF', 'no', 'NO']:
-        print(f'Unexpected value environment variable `BUILD_SOX={val}`.')
+    if val not in falses:
+        print(
+            f'WARNING: Unexpected environment variable value `BUILD_SOX={val}`. '
+            f'Expected one of {trues + falses}')
     return False
 
 

--- a/packaging/build_wheel.sh
+++ b/packaging/build_wheel.sh
@@ -15,5 +15,5 @@ if [[ "$OSTYPE" == "msys" ]]; then
     python_tag="$(echo "cp$PYTHON_VERSION" | tr -d '.')"
     python setup.py bdist_wheel --plat-name win_amd64 --python-tag $python_tag
 else
-    BUILD_SOX= python setup.py bdist_wheel
+    BUILD_SOX=1 python setup.py bdist_wheel
 fi

--- a/packaging/build_wheel.sh
+++ b/packaging/build_wheel.sh
@@ -15,5 +15,5 @@ if [[ "$OSTYPE" == "msys" ]]; then
     python_tag="$(echo "cp$PYTHON_VERSION" | tr -d '.')"
     python setup.py bdist_wheel --plat-name win_amd64 --python-tag $python_tag
 else
-    python setup.py bdist_wheel
+    BUILD_SOX= python setup.py bdist_wheel
 fi

--- a/packaging/torchaudio/build.sh
+++ b/packaging/torchaudio/build.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -ex
 
-python setup.py install --single-version-externally-managed --record=record.txt
+BUILD_SOX= python setup.py install --single-version-externally-managed --record=record.txt

--- a/packaging/torchaudio/build.sh
+++ b/packaging/torchaudio/build.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -ex
 
-BUILD_SOX= python setup.py install --single-version-externally-managed --record=record.txt
+BUILD_SOX=1 python setup.py install --single-version-externally-managed --record=record.txt


### PR DESCRIPTION
This PR changes
 
1. The way how to decide if codecs/SoX should be built when building torchaudio C++ extension.
    It check whether `BUILD_SOX` env is defined or not. (Originally, it was checking the existence of `.use_external_sox` file.)
2. Revert the default behavior of codecs/SoX build.
    It does not build codecs/SoX by default.
