### PR TITLE
Updates test_transform.py to no longer perform floor division

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -34,7 +34,7 @@ class Tester(TestCase):
         if not waveform.is_floating_point():
             waveform = waveform.to(torch.get_default_dtype())
         waveform /= torch.abs(waveform).max()
-        
+
         self.assertTrue(waveform.min() >= -1. and waveform.max() <= 1.)
 
         waveform_mu = transforms.MuLawEncoding(quantization_channels)(waveform)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -31,7 +31,10 @@ class Tester(TestCase):
         quantization_channels = 256
 
         waveform = self.waveform.clone()
+        if not waveform.is_floating_point():
+            waveform = waveform.to(torch.get_default_dtype())
         waveform /= torch.abs(waveform).max()
+        
         self.assertTrue(waveform.min() >= -1. and waveform.max() <= 1.)
 
         waveform_mu = transforms.MuLawEncoding(quantization_channels)(waveform)


### PR DESCRIPTION
This will prevent this test from breaking when torch.div is updating to throw a runtime error when it would have performed floor division.