### PR TITLE
Skip lowpass test on macOS

### DIFF
--- a/test/test_sox_effects.py
+++ b/test/test_sox_effects.py
@@ -1,3 +1,4 @@
+import sys
 import math
 import unittest
 
@@ -34,6 +35,7 @@ class Test_SoxEffectsChain(common_utils.TorchaudioTestCase):
         self.assertEqual(sr, target_rate)
         self.assertEqual(x.size(0), target_channels)
 
+    @unittest.skipIf(sys.platform == 'darwin', 'This test is known to fail on macOS')
     def test_lowpass_speed(self):
         speed = .8
         si, _ = torchaudio.info(self.test_filepath)


### PR DESCRIPTION
`test/test_sox_effects.py::Test_SoxEffectsChain::test_lowpass_speed` has some issue on our macOS CI, even though there was no issue at #777 .

While we figure out the fix, we disable this test for macOS.