### PR TITLE
Add deprecation warning to initialize/shutdown_sox

### DIFF
--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -35,12 +35,18 @@ except ImportError:
     pass
 
 
-@_mod_utils.depricate("Use `torchaudio.sox_effects.init_sox_effects`.")
+@_mod_utils.deprecated(
+    "Use `torchaudio.sox_effects.init_sox_effects`, or simply remove the call. "
+    "It is automatically handled."
+)
 def initialize_sox():
     init_sox_effects()
 
 
-@_mod_utils.depricate("Use `torchaudio.sox_effects.shutdown_sox`.")
+@_mod_utils.deprecated(
+    "Use `torchaudio.sox_effects.shutdown_sox`, or remove the call. "
+    "It is automatically handled."
+)
 def shutdown_sox():
     shutdown_sox_effects()
 

--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional, Tuple, Union
 
 from torch import Tensor
+from torchaudio._internal import module_utils as _mod_utils
 from torchaudio import (
     compliance,
     datasets,
@@ -24,14 +25,24 @@ from torchaudio.backend import (
     EncodingInfo,
 )
 from torchaudio.sox_effects import (
-    init_sox_effects as initialize_sox,
-    shutdown_sox_effects as shutdown_sox,
+    init_sox_effects,
+    shutdown_sox_effects,
 )
 
 try:
     from .version import __version__, git_version  # noqa: F401
 except ImportError:
     pass
+
+
+@_mod_utils.depricate("Use `torchaudio.sox_effects.init_sox_effects`.")
+def initialize_sox():
+    init_sox_effects()
+
+
+@_mod_utils.depricate("Use `torchaudio.sox_effects.shutdown_sox`.")
+def shutdown_sox():
+    shutdown_sox_effects()
 
 
 def load(filepath: Union[str, Path],

--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -36,9 +36,7 @@ except ImportError:
 
 
 @_mod_utils.deprecated(
-    "Use `torchaudio.sox_effects.init_sox_effects`, or simply remove the call. "
-    "It is automatically handled."
-)
+    "Please remove the function call. Resource initialization is automatically handled")
 def initialize_sox() -> int:
     """Initialize sox effects.
 
@@ -48,9 +46,7 @@ def initialize_sox() -> int:
 
 
 @_mod_utils.deprecated(
-    "Use `torchaudio.sox_effects.shutdown_sox`, or remove the call. "
-    "It is automatically handled."
-)
+    "Please remove the function call. Resource clean up is automatically handled")
 def shutdown_sox():
     """Shutdown sox effects.
 

--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -39,7 +39,11 @@ except ImportError:
     "Use `torchaudio.sox_effects.init_sox_effects`, or simply remove the call. "
     "It is automatically handled."
 )
-def initialize_sox():
+def initialize_sox() -> int:
+    """Initialize sox effects.
+
+    This function is deprecated. See ``torchaudio.sox_effects.init_sox_effects``
+    """
     init_sox_effects()
 
 
@@ -48,6 +52,10 @@ def initialize_sox():
     "It is automatically handled."
 )
 def shutdown_sox():
+    """Shutdown sox effects.
+
+    This function is deprecated. See ``torchaudio.sox_effects.shutdown_sox_effects``
+    """
     shutdown_sox_effects()
 
 

--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -25,8 +25,8 @@ from torchaudio.backend import (
     EncodingInfo,
 )
 from torchaudio.sox_effects import (
-    _init_sox_effects,
-    _shutdown_sox_effects,
+    init_sox_effects as _init_sox_effects,
+    shutdown_sox_effects as _shutdown_sox_effects,
 )
 
 try:

--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -25,8 +25,8 @@ from torchaudio.backend import (
     EncodingInfo,
 )
 from torchaudio.sox_effects import (
-    init_sox_effects,
-    shutdown_sox_effects,
+    init_sox_effects as _init_sox_effects,
+    shutdown_sox_effects as _shutdown_sox_effects,
 )
 
 try:
@@ -44,7 +44,7 @@ def initialize_sox() -> int:
 
     This function is deprecated. See ``torchaudio.sox_effects.init_sox_effects``
     """
-    init_sox_effects()
+    _init_sox_effects()
 
 
 @_mod_utils.deprecated(
@@ -56,7 +56,7 @@ def shutdown_sox():
 
     This function is deprecated. See ``torchaudio.sox_effects.shutdown_sox_effects``
     """
-    shutdown_sox_effects()
+    _shutdown_sox_effects()
 
 
 def load(filepath: Union[str, Path],

--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -25,8 +25,8 @@ from torchaudio.backend import (
     EncodingInfo,
 )
 from torchaudio.sox_effects import (
-    init_sox_effects as _init_sox_effects,
-    shutdown_sox_effects as _shutdown_sox_effects,
+    _init_sox_effects,
+    _shutdown_sox_effects,
 )
 
 try:

--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -36,7 +36,8 @@ except ImportError:
 
 
 @_mod_utils.deprecated(
-    "Please remove the function call. Resource initialization is automatically handled")
+    "Please remove the function call to initialize_sox. "
+    "Resource initialization is now automatically handled.")
 def initialize_sox() -> int:
     """Initialize sox effects.
 
@@ -46,7 +47,10 @@ def initialize_sox() -> int:
 
 
 @_mod_utils.deprecated(
-    "Please remove the function call. Resource clean up is automatically handled")
+    "Please remove the function call to torchaudio.shutdown_sox. "
+    "Resource clean up is now automatically handled. "
+    "In the unlikely event that you need to manually shutdown sox, "
+    "please use torchaudio.sox_effects.shutdown_sox_effects.")
 def shutdown_sox():
     """Shutdown sox effects.
 

--- a/torchaudio/_internal/module_utils.py
+++ b/torchaudio/_internal/module_utils.py
@@ -1,5 +1,6 @@
 import warnings
 import importlib.util
+from typing import Optional
 from functools import wraps
 
 
@@ -36,7 +37,7 @@ def requires_module(*modules: str):
     return decorator
 
 
-def deprecated(direction: str):
+def deprecated(direction: str, version: Optional[str] = None):
     """Decorator to add deprecation message
 
     Args:
@@ -45,7 +46,10 @@ def deprecated(direction: str):
     def decorator(func):
         @wraps(func)
         def wrapped(*args, **kwargs):
-            message = f'{func.__module__}.{func.__name__} has been deprecated. f{direction}'
+            message = (
+                f'{func.__module__}.{func.__name__} has been deprecated '
+                f'and will be removed from {"future" if version is None else version} release.'
+                f'{direction}')
             warnings.warn(message, stacklevel=2)
             return func(*args, **kwargs)
         return wrapped

--- a/torchaudio/_internal/module_utils.py
+++ b/torchaudio/_internal/module_utils.py
@@ -1,3 +1,4 @@
+import warnings
 import importlib.util
 from functools import wraps
 
@@ -32,4 +33,15 @@ def requires_module(*modules: str):
             def wrapped(*args, **kwargs):
                 raise RuntimeError(f'{func.__module__}.{func.__name__} requires {req}')
             return wrapped
+    return decorator
+
+
+def depricate(direction: str):
+    """Decorator to add depciration message"""
+    def decorator(func):
+        @wraps(func)
+        def wrapped(*args, **kwargs):
+            warnings.warn(f'{func.__module__}.{func.__name__} has been deprecated. f{direction}')
+            return func(*args, **kwargs)
+        return wrapped
     return decorator

--- a/torchaudio/_internal/module_utils.py
+++ b/torchaudio/_internal/module_utils.py
@@ -36,12 +36,17 @@ def requires_module(*modules: str):
     return decorator
 
 
-def depricate(direction: str):
-    """Decorator to add depciration message"""
+def deprecated(direction: str):
+    """Decorator to add deprecation message
+
+    Args:
+        direction: Migration steps to be given to users.
+    """
     def decorator(func):
         @wraps(func)
         def wrapped(*args, **kwargs):
-            warnings.warn(f'{func.__module__}.{func.__name__} has been deprecated. f{direction}')
+            message = f'{func.__module__}.{func.__name__} has been deprecated. f{direction}'
+            warnings.warn(message, stacklevel=2)
             return func(*args, **kwargs)
         return wrapped
     return decorator

--- a/torchaudio/sox_effects/__init__.py
+++ b/torchaudio/sox_effects/__init__.py
@@ -1,7 +1,7 @@
 from torchaudio._internal import module_utils as _mod_utils
 from .sox_effects import (
-    _init_sox_effects,
-    _shutdown_sox_effects,
+    init_sox_effects,
+    shutdown_sox_effects,
     effect_names,
     SoxEffect,
     SoxEffectsChain,
@@ -9,4 +9,4 @@ from .sox_effects import (
 
 
 if _mod_utils.is_module_available('torchaudio._torchaudio'):
-    _init_sox_effects()
+    init_sox_effects()

--- a/torchaudio/sox_effects/__init__.py
+++ b/torchaudio/sox_effects/__init__.py
@@ -1,7 +1,7 @@
 from torchaudio._internal import module_utils as _mod_utils
 from .sox_effects import (
-    init_sox_effects,
-    shutdown_sox_effects,
+    _init_sox_effects,
+    _shutdown_sox_effects,
     effect_names,
     SoxEffect,
     SoxEffectsChain,
@@ -9,4 +9,4 @@ from .sox_effects import (
 
 
 if _mod_utils.is_module_available('torchaudio._torchaudio'):
-    init_sox_effects()
+    _init_sox_effects()

--- a/torchaudio/sox_effects/sox_effects.py
+++ b/torchaudio/sox_effects/sox_effects.py
@@ -25,7 +25,7 @@ _SOX_SUCCESS_CODE = 0
 
 
 @_mod_utils.requires_module('torchaudio._torchaudio')
-def init_sox_effects() -> int:
+def _init_sox_effects() -> int:
     """Initialize resources required to use ``SoxEffectsChain``
 
     You do not need to call this function manually. It is called automatically.
@@ -50,13 +50,13 @@ def init_sox_effects() -> int:
         code = _torchaudio.initialize_sox()
         if code == _SOX_SUCCESS_CODE:
             _SOX_INITIALIZED = True
-            atexit.register(shutdown_sox_effects)
+            atexit.register(_shutdown_sox_effects)
         return code
     return _SOX_SUCCESS_CODE
 
 
 @_mod_utils.requires_module("torchaudio._torchaudio")
-def shutdown_sox_effects() -> int:
+def _shutdown_sox_effects() -> int:
     """Clean up resources required to use ``SoxEffectsChain``
 
     You do not need to call this function manually. It is called automatically.

--- a/torchaudio/sox_effects/sox_effects.py
+++ b/torchaudio/sox_effects/sox_effects.py
@@ -25,7 +25,7 @@ _SOX_SUCCESS_CODE = 0
 
 
 @_mod_utils.requires_module('torchaudio._torchaudio')
-def _init_sox_effects() -> int:
+def init_sox_effects() -> int:
     """Initialize resources required to use ``SoxEffectsChain``
 
     You do not need to call this function manually. It is called automatically.
@@ -50,13 +50,13 @@ def _init_sox_effects() -> int:
         code = _torchaudio.initialize_sox()
         if code == _SOX_SUCCESS_CODE:
             _SOX_INITIALIZED = True
-            atexit.register(_shutdown_sox_effects)
+            atexit.register(shutdown_sox_effects)
         return code
     return _SOX_SUCCESS_CODE
 
 
 @_mod_utils.requires_module("torchaudio._torchaudio")
-def _shutdown_sox_effects() -> int:
+def shutdown_sox_effects() -> int:
     """Clean up resources required to use ``SoxEffectsChain``
 
     You do not need to call this function manually. It is called automatically.

--- a/torchaudio/sox_effects/sox_effects.py
+++ b/torchaudio/sox_effects/sox_effects.py
@@ -26,12 +26,15 @@ _SOX_SUCCESS_CODE = 0
 
 @_mod_utils.requires_module('torchaudio._torchaudio')
 def init_sox_effects() -> int:
-    """Initialize sox for use with effects chains.
+    """Initialize resources required to use ``SoxEffectsChain``
 
-    You only need to call this function once to use SoX effects chains multiple times.
-    It is safe to call this function multiple times as long as ``shutdown_sox`` is not yet called.
-    Once ``shutdown_sox`` is called, you can no longer use SoX effects and calling this function
-    results in `RuntimeError`.
+    You do not need to call this function manually. It is called automatically.
+
+    Once initialized, you do not need to call this function again across the multiple call of
+    ``SoxEffectsChain.sox_build_flow_effects``, though it is safe to do so as long as
+    ``shutdown_sox_effects`` is not called yet.
+    Once ``shutdown_sox_effects`` is called, you can no longer use SoX effects and calling
+    this function results in `RuntimeError`.
 
     Note:
         This function is not required for simple loading.
@@ -54,12 +57,14 @@ def init_sox_effects() -> int:
 
 @_mod_utils.requires_module("torchaudio._torchaudio")
 def shutdown_sox_effects() -> int:
-    """Showdown sox for effects chain.
+    """Clean up resources required to use ``SoxEffectsChain``
 
-    You do not need to call this function as it will be called automatically
-    at the end of program execution, if ``initialize_sox`` was called.
+    You do not need to call this function manually. It is called automatically.
 
     It is safe to call this function multiple times.
+    Once ``shutdown_sox_effects`` is called, you can no longer use SoX effects and calling
+    this function results in `RuntimeError`.
+
 
     Returns:
         int: Code corresponding to sox_error_t enum. See


### PR DESCRIPTION
`torchaudio.initialize_sox` (and corresponding `torchaudio.shutdown_sox`) is a confusing function because it sounds like this function has to be called to use any sox functionality though it is required only for SoX Effects. This PR proposes to deprecate these functions and direct users to use `torchaudio.sox_effects.init_sox_effects` (and `torchaudio.sox_effects.shutdown_sox_effects`), if necessary.