### PR TITLE
[CI] Increase resource class to prevent OOM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -608,7 +608,7 @@ jobs:
   torchscript_bc_test:
     docker:
       - image: "pytorch/torchaudio_unittest_base:manylinux"
-    resource_class: medium
+    resource_class: large
     steps:
       - checkout
       - generate_cache_key

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -608,7 +608,7 @@ jobs:
   torchscript_bc_test:
     docker:
       - image: "pytorch/torchaudio_unittest_base:manylinux"
-    resource_class: medium
+    resource_class: large
     steps:
       - checkout
       - generate_cache_key


### PR DESCRIPTION
`torchscript_bc_test` which compiles multiple version of `torchaudio` gets OOM errors. This PR fixes it by increasing the CI resource.