### PR TITLE
Run tests in parallel with pytest-xdist

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - numpy
   - pytest
   - pytest-cov
+  - pytest-xdist
   - codecov
   - librosa
   - llvmlite==0.31  # See https://github.com/pytorch/audio/pull/766

--- a/.circleci/unittest/linux/scripts/run_test.sh
+++ b/.circleci/unittest/linux/scripts/run_test.sh
@@ -2,9 +2,20 @@
 
 set -e
 
+case "$(uname -s)" in
+    Darwin*) os=MacOSX;;
+    *) os=Linux
+esac
+
+
 eval "$(./conda/bin/conda shell.bash hook)"
 conda activate ./env
 
 python -m torch.utils.collect_env
 export PATH="${PWD}/third_party/install/bin/:${PATH}"
-pytest -q -n auto --dist=loadscope --cov=torchaudio --junitxml=test-results/junit.xml --durations 20 test
+
+if [ "${os}" == MacOSX ] ; then
+    pytest -q -n auto --dist=loadscope --cov=torchaudio --junitxml=test-results/junit.xml --durations 20 test
+else
+    pytest -v --cov=torchaudio --junitxml=test-results/junit.xml --durations 20 test
+fi

--- a/.circleci/unittest/linux/scripts/run_test.sh
+++ b/.circleci/unittest/linux/scripts/run_test.sh
@@ -7,4 +7,4 @@ conda activate ./env
 
 python -m torch.utils.collect_env
 export PATH="${PWD}/third_party/install/bin/:${PATH}"
-pytest --cov=torchaudio --junitxml=test-results/junit.xml -v --durations 20 test
+pytest -q -n auto --dist=loadscope --cov=torchaudio --junitxml=test-results/junit.xml --durations 20 test


### PR DESCRIPTION
Currently macOS CI job takes twice the time of linux unit tests.
This PR uses `pytest-xdist` to run unit tests in parallel on macOS CI job. 

Interestingly applying the same technique to linux unit tests make the test execution longer.
So the change is only applied to macOS.

macOS 27 mins -> 17 mins 😸
linux 14 mins -> 1 hours 😾
