### PR TITLE
Offer pretrained wavernn model

### DIFF
--- a/torchaudio/models/_wavernn.py
+++ b/torchaudio/models/_wavernn.py
@@ -4,7 +4,7 @@ import torch
 from torch import Tensor
 from torch import nn
 
-from .utils import load_state_dict_from_url
+from utils import load_state_dict_from_url
 
 
 __all__ = ["_ResBlock", "_MelResNet", "_Stretch2d", "_UpsampleNetwork", "_WaveRNN", "_wavernn"]

--- a/torchaudio/models/_wavernn.py
+++ b/torchaudio/models/_wavernn.py
@@ -11,7 +11,8 @@ __all__ = ["_ResBlock", "_MelResNet", "_Stretch2d", "_UpsampleNetwork", "_WaveRN
 
 
 model_urls = {
-    '_wavernn': 'https://ossci-assets.s3.amazonaws.com/torchaudio/wavernn_8bits_waveform_ljspeech.pth',
+    # FIXME Replace URL by final one once determined
+    '_wavernn': 'https://download.pytorch.org/models/_wavernn.pth',
 }
 
 

--- a/torchaudio/models/_wavernn.py
+++ b/torchaudio/models/_wavernn.py
@@ -3,6 +3,7 @@ from typing import List
 import torch
 from torch import Tensor
 from torch import nn
+
 from .utils import load_state_dict_from_url
 
 
@@ -10,7 +11,7 @@ __all__ = ["_ResBlock", "_MelResNet", "_Stretch2d", "_UpsampleNetwork", "_WaveRN
 
 
 model_urls = {
-    '_wavernn': 'https://download.pytorch.org/models/_wavernn.pth',
+    '_wavernn': 'https://ossci-assets.s3.amazonaws.com/torchaudio/wavernn_8bits_waveform_ljspeech.pth',
 }
 
 

--- a/torchaudio/models/_wavernn.py
+++ b/torchaudio/models/_wavernn.py
@@ -4,7 +4,7 @@ import torch
 from torch import Tensor
 from torch import nn
 
-from utils import load_state_dict_from_url
+from .utils import load_state_dict_from_url
 
 
 __all__ = ["_ResBlock", "_MelResNet", "_Stretch2d", "_UpsampleNetwork", "_WaveRNN", "_wavernn"]

--- a/torchaudio/models/_wavernn.py
+++ b/torchaudio/models/_wavernn.py
@@ -3,8 +3,15 @@ from typing import List
 import torch
 from torch import Tensor
 from torch import nn
+from .utils import load_state_dict_from_url
 
-__all__ = ["_ResBlock", "_MelResNet", "_Stretch2d", "_UpsampleNetwork", "_WaveRNN"]
+
+__all__ = ["_ResBlock", "_MelResNet", "_Stretch2d", "_UpsampleNetwork", "_WaveRNN", "_wavernn"]
+
+
+model_urls = {
+    '_wavernn': 'https://download.pytorch.org/models/_wavernn.pth',
+}
 
 
 class _ResBlock(nn.Module):
@@ -329,3 +336,19 @@ class _WaveRNN(nn.Module):
 
         # bring back channel dimension
         return x.unsqueeze(1)
+
+
+def _wavernn(pretrained=False, progress=True, **kwargs):
+    r"""WaveRNN model based on the implementation from
+    `fatchord <https://github.com/fatchord/WaveRNN>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on LJSpeech
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    model = _WaveRNN(**kwargs)
+    if pretrained:
+        state_dict = load_state_dict_from_url(model_urls['_wavernn'],
+                                              progress=progress)
+        model.load_state_dict(state_dict)
+    return model

--- a/torchaudio/models/utils.py
+++ b/torchaudio/models/utils.py
@@ -1,0 +1,4 @@
+try:
+    from torch.hub import load_state_dict_from_url
+except ImportError:
+    from torch.utils.model_zoo import load_url as load_state_dict_from_url


### PR DESCRIPTION
Offer WaveRNN model with pretrained weights (8 bits waveform mode) on LJSpeech using the method as [torchvision example](https://github.com/pytorch/vision/blob/master/torchvision/models/alexnet.py#L52).

Related to #735  #749 
[Internal](https://drive.google.com/drive/folders/10XmuONMpff1zZIh-qc2pJgnHRKztpMSJ?usp=sharing)