### PR TITLE
Fix integer division

### DIFF
--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -381,7 +381,7 @@ def test_mask_along_axis(specgram, mask_param, mask_value, axis):
 
     masked_columns = (mask_specgram == mask_value).sum(other_axis)
     num_masked_columns = (masked_columns == mask_specgram.size(other_axis)).sum()
-    num_masked_columns /= mask_specgram.size(0)
+    num_masked_columns //= mask_specgram.size(0)
 
     assert mask_specgram.size() == specgram.size()
     assert num_masked_columns < mask_param

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -1382,7 +1382,7 @@ def _generate_wave_table(
         d = (torch.sin(point.to(torch.float64) / table_size * 2 * math.pi) + 1) / 2
     elif wave_type == 'TRIANGLE':
         d = point.to(torch.float64) * 2 / table_size
-        value = 4 * point / table_size
+        value = 4 * point // table_size
         d[value == 0] = d[value == 0] + 0.5
         d[value == 1] = 1.5 - d[value == 1]
         d[value == 2] = 1.5 - d[value == 2]


### PR DESCRIPTION
PyTorch started to raise errors when performing integer division with `/`. This PR fixes this with `//`.
Closes #713 