### PR TITLE
Move BACKEDNS and BACKENDS_MP3 to test module from common_utils

### DIFF
--- a/test/common_utils/__init__.py
+++ b/test/common_utils/__init__.py
@@ -5,8 +5,6 @@ from .data_utils import (
 )
 from .backend_utils import (
     set_audio_backend,
-    BACKENDS,
-    BACKENDS_MP3,
 )
 from .case_utils import (
     TempDirMixin,

--- a/test/common_utils/backend_utils.py
+++ b/test/common_utils/backend_utils.py
@@ -2,36 +2,14 @@ import unittest
 
 import torchaudio
 
-from .import data_utils
-
-
-BACKENDS = torchaudio.list_audio_backends()
-
-
-def _filter_backends_with_mp3(backends):
-    # Filter out backends that do not support mp3
-    test_filepath = data_utils.get_asset_path('steam-train-whistle-daniel_simon.mp3')
-
-    def supports_mp3(backend):
-        torchaudio.set_audio_backend(backend)
-        try:
-            torchaudio.load(test_filepath)
-            return True
-        except (RuntimeError, ImportError):
-            return False
-
-    return [backend for backend in backends if supports_mp3(backend)]
-
-
-BACKENDS_MP3 = _filter_backends_with_mp3(BACKENDS)
-
 
 def set_audio_backend(backend):
     """Allow additional backend value, 'default'"""
+    backends = torchaudio.list_audio_backends()
     if backend == 'default':
-        if 'sox_io' in BACKENDS:
+        if 'sox_io' in backends:
             be = 'sox_io'
-        elif 'soundfile' in BACKENDS:
+        elif 'soundfile' in backends:
             be = 'soundfile'
         else:
             raise unittest.SkipTest('No default backend available')

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -6,8 +6,25 @@ import unittest
 
 import torch
 import torchaudio
+from torchaudio.utils import sox_utils
+from torchaudio._internal.module_utils import is_module_available
 
-from .common_utils import BACKENDS, BACKENDS_MP3, get_asset_path
+from .common_utils import get_asset_path
+
+BACKENDS = []
+BACKENDS_MP3 = []
+
+if is_module_available('soundfile'):
+    BACKENDS.append('soundfile')
+
+if is_module_available('torchaudio._torchaudio'):
+    BACKENDS.append('sox')
+
+    if (
+            'mp3' in sox_utils.list_read_formats() and
+            'mp3' in sox_utils.list_write_formats()
+    ):
+        BACKENDS_MP3 = ['sox']
 
 
 def create_temp_assets_dir():
@@ -30,15 +47,11 @@ class Test_LoadSave(unittest.TestCase):
 
     def test_1_save(self):
         for backend in BACKENDS_MP3:
-            if backend == 'sox_io':
-                continue
             with self.subTest():
                 torchaudio.set_audio_backend(backend)
                 self._test_1_save(self.test_filepath, False)
 
         for backend in BACKENDS:
-            if backend == 'sox_io':
-                continue
             with self.subTest():
                 torchaudio.set_audio_backend(backend)
                 self._test_1_save(self.test_filepath_wav, True)
@@ -85,8 +98,6 @@ class Test_LoadSave(unittest.TestCase):
 
     def test_1_save_sine(self):
         for backend in BACKENDS:
-            if backend == 'sox_io':
-                continue
             with self.subTest():
                 torchaudio.set_audio_backend(backend)
                 self._test_1_save_sine()
@@ -120,15 +131,11 @@ class Test_LoadSave(unittest.TestCase):
 
     def test_2_load(self):
         for backend in BACKENDS_MP3:
-            if backend == 'sox_io':
-                continue
             with self.subTest():
                 torchaudio.set_audio_backend(backend)
                 self._test_2_load(self.test_filepath, 278756)
 
         for backend in BACKENDS:
-            if backend == 'sox_io':
-                continue
             with self.subTest():
                 torchaudio.set_audio_backend(backend)
                 self._test_2_load(self.test_filepath_wav, 276858)
@@ -224,8 +231,6 @@ class Test_LoadSave(unittest.TestCase):
 
     def test_4_load_partial(self):
         for backend in BACKENDS_MP3:
-            if backend == 'sox_io':
-                continue
             with self.subTest():
                 torchaudio.set_audio_backend(backend)
                 self._test_4_load_partial()
@@ -268,8 +273,6 @@ class Test_LoadSave(unittest.TestCase):
 
     def test_5_get_info(self):
         for backend in BACKENDS:
-            if backend == 'sox_io':
-                continue
             with self.subTest():
                 torchaudio.set_audio_backend(backend)
                 self._test_5_get_info()


### PR DESCRIPTION
Now that most of our test cases are backend aware/agnostic,
the use of BACKENDS and BACKENDS_MP3 is anti-pattern.

This change moves these definitions to the legacy test module `test_io` which is 
the only module using these.

If a new backend is added in future, that backend should have separate test suite,
(like the ones in `test/sox_io_backend`) so instead of dynamically listing available
backend in `test_io`, the changed code only checks "sox" backend and "soundfile" backend.