### PR TITLE
[BC Breaking] Replace sox_effects init/list/shutdown with TS binding

### DIFF
--- a/torchaudio/csrc/register.cpp
+++ b/torchaudio/csrc/register.cpp
@@ -1,6 +1,7 @@
 #ifndef TORCHAUDIO_REGISTER_H
 #define TORCHAUDIO_REGISTER_H
 
+#include <torchaudio/csrc/sox_effects.h>
 #include <torchaudio/csrc/sox_io.h>
 #include <torchaudio/csrc/typedefs.h>
 
@@ -19,6 +20,17 @@ static auto registerGetInfo = torch::RegisterOperators().op(
         .schema(
             "torchaudio::sox_io_get_info(str path) -> __torch__.torch.classes.torchaudio.SignalInfo info")
         .catchAllKernel<decltype(sox_io::get_info), &sox_io::get_info>());
+
+////////////////////////////////////////////////////////////////////////////////
+// sox_effects.h
+////////////////////////////////////////////////////////////////////////////////
+static auto registerSoxEffects =
+    torch::RegisterOperators(
+        "torchaudio::sox_effects_initialize_sox_effects",
+        &sox_effects::initialize_sox_effects)
+        .op("torchaudio::sox_effects_shutdown_sox_effects",
+            &sox_effects::shutdown_sox_effects)
+        .op("torchaudio::sox_effects_list_effects", &sox_effects::list_effects);
 
 } // namespace
 } // namespace torchaudio

--- a/torchaudio/csrc/sox.cpp
+++ b/torchaudio/csrc/sox.cpp
@@ -82,17 +82,6 @@ std::tuple<sox_signalinfo_t, sox_encodinginfo_t> get_info(
   return std::make_tuple(fd->signal, fd->encoding);
 }
 
-std::vector<std::string> get_effect_names() {
-  sox_effect_fn_t const * fns = sox_get_effect_fns();
-  std::vector<std::string> sv;
-  for(int i = 0; fns[i]; ++i) {
-    const sox_effect_handler_t *eh = fns[i] ();
-    if(eh && eh->name)
-      sv.push_back(eh->name);
-  }
-  return sv;
-}
-
 int read_audio_file(
     const std::string& file_name,
     at::Tensor output,
@@ -184,16 +173,6 @@ void write_audio_file(
     throw std::runtime_error(
         "Error writing audio file: could not write entire buffer");
   }
-}
-
-int initialize_sox() {
-  /* Initialization for sox effects.  Only initialize once  */
-  return sox_init();
-}
-
-int shutdown_sox() {
-  /* Shutdown for sox effects.  Do not shutdown between multiple calls  */
-  return sox_quit();
 }
 
 int build_flow_effects(const std::string& file_name,
@@ -490,19 +469,7 @@ PYBIND11_MODULE(_torchaudio, m) {
       &torch::audio::get_info,
       "Gets information about an audio file");
   m.def(
-      "get_effect_names",
-      &torch::audio::get_effect_names,
-      "Gets the names of all available effects");
-  m.def(
       "build_flow_effects",
       &torch::audio::build_flow_effects,
       "build effects and flow chain into tensors");
-  m.def(
-      "initialize_sox",
-      &torch::audio::initialize_sox,
-      "initialize sox for effects");
-  m.def(
-      "shutdown_sox",
-      &torch::audio::shutdown_sox,
-      "shutdown sox for effects");
 }

--- a/torchaudio/csrc/sox.h
+++ b/torchaudio/csrc/sox.h
@@ -45,13 +45,6 @@ void write_audio_file(
 std::tuple<sox_signalinfo_t, sox_encodinginfo_t> get_info(
     const std::string& file_name);
 
-// get names of all sox effects
-std::vector<std::string> get_effect_names();
-
-// Initialize and Shutdown SoX effects chain.  These functions should only be run once.
-int initialize_sox();
-int shutdown_sox();
-
 // Struct for build_flow_effects function
 struct SoxEffect {
   SoxEffect() : ename(""), eopts({""})  { }

--- a/torchaudio/csrc/sox_effects.cpp
+++ b/torchaudio/csrc/sox_effects.cpp
@@ -1,0 +1,54 @@
+#include <sox.h>
+#include <torchaudio/csrc/sox_effects.h>
+
+using namespace torch::indexing;
+
+namespace torchaudio {
+namespace sox_effects {
+
+namespace {
+
+enum SoxEffectsResourceState { NotInitialized, Initialized, ShutDown };
+SoxEffectsResourceState SOX_RESOURCE_STATE = NotInitialized;
+
+} // namespace
+
+void initialize_sox_effects() {
+  if (SOX_RESOURCE_STATE == ShutDown) {
+    throw std::runtime_error(
+        "SoX Effects has been shut down. Cannot initialize again.");
+  }
+  if (SOX_RESOURCE_STATE == NotInitialized) {
+    if (sox_init() != SOX_SUCCESS) {
+      throw std::runtime_error("Failed to initialize sox effects.");
+    };
+    SOX_RESOURCE_STATE = Initialized;
+  }
+};
+
+void shutdown_sox_effects() {
+  if (SOX_RESOURCE_STATE == NotInitialized) {
+    throw std::runtime_error(
+        "SoX Effects is not initialized. Cannot shutdown.");
+  }
+  if (SOX_RESOURCE_STATE == Initialized) {
+    if (sox_quit() != SOX_SUCCESS) {
+      throw std::runtime_error("Failed to initialize sox effects.");
+    };
+    SOX_RESOURCE_STATE = ShutDown;
+  }
+}
+
+std::vector<std::string> list_effects() {
+  std::vector<std::string> names;
+  const sox_effect_fn_t* fns = sox_get_effect_fns();
+  for (int i = 0; fns[i]; ++i) {
+    const sox_effect_handler_t* handler = fns[i]();
+    if (handler && handler->name)
+      names.push_back(handler->name);
+  }
+  return names;
+}
+
+} // namespace sox_effects
+} // namespace torchaudio

--- a/torchaudio/csrc/sox_effects.h
+++ b/torchaudio/csrc/sox_effects.h
@@ -1,0 +1,19 @@
+#ifndef TORCHAUDIO_SOX_EFFECTS_H
+#define TORCHAUDIO_SOX_EFFECTS_H
+
+#include <torch/script.h>
+#include <torchaudio/csrc/typedefs.h>
+
+namespace torchaudio {
+namespace sox_effects {
+
+void initialize_sox_effects();
+
+void shutdown_sox_effects();
+
+std::vector<std::string> list_effects();
+
+} // namespace sox_effects
+} // namespace torchaudio
+
+#endif

--- a/torchaudio/sox_effects/__init__.py
+++ b/torchaudio/sox_effects/__init__.py
@@ -9,4 +9,6 @@ from .sox_effects import (
 
 
 if _mod_utils.is_module_available('torchaudio._torchaudio'):
+    import atexit
     init_sox_effects()
+    atexit.register(shutdown_sox_effects)


### PR DESCRIPTION
This PR replaces sox effects `init/list/shutdown` functions with Torch Script binding. (SoxEffectsChain is not changed yet.)
I also moved error checking to C++, so the function signature is changed -> BC breaking.
The previous implementation returned `sox_errot_t` enum to Python, which is practically useless so I think this BC breaking does not have an impact.