### PR TITLE
[CI] Make *nix unit test fail if C++ extension is not available

### DIFF
--- a/.circleci/unittest/linux/scripts/run_test.sh
+++ b/.circleci/unittest/linux/scripts/run_test.sh
@@ -12,6 +12,7 @@ eval "$(./conda/bin/conda shell.bash hook)"
 conda activate ./env
 
 python -m torch.utils.collect_env
+export TORCHAUDIO_TEST_FAIL_IF_NO_EXTENSION=1
 export PATH="${PWD}/third_party/install/bin/:${PATH}"
 
 if [ "${os}" == MacOSX ] ; then

--- a/test/common_utils/case_utils.py
+++ b/test/common_utils/case_utils.py
@@ -67,4 +67,12 @@ def skipIfNoModule(module, display_name=None):
 skipIfNoSoxBackend = unittest.skipIf(
     'sox' not in torchaudio.list_audio_backends(), 'Sox backend not available')
 skipIfNoCuda = unittest.skipIf(not torch.cuda.is_available(), reason='CUDA not available')
-skipIfNoExtension = skipIfNoModule('torchaudio._torchaudio', 'torchaudio C++ extension')
+
+
+def skipIfNoExtension(test_item):
+    if (
+            not is_module_available('torchaudio._torchaudio')
+            and 'TORCHAUDIO_TEST_FAIL_IF_NO_EXTENSION' in os.environ
+    ):
+        raise RuntimeError('torchaudio C++ extension is not available.')
+    return unittest.skip('torchaudio C++ extension is not available')(test_item)


### PR DESCRIPTION
I am trying to fix the issue C++ extension availability when building/installing torchaudio from source. See https://github.com/pytorch/audio/pull/842 for the detail.

Currently our test suites automatically/silently skip tests on C++ extension if it is not available.
This is nice in local env, but in CI these tests should be enforced and reported as failure if C++ extension is not available.

This PR adds switch for making tests fail if C++ extension is not available.

This should make https://github.com/pytorch/audio/pull/845 fail so that we can debug what is wrong with the current setup.