### PR TITLE
[BC Breaking] Split `list_formats()` for read and write

### DIFF
--- a/test/sox_io_backend/smoke_test.py
+++ b/test/sox_io_backend/smoke_test.py
@@ -1,6 +1,9 @@
 import itertools
+import unittest
 
+from torchaudio.utils import sox_utils
 from torchaudio.backend import sox_io_backend
+from torchaudio._internal.module_utils import is_module_available
 from parameterized import parameterized
 
 from ..common_utils import (
@@ -10,6 +13,13 @@ from ..common_utils import (
     get_wav_data,
 )
 from .common import name_func
+
+
+skipIfNoMP3 = unittest.skipIf(
+    not is_module_available('torchaudio._torchaudio') or
+    'mp3' not in sox_utils.list_read_formats() or
+    'mp3' not in sox_utils.list_write_formats(),
+    '"sox_io" backend does not support MP3')
 
 
 @skipIfNoExtension
@@ -53,6 +63,7 @@ class SmokeTest(TempDirMixin, TorchaudioTestCase):
         [1, 2],
         [-4.2, -0.2, 0, 0.2, 96, 128, 160, 192, 224, 256, 320],
     )), name_func=name_func)
+    @skipIfNoMP3
     def test_mp3(self, sample_rate, num_channels, bit_rate):
         """Run smoke test on mp3 format"""
         self.run_smoke_test('mp3', sample_rate, num_channels, compression=bit_rate)

--- a/test/utils/test_sox_utils.py
+++ b/test/utils/test_sox_utils.py
@@ -38,7 +38,12 @@ class TestSoxUtils(PytorchTestCase):
         assert 'phaser' in effects
         assert 'gain' in effects
 
-    def test_list_formats(self):
-        """`list_formats` returns the list of supported formats"""
-        formats = sox_utils.list_formats()
+    def test_list_read_formats(self):
+        """`list_read_formats` returns the list of supported formats"""
+        formats = sox_utils.list_read_formats()
         assert 'wav' in formats
+
+    def test_list_write_formats(self):
+        """`list_write_formats` returns the list of supported formats"""
+        formats = sox_utils.list_write_formats()
+        assert 'opus' not in formats

--- a/torchaudio/csrc/register.cpp
+++ b/torchaudio/csrc/register.cpp
@@ -27,7 +27,10 @@ static auto registerSetSoxOptions =
         .op("torchaudio::sox_utils_set_buffer_size",
             &sox_utils::set_buffer_size)
         .op("torchaudio::sox_utils_list_effects", &sox_utils::list_effects)
-        .op("torchaudio::sox_utils_list_formats", &sox_utils::list_formats);
+        .op("torchaudio::sox_utils_list_read_formats",
+            &sox_utils::list_read_formats)
+        .op("torchaudio::sox_utils_list_write_formats",
+            &sox_utils::list_write_formats);
 
 ////////////////////////////////////////////////////////////////////////////////
 // sox_io.h

--- a/torchaudio/csrc/sox_utils.cpp
+++ b/torchaudio/csrc/sox_utils.cpp
@@ -37,11 +37,24 @@ std::vector<std::vector<std::string>> list_effects() {
   return effects;
 }
 
-std::vector<std::string> list_formats() {
+std::vector<std::string> list_write_formats() {
   std::vector<std::string> formats;
   for (const sox_format_tab_t* fns = sox_get_format_fns(); fns->fn; ++fns) {
-    for (const char* const* names = fns->fn()->names; *names; ++names) {
-      if (!strchr(*names, '/'))
+    const sox_format_handler_t* handler = fns->fn();
+    for (const char* const* names = handler->names; *names; ++names) {
+      if (!strchr(*names, '/') && handler->write)
+        formats.emplace_back(*names);
+    }
+  }
+  return formats;
+}
+
+std::vector<std::string> list_read_formats() {
+  std::vector<std::string> formats;
+  for (const sox_format_tab_t* fns = sox_get_format_fns(); fns->fn; ++fns) {
+    const sox_format_handler_t* handler = fns->fn();
+    for (const char* const* names = handler->names; *names; ++names) {
+      if (!strchr(*names, '/') && handler->read)
         formats.emplace_back(*names);
     }
   }

--- a/torchaudio/csrc/sox_utils.h
+++ b/torchaudio/csrc/sox_utils.h
@@ -22,7 +22,9 @@ void set_buffer_size(const int64_t buffer_size);
 
 std::vector<std::vector<std::string>> list_effects();
 
-std::vector<std::string> list_formats();
+std::vector<std::string> list_read_formats();
+
+std::vector<std::string> list_write_formats();
 
 /// Class for exchanging signal infomation (tensor + meta data) between
 /// C++ and Python for read/write operation.

--- a/torchaudio/utils/sox_utils.py
+++ b/torchaudio/utils/sox_utils.py
@@ -75,10 +75,20 @@ def list_effects() -> Dict[str, str]:
 
 
 @_mod_utils.requires_module('torchaudio._torchaudio')
-def list_formats() -> List[str]:
-    """List the supported audio formats
+def list_read_formats() -> List[str]:
+    """List the supported audio formats for read
 
     Returns:
         List[str]: List of supported audio formats
     """
-    return torch.ops.torchaudio.sox_utils_list_formats()
+    return torch.ops.torchaudio.sox_utils_list_read_formats()
+
+
+@_mod_utils.requires_module('torchaudio._torchaudio')
+def list_write_formats() -> List[str]:
+    """List the supported audio formats for write
+
+    Returns:
+        List[str]: List of supported audio formats
+    """
+    return torch.ops.torchaudio.sox_utils_list_write_formats()


### PR DESCRIPTION
Turned out that `libsox` in fbcode only has reader (`libmad`) and not writer (`libmp3lame`), therefor the smoke test added in #806 cannot run as is.
I tried to add skip condition using `sox_utils.list_formats` utility but this function does not care if a format handler has writer or not. (cf. `libsox` does not implement writer for `opus` too)

From the user point of view, and debugging the installation, this is confusing and not very convenient, so this PR splits `torchaudio.utils.sox_utils.list_formats()` into `torchaudio.utils.sox_utils.list_read_formats()` and `torchaudio.utils.sox_utils.list_write_formats()`.