### PR TITLE
Add spectrogram normalization option

### DIFF
--- a/examples/pipeline_wavernn/main.py
+++ b/examples/pipeline_wavernn/main.py
@@ -163,6 +163,9 @@ def parse_args():
     parser.add_argument(
         "--file-path", default="", type=str, help="the path of audio files",
     )
+    parser.add_argument(
+        "--normalization", default=True, action="store_true", help="if True, spectrogram is normalized",
+    )
 
     args = parser.parse_args()
     return args
@@ -273,7 +276,7 @@ def main(args):
             n_mels=args.n_freq,
             fmin=args.f_min,
         ),
-        NormalizeDB(min_level_db=args.min_level_db),
+        NormalizeDB(min_level_db=args.min_level_db, normalization=args.normalization),
     )
 
     train_dataset, val_dataset = split_process_dataset(args, transforms)

--- a/examples/pipeline_wavernn/processing.py
+++ b/examples/pipeline_wavernn/processing.py
@@ -31,15 +31,19 @@ class NormalizeDB(nn.Module):
     r"""Normalize the spectrogram with a minimum db value
     """
 
-    def __init__(self, min_level_db):
+    def __init__(self, min_level_db, normalization):
         super().__init__()
         self.min_level_db = min_level_db
+        self.normalization = normalization
 
     def forward(self, specgram):
-        specgram = 20 * torch.log10(torch.clamp(specgram, min=1e-5))
-        return torch.clamp(
-            (self.min_level_db - specgram) / self.min_level_db, min=0, max=1
-        )
+        if self.normalization:
+            specgram = 20 * torch.log10(torch.clamp(specgram, min=1e-5))
+            return torch.clamp(
+                (self.min_level_db - specgram) / self.min_level_db, min=0, max=1
+            )
+        else:
+            return torch.log10(torch.clamp(specgram, min=1e-5))
 
 
 def normalized_waveform_to_bits(waveform, bits):

--- a/examples/pipeline_wavernn/processing.py
+++ b/examples/pipeline_wavernn/processing.py
@@ -37,13 +37,12 @@ class NormalizeDB(nn.Module):
         self.normalization = normalization
 
     def forward(self, specgram):
+        specgram = torch.log10(torch.clamp(specgram, min=1e-5))
         if self.normalization:
-            specgram = 20 * torch.log10(torch.clamp(specgram, min=1e-5))
             return torch.clamp(
-                (self.min_level_db - specgram) / self.min_level_db, min=0, max=1
+                (self.min_level_db - 20 * specgram) / self.min_level_db, min=0, max=1
             )
-        else:
-            return torch.log10(torch.clamp(specgram, min=1e-5))
+        return specgram
 
 
 def normalized_waveform_to_bits(waveform, bits):


### PR DESCRIPTION
This is to add the spectrogram normalization option in [WaveRNN pipeline](https://github.com/pytorch/audio/pull/749).
