### PR TITLE
Fix import order to suppress the setuptools warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-import distutils.command.clean
 from setuptools import setup, find_packages
+import distutils.command.clean
 
 from build_tools import setup_helpers
 


### PR DESCRIPTION
setuptools warns that it should be imported before Distutils

```
site-packages/setuptools/distutils_patch.py:25: UserWarning: Distutils was imported before Setuptools. This usage is discouraged and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools first.
```