### PR TITLE
[CI] Fix macOS unittest env setup

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
 dependencies:
   - flake8
-  - numpy
+  - numpy >= 1.11
   - pytest
   - pytest-cov
   - pytest-xdist


### PR DESCRIPTION
Conda environment set up fails for the second time when NumPy version is unspecified.