### PR TITLE
.circleci: Only install the binaries from the channel we want

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,12 +277,13 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/workspace
+      - designate_upload_channel
       - run:
           name: install binaries
           command: |
             set -x
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
-            conda install -v -y -c pytorch-test -c pytorch-nightly pytorch
+            conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch
             conda install -v -y $(ls ~/workspace/torchaudio*.tar.bz2)
       - run:
           name: smoke test

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -277,12 +277,13 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/workspace
+      - designate_upload_channel
       - run:
           name: install binaries
           command: |
             set -x
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
-            conda install -v -y -c pytorch-test -c pytorch-nightly pytorch
+            conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch
             conda install -v -y $(ls ~/workspace/torchaudio*.tar.bz2)
       - run:
           name: smoke test


### PR DESCRIPTION
There was an issue where binaries from the `pytorch-test` channel were
being installed when smoke testing for the `pytorch-nightly` channel,
this remedies that by only using the channel we're actually supposed to
be testing with.

Resolves https://github.com/pytorch/audio/issues/858

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>