### PR TITLE
Add tedlium dataset (all 3 releases)

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -4,11 +4,11 @@ torchaudio.datasets
 All datasets are subclasses of :class:`torch.utils.data.Dataset`
 i.e, they have ``__getitem__`` and ``__len__`` methods implemented.
 Hence, they can all be passed to a :class:`torch.utils.data.DataLoader`
-which can load multiple samples parallelly using ``torch.multiprocessing`` workers. 
+which can load multiple samples parallelly using ``torch.multiprocessing`` workers.
 For example: ::
-    
+
     yesno_data = torchaudio.datasets.YESNO('.', download=True)
-    data_loader = torch.utils.data.DataLoader(yesno_data, 
+    data_loader = torch.utils.data.DataLoader(yesno_data,
                                               batch_size=1,
                                               shuffle=True,
                                               num_workers=args.nThreads)
@@ -22,7 +22,7 @@ All the datasets have almost similar API. They all have two common arguments:
 ``transform`` and  ``target_transform`` to transform the input and target respectively.
 
 
-.. currentmodule:: torchaudio.datasets 
+.. currentmodule:: torchaudio.datasets
 
 
 CMUARCTIC
@@ -80,6 +80,13 @@ SPEECHCOMMANDS
   :members: __getitem__
   :special-members:
 
+
+TEDLIUM
+~~~~~~~~~~~~~~
+
+.. autoclass:: TEDLIUM
+  :members: __getitem__
+  :special-members: get_phoneme_dict
 
 VCTK
 ~~~~

--- a/test/torchaudio_unittest/datasets/tedlium_test.py
+++ b/test/torchaudio_unittest/datasets/tedlium_test.py
@@ -19,6 +19,16 @@ UTTERANCES = [
     "AaronHuey_2010X 1 AaronHuey_2010X 8.0 10.0 <o,f0,female> script5\n",
 ]
 
+PHONEME = [
+    "a AH",
+    "a(2) EY",
+    "aachen AA K AH N",
+    "aad AE D",
+    "aaden EY D AH N",
+    "aadmi AE D M IY",
+    "aae EY EY",
+]
+
 
 class TestTedlium(TempDirMixin, TorchaudioTestCase):
     backend = "default"
@@ -60,6 +70,11 @@ class TestTedlium(TempDirMixin, TorchaudioTestCase):
             with open(trans_path, "w") as f:
                 f.write("".join(UTTERANCES))
 
+            dict_filename = f"{release}.dic"
+            dict_path = os.path.join(release_dir, dict_filename)
+            with open(dict_path, "w") as f:
+                f.write("\n".join(PHONEME))
+
             # Create a samples list to compare with
             cls.samples[release] = []
             for utterance in UTTERANCES:
@@ -92,6 +107,11 @@ class TestTedlium(TempDirMixin, TorchaudioTestCase):
 
         assert num_samples == len(self.samples[release])
 
+        dataset._dict_path = os.path.join(dataset._path, f"{release}.dic")
+        phoneme_dict = dataset.phoneme_dict
+        phoenemes = [f"{key} {' '.join(value)}" for key, value in phoneme_dict.items()]
+        assert phoenemes == PHONEME
+
     def test_tedlium_release2(self):
         release = "release2"
         dataset = tedlium.TEDLIUM(self.root_dir, release=release)
@@ -107,6 +127,11 @@ class TestTedlium(TempDirMixin, TorchaudioTestCase):
 
         assert num_samples == len(self.samples[release])
 
+        dataset._dict_path = os.path.join(dataset._path, f"{release}.dic")
+        phoneme_dict = dataset.phoneme_dict
+        phoenemes = [f"{key} {' '.join(value)}" for key, value in phoneme_dict.items()]
+        assert phoenemes == PHONEME
+
     def test_tedlium_release3(self):
         release = "release3"
         dataset = tedlium.TEDLIUM(self.root_dir, release=release)
@@ -121,4 +146,9 @@ class TestTedlium(TempDirMixin, TorchaudioTestCase):
             num_samples += 1
 
         assert num_samples == len(self.samples[release])
+
+        dataset._dict_path = os.path.join(dataset._path, f"{release}.dic")
+        phoneme_dict = dataset.phoneme_dict
+        phoenemes = [f"{key} {' '.join(value)}" for key, value in phoneme_dict.items()]
+        assert phoenemes == PHONEME
 

--- a/test/torchaudio_unittest/datasets/tedlium_test.py
+++ b/test/torchaudio_unittest/datasets/tedlium_test.py
@@ -151,4 +151,3 @@ class TestTedlium(TempDirMixin, TorchaudioTestCase):
         phoneme_dict = dataset.phoneme_dict
         phoenemes = [f"{key} {' '.join(value)}" for key, value in phoneme_dict.items()]
         assert phoenemes == PHONEME
-

--- a/test/torchaudio_unittest/datasets/tedlium_test.py
+++ b/test/torchaudio_unittest/datasets/tedlium_test.py
@@ -1,0 +1,93 @@
+import os
+
+from torchaudio.datasets import tedlium
+
+from torchaudio_unittest.common_utils import (
+    TempDirMixin,
+    TorchaudioTestCase,
+    get_whitenoise,
+    save_wav,
+    normalize_wav,
+)
+
+# Used to generate a unique utterance for each dummy audio file
+UTTERANCES = [
+    "AaronHuey_2010X 1 AaronHuey_2010X 0.0 2.0 <o,f0,female> script1\n",
+    "AaronHuey_2010X 1 AaronHuey_2010X 2.0 4.0 <o,f0,female> script2\n",
+    "AaronHuey_2010X 1 AaronHuey_2010X 4.0 6.0 <o,f0,female> script3\n",
+    "AaronHuey_2010X 1 AaronHuey_2010X 6.0 8.0 <o,f0,female> script4\n",
+    "AaronHuey_2010X 1 AaronHuey_2010X 8.0 10.0 <o,f0,female> script5\n",
+]
+
+
+class TestTedlium(TempDirMixin, TorchaudioTestCase):
+    backend = "default"
+
+    root_dir = None
+    samples = []
+
+    @classmethod
+    def setUpClass(cls):
+        cls.root_dir = cls.get_base_temp_dir()
+        cls.root_dir = dataset_dir = os.path.join(cls.root_dir, "tedlium")
+        os.makedirs(dataset_dir, exist_ok=True)
+        sample_rate = 16000  # 16kHz
+        seed = 0
+        data = get_whitenoise(sample_rate=sample_rate, duration=10.00, n_channels=1, dtype="float32", seed=seed)
+        for release in ["release1", "release2", "release3"]:
+            if release in ["release1", "release2"]:
+                release_dir = os.path.join(
+                    dataset_dir,
+                    tedlium._RELEASE_CONFIGS[release]["folder_in_archive"],
+                    tedlium._RELEASE_CONFIGS[release]["subset"],
+                )
+            else:
+                release_dir = os.path.join(dataset_dir, tedlium._RELEASE_CONFIGS[release]["folder_in_archive"])
+            os.makedirs(release_dir, exist_ok=True)
+            os.makedirs(os.path.join(release_dir, "stm"), exist_ok=True)  # Subfolder for transcripts
+            os.makedirs(os.path.join(release_dir, "sph"), exist_ok=True)  # Subfolder for audio files
+            filename = f"{release}.sph"
+            path = os.path.join(os.path.join(release_dir, "sph"), filename)
+            save_wav(path, data, sample_rate)
+
+            trans_filename = f"{release}.stm"
+            trans_path = os.path.join(os.path.join(release_dir, "stm"), trans_filename)
+            with open(trans_path, "w") as f:
+                f.write("".join(UTTERANCES))
+
+        # Create a samples list to compare with
+        for i, utterance in enumerate(UTTERANCES):
+            talk_id, _, speaker_id, start_time, end_time, identifier, transcript = utterance.split(" ", 6)
+            start_time = int(float(start_time)) * 16000
+            end_time = int(float(end_time)) * 16000
+            sample = (
+                data[:, start_time:end_time],
+                sample_rate,
+                transcript,
+                talk_id,
+                speaker_id,
+                identifier,
+            )
+            cls.samples.append(sample)
+
+    @classmethod
+    def tearDownClass(cls):
+        # In case of test failure
+        tedlium.TEDLIUM._ext_audio = ".flac"
+
+    def test_tedlium(self):
+        tedlium.TEDLIUM._ext_audio = ".wav"
+        dataset = tedlium.TEDLIUM(self.root_dir)
+        print(dataset._path)
+        num_samples = 0
+        for i, (data, sample_rate, transcript, talk_id, speaker_id, identifier) in enumerate(dataset):
+            self.assertEqual(data, self.samples[i][0], atol=5e-5, rtol=1e-8)
+            assert sample_rate == self.samples[i][1]
+            assert transcript == self.samples[i][2]
+            assert talk_id == self.samples[i][3]
+            assert speaker_id == self.samples[i][4]
+            assert identifier == self.samples[i][5]
+            num_samples += 1
+
+        assert num_samples == len(self.samples)
+        tedlium.TEDLIUM._ext_audio = ".flac"

--- a/test/torchaudio_unittest/datasets/tedlium_test.py
+++ b/test/torchaudio_unittest/datasets/tedlium_test.py
@@ -62,7 +62,7 @@ class TestTedlium(TempDirMixin, TorchaudioTestCase):
 
             # Create a samples list to compare with
             cls.samples[release] = []
-            for i, utterance in enumerate(UTTERANCES):
+            for utterance in UTTERANCES:
                 talk_id, _, speaker_id, start_time, end_time, identifier, transcript = utterance.split(" ", 6)
                 start_time = int(float(start_time)) * sample_rate
                 end_time = int(float(end_time)) * sample_rate

--- a/torchaudio/datasets/__init__.py
+++ b/torchaudio/datasets/__init__.py
@@ -8,6 +8,7 @@ from .yesno import YESNO
 from .ljspeech import LJSPEECH
 from .cmuarctic import CMUARCTIC
 from .libritts import LIBRITTS
+from .tedlium import TEDLIUM
 
 __all__ = (
     "COMMONVOICE",
@@ -18,7 +19,8 @@ __all__ = (
     "LJSPEECH",
     "GTZAN",
     "CMUARCTIC",
-    "LIBRITTS"
+    "LIBRITTS",
     "diskcache_iterator",
     "bg_iterator",
+    "TEDLIUM",
 )

--- a/torchaudio/datasets/tedlium.py
+++ b/torchaudio/datasets/tedlium.py
@@ -57,7 +57,7 @@ class TEDLIUM(Dataset):
         Args:
             root (str): Path containing dataset or target path where its downloaded if needed
             release (str, optional): TEDLIUM identifier (release1,release2,release3). Defaults to RELEASE.
-            subset (str, optional): Subset of data(train,test,dev) supported for release 1 and 2. Defaults to Train/None.
+            subset (str, optional): Subset of data(train,test,dev) supported for release 1,2. Defaults to Train/None.
             download (bool, optional): Download dataset in case is not founded in root path. Defaults to False.
             audio_ext (str, optional): Overwrite audio extension when loading items. Defaults to ".sph".
 

--- a/torchaudio/datasets/tedlium.py
+++ b/torchaudio/datasets/tedlium.py
@@ -105,7 +105,7 @@ class TEDLIUM(Dataset):
             identifier,
         )
 
-    def load_audio(self, path: str) -> Tensor:
+    def load_audio(self, path: str) -> [Tensor, int]:
         return torchaudio.load(path)
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, int, int, int]:

--- a/torchaudio/datasets/tedlium.py
+++ b/torchaudio/datasets/tedlium.py
@@ -105,7 +105,7 @@ class TEDLIUM(Dataset):
             identifier,
         )
 
-    def load_audio(self, path: str) -> [Tensor]:
+    def load_audio(self, path: str) -> Tensor:
         return torchaudio.load(path)
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, int, int, int]:

--- a/torchaudio/datasets/tedlium.py
+++ b/torchaudio/datasets/tedlium.py
@@ -9,6 +9,8 @@ from torchaudio.datasets.utils import (
     extract_archive,
     walk_files,
 )
+from collections import namedtuple
+
 
 RELEASE = "release1"  # Default release
 
@@ -16,38 +18,53 @@ _RELEASE_CONFIGS = {
     "release1": {
         "folder_in_archive": "TEDLIUM_release1",
         "url": "http://www.openslr.org/resources/7/TEDLIUM_release1.tar.gz",
-        "checksum": "ffd31f96d81a21bf4928eaf9bb0b0c2dea7a5247",
+        "checksum": "30301975fd8c5cac4040c261c0852f57cfa8adbbad2ce78e77e4986957445f27",
         "data_path": "",
         "subset": "train",
     },
     "release2": {
         "folder_in_archive": "TEDLIUM_release2",
         "url": "http://www.openslr.org/resources/19/TEDLIUM_release2.tar.gz",
-        "checksum": "5c8fb045246d1c64296f57b47aa7dc79d16b184f",
+        "checksum": "93281b5fcaaae5c88671c9d000b443cb3c7ea3499ad12010b3934ca41a7b9c58",
         "data_path": "",
         "subset": "train",
     },
     "release3": {
         "folder_in_archive": "TEDLIUM_release-3",
         "url": "http://www.openslr.org/resources/51/TEDLIUM_release-3.tgz",
-        "checksum": "685d27c39c53217383d7933cc405a07048004127",
+        "checksum": "ad1e454d14d1ad550bc2564c462d87c7a7ec83d4dc2b9210f22ab4973b9eccdb",
         "data_path": "data/",
         "subset": None,
     },
 }
 
+Tedlium_item = namedtuple(
+    "Tedlium_item", ["waveform", "sample_rate", "transcript", "talk_id", "speaker_id", "identifier"]
+)
+
 
 class TEDLIUM(Dataset):
     """
     Create a Dataset for Tedlium. Each item is a tuple of the form:
-    waveform, sample_rate, utterance, speaker_id, chapter_id, utterance_id
+    [waveform, sample_rate, transcript, talk_id, speaker_id, identifier]
     """
 
-    _ext_txt = ".stm"
-    _ext_audio = ".sph"
+    def __init__(
+        self, root: str, release: str = RELEASE, subset: str = None, download: bool = False, audio_ext=".sph"
+    ) -> None:
+        """Constructor for TEDLIUM dataset
 
-    def __init__(self, root: str, release: str = RELEASE, subset: str = None, download: bool = False) -> None:
+        Args:
+            root (str): Path containing dataset or target path where its downloaded if needed
+            release (str, optional): TEDLIUM identifier (release1,release2,release3). Defaults to RELEASE.
+            subset (str, optional): Subset of data(train,test,dev) supported for release 1 and 2. Defaults to Train/None.
+            download (bool, optional): Download dataset in case is not founded in root path. Defaults to False.
+            audio_ext (str, optional): Overwrite audio extension when loading items. Defaults to ".sph".
 
+        Raises:
+            RuntimeError: If release identifier does not match any supported release,
+        """
+        self._ext_audio = audio_ext
         if release in _RELEASE_CONFIGS.keys():
             folder_in_archive = _RELEASE_CONFIGS[release]["folder_in_archive"]
             url = _RELEASE_CONFIGS[release]["url"]
@@ -75,18 +92,28 @@ class TEDLIUM(Dataset):
                     download_url(url, root, hash_value=checksum)
                 extract_archive(archive)
 
-        walker = walk_files(self._path, suffix=self._ext_txt, prefix=False, remove_suffix=True)
+        walker = walk_files(self._path, suffix=".stm", prefix=False, remove_suffix=True)
         self._walker = list(walker)
         self._extended_walker = []
         for file in self._walker:
-            stm_path = os.path.join(self._path, "stm", file + self._ext_txt)
+            stm_path = os.path.join(self._path, "stm", file + ".stm")
             with open(stm_path) as f:
                 l = len(f.readlines())
                 self._extended_walker += [(file, line) for line in range(l)]
 
-    def load_tedlium_item(self, fileid: str, line: int, path: str) -> Tuple[Tensor, int, str, int, int, int]:
+    def load_tedlium_item(self, fileid: str, line: int, path: str) -> Tedlium_item:
+        """Loads a TEDLIUM dataset sample given a file name and corresponding sentence name
+
+        Args:
+            fileid (str): File id to identify both text and audio files corresponding to the sample
+            line (int): Line identifier for the sample inside the text file
+            path (str): Dataset root path
+
+        Returns:
+            Tedlium_item: A namedTuple containing [waveform, sample_rate, transcript, talk_id, speaker_id, identifier]
+        """
         transcript_path = os.path.join(path, "stm", fileid)
-        with open(transcript_path + self._ext_txt) as f:
+        with open(transcript_path + ".stm") as f:
             transcript = f.readlines()[line]
             talk_id, _, speaker_id, start_time, end_time, identifier, transcript = transcript.split(" ", 6)
 
@@ -96,21 +123,36 @@ class TEDLIUM(Dataset):
         start_time = int(float(start_time) * sample_rate)
         end_time = int(float(end_time) * sample_rate)
         waveform = waveform[:, start_time:end_time]
-        return (
-            waveform,
-            sample_rate,
-            transcript,
-            talk_id,
-            speaker_id,
-            identifier,
-        )
+        return Tedlium_item(waveform, sample_rate, transcript, talk_id, speaker_id, identifier)
 
     def load_audio(self, path: str) -> [Tensor, int]:
+        """Default load function used in TEDLIUM dataset, you can overwrite this function to customize functionality
+
+        Args:
+            path (str): Path to audio file
+
+        Returns:
+            [Tensor, int]: Audio tensor representation and sample rate
+        """
         return torchaudio.load(path)
 
-    def __getitem__(self, n: int) -> Tuple[Tensor, int, str, int, int, int]:
+    def __getitem__(self, n: int) -> Tedlium_item:
+        """TEDLIUM dataset custom function overwritting default loadbehaviour.
+        Loads a TEDLIUM sample given a index N
+
+        Args:
+            n (int): Index of sample to be loaded
+
+        Returns:
+            Tedlium_item: A namedTuple containing [waveform, sample_rate, transcript, talk_id, speaker_id, identifier]
+        """
         fileid, line = self._extended_walker[n]
         return self.load_tedlium_item(fileid, line, self._path)
 
     def __len__(self) -> int:
+        """DTEDLIUM dataset custom function overwritting len default behaviour.
+
+        Returns:
+            int: TEDLIUM dataset length
+        """
         return len(self._extended_walker)

--- a/torchaudio/datasets/tedlium.py
+++ b/torchaudio/datasets/tedlium.py
@@ -128,7 +128,8 @@ class TEDLIUM(Dataset):
                     file = file.replace(".stm", "")
                     self._filelist.extend((file, line) for line in range(l))
         # Create dict path for later read
-        self.dict_path = os.path.join(root, folder_in_archive, _RELEASE_CONFIGS[release]["dict"])
+        self._dict_path = os.path.join(root, folder_in_archive, _RELEASE_CONFIGS[release]["dict"])
+        self._phoneme_dict = None
 
     def _load_tedlium_item(self, fileid: str, line: int, path: str) -> Tuple[Tensor, int, str, int, int, int]:
         """Loads a TEDLIUM dataset sample given a file name and corresponding sentence name
@@ -190,6 +191,7 @@ class TEDLIUM(Dataset):
         """
         return len(self._filelist)
 
+    @property
     def get_phoneme_dict(self):
         """Returns the phoneme dictionary of a TEDLIUM release
 
@@ -197,10 +199,10 @@ class TEDLIUM(Dataset):
             dictionary: Phoneme dictionary for the current tedlium release
         """
         # Read phoneme dictionary
-        if not hasattr(self, "phoneme_dict"):
-            self.phoneme_dict = {}
+        if not self._phoneme_dict:
+            self._phoneme_dict = {}
             with open(self.dict_path, "r", encoding="utf-8") as f:
                 for line in f.readlines():
                     content = line.strip().split(maxsplit=1)
-                    self.phoneme_dict[content[0]] = content[1:]  # content[1:] can be empty list
-        return self.phoneme_dict
+                    self._phoneme_dict[content[0]] = content[1:]  # content[1:] can be empty list
+        return self._phoneme_dict.copy()

--- a/torchaudio/datasets/tedlium.py
+++ b/torchaudio/datasets/tedlium.py
@@ -1,0 +1,133 @@
+import os
+from typing import Tuple
+
+import torchaudio
+from torch import Tensor
+from torch.utils.data import Dataset
+from torchaudio.datasets.utils import (
+    download_url,
+    extract_archive,
+    walk_files,
+)
+
+RELEASE = "release1"  # Default release
+
+_RELEASE_CONFIGS = {
+    "release1": {
+        "folder_in_archive": "TEDLIUM_release1",
+        "url": "http://www.openslr.org/resources/7/TEDLIUM_release1.tar.gz",
+        "checksum": "ffd31f96d81a21bf4928eaf9bb0b0c2dea7a5247",
+        "data_path": "",
+        "subset": "train",
+    },
+    "release2": {
+        "folder_in_archive": "TEDLIUM_release2",
+        "url": "http://www.openslr.org/resources/19/TEDLIUM_release2.tar.gz",
+        "checksum": "5c8fb045246d1c64296f57b47aa7dc79d16b184f",
+        "data_path": "",
+        "subset": "train",
+    },
+    "release3": {
+        "folder_in_archive": "TEDLIUM_release-3",
+        "url": "http://www.openslr.org/resources/51/TEDLIUM_release-3.tgz",
+        "checksum": "685d27c39c53217383d7933cc405a07048004127",
+        "data_path": "data/",
+        "subset": None,
+    },
+}
+
+
+def load_tedlium_item(
+    fileid: str, line: int, path: str, ext_audio: str, ext_txt: str
+) -> Tuple[Tensor, int, str, int, int, int]:
+    transcript_path = os.path.join(path, "stm/", fileid)
+    with open(transcript_path + ext_txt) as f:
+        transcript = f.readlines()[line]
+        talk_id, _, speaker_id, start_time, end_time, identifier, transcript = transcript.split(
+            " ", 6
+        )
+
+    wave_path = os.path.join(path, "sph/", fileid)
+    waveform, sample_rate = torchaudio.load(wave_path + ext_audio)
+    print(wave_path + ext_audio)
+    # Calculate indexes for start time and endtime
+    start_time = int(float(start_time) * sample_rate)
+    end_time = int(float(end_time) * sample_rate)
+    print(start_time, end_time)
+    waveform = waveform[:, start_time:end_time]
+    return (
+        waveform,
+        sample_rate,
+        transcript,
+        talk_id,
+        speaker_id,
+        identifier,
+        transcript,
+    )
+
+
+class TEDLIUM(Dataset):
+    """
+    Create a Dataset for Tedlium. Each item is a tuple of the form:
+    waveform, sample_rate, utterance, speaker_id, chapter_id, utterance_id
+    """
+
+    _ext_txt = ".stm"
+    _ext_audio = ".sph"
+    _folder_audio = "sph/"
+    _folder_txt = "stm/"
+
+    def __init__(
+        self,
+        root: str,
+        release: str = RELEASE,
+        subset: str = None,
+        folder_in_archive: str = _RELEASE_CONFIGS[RELEASE]["folder_in_archive"],
+        download: bool = False,
+    ) -> None:
+
+        if release in _RELEASE_CONFIGS.keys():
+            folder_in_archive = _RELEASE_CONFIGS[release]["folder_in_archive"]
+            url = _RELEASE_CONFIGS[release]["url"]
+            subset = subset if subset else _RELEASE_CONFIGS[release]["subset"]
+        else:
+            # Raise warning
+            raise RuntimeError(
+                "The release {} does not match any of the supported tedlium releases{} ".format(
+                    filepath, _RELEASE_CONFIGS.keys(),
+                )
+            )
+
+        basename = os.path.basename(url)
+        archive = os.path.join(root, basename)
+
+        basename = basename.split(".")[0]
+
+        self._path = os.path.join(root, folder_in_archive, _RELEASE_CONFIGS[release]["data_path"])
+        if subset in ["train", "dev", "test"]:
+            self._path = os.path.join(self._path, subset + "/")
+        if download:
+            if not os.path.isdir(self._path):
+                if not os.path.isfile(archive):
+                    checksum = _CHECKSUMS.get(url, None)
+                    download_url(url, root, hash_value=checksum)
+                extract_archive(archive)
+
+        walker = walk_files(self._path, suffix=self._ext_txt, prefix=False, remove_suffix=True)
+        self._walker = list(walker)
+        self._extended_walker = []
+        for file in self._walker:
+            stm_path = os.path.join(self._path, self._folder_txt, file + self._ext_txt)
+            with open(stm_path) as f:
+                l = len(f.readlines())
+                self._extended_walker += [(file, line) for line in range(l)]
+
+    def __getitem__(self, n: int) -> Tuple[Tensor, int, str, int, int, int]:
+        fileid, line = self._extended_walker[n]
+        return load_tedlium_item(fileid, line, self._path, self._ext_audio, self._ext_txt)
+
+    def __len__(self) -> int:
+        return len(self._extended_walker)
+
+    def _getdict(self):
+        return 1

--- a/torchaudio/datasets/tedlium.py
+++ b/torchaudio/datasets/tedlium.py
@@ -164,8 +164,8 @@ class TEDLIUM(Dataset):
         Returns:
             [Tensor, int]: Audio tensor representation and sample rate
         """
-        start_time = int(float(start_time) * 16000)
-        end_time = int(float(end_time) * 16000)
+        start_time = int(float(start_time) * sample_rate)
+        end_time = int(float(end_time) * sample_rate)
         if torchaudio.get_audio_backend() == "sox_io":
             return torchaudio.load(path, frame_offset=start_time, num_frames=end_time - start_time)
         return torchaudio.load(path)[:, start_time:end_time]
@@ -201,8 +201,8 @@ class TEDLIUM(Dataset):
         # Read phoneme dictionary
         if not self._phoneme_dict:
             self._phoneme_dict = {}
-            with open(self.dict_path, "r", encoding="utf-8") as f:
+            with open(self._dict_path, "r", encoding="utf-8") as f:
                 for line in f.readlines():
-                    content = line.strip().split(maxsplit=1)
+                    content = line.strip().split()
                     self._phoneme_dict[content[0]] = tuple(content[1:])  # content[1:] can be empty list
         return self._phoneme_dict.copy()

--- a/torchaudio/datasets/tedlium.py
+++ b/torchaudio/datasets/tedlium.py
@@ -44,7 +44,7 @@ _RELEASE_CONFIGS = {
 class TEDLIUM(Dataset):
     """
     Create a Dataset for Tedlium. It supports releases 1,2 and 3, each item is a list containings:
-    [waveform, sample_rate, transcript, talk_id, speaker_id, identifier]
+    [waveform, sample_rate, transcript, talk_id, speaker_id, identifier].
 
     Constructor arguments:
 
@@ -69,7 +69,7 @@ class TEDLIUM(Dataset):
     def __init__(
         self, root: str, release: str = "release1", subset: str = None, download: bool = False, audio_ext=".sph"
     ) -> None:
-        """Constructor for TEDLIUM dataset
+        """Constructor for TEDLIUM dataset.
 
         Args:
             root (str): Path containing dataset or target path where its downloaded if needed
@@ -132,7 +132,7 @@ class TEDLIUM(Dataset):
         self._phoneme_dict = None
 
     def _load_tedlium_item(self, fileid: str, line: int, path: str) -> Tuple[Tensor, int, str, int, int, int]:
-        """Loads a TEDLIUM dataset sample given a file name and corresponding sentence name
+        """Loads a TEDLIUM dataset sample given a file name and corresponding sentence name.
 
         Args:
             fileid (str): File id to identify both text and audio files corresponding to the sample
@@ -154,7 +154,7 @@ class TEDLIUM(Dataset):
 
     def _load_audio(self, path: str, start_time: float, end_time: float, sample_rate: int = 16000) -> [Tensor, int]:
         """Default load function used in TEDLIUM dataset, you can overwrite this function to customize functionality
-        and load individual sentences from a full ted audio talk file
+        and load individual sentences from a full ted audio talk file.
 
         Args:
             path (str): Path to audio file
@@ -171,8 +171,8 @@ class TEDLIUM(Dataset):
         return torchaudio.load(path)[:, start_time:end_time]
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, int, int, int]:
-        """TEDLIUM dataset custom function overwritting default loadbehaviour.
-        Loads a TEDLIUM sample given a index N
+        """TEDLIUM dataset custom function overwritting default loadbehaviour
+        Loads a TEDLIUM sample given a index N.
 
         Args:
             n (int): Index of sample to be loaded
@@ -184,7 +184,7 @@ class TEDLIUM(Dataset):
         return self._load_tedlium_item(fileid, line, self._path)
 
     def __len__(self) -> int:
-        """DTEDLIUM dataset custom function overwritting len default behaviour.
+        """TEDLIUM dataset custom function overwritting len default behaviour.
 
         Returns:
             int: TEDLIUM dataset length
@@ -192,8 +192,8 @@ class TEDLIUM(Dataset):
         return len(self._filelist)
 
     @property
-    def get_phoneme_dict(self):
-        """Returns the phoneme dictionary of a TEDLIUM release
+    def phoneme_dict(self):
+        """Returns the phoneme dictionary of a TEDLIUM release.
 
         Returns:
             dictionary: Phoneme dictionary for the current tedlium release
@@ -204,5 +204,5 @@ class TEDLIUM(Dataset):
             with open(self.dict_path, "r", encoding="utf-8") as f:
                 for line in f.readlines():
                     content = line.strip().split(maxsplit=1)
-                    self._phoneme_dict[content[0]] = content[1:]  # content[1:] can be empty list
+                    self._phoneme_dict[content[0]] = tuple(content[1:])  # content[1:] can be empty list
         return self._phoneme_dict.copy()


### PR DESCRIPTION
Hi!

So this is my pull request for adding tedlium support (all 3 releases of tedlium) reference to https://github.com/pytorch/audio/issues/765.

The code is not yet finished (still need to add test, read the phonetic dictionaries of each release, proper formatting) but I wanted to create the PR to get some feedback on the way I read/iterate tedlium files and if the torchaudio manteiners are okay with it or have an idea on how to improve it. This way I make sure the core of the datasetloader is good to merge and I can start working on the test or change it before coding the tests. I will explain how I iterate through the dataset now.

Tedlium dataset (all releases) is composed of `.sph` and `.stm` files. These files are divided in the root folder in two different folders:
```
sph/
stm/
```

Each `.stm` file contains the transcripts for a FULL tedtalk and while the brother audio `.sph` file contains the audio for the FULL tedtalk as well. 

Since this dataset is used in speech recognition, people don't train in full tedtalk audios but rather split into sentences. Each sentence corresponds to a line in the `.stm` file. This means that a `.stm` file contains as many training samples as lines inside the file. 


The previous datasets that I found in torchaudio didn't encounter this case and treated every transcript file as a sample, so I had to make a small change to the `self._walker` used in the datasets. I created a new `self._extended_walker` list that contains as many occurrences of a `.stm` file with its line number as lines this file has, so for example if we had two stm files A (5 lines/5 samples) and B (3 lines/3 samples) `self._extended_walker` will look like this:
```
self._extended_walker = [[A,0],[A,1],[A,2],[A,3],[A,4],[B,0,][B,1]]
```

And every time we load an item `i` of the dataset we will index this `_extended_walker` where we retrieve the file containing the sample and the corresponding line, the line contains the transcript and start time,end time of the audio file corresponding to the audio file. With all of this information we can load the line transcript and corresponding subaudio from the full ted talk.


This will allow the dataset to work as any other torchaudio datasets(being able to run sequentially or shuffling it). Looks great right? Then why I am checking with the maintainers if this is a good idea?

Well, in order to create this `_extended_walker` list we have to read how many lines each of our `.stm` file has while initializing the dataset, causing a "not optimal I/O operation". The operation happens in 119-123:
```python
for file in self._walker:
    stm_path = os.path.join(self._path, self._folder_txt, file + self._ext_txt)
    with open(stm_path) as f:
        l = len(f.readlines())
        self._extended_walker += [(file, line) for line in range(l)]
```

Is fast enough to not represent any downside for the user
![image](https://user-images.githubusercontent.com/10882086/90311697-1692cb80-defe-11ea-9c62-2165a831e20d.png)
(release 3 contains the higher number of files)

I'm open for edits and suggestions on the implementation of the TEDLIUM dataset and please notice is still a work in progress.



## Things that still need work:
* `_getdict` function to return the phonems dictionary of the dataset
* Several test for the dataset and different releases.
* Upload my notebook where I play with the dataset object to show the functionality for reviewers
* Better styling and compliance with the rest of torchaudio code

Thanks