### PR TITLE
Move I/O related Tensor ops to misc_ops module

### DIFF
--- a/torchaudio/_backend.py
+++ b/torchaudio/_backend.py
@@ -1,9 +1,7 @@
-from functools import wraps
-from typing import Any, List, Union
+from typing import Any
 
 import platform
-import torch
-from torch import Tensor
+
 
 from . import _soundfile_backend, _sox_backend
 
@@ -43,10 +41,3 @@ def _get_audio_backend_module() -> Any:
     """
     backend = get_audio_backend()
     return _audio_backends[backend]
-
-
-def check_input(src: Tensor) -> None:
-    if not torch.is_tensor(src):
-        raise TypeError('Expected a tensor, got %s' % type(src))
-    if src.is_cuda:
-        raise TypeError('Expected a CPU based tensor, got %s' % type(src))

--- a/torchaudio/_internal/misc_ops.py
+++ b/torchaudio/_internal/misc_ops.py
@@ -1,0 +1,30 @@
+from typing import Union, Callable
+
+import torch
+from torch import Tensor
+
+
+def normalize_audio(signal: Tensor, normalization: Union[bool, float, Callable]) -> None:
+    """Audio normalization of a tensor in-place.  The normalization can be a bool,
+    a number, or a callable that takes the audio tensor as an input. SoX uses
+    32-bit signed integers internally, thus bool normalizes based on that assumption.
+    """
+
+    if not normalization:
+        return
+
+    if isinstance(normalization, bool):
+        normalization = 1 << 31
+
+    if isinstance(normalization, (float, int)):
+        # normalize with custom value
+        signal /= normalization
+    elif callable(normalization):
+        signal /= normalization(signal)
+
+
+def check_input(src: Tensor) -> None:
+    if not torch.is_tensor(src):
+        raise TypeError('Expected a tensor, got %s' % type(src))
+    if src.is_cuda:
+        raise TypeError('Expected a CPU based tensor, got %s' % type(src))

--- a/torchaudio/_soundfile_backend.py
+++ b/torchaudio/_soundfile_backend.py
@@ -4,6 +4,9 @@ from typing import Any, Optional, Tuple, Union
 import torch
 from torch import Tensor
 
+from torchaudio._internal import misc_ops as _misc_ops
+
+
 _subtype_to_precision = {
     'PCM_S8': 8,
     'PCM_16': 16,
@@ -41,13 +44,6 @@ class EncodingInfo:
         self.reverse_nibbles = reverse_nibbles
         self.reverse_bits = reverse_bits
         self.opposite_endian = opposite_endian
-
-
-def check_input(src: Tensor) -> None:
-    if not torch.is_tensor(src):
-        raise TypeError("Expected a tensor, got %s" % type(src))
-    if src.is_cuda:
-        raise TypeError("Expected a CPU based tensor, got %s" % type(src))
 
 
 def load(filepath: str,
@@ -108,7 +104,7 @@ def save(filepath: str, src: Tensor, sample_rate: int, precision: int = 16, chan
     if not os.path.isdir(abs_dirpath):
         raise OSError("Directory does not exist: {}".format(abs_dirpath))
     # check that src is a CPU tensor
-    check_input(src)
+    _misc_ops.check_input(src)
     # Check/Fix shape of source data
     if src.dim() == 1:
         # 1d tensors as assumed to be mono signals

--- a/torchaudio/_sox_backend.py
+++ b/torchaudio/_sox_backend.py
@@ -5,7 +5,10 @@ import torch
 from torch import Tensor
 
 import torchaudio
-from torchaudio._internal import module_utils as _mod_utils
+from torchaudio._internal import (
+    module_utils as _mod_utils,
+    misc_ops as _misc_ops,
+)
 from torchaudio._soundfile_backend import SignalInfo, EncodingInfo
 
 if _mod_utils.is_module_available('torchaudio._torchaudio'):
@@ -32,7 +35,7 @@ def load(filepath: str,
 
     # initialize output tensor
     if out is not None:
-        torchaudio.check_input(out)
+        _misc_ops.check_input(out)
     else:
         out = torch.FloatTensor()
 
@@ -53,7 +56,7 @@ def load(filepath: str,
     )
 
     # normalize if needed
-    torchaudio._audio_normalization(out, normalization)
+    _misc_ops.normalize_audio(out, normalization)
 
     return out, sample_rate
 

--- a/torchaudio/sox_effects.py
+++ b/torchaudio/sox_effects.py
@@ -5,7 +5,10 @@ import torch
 import torchaudio
 from torch import Tensor
 
-from torchaudio._internal import module_utils as _mod_utils
+from torchaudio._internal import (
+    module_utils as _mod_utils,
+    misc_ops as _misc_ops,
+)
 
 if _mod_utils.is_module_available('torchaudio._torchaudio'):
     from . import _torchaudio
@@ -200,7 +203,7 @@ class SoxEffectsChain(object):
         """
         # initialize output tensor
         if out is not None:
-            torchaudio.check_input(out)
+            _misc_ops.check_input(out)
         else:
             out = torch.FloatTensor()
         if not len(self.chain):
@@ -220,7 +223,7 @@ class SoxEffectsChain(object):
                                             self.chain,
                                             self.MAX_EFFECT_OPTS)
 
-        torchaudio._audio_normalization(out, self.normalization)
+        _misc_ops.normalize_audio(out, self.normalization)
 
         return out, sr
 


### PR DESCRIPTION
`check_input` and `audio_normalization` functions defined in `__init__.py`, `_backend.py` and `_soundfilebackend` (duplicated) are referred from multiple modules and cause cyclic module dependencies and preventing modularizing backends. This PR resolve this by putting them in a separate dedicated module `_internal.misc_ops`.

Also change the helper function name from `audio_normalization` (noun) to `normalize_audio` (verb) for consistency.