### PR TITLE
Add TorchScript-based SoX I/O backend

### DIFF
--- a/test/sox_io_backend/test_torchscript.py
+++ b/test/sox_io_backend/test_torchscript.py
@@ -2,7 +2,7 @@ import itertools
 from typing import Optional
 
 import torch
-from torchaudio.backend import sox_io_backend
+import torchaudio
 from parameterized import parameterized
 
 from ..common_utils import (
@@ -21,11 +21,11 @@ from .common import (
 
 
 def py_info_func(filepath: str) -> torch.classes.torchaudio.SignalInfo:
-    return sox_io_backend.info(filepath)
+    return torchaudio.info(filepath)
 
 
 def py_load_func(filepath: str, normalize: bool, channels_first: bool):
-    return sox_io_backend.load(
+    return torchaudio.load(
         filepath, normalize=normalize, channels_first=channels_first)
 
 
@@ -36,13 +36,15 @@ def py_save_func(
         channels_first: bool = True,
         compression: Optional[float] = None,
 ):
-    sox_io_backend.save(filepath, tensor, sample_rate, channels_first, compression)
+    torchaudio.save(filepath, tensor, sample_rate, channels_first, compression)
 
 
 @skipIfNoExec('sox')
 @skipIfNoExtension
 class SoxIO(TempDirMixin, TorchaudioTestCase):
     """TorchScript-ability Test suite for `sox_io_backend`"""
+    backend = 'sox_io'
+
     @parameterized.expand(list(itertools.product(
         ['float32', 'int32', 'int16', 'uint8'],
         [8000, 16000],

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -1,5 +1,3 @@
-import unittest
-
 import torchaudio
 
 from . import common_utils
@@ -31,6 +29,12 @@ class TestBackendSwitch_NoBackend(BackendSwitchMixin, common_utils.TorchaudioTes
 class TestBackendSwitch_SoX(BackendSwitchMixin, common_utils.TorchaudioTestCase):
     backend = 'sox'
     backend_module = torchaudio.backend.sox_backend
+
+
+@common_utils.skipIfNoExtension
+class TestBackendSwitch_SoXIO(BackendSwitchMixin, common_utils.TorchaudioTestCase):
+    backend = 'sox_io'
+    backend_module = torchaudio.backend.sox_io_backend
 
 
 @common_utils.skipIfNoModule('soundfile')

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -30,11 +30,15 @@ class Test_LoadSave(unittest.TestCase):
 
     def test_1_save(self):
         for backend in BACKENDS_MP3:
+            if backend == 'sox_io':
+                continue
             with self.subTest():
                 torchaudio.set_audio_backend(backend)
                 self._test_1_save(self.test_filepath, False)
 
         for backend in BACKENDS:
+            if backend == 'sox_io':
+                continue
             with self.subTest():
                 torchaudio.set_audio_backend(backend)
                 self._test_1_save(self.test_filepath_wav, True)
@@ -81,6 +85,8 @@ class Test_LoadSave(unittest.TestCase):
 
     def test_1_save_sine(self):
         for backend in BACKENDS:
+            if backend == 'sox_io':
+                continue
             with self.subTest():
                 torchaudio.set_audio_backend(backend)
                 self._test_1_save_sine()
@@ -114,11 +120,15 @@ class Test_LoadSave(unittest.TestCase):
 
     def test_2_load(self):
         for backend in BACKENDS_MP3:
+            if backend == 'sox_io':
+                continue
             with self.subTest():
                 torchaudio.set_audio_backend(backend)
                 self._test_2_load(self.test_filepath, 278756)
 
         for backend in BACKENDS:
+            if backend == 'sox_io':
+                continue
             with self.subTest():
                 torchaudio.set_audio_backend(backend)
                 self._test_2_load(self.test_filepath_wav, 276858)
@@ -155,6 +165,8 @@ class Test_LoadSave(unittest.TestCase):
 
     def test_2_load_nonormalization(self):
         for backend in BACKENDS_MP3:
+            if backend == 'sox_io':
+                continue
             with self.subTest():
                 torchaudio.set_audio_backend(backend)
                 self._test_2_load_nonormalization(self.test_filepath, 278756)
@@ -172,6 +184,8 @@ class Test_LoadSave(unittest.TestCase):
 
     def test_3_load_and_save_is_identity(self):
         for backend in BACKENDS:
+            if backend == 'sox_io':
+                continue
             with self.subTest():
                 torchaudio.set_audio_backend(backend)
                 self._test_3_load_and_save_is_identity()
@@ -210,6 +224,8 @@ class Test_LoadSave(unittest.TestCase):
 
     def test_4_load_partial(self):
         for backend in BACKENDS_MP3:
+            if backend == 'sox_io':
+                continue
             with self.subTest():
                 torchaudio.set_audio_backend(backend)
                 self._test_4_load_partial()
@@ -252,6 +268,8 @@ class Test_LoadSave(unittest.TestCase):
 
     def test_5_get_info(self):
         for backend in BACKENDS:
+            if backend == 'sox_io':
+                continue
             with self.subTest():
                 torchaudio.set_audio_backend(backend)
                 self._test_5_get_info()

--- a/torchaudio/backend/utils.py
+++ b/torchaudio/backend/utils.py
@@ -7,6 +7,7 @@ from torchaudio._internal.module_utils import is_module_available
 from . import (
     no_backend,
     sox_backend,
+    sox_io_backend,
     soundfile_backend,
 )
 
@@ -24,6 +25,7 @@ def list_audio_backends() -> List[str]:
         backends.append('soundfile')
     if is_module_available('torchaudio._torchaudio'):
         backends.append('sox')
+        backends.append('sox_io')
     return backends
 
 
@@ -43,6 +45,8 @@ def set_audio_backend(backend: Optional[str]) -> None:
         module = no_backend
     elif backend == 'sox':
         module = sox_backend
+    elif backend == 'sox_io':
+        module = sox_io_backend
     elif backend == 'soundfile':
         module = soundfile_backend
     else:
@@ -69,6 +73,8 @@ def get_audio_backend() -> Optional[str]:
         return None
     if torchaudio.load == sox_backend.load:
         return 'sox'
+    if torchaudio.load == sox_io_backend.load:
+        return 'sox_io'
     if torchaudio.load == soundfile_backend.load:
         return 'soundfile'
     raise ValueError('Unknown backend.')


### PR DESCRIPTION
This PR (and dependent PRs) adds a new backend "sox_io" backend.
 - [x] #718 Add SignalInfo typedef
 - [x] #728 Add "info"
 - [x] #734 Fix SignalInfo
 - [x] #731 Add "load"
 - [x] #732 Add "save"
 - [ ] This PR Add "sox_io" to the list of available backends.
   (So that users can opt-in, but we do not intend to change the default yet.)

The new "sox_io" backend has the following advantages;
 - TorchScript-able 
    The data process pipeline written using the new backend can be dumped and used from C++.
 - Correct
    The original "sox" backend had a number of issues,
     - #618 #236 Info length and rate returns different
     - #430 #252 Save then load would degrade the data
     - https://github.com/pytorch/audio/issues/400#issuecomment-615502956 `load` function cannot handle WAV file correctly.
    I have added bunch of tests to make sure that the new backend does not have the same issue.
    This includes read/write operaions of `wav`, `flac`, `mp3` and `ogg/vorbis` formats. *
    This backend can also read `opus`, ~~though it's not in unit test.~~ #755 
 - Cleaner interface
    - When loading WAV file, correct `dtype` is picked depending on the internal representation of WAV format. This behavior is same as [how SciPy handles WAV file](https://docs.scipy.org/doc/scipy/reference/generated/scipy.io.wavfile.read.html).
        - Load function also provides `normalize` option, which correctly maps integer value range to `[-1.0, 1.0]` with `float32`. 
    - The  existing"sox" backend exposes `sox_signalinfo_t` and `sox_encodinginfo_t` structs directly, but TorchScript does not allow this. Also setting the correct parameters for these structs is not easy. In the new backend, options related to sox-internal are handled in C++, and users only need to provide `compression` option that corresponds to `sox`'s `-C` option.

~~Note The current binary distribution of torchaudio does not contain `ogg/vorbis` codecs. To handle these files, you need to build torchaudio from the source. Refer to [README](https://github.com/pytorch/audio#from-source) for the instruction.~~ #750 