### PR TITLE
Fix skipIfNoExtension

### DIFF
--- a/test/common_utils/case_utils.py
+++ b/test/common_utils/case_utils.py
@@ -70,9 +70,8 @@ skipIfNoCuda = unittest.skipIf(not torch.cuda.is_available(), reason='CUDA not a
 
 
 def skipIfNoExtension(test_item):
-    if (
-            not is_module_available('torchaudio._torchaudio')
-            and 'TORCHAUDIO_TEST_FAIL_IF_NO_EXTENSION' in os.environ
-    ):
+    if is_module_available('torchaudio._torchaudio'):
+        return test_item
+    if 'TORCHAUDIO_TEST_FAIL_IF_NO_EXTENSION' in os.environ:
         raise RuntimeError('torchaudio C++ extension is not available.')
     return unittest.skip('torchaudio C++ extension is not available')(test_item)


### PR DESCRIPTION
There was a flaw in the logic introduced in #847, and now that tests that require C++ extension are skipped all the time. This PR fixes it. 