### PR TITLE
Add sample_rate conversion option to `sox_io_backend.load`

### DIFF
--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -40,6 +40,7 @@ def load(
         num_frames: int = -1,
         normalize: bool = True,
         channels_first: bool = True,
+        sample_rate: Optional[int] = None,
 ) -> Tuple[torch.Tensor, int]:
     """Load audio data from file.
 
@@ -84,11 +85,13 @@ def load(
             Path to audio file
         frame_offset (int):
             Number of frames to skip before start reading data.
+            If ``sample_rate`` is given, frame counts start after the audio is resampled.
         num_frames (int):
             Maximum number of frames to read. ``-1`` reads all the remaining samples,
             starting from ``frame_offset``.
             This function may return the less number of frames if there is not enough
             frames in the given file.
+            If ``sample_rate`` is given, frame counts start after the audio is resampled.
         normalize (bool):
             When ``True``, this function always return ``float32``, and sample values are
             normalized to ``[-1.0, 1.0]``.
@@ -98,6 +101,8 @@ def load(
         channels_first (bool):
             When True, the returned Tensor has dimension ``[channel, time]``.
             Otherwise, the returned Tensor's dimension is ``[time, channel]``.
+        sample_rate (int, optional):
+            Perform resampling.
 
     Returns:
         torch.Tensor:
@@ -105,8 +110,9 @@ def load(
             integer type, else ``float32`` type. If ``channels_first=True``, it has
             ``[channel, time]`` else ``[time, channel]``.
     """
-    signal = torch.ops.torchaudio.sox_io_load_audio_file(
-        filepath, frame_offset, num_frames, normalize, channels_first)
+    sample_rate = -1 if sample_rate is None else sample_rate
+    signal = torch.ops.torchaudio.sox_io_load_audio_file_v1(
+        filepath, frame_offset, num_frames, normalize, channels_first, sample_rate)
     return signal.get_tensor(), signal.get_sample_rate()
 
 

--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -111,7 +111,7 @@ def load(
             ``[channel, time]`` else ``[time, channel]``.
     """
     sample_rate = -1 if sample_rate is None else sample_rate
-    signal = torch.ops.torchaudio.sox_io_load_audio_file_v1(
+    signal = torch.ops.torchaudio.sox_io_load_audio_file(
         filepath, frame_offset, num_frames, normalize, channels_first, sample_rate)
     return signal.get_tensor(), signal.get_sample_rate()
 

--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -111,7 +111,7 @@ def load(
             ``[channel, time]`` else ``[time, channel]``.
     """
     sample_rate = -1 if sample_rate is None else sample_rate
-    signal = torch.ops.torchaudio.sox_io_load_audio_file(
+    signal = torch.ops.torchaudio.sox_io_load_audio_file_v1(
         filepath, frame_offset, num_frames, normalize, channels_first, sample_rate)
     return signal.get_tensor(), signal.get_sample_rate()
 

--- a/torchaudio/csrc/register.cpp
+++ b/torchaudio/csrc/register.cpp
@@ -52,9 +52,6 @@ TORCH_LIBRARY(torchaudio, m) {
       "torchaudio::sox_io_load_audio_file",
       &torchaudio::sox_io::load_audio_file);
   m.def(
-      "torchaudio::sox_io_load_audio_file_v1",
-      &torchaudio::sox_io::load_audio_file_v1);
-  m.def(
       "torchaudio::sox_io_save_audio_file",
       &torchaudio::sox_io::save_audio_file);
 

--- a/torchaudio/csrc/register.cpp
+++ b/torchaudio/csrc/register.cpp
@@ -52,6 +52,9 @@ TORCH_LIBRARY(torchaudio, m) {
       "torchaudio::sox_io_load_audio_file",
       &torchaudio::sox_io::load_audio_file);
   m.def(
+      "torchaudio::sox_io_load_audio_file_v1",
+      &torchaudio::sox_io::load_audio_file_v1);
+  m.def(
       "torchaudio::sox_io_save_audio_file",
       &torchaudio::sox_io::save_audio_file);
 

--- a/torchaudio/csrc/sox_io.cpp
+++ b/torchaudio/csrc/sox_io.cpp
@@ -52,6 +52,15 @@ c10::intrusive_ptr<TensorSignal> load_audio_file(
     const int64_t frame_offset,
     const int64_t num_frames,
     const bool normalize,
+    const bool channels_first) {
+  return load_audio_file_v1(path, frame_offset, num_frames, channels_first, -1);
+}
+
+c10::intrusive_ptr<TensorSignal> load_audio_file_v1(
+    const std::string& path,
+    const int64_t frame_offset,
+    const int64_t num_frames,
+    const bool normalize,
     const bool channels_first,
     const int64_t sample_rate) {
   if (frame_offset < 0) {

--- a/torchaudio/csrc/sox_io.cpp
+++ b/torchaudio/csrc/sox_io.cpp
@@ -52,15 +52,6 @@ c10::intrusive_ptr<TensorSignal> load_audio_file(
     const int64_t frame_offset,
     const int64_t num_frames,
     const bool normalize,
-    const bool channels_first) {
-  return load_audio_file_v1(path, frame_offset, num_frames, channels_first, -1);
-}
-
-c10::intrusive_ptr<TensorSignal> load_audio_file_v1(
-    const std::string& path,
-    const int64_t frame_offset,
-    const int64_t num_frames,
-    const bool normalize,
     const bool channels_first,
     const int64_t sample_rate) {
   if (frame_offset < 0) {

--- a/torchaudio/csrc/sox_io.cpp
+++ b/torchaudio/csrc/sox_io.cpp
@@ -53,6 +53,16 @@ c10::intrusive_ptr<TensorSignal> load_audio_file(
     const int64_t num_frames,
     const bool normalize,
     const bool channels_first) {
+  return load_audio_file_v1(path, frame_offset, num_frames, channels_first, -1);
+}
+
+c10::intrusive_ptr<TensorSignal> load_audio_file_v1(
+    const std::string& path,
+    const int64_t frame_offset,
+    const int64_t num_frames,
+    const bool normalize,
+    const bool channels_first,
+    const int64_t sample_rate) {
   if (frame_offset < 0) {
     throw std::runtime_error(
         "Invalid argument: frame_offset must be non-negative.");
@@ -61,8 +71,16 @@ c10::intrusive_ptr<TensorSignal> load_audio_file(
     throw std::runtime_error(
         "Invalid argument: num_frames must be -1 or greater than 0.");
   }
+  if (sample_rate == 0 || sample_rate < -1) {
+    throw std::runtime_error(
+        "Invalid argument: sample_rate must be -1 or greater than 0.");
+  }
 
   std::vector<std::vector<std::string>> effects;
+  if (sample_rate != -1) {
+    effects.emplace_back(
+        std::vector<std::string>{"rate", std::to_string(sample_rate)});
+  }
   if (num_frames != -1) {
     std::ostringstream offset, frames;
     offset << frame_offset << "s";

--- a/torchaudio/csrc/sox_io.h
+++ b/torchaudio/csrc/sox_io.h
@@ -23,16 +23,7 @@ struct SignalInfo : torch::CustomClassHolder {
 
 c10::intrusive_ptr<SignalInfo> get_info(const std::string& path);
 
-// ver. 0
 c10::intrusive_ptr<torchaudio::sox_utils::TensorSignal> load_audio_file(
-    const std::string& path,
-    const int64_t frame_offset = 0,
-    const int64_t num_frames = -1,
-    const bool normalize = true,
-    const bool channels_first = true);
-
-// ver. 1 sample_rate is added
-c10::intrusive_ptr<torchaudio::sox_utils::TensorSignal> load_audio_file_v1(
     const std::string& path,
     const int64_t frame_offset = 0,
     const int64_t num_frames = -1,

--- a/torchaudio/csrc/sox_io.h
+++ b/torchaudio/csrc/sox_io.h
@@ -23,7 +23,16 @@ struct SignalInfo : torch::CustomClassHolder {
 
 c10::intrusive_ptr<SignalInfo> get_info(const std::string& path);
 
+// ver. 0
 c10::intrusive_ptr<torchaudio::sox_utils::TensorSignal> load_audio_file(
+    const std::string& path,
+    const int64_t frame_offset = 0,
+    const int64_t num_frames = -1,
+    const bool normalize = true,
+    const bool channels_first = true);
+
+// ver. 1 sample_rate is added
+c10::intrusive_ptr<torchaudio::sox_utils::TensorSignal> load_audio_file_v1(
     const std::string& path,
     const int64_t frame_offset = 0,
     const int64_t num_frames = -1,

--- a/torchaudio/csrc/sox_io.h
+++ b/torchaudio/csrc/sox_io.h
@@ -23,12 +23,22 @@ struct SignalInfo : torch::CustomClassHolder {
 
 c10::intrusive_ptr<SignalInfo> get_info(const std::string& path);
 
+// ver. 0
 c10::intrusive_ptr<torchaudio::sox_utils::TensorSignal> load_audio_file(
     const std::string& path,
     const int64_t frame_offset = 0,
     const int64_t num_frames = -1,
     const bool normalize = true,
     const bool channels_first = true);
+
+// ver. 1 sample_rate is added
+c10::intrusive_ptr<torchaudio::sox_utils::TensorSignal> load_audio_file_v1(
+    const std::string& path,
+    const int64_t frame_offset = 0,
+    const int64_t num_frames = -1,
+    const bool normalize = true,
+    const bool channels_first = true,
+    const int64_t sample_rate = -1);
 
 void save_audio_file(
     const std::string& file_name,


### PR DESCRIPTION
This PR adds `sample_rate` option to `sox_io_backend.load` function which performs resampling when loading audio data from file.

Inspired by [this comment](https://github.com/pytorch/audio/issues/800#issuecomment-661661511)

~On Python interface this change is backward compatible, but Torchscript registration schema is changed, (see `register.cpp`), therefore previously dumped Torchscript object that includes call to `sox_io_backend.load` will stop working. -> BC breaking.~
~Added backward compatibility. TODO: test -> https://github.com/pytorch/audio/pull/838~