### PR TITLE
[CI] Install conda package from workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,9 +144,9 @@ jobs:
       - store_artifacts:
           path: /opt/conda/conda-bld/linux-64
       - persist_to_workspace:
-          root: /opt/conda/conda-bld/linux-64
+          root: /opt/conda
           paths:
-            - "*"
+            - "conda-bld/*"
 
   binary_macos_wheel:
     <<: *binary_common
@@ -192,9 +192,9 @@ jobs:
       - store_artifacts:
           path: /Users/distiller/miniconda3/conda-bld/osx-64
       - persist_to_workspace:
-          root: /Users/distiller/miniconda3/conda-bld/osx-64
+          root: /Users/distiller/miniconda3
           paths:
-            - "*"
+            - "conda-bld/*"
 
   binary_windows_wheel:
     <<: *binary_common
@@ -231,9 +231,9 @@ jobs:
       - store_artifacts:
           path: C:/tools/miniconda3/conda-bld/win-64
       - persist_to_workspace:
-          root: C:/tools/miniconda3/conda-bld/win-64
+          root: C:/tools/miniconda3
           paths:
-            - "*"
+            - "conda-bld/*"
 
   # Requires org-member context
   binary_conda_upload:
@@ -248,7 +248,7 @@ jobs:
             # Prevent credential from leaking
             conda install -yq anaconda-client
             set -x
-            anaconda -t "${CONDA_PYTORCHBOT_TOKEN}" upload ~/workspace/*.tar.bz2 -u "pytorch-${UPLOAD_CHANNEL}" --label main --no-progress --force
+            anaconda -t "${CONDA_PYTORCHBOT_TOKEN}" upload ~/workspace/conda-bld/*/*.tar.bz2 -u "pytorch-${UPLOAD_CHANNEL}" --label main --no-progress --force
 
   # Requires org-member context
   binary_wheel_upload:
@@ -284,7 +284,7 @@ jobs:
             set -x
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
             conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch
-            conda install -v -y $(ls ~/workspace/torchaudio*.tar.bz2)
+            conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
       - run:
           name: smoke test
           command: |

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -144,9 +144,9 @@ jobs:
       - store_artifacts:
           path: /opt/conda/conda-bld/linux-64
       - persist_to_workspace:
-          root: /opt/conda/conda-bld/linux-64
+          root: /opt/conda
           paths:
-            - "*"
+            - "conda-bld/*"
 
   binary_macos_wheel:
     <<: *binary_common
@@ -192,9 +192,9 @@ jobs:
       - store_artifacts:
           path: /Users/distiller/miniconda3/conda-bld/osx-64
       - persist_to_workspace:
-          root: /Users/distiller/miniconda3/conda-bld/osx-64
+          root: /Users/distiller/miniconda3
           paths:
-            - "*"
+            - "conda-bld/*"
 
   binary_windows_wheel:
     <<: *binary_common
@@ -231,9 +231,9 @@ jobs:
       - store_artifacts:
           path: C:/tools/miniconda3/conda-bld/win-64
       - persist_to_workspace:
-          root: C:/tools/miniconda3/conda-bld/win-64
+          root: C:/tools/miniconda3
           paths:
-            - "*"
+            - "conda-bld/*"
 
   # Requires org-member context
   binary_conda_upload:
@@ -248,7 +248,7 @@ jobs:
             # Prevent credential from leaking
             conda install -yq anaconda-client
             set -x
-            anaconda -t "${CONDA_PYTORCHBOT_TOKEN}" upload ~/workspace/*.tar.bz2 -u "pytorch-${UPLOAD_CHANNEL}" --label main --no-progress --force
+            anaconda -t "${CONDA_PYTORCHBOT_TOKEN}" upload ~/workspace/conda-bld/*/*.tar.bz2 -u "pytorch-${UPLOAD_CHANNEL}" --label main --no-progress --force
 
   # Requires org-member context
   binary_wheel_upload:
@@ -284,7 +284,7 @@ jobs:
             set -x
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
             conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch
-            conda install -v -y $(ls ~/workspace/torchaudio*.tar.bz2)
+            conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
       - run:
           name: smoke test
           command: |


### PR DESCRIPTION
When running smoke test, proper way to install conda package is to
install from workspace, instead of installing from archive.
Otherwise the dependencies are not properly installed

https://github.com/conda/conda/issues/1884

For this, we pass the whole `conda-bld` directory from
conda package build job to upload job then smoke test job.

`torchaudio` does not have a mandatory third-party python package dependency,
so this was not an issue.

See also https://github.com/pytorch/text/pull/803