### PR TITLE
Remove codecov and store coverage on CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,7 +427,7 @@ jobs:
       - store_test_results:
           path: test-results
       - store_artifacts:
-          path: htmlcov
+          path: test/htmlcov
   unittest_linux_gpu:
     <<: *binary_common
     machine:
@@ -457,7 +457,7 @@ jobs:
       - store_test_results:
           path: test-results
       - store_artifacts:
-          path: htmlcov
+          path: test/htmlcov
 
   unittest_windows_cpu:
     <<: *binary_common
@@ -479,7 +479,7 @@ jobs:
       - store_test_results:
           path: test-results
       - store_artifacts:
-          path: htmlcov
+          path: test/htmlcov
 
   unittest_windows_gpu:
     <<: *binary_common
@@ -504,7 +504,7 @@ jobs:
       - store_test_results:
           path: test-results
       - store_artifacts:
-          path: htmlcov
+          path: test/htmlcov
 
   unittest_macos_cpu:
     <<: *binary_common
@@ -530,7 +530,7 @@ jobs:
       - store_test_results:
           path: test-results
       - store_artifacts:
-          path: htmlcov
+          path: test/htmlcov
 
   stylecheck:
     <<: *binary_common

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -424,12 +424,13 @@ jobs:
       - run:
           name: Run tests
           command: .circleci/unittest/linux/scripts/run_test.sh
+      - store_test_results:
+          path: test-results
       - run:
           name: Post process
           command: .circleci/unittest/linux/scripts/post_process.sh
-      - store_test_results:
-          path: test-results
-
+      - store_artifacts:
+          path: htmlcov
   unittest_linux_gpu:
     <<: *binary_common
     machine:
@@ -456,11 +457,13 @@ jobs:
       - run:
           name: Run tests
           command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
+      - store_test_results:
+          path: test-results
       - run:
           name: Post Process
           command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/post_process.sh
-      - store_test_results:
-          path: test-results
+      - store_artifacts:
+          path: htmlcov
 
   unittest_windows_cpu:
     <<: *binary_common
@@ -479,11 +482,13 @@ jobs:
       - run:
           name: Run tests
           command: .circleci/unittest/windows/scripts/run_test.sh
+      - store_test_results:
+          path: test-results
       - run:
           name: Post process
           command: .circleci/unittest/windows/scripts/post_process.sh
-      - store_test_results:
-          path: test-results
+      - store_artifacts:
+          path: htmlcov
 
   unittest_windows_gpu:
     <<: *binary_common
@@ -505,11 +510,13 @@ jobs:
       - run:
           name: Run tests
           command: .circleci/unittest/windows/scripts/run_test.sh
+      - store_test_results:
+          path: test-results
       - run:
           name: Post process
           command: .circleci/unittest/windows/scripts/post_process.sh
-      - store_test_results:
-          path: test-results
+      - store_artifacts:
+          path: htmlcov
 
   unittest_macos_cpu:
     <<: *binary_common

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,9 +426,6 @@ jobs:
           command: .circleci/unittest/linux/scripts/run_test.sh
       - store_test_results:
           path: test-results
-      - run:
-          name: Post process
-          command: .circleci/unittest/linux/scripts/post_process.sh
       - store_artifacts:
           path: htmlcov
   unittest_linux_gpu:
@@ -459,9 +456,6 @@ jobs:
           command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
       - store_test_results:
           path: test-results
-      - run:
-          name: Post Process
-          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/post_process.sh
       - store_artifacts:
           path: htmlcov
 
@@ -484,9 +478,6 @@ jobs:
           command: .circleci/unittest/windows/scripts/run_test.sh
       - store_test_results:
           path: test-results
-      - run:
-          name: Post process
-          command: .circleci/unittest/windows/scripts/post_process.sh
       - store_artifacts:
           path: htmlcov
 
@@ -512,9 +503,6 @@ jobs:
           command: .circleci/unittest/windows/scripts/run_test.sh
       - store_test_results:
           path: test-results
-      - run:
-          name: Post process
-          command: .circleci/unittest/windows/scripts/post_process.sh
       - store_artifacts:
           path: htmlcov
 
@@ -539,11 +527,10 @@ jobs:
       - run:
           name: Run tests
           command: .circleci/unittest/linux/scripts/run_test.sh
-      - run:
-          name: Post process
-          command: .circleci/unittest/linux/scripts/post_process.sh
       - store_test_results:
           path: test-results
+      - store_artifacts:
+          path: htmlcov
 
   stylecheck:
     <<: *binary_common

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -427,7 +427,7 @@ jobs:
       - store_test_results:
           path: test-results
       - store_artifacts:
-          path: htmlcov
+          path: test/htmlcov
   unittest_linux_gpu:
     <<: *binary_common
     machine:
@@ -457,7 +457,7 @@ jobs:
       - store_test_results:
           path: test-results
       - store_artifacts:
-          path: htmlcov
+          path: test/htmlcov
 
   unittest_windows_cpu:
     <<: *binary_common
@@ -479,7 +479,7 @@ jobs:
       - store_test_results:
           path: test-results
       - store_artifacts:
-          path: htmlcov
+          path: test/htmlcov
 
   unittest_windows_gpu:
     <<: *binary_common
@@ -504,7 +504,7 @@ jobs:
       - store_test_results:
           path: test-results
       - store_artifacts:
-          path: htmlcov
+          path: test/htmlcov
 
   unittest_macos_cpu:
     <<: *binary_common
@@ -530,7 +530,7 @@ jobs:
       - store_test_results:
           path: test-results
       - store_artifacts:
-          path: htmlcov
+          path: test/htmlcov
 
   stylecheck:
     <<: *binary_common

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -424,12 +424,13 @@ jobs:
       - run:
           name: Run tests
           command: .circleci/unittest/linux/scripts/run_test.sh
+      - store_test_results:
+          path: test-results
       - run:
           name: Post process
           command: .circleci/unittest/linux/scripts/post_process.sh
-      - store_test_results:
-          path: test-results
-
+      - store_artifacts:
+          path: htmlcov
   unittest_linux_gpu:
     <<: *binary_common
     machine:
@@ -456,11 +457,13 @@ jobs:
       - run:
           name: Run tests
           command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
+      - store_test_results:
+          path: test-results
       - run:
           name: Post Process
           command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/post_process.sh
-      - store_test_results:
-          path: test-results
+      - store_artifacts:
+          path: htmlcov
 
   unittest_windows_cpu:
     <<: *binary_common
@@ -479,11 +482,13 @@ jobs:
       - run:
           name: Run tests
           command: .circleci/unittest/windows/scripts/run_test.sh
+      - store_test_results:
+          path: test-results
       - run:
           name: Post process
           command: .circleci/unittest/windows/scripts/post_process.sh
-      - store_test_results:
-          path: test-results
+      - store_artifacts:
+          path: htmlcov
 
   unittest_windows_gpu:
     <<: *binary_common
@@ -505,11 +510,13 @@ jobs:
       - run:
           name: Run tests
           command: .circleci/unittest/windows/scripts/run_test.sh
+      - store_test_results:
+          path: test-results
       - run:
           name: Post process
           command: .circleci/unittest/windows/scripts/post_process.sh
-      - store_test_results:
-          path: test-results
+      - store_artifacts:
+          path: htmlcov
 
   unittest_macos_cpu:
     <<: *binary_common

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -426,9 +426,6 @@ jobs:
           command: .circleci/unittest/linux/scripts/run_test.sh
       - store_test_results:
           path: test-results
-      - run:
-          name: Post process
-          command: .circleci/unittest/linux/scripts/post_process.sh
       - store_artifacts:
           path: htmlcov
   unittest_linux_gpu:
@@ -459,9 +456,6 @@ jobs:
           command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
       - store_test_results:
           path: test-results
-      - run:
-          name: Post Process
-          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/post_process.sh
       - store_artifacts:
           path: htmlcov
 
@@ -484,9 +478,6 @@ jobs:
           command: .circleci/unittest/windows/scripts/run_test.sh
       - store_test_results:
           path: test-results
-      - run:
-          name: Post process
-          command: .circleci/unittest/windows/scripts/post_process.sh
       - store_artifacts:
           path: htmlcov
 
@@ -512,9 +503,6 @@ jobs:
           command: .circleci/unittest/windows/scripts/run_test.sh
       - store_test_results:
           path: test-results
-      - run:
-          name: Post process
-          command: .circleci/unittest/windows/scripts/post_process.sh
       - store_artifacts:
           path: htmlcov
 
@@ -539,11 +527,10 @@ jobs:
       - run:
           name: Run tests
           command: .circleci/unittest/linux/scripts/run_test.sh
-      - run:
-          name: Post process
-          command: .circleci/unittest/linux/scripts/post_process.sh
       - store_test_results:
           path: test-results
+      - store_artifacts:
+          path: htmlcov
 
   stylecheck:
     <<: *binary_common

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -56,5 +56,5 @@ fi
 (
     set -x
     conda install -y -c conda-forge ${NUMBA_DEV_CHANNEL} 'librosa>=0.8.0' parameterized 'requests>=2.20'
-    pip install kaldi-io SoundFile codecov pytest pytest-cov scipy
+    pip install kaldi-io SoundFile coverage pytest pytest-cov scipy
 )

--- a/.circleci/unittest/linux/scripts/post_process.sh
+++ b/.circleci/unittest/linux/scripts/post_process.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-eval "$(./conda/bin/conda shell.bash hook)"
-conda activate ./env
-
-codecov

--- a/.circleci/unittest/linux/scripts/run_test.sh
+++ b/.circleci/unittest/linux/scripts/run_test.sh
@@ -24,3 +24,4 @@ declare -a args=(
 
 cd test
 pytest "${args[@]}" torchaudio_unittest
+coverage html

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -44,5 +44,5 @@ fi
 (
     set -x
     conda install -y -c conda-forge ${NUMBA_DEV_CHANNEL} 'librosa>=0.8.0' parameterized 'requests>=2.20'
-    pip install kaldi-io SoundFile codecov pytest pytest-cov scipy
+    pip install kaldi-io SoundFile coverage pytest pytest-cov scipy
 )

--- a/.circleci/unittest/windows/scripts/post_process.sh
+++ b/.circleci/unittest/windows/scripts/post_process.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-eval "$(./conda/Scripts/conda.exe 'shell.bash' 'hook')"
-conda activate ./env
-
-codecov

--- a/.circleci/unittest/windows/scripts/run_test.sh
+++ b/.circleci/unittest/windows/scripts/run_test.sh
@@ -8,3 +8,4 @@ conda activate ./env
 python -m torch.utils.collect_env
 cd test
 pytest --cov=torchaudio --junitxml=../test-results/junit.xml -v --durations 20 torchaudio_unittest
+coverage html


### PR DESCRIPTION
Circle CI can display coverage report nicely.
Doc: https://circleci.com/docs/2.0/code-coverage/
https://201041-90321822-gh.circle-artifacts.com/0/test/htmlcov/index.html

This way, we can get rid of `codecov`, yet can have coverage report available all the time.
Thoughts? @fmassa @cpuhrsch 