### PR TITLE
Add Waveforms for Testing Purposes section to test/README.md

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -41,6 +41,74 @@ The following test modules are defined for corresponding `torchaudio` module/fun
 - [assets/kaldi](./assets/kaldi): Contains Kaldi format matrix files used in [./test_compliance_kaldi.py](./test_compliance_kaldi.py).
 - [compliance](./compliance): Scripts used to generate above Kaldi matrix files.
 
+### Waveforms for Testing Purposes
+
+When testing transforms we often need waveforms of specific type (ex: pure tone, noise, or voice), with specific bitrate (ex. 8 or 16 kHz) and number of channels (ex. mono, stereo). Below are some tips on how to construct waveforms and guidance around existing audio files.
+
+#### Load a Waveform from a File
+
+```python
+filepath = common_utils.get_asset_path('filename.wav')
+waveform, sample_rate = scipy.io.wavfile.read(filepath)
+```
+
+*Note: Should you choose to contribute an audio file, please leave a comment in the issue or pull request, mentioning content source and licensing information. WAV files are preferred. Other formats should be used only when there is no alternative. (i.e. dataset implementation comes with hardcoded non-wav extension).*
+
+#### Pure Tone
+
+Code:
+
+```python
+ waveform = common_utils.get_sinusoid(
+     frequency=300,
+     sample_rate=16000,
+     duration=1,  # seconds
+    n_channels=1,
+    dtype="float32",
+    device="cpu",
+)
+```
+
+Files:
+
+* `sinewave.wav`
+* `100Hz_44100Hz_16bit_05sec.wav`
+* `440Hz_44100Hz_16bit_05sec.wav`
+
+#### Noise
+
+Code:
+
+```python
+tensor = common_utils.get_whitenoise()
+```
+
+Files:
+
+* `whitenoise.wav`
+* `whitenoise.mp3`
+* `whitenoise_1min.mp3`
+* `steam-train-whistle-daniel_simon.wav`
+* `steam-train-whistle-daniel_simon.mp3`
+
+#### Voice
+
+Files:
+
+* `CommonVoice/cv-corpus-4-2019-12-10/tt/clips/common_voice_tt_00000000.mp3`
+* `LibriSpeech/dev-clean/1272/128104/1272-128104-0000.flac`
+* `LJSpeech-1.1/wavs/LJ001-0001.wav`
+* `SpeechCommands/speech_commands_v0.02/go/0a9f9af7_nohash_0.wav`
+* `VCTK-Corpus/wav48/p224/p224_002.wav`
+* `waves_yesno/0_1_0_1_0_1_1_0.wav`
+* `vad-go-stereo-44100.wav`
+* `vad-go-mono-32000.wav`
+
+#### Other
+
+* `kaldi_file.wav`
+* `test.wav`
+* `kaldi_file_8000.wav`
 
 ## Adding test
 

--- a/test/README.md
+++ b/test/README.md
@@ -49,7 +49,7 @@ When testing transforms we often need waveforms of specific type (ex: pure tone,
 
 ```python
 filepath = common_utils.get_asset_path('filename.wav')
-waveform, sample_rate = scipy.io.wavfile.read(filepath)
+waveform, sample_rate = common_utils.load_wav(path)
 ```
 
 *Note: Should you choose to contribute an audio file, please leave a comment in the issue or pull request, mentioning content source and licensing information. WAV files are preferred. Other formats should be used only when there is no alternative. (i.e. dataset implementation comes with hardcoded non-wav extension).*

--- a/test/README.md
+++ b/test/README.md
@@ -49,7 +49,7 @@ When testing transforms we often need waveforms of specific type (ex: pure tone,
 
 ```python
 filepath = common_utils.get_asset_path('filename.wav')
-waveform, sample_rate = common_utils.load_wav(path)
+waveform, sample_rate = common_utils.load_wav(filepath)
 ```
 
 *Note: Should you choose to contribute an audio file, please leave a comment in the issue or pull request, mentioning content source and licensing information. WAV files are preferred. Other formats should be used only when there is no alternative. (i.e. dataset implementation comes with hardcoded non-wav extension).*

--- a/test/README.md
+++ b/test/README.md
@@ -79,9 +79,6 @@ tensor = common_utils.get_whitenoise()
 
 Files:
 
-* `whitenoise.wav`
-* `whitenoise.mp3`
-* `whitenoise_1min.mp3`
 * `steam-train-whistle-daniel_simon.wav`
 
 #### Voice

--- a/test/README.md
+++ b/test/README.md
@@ -69,12 +69,6 @@ Code:
 )
 ```
 
-Files:
-
-* `sinewave.wav`
-* `100Hz_44100Hz_16bit_05sec.wav`
-* `440Hz_44100Hz_16bit_05sec.wav`
-
 #### Noise
 
 Code:
@@ -89,7 +83,6 @@ Files:
 * `whitenoise.mp3`
 * `whitenoise_1min.mp3`
 * `steam-train-whistle-daniel_simon.wav`
-* `steam-train-whistle-daniel_simon.mp3`
 
 #### Voice
 
@@ -107,7 +100,6 @@ Files:
 #### Other
 
 * `kaldi_file.wav`
-* `test.wav`
 * `kaldi_file_8000.wav`
 
 ## Adding test

--- a/test/README.md
+++ b/test/README.md
@@ -59,13 +59,13 @@ waveform, sample_rate = common_utils.load_wav(filepath)
 Code:
 
 ```python
- waveform = common_utils.get_sinusoid(
-     frequency=300,
-     sample_rate=16000,
-     duration=1,  # seconds
-    n_channels=1,
-    dtype="float32",
-    device="cpu",
+waveform = common_utils.get_sinusoid(
+	frequency=300,
+	sample_rate=16000,
+	duration=1,  # seconds
+	n_channels=1,
+	dtype="float32",
+	device="cpu",
 )
 ```
 
@@ -96,11 +96,6 @@ Files:
 * `waves_yesno/0_1_0_1_0_1_1_0.wav`
 * `vad-go-stereo-44100.wav`
 * `vad-go-mono-32000.wav`
-
-#### Other
-
-* `kaldi_file.wav`
-* `kaldi_file_8000.wav`
 
 ## Adding test
 


### PR DESCRIPTION
This PR adds instructions around generating waveforms in tests from files and on the fly, as well as contributing new assets.