### PR TITLE
Bake libsox in test base Docker image

### DIFF
--- a/.circleci/unittest/linux/docker/Dockerfile
+++ b/.circleci/unittest/linux/docker/Dockerfile
@@ -55,6 +55,9 @@ RUN apt update && apt install -y \
         curl \
         make \
         file \
+        sox \
+        libsox-dev \
+        libsox-fmt-all \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /kaldi /kaldi
 COPY --from=builder /third_party /third_party

--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -35,6 +35,3 @@ conda env update --file "${this_dir}/environment.yml" --prune
 
 # 4. Build codecs
 # build_tools/setup_helpers/build_third_party.sh
-# 4. Install codecs
-apt update -q
-apt install -y -q sox libsox-dev libsox-fmt-all


### PR DESCRIPTION
In #728, linux unit test switches to libsox provided by apt.
For CPU jobs this is fine because all the job steps share the same Docker container,
but on CPU job, each job step runs a script in a new Docker container, so
libsox installed in a step is not available to the subsequent steps.

To fix this, this PR moves the installation of libsox and sox to Docker build.