### PR TITLE
Unittest function in test

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,3 +1,5 @@
+import unittest
+
 import torch
 from torchaudio.models import Wav2Letter, _MelResNet
 
@@ -51,3 +53,7 @@ class TestMelResNet(common_utils.TorchaudioTestCase):
         out = model(x)
 
         assert out.size() == (batch_size, output_dims, num_features - pad * 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is related to #727. 
Compared to this pull request and other test files (e.g. [here](https://github.com/pytorch/audio/blob/master/test/test_datasets.py)), I remove the `unittest.main` function in the end and `import unittest` function in the first line in #727 .