### PR TITLE
Remove if __name__ == __main__ from test code

### DIFF
--- a/test/functional_cpu_test.py
+++ b/test/functional_cpu_test.py
@@ -405,7 +405,3 @@ def test_mask_along_axis_iid(mask_param, mask_value, axis):
 
     assert mask_specgrams.size() == specgrams.size()
     assert (num_masked_columns < mask_param).sum() == num_masked_columns.numel()
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_batch_consistency.py
+++ b/test/test_batch_consistency.py
@@ -288,7 +288,3 @@ class TestTransforms(common_utils.TorchaudioTestCase):
         # Batch then transform
         computed = torchaudio.transforms.Vol(gain=1.1)(waveform.repeat(3, 1, 1))
         self.assertEqual(computed, expected)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_compliance_kaldi.py
+++ b/test/test_compliance_kaldi.py
@@ -246,7 +246,3 @@ class Test_Kaldi(common_utils.TempDirMixin, common_utils.TorchaudioTestCase):
             single_channel_sampled = kaldi.resample_waveform(single_channel, self.test1_signal_sr,
                                                              self.test1_signal_sr // 2)
             torch.testing.assert_allclose(multi_sound_sampled[i, :], single_channel_sampled[0], rtol=1e-4, atol=1e-7)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -37,7 +37,3 @@ class Test_DataLoader(common_utils.TorchaudioTestCase):
         dl = DataLoader(ds, batch_size=2)
         for x in dl:
             self.assertTrue(x.size() == expected_size)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -171,7 +171,3 @@ class TestLibriTTS(TempDirMixin, TorchaudioTestCase):
             assert original_text == self.original_text
             assert normalized_text == self.normalized_text
             assert utterance_id == f'{"_".join(str(u) for u in expected_ids[-4:])}'
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -282,6 +282,3 @@ class Test_LoadSave(unittest.TestCase):
         self.assertEqual(si.length, samples)
         self.assertEqual(si.rate, rate)
         self.assertEqual(ei.bits_per_sample, precision)
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_kaldi_io.py
+++ b/test/test_kaldi_io.py
@@ -33,7 +33,3 @@ class Test_KaldiIO(common_utils.TorchaudioTestCase):
 
     def test_read_mat_ark(self):
         self._test_helper("mat.ark", [self.data1, self.data2], kio.read_mat_ark, torch.float32)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_librosa_compatibility.py
+++ b/test/test_librosa_compatibility.py
@@ -347,7 +347,3 @@ class TestTransforms(common_utils.TorchaudioTestCase):
         # torch.dist(spec_lr, spec_ta, p=1)
         # >>> tensor(943.2759)
         assert torch.dist(spec_orig, spec_ta, p=1) < threshold
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_sox_compatibility.py
+++ b/test/test_sox_compatibility.py
@@ -299,7 +299,3 @@ class TestFunctionalFiltering(TempDirMixin, TorchaudioTestCase):
         data, path = self.get_whitenoise()
         result = F.lfilter(data, torch.tensor([a0, a1, a2]), torch.tensor([b0, b1, b2]))
         self.assert_sox_effect(result, path, ['biquad', b0, b1, b2, a0, a1, a2])
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_sox_effects.py
+++ b/test/test_sox_effects.py
@@ -270,7 +270,3 @@ class Test_SoxEffectsChain(common_utils.TorchaudioTestCase):
 
             y = vad(x_orig)
             self.assertTrue(x.allclose(y, rtol=1e-4, atol=1e-4))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -219,7 +219,3 @@ class Tester(common_utils.TorchaudioTestCase):
         computed = transform(specgram)
         assert computed.shape == expected.shape, (computed.shape, expected.shape)
         self.assertEqual(computed, expected, atol=1e-6, rtol=1e-8)
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
Before the change:
```
grep 'if __name__' -r test
test/test_batch_consistency.py:if __name__ == '__main__':
test/test_kaldi_io.py:if __name__ == '__main__':
test/test_compliance_kaldi.py:if __name__ == '__main__':
test/test_dataloader.py:if __name__ == '__main__':
test/test_sox_compatibility.py:if __name__ == "__main__":
test/test_datasets.py:if __name__ == "__main__":
test/functional_cpu_test.py:if __name__ == '__main__':
test/test_sox_effects.py:if __name__ == '__main__':
test/test_io.py:if __name__ == '__main__':
test/compliance/generate_fbank_data.py:if __name__ == '__main__':
test/compliance/generate_test_stft_data.py:if __name__ == '__main__':
test/test_transforms.py:if __name__ == '__main__':
test/assets/io/generate_opus.py:if __name__ == '__main__':
test/test_librosa_compatibility.py:if __name__ == '__main__':
```

after the change:
```
grep 'if __name__' -r test
test/compliance/generate_fbank_data.py:if __name__ == '__main__':
test/compliance/generate_test_stft_data.py:if __name__ == '__main__':
test/assets/io/generate_opus.py:if __name__ == '__main__':
```
I checked these 3 files, it's not handled by `unittest.main()` before. So I think it's irrelevant to this change.