### PR TITLE
Set zip_safe = False to disable egg installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,5 +85,6 @@ setup(
     cmdclass={
         'build_ext': setup_helpers.BuildExtension.with_options(no_python_abi_suffix=True)
     },
-    install_requires=[pytorch_package_dep]
+    install_requires=[pytorch_package_dep],
+    zip_safe=False,
 )


### PR DESCRIPTION
Currently `setuptools` assumes that torhcaudio is zip safe and performs
egg (zip) installation when `python setup.py install` (or `pip install .`).

When torchaudio load extension module written for Torchscript, the corresponding
loading function requires the `so` file to be present as an actual file, and this
does not work well with egg installation.

This PR fixes this by setting `zip_safe=False` in setup.py and disable egg
installation, so that `python setup.py install` installs uncompressed files
with regular directory structure.

The following is the error you get when you try to use the package installed with
`python setup.py install`, before this change.

```
    import torchaudio
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 656, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 626, in _load_backward_compatible
  File "/torchaudio/envs/master-py3.6/lib/python3.6/site-packages/torchaudio-0.7.0a0+d6831c6-py3.6-linux-x86_64.egg/torchaudio/__init__.py", line 1, in <module>
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 656, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 626, in _load_backward_compatible
  File "/torchaudio/envs/master-py3.6/lib/python3.6/site-packages/torchaudio-0.7.0a0+d6831c6-py3.6-linux-x86_64.egg/torchaudio/extension/__init__.py", line 5, in <module>
  File "/torchaudio/envs/master-py3.6/lib/python3.6/site-packages/torchaudio-0.7.0a0+d6831c6-py3.6-linux-x86_64.egg/torchaudio/extension/extension.py", line 12, in _init_extension
  File "/torchaudio/envs/master-py3.6/lib/python3.6/site-packages/torchaudio-0.7.0a0+d6831c6-py3.6-linux-x86_64.egg/torchaudio/extension/extension.py", line 19, in _init_script_module
  File "/torchaudio/envs/master-py3.6/lib/python3.6/site-packages/torch/_classes.py", line 46, in load_library
    torch.ops.load_library(path)
  File "/torchaudio/envs/master-py3.6/lib/python3.6/site-packages/torch/_ops.py", line 105, in load_library
    ctypes.CDLL(path)
  File "/torchaudio/envs/master-py3.6/lib/python3.6/ctypes/__init__.py", line 348, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: /torchaudio/envs/master-py3.6/lib/python3.6/site-packages/torchaudio-0.7.0a0+d6831c6-py3.6-linux-x86_64.egg/torchaudio/_torchaudio.py
```