### PR TITLE
Fix CI: Cannot uninstall a distutils installed project

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -14,4 +14,3 @@ dependencies:
     - kaldi-io
     - scipy
     - parameterized
-    - numba==0.48

--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -8,11 +8,11 @@ dependencies:
   - pytest-cov
   - codecov
   - librosa
-  - llvmlite==0.31
+  - llvmlite==0.31  # See https://github.com/pytorch/audio/pull/766
   - pip
   - pip:
     - clang-format
     - kaldi-io
     - scipy
     - parameterized
-    - numba==0.48
+    - numba==0.48  # See https://github.com/librosa/librosa/issues/1160

--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -8,9 +8,11 @@ dependencies:
   - pytest-cov
   - codecov
   - librosa
+  - llvmlite==0.31
   - pip
   - pip:
     - clang-format
     - kaldi-io
     - scipy
     - parameterized
+    - numba==0.48


### PR DESCRIPTION
Issue: https://app.circleci.com/pipelines/github/pytorch/audio/2663/workflows/39102954-8aee-48c3-8e1c-6ff8c61b246b/jobs/71492/steps

Explanation: https://github.com/pypa/pip/issues/5247

When we install dependencies with `conda env update --file "${this_dir}/environment.yml" --prune`, `conda` first installs `llvmlite-0.33.0` but after that when `pip` tries to install `llvmlite<0.32.0,>=0.31.0dev0`, `pip` cannot determine which files it should be deleting so the installation process fails.

~~This was caused by pinned `numba` and removing it resolves it.~~

~~@peterjc123 I saw you added this line, but do we need to pin or even include `numba` in test env requirements? It is not directly required by `torchaudio` or its test job, so I think removing it is safe but would like to understand why it was added, if you still remember.~~

Update: oh I see [why `numba` is required](https://app.circleci.com/pipelines/github/pytorch/audio/2667/workflows/cc1a28ef-378a-4c4a-94d8-a9dd12ecc7dc/jobs/71594/steps). 

The proposed solution is to pin `llvmlite` version to 0.32 so that `pip` does not attempt to uninstall existing one.