### PR TITLE
Refactor test_sox_effects

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -29,7 +29,7 @@ The following test modules are defined for corresponding `torchaudio` module/fun
 - [`torchaudio.transforms`](./test_transforms.py)
 - [`torchaudio.compliance.kaldi`](./test_compliance_kaldi.py)
 - [`torchaudio.kaldi_io`](./test_kaldi_io.py)
-- [`torchaudio.sox_effects`](test/test_sox_effects.py)
+- [`torchaudio.sox_effects`](test/sox_effects)
 - [`torchaudio.save`, `torchaudio.load`, `torchaudio.info`](test/test_io.py)
 
 ### Test modules that do not fall into the above categories

--- a/test/test_sox_compatibility.py
+++ b/test/test_sox_compatibility.py
@@ -2,6 +2,8 @@ import unittest
 
 import torch
 import torchaudio.functional as F
+import torchaudio.transforms as T
+from parameterized import parameterized
 
 from .common_utils import (
     skipIfNoSoxBackend,
@@ -299,3 +301,31 @@ class TestFunctionalFiltering(TempDirMixin, TorchaudioTestCase):
         data, path = self.get_whitenoise()
         result = F.lfilter(data, torch.tensor([a0, a1, a2]), torch.tensor([b0, b1, b2]))
         self.assert_sox_effect(result, path, ['biquad', b0, b1, b2, a0, a1, a2])
+
+    @parameterized.expand([
+        ('q', 'quarter_sine'),
+        ('h', 'half_sine'),
+        ('t', 'linear'),
+    ])
+    def test_fade(self, fade_shape_sox, fade_shape):
+        fade_in_len, fade_out_len = 44100, 44100
+        data, path = self.get_whitenoise(sample_rate=44100)
+        result = T.Fade(fade_in_len, fade_out_len, fade_shape)(data)
+        self.assert_sox_effect(result, path, ['fade', fade_shape_sox, '1', '0', '1'])
+
+    @parameterized.expand([
+        ('amplitude', 1.1),
+        ('db', 2),
+        ('power', 2),
+    ])
+    def test_vol(self, gain_type, gain):
+        data, path = self.get_whitenoise()
+        result = T.Vol(gain, gain_type)(data)
+        self.assert_sox_effect(result, path, ['vol', f'{gain}', gain_type])
+
+    @parameterized.expand(['vad-go-stereo-44100.wav', 'vad-go-mono-32000.wav'])
+    def test_vad(self, filename):
+        path = get_asset_path(filename)
+        data, sample_rate = load_wav(path)
+        result = T.Vad(sample_rate)(data)
+        self.assert_sox_effect(result, path, ['vad'])


### PR DESCRIPTION
1. Move misplaced sox compatibility tests (`T,Fade`, `T.Vol`, `T.Vad`) from `test_sox_effects.py` to `test_sox_compatibility.py`
2. Move `test_sox_effects.py` to `test/sox_effect/` where all the other functionalities from `torchaudio.sox_effects` are tested