### PR TITLE
Change parameterized testing system to be compatible with unittest

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -119,6 +119,15 @@ def define_test_suites(
                 scope[t.__name__] = t
 
 
+def common_test_class_parameters(
+    dtypes: Iterable[str] = ("float32", "float64"),
+    devices: Iterable[str] = ("cpu", "cuda"),
+):
+    for device in devices:
+        for dtype in dtypes:
+            yield {"device": torch.device(device), "dtype": getattr(torch, dtype)}
+
+
 def get_whitenoise(
     *,
     sample_rate: int = 16000,

--- a/test/torchscript_consistency_cpu_test.py
+++ b/test/torchscript_consistency_cpu_test.py
@@ -1,5 +1,14 @@
-from .common_utils import define_test_suites
+from parameterized import parameterized_class
+
+from .common_utils import TestCase, common_test_class_parameters
 from .torchscript_consistency_impl import Functional, Transforms
 
+parameters = list(common_test_class_parameters(devices=['cpu']))
+@parameterized_class(parameters)
+class TestFunctional(Functional, TestCase):
+    pass
 
-define_test_suites(globals(), [Functional, Transforms], devices=['cpu'])
+
+@parameterized_class(parameters)
+class TestTransforms(Transforms, TestCase):
+    pass

--- a/test/torchscript_consistency_cpu_test.py
+++ b/test/torchscript_consistency_cpu_test.py
@@ -3,7 +3,10 @@ from parameterized import parameterized_class
 from .common_utils import TestCase, common_test_class_parameters
 from .torchscript_consistency_impl import Functional, Transforms
 
+
 parameters = list(common_test_class_parameters(devices=['cpu']))
+
+
 @parameterized_class(parameters)
 class TestFunctional(Functional, TestCase):
     pass


### PR DESCRIPTION
Summary: The previous implementation of parameterized testing worked by modifying test.common_utils inplace.  This doesn't work in general because unittest's contract with test modules is such that it must be able to load the module and run the test itself.  Because the previous implementation needed to load the module and modify it, it is incompatible.

Reviewed By: mthrok

Differential Revision: D21964676