### PR TITLE
Replace `torchaudio.load_wav` with `common_utils.load_wav`

### DIFF
--- a/test/functional_cpu_test.py
+++ b/test/functional_cpu_test.py
@@ -299,8 +299,6 @@ class TestIstft(common_utils.TorchaudioTestCase):
 
 
 class TestDetectPitchFrequency(common_utils.TorchaudioTestCase):
-    backend = 'default'
-
     def test_pitch(self):
         test_filepath_100 = common_utils.get_asset_path("100Hz_44100Hz_16bit_05sec.wav")
         test_filepath_440 = common_utils.get_asset_path("440Hz_44100Hz_16bit_05sec.wav")
@@ -312,7 +310,7 @@ class TestDetectPitchFrequency(common_utils.TorchaudioTestCase):
         ]
 
         for filename, freq_ref in tests:
-            waveform, sample_rate = torchaudio.load(filename)
+            waveform, sample_rate = common_utils.load_wav(filename)
 
             freq = torchaudio.functional.detect_pitch_frequency(waveform, sample_rate)
 

--- a/test/test_librosa_compatibility.py
+++ b/test/test_librosa_compatibility.py
@@ -160,7 +160,8 @@ class TestTransforms(common_utils.TorchaudioTestCase):
     """Test suite for functions in `transforms` module."""
     def assert_compatibilities(self, n_fft, hop_length, power, n_mels, n_mfcc, sample_rate):
         common_utils.set_audio_backend('default')
-        sound, sample_rate = _load_audio_asset('sinewave.wav')
+        path = common_utils.get_asset_path('sinewave.wav')
+        sound, sample_rate = common_utils.load_wav(path)
         sound_librosa = sound.cpu().numpy().squeeze()  # (64000)
 
         # test core spectrogram
@@ -300,9 +301,9 @@ class TestTransforms(common_utils.TorchaudioTestCase):
         hop_length = n_fft // 4
 
         # Prepare mel spectrogram input. We use torchaudio to compute one.
-        common_utils.set_audio_backend('default')
-        sound, sample_rate = _load_audio_asset(
-            'steam-train-whistle-daniel_simon.wav', offset=2**10, num_frames=2**14)
+        path = common_utils.get_asset_path('steam-train-whistle-daniel_simon.wav')
+        sound, sample_rate = common_utils.load_wav(path)
+        sound = sound[:, 2**10:2**10 + 2**14]
         sound = sound.mean(dim=0, keepdim=True)
         spec_orig = F.spectrogram(
             sound, pad=0, window=torch.hann_window(n_fft), n_fft=n_fft,

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -45,7 +45,7 @@ class Tester(common_utils.TorchaudioTestCase):
 
     def test_AmplitudeToDB(self):
         filepath = common_utils.get_asset_path('steam-train-whistle-daniel_simon.wav')
-        waveform, sample_rate = torchaudio.load(filepath)
+        waveform = common_utils.load_wav(filepath)[0]
 
         mag_to_db_transform = transforms.AmplitudeToDB('magnitude', 80.)
         power_to_db_transform = transforms.AmplitudeToDB('power', 80.)
@@ -115,7 +115,7 @@ class Tester(common_utils.TorchaudioTestCase):
         self.assertTrue(mel_transform2.mel_scale.fb.sum(1).ge(0.).all())
         # check on multi-channel audio
         filepath = common_utils.get_asset_path('steam-train-whistle-daniel_simon.wav')
-        x_stereo, sr_stereo = torchaudio.load(filepath)  # (2, 278756), 44100
+        x_stereo = common_utils.load_wav(filepath)[0]  # (2, 278756), 44100
         spectrogram_stereo = s2db(mel_transform(x_stereo))  # (2, 128, 1394)
         self.assertTrue(spectrogram_stereo.dim() == 3)
         self.assertTrue(spectrogram_stereo.size(0) == 2)
@@ -166,7 +166,7 @@ class Tester(common_utils.TorchaudioTestCase):
 
     def test_resample_size(self):
         input_path = common_utils.get_asset_path('sinewave.wav')
-        waveform, sample_rate = torchaudio.load(input_path)
+        waveform, sample_rate = common_utils.load_wav(input_path)
 
         upsample_rate = sample_rate * 2
         downsample_rate = sample_rate // 2

--- a/test/torchscript_consistency_impl.py
+++ b/test/torchscript_consistency_impl.py
@@ -2,7 +2,6 @@
 import unittest
 
 import torch
-import torchaudio
 import torchaudio.functional as F
 import torchaudio.transforms as T
 
@@ -616,6 +615,5 @@ class Transforms(common_utils.TestBaseMixin):
 
     def test_Vad(self):
         filepath = common_utils.get_asset_path("vad-go-mono-32000.wav")
-        common_utils.set_audio_backend('default')
-        waveform, sample_rate = torchaudio.load(filepath)
+        waveform, sample_rate = common_utils.load_wav(filepath)
         self._assert_consistency(T.Vad(sample_rate=sample_rate), waveform)


### PR DESCRIPTION
This PR replaces `torchaudio.load_wav` with `common_utils.load_wav`, which is a wrapper around `scipy.io.wavfile.read`.

This allows each test to not depend on torchaudio's I/O implementation.