### PR TITLE
Get rid of dynamic test suite generation

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 import unittest
-from typing import Type, Iterable, Union
+from typing import Iterable, Union
 from contextlib import contextmanager
 from shutil import copytree
 
@@ -88,35 +88,7 @@ class TestBaseMixin:
     device = None
 
 
-_SKIP_IF_NO_CUDA = unittest.skipIf(not torch.cuda.is_available(), reason='CUDA not available')
-
-
-def define_test_suite(testbase: Type[TestBaseMixin], dtype: str, device: str):
-    if dtype not in ['float32', 'float64']:
-        raise NotImplementedError(f'Unexpected dtype: {dtype}')
-    if device not in ['cpu', 'cuda']:
-        raise NotImplementedError(f'Unexpected device: {device}')
-
-    name = f'Test{testbase.__name__}_{device.upper()}_{dtype.capitalize()}'
-    attrs = {'dtype': getattr(torch, dtype), 'device': torch.device(device)}
-    testsuite = type(name, (testbase, TestCase), attrs)
-
-    if device == 'cuda':
-        testsuite = _SKIP_IF_NO_CUDA(testsuite)
-    return testsuite
-
-
-def define_test_suites(
-        scope: dict,
-        testbases: Iterable[Type[TestBaseMixin]],
-        dtypes: Iterable[str] = ('float32', 'float64'),
-        devices: Iterable[str] = ('cpu', 'cuda'),
-):
-    for suite in testbases:
-        for device in devices:
-            for dtype in dtypes:
-                t = define_test_suite(suite, dtype, device)
-                scope[t.__name__] = t
+skipIfNoCuda = unittest.skipIf(not torch.cuda.is_available(), reason='CUDA not available')
 
 
 def common_test_class_parameters(

--- a/test/functional_cpu_test.py
+++ b/test/functional_cpu_test.py
@@ -7,35 +7,17 @@ import torchaudio.functional as F
 import pytest
 
 from . import common_utils
+from .functional_impl import Lfilter
 
 
-class Lfilter(common_utils.TestBaseMixin):
-    def test_simple(self):
-        """
-        Create a very basic signal,
-        Then make a simple 4th order delay
-        The output should be same as the input but shifted
-        """
-
-        torch.random.manual_seed(42)
-        waveform = torch.rand(2, 44100 * 1, dtype=self.dtype, device=self.device)
-        b_coeffs = torch.tensor([0, 0, 0, 1], dtype=self.dtype, device=self.device)
-        a_coeffs = torch.tensor([1, 0, 0, 0], dtype=self.dtype, device=self.device)
-        output_waveform = F.lfilter(waveform, a_coeffs, b_coeffs)
-
-        self.assertEqual(output_waveform[:, 3:], waveform[:, 0:-3], atol=1e-5, rtol=1e-5)
-
-    def test_clamp(self):
-        input_signal = torch.ones(1, 44100 * 1, dtype=self.dtype, device=self.device)
-        b_coeffs = torch.tensor([1, 0], dtype=self.dtype, device=self.device)
-        a_coeffs = torch.tensor([1, -0.95], dtype=self.dtype, device=self.device)
-        output_signal = F.lfilter(input_signal, a_coeffs, b_coeffs, clamp=True)
-        assert output_signal.max() <= 1
-        output_signal = F.lfilter(input_signal, a_coeffs, b_coeffs, clamp=False)
-        assert output_signal.max() > 1
+class TestLFilterFloat32(Lfilter, common_utils.TestCase):
+    dtype = torch.float32
+    device = torch.device('cpu')
 
 
-common_utils.define_test_suites(globals(), [Lfilter])
+class TestLFilterFloat64(Lfilter, common_utils.TestCase):
+    dtype = torch.float64
+    device = torch.device('cpu')
 
 
 class TestComputeDeltas(unittest.TestCase):

--- a/test/functional_cuda_test.py
+++ b/test/functional_cuda_test.py
@@ -1,16 +1,16 @@
 import torch
 
 from . import common_utils
-from .kaldi_compatibility_impl import Kaldi
+from .functional_impl import Lfilter
 
 
 @common_utils.skipIfNoCuda
-class TestKaldiFloat32(Kaldi, common_utils.TestCase):
+class TestLFilterFloat32(Lfilter, common_utils.TestCase):
     dtype = torch.float32
     device = torch.device('cuda')
 
 
 @common_utils.skipIfNoCuda
-class TestKaldiFloat64(Kaldi, common_utils.TestCase):
+class TestLFilterFloat64(Lfilter, common_utils.TestCase):
     dtype = torch.float64
     device = torch.device('cuda')

--- a/test/functional_impl.py
+++ b/test/functional_impl.py
@@ -1,0 +1,31 @@
+"""Test defintion common to CPU and CUDA"""
+import torch
+import torchaudio.functional as F
+
+from . import common_utils
+
+
+class Lfilter(common_utils.TestBaseMixin):
+    def test_simple(self):
+        """
+        Create a very basic signal,
+        Then make a simple 4th order delay
+        The output should be same as the input but shifted
+        """
+
+        torch.random.manual_seed(42)
+        waveform = torch.rand(2, 44100 * 1, dtype=self.dtype, device=self.device)
+        b_coeffs = torch.tensor([0, 0, 0, 1], dtype=self.dtype, device=self.device)
+        a_coeffs = torch.tensor([1, 0, 0, 0], dtype=self.dtype, device=self.device)
+        output_waveform = F.lfilter(waveform, a_coeffs, b_coeffs)
+
+        self.assertEqual(output_waveform[:, 3:], waveform[:, 0:-3], atol=1e-5, rtol=1e-5)
+
+    def test_clamp(self):
+        input_signal = torch.ones(1, 44100 * 1, dtype=self.dtype, device=self.device)
+        b_coeffs = torch.tensor([1, 0], dtype=self.dtype, device=self.device)
+        a_coeffs = torch.tensor([1, -0.95], dtype=self.dtype, device=self.device)
+        output_signal = F.lfilter(input_signal, a_coeffs, b_coeffs, clamp=True)
+        assert output_signal.max() <= 1
+        output_signal = F.lfilter(input_signal, a_coeffs, b_coeffs, clamp=False)
+        assert output_signal.max() > 1

--- a/test/kaldi_compatibility_cpu_test.py
+++ b/test/kaldi_compatibility_cpu_test.py
@@ -1,5 +1,14 @@
+import torch
+
 from . import common_utils
 from .kaldi_compatibility_impl import Kaldi
 
 
-common_utils.define_test_suites(globals(), [Kaldi], devices=['cpu'])
+class TestKaldiFloat32(Kaldi, common_utils.TestCase):
+    dtype = torch.float32
+    device = torch.device('cpu')
+
+
+class TestKaldiFloat64(Kaldi, common_utils.TestCase):
+    dtype = torch.float64
+    device = torch.device('cpu')

--- a/test/torchscript_consistency_cpu_test.py
+++ b/test/torchscript_consistency_cpu_test.py
@@ -1,17 +1,24 @@
-from parameterized import parameterized_class
+import torch
 
-from .common_utils import TestCase, common_test_class_parameters
+from . import common_utils
 from .torchscript_consistency_impl import Functional, Transforms
 
 
-parameters = list(common_test_class_parameters(devices=['cpu']))
+class TestFunctionalFloat32(Functional, common_utils.TestCase):
+    dtype = torch.float32
+    device = torch.device('cpu')
 
 
-@parameterized_class(parameters)
-class TestFunctional(Functional, TestCase):
-    pass
+class TestFunctionalFloat64(Functional, common_utils.TestCase):
+    dtype = torch.float64
+    device = torch.device('cpu')
 
 
-@parameterized_class(parameters)
-class TestTransforms(Transforms, TestCase):
-    pass
+class TestTransformsFloat32(Transforms, common_utils.TestCase):
+    dtype = torch.float32
+    device = torch.device('cpu')
+
+
+class TestTransformsFloat64(Transforms, common_utils.TestCase):
+    dtype = torch.float64
+    device = torch.device('cpu')

--- a/test/torchscript_consistency_cuda_test.py
+++ b/test/torchscript_consistency_cuda_test.py
@@ -1,5 +1,28 @@
-from .common_utils import define_test_suites
+import torch
+
+from . import common_utils
 from .torchscript_consistency_impl import Functional, Transforms
 
 
-define_test_suites(globals(), [Functional, Transforms], devices=['cuda'])
+@common_utils.skipIfNoCuda
+class TestFunctionalFloat32(Functional, common_utils.TestCase):
+    dtype = torch.float32
+    device = torch.device('cuda')
+
+
+@common_utils.skipIfNoCuda
+class TestFunctionalFloat64(Functional, common_utils.TestCase):
+    dtype = torch.float64
+    device = torch.device('cuda')
+
+
+@common_utils.skipIfNoCuda
+class TestTransformsFloat32(Transforms, common_utils.TestCase):
+    dtype = torch.float32
+    device = torch.device('cuda')
+
+
+@common_utils.skipIfNoCuda
+class TestTransformsFloat64(Transforms, common_utils.TestCase):
+    dtype = torch.float64
+    device = torch.device('cuda')


### PR DESCRIPTION
`type` used in `common_utils` generates test class definition in `common_utils` and
this modifies the module state after it's imported. This is anti-pattern.
This PR get rid of the related utility functions and define test suite manually.

Follow up #712 