### PR TITLE
Remove default compression level test for mp3

### DIFF
--- a/test/torchaudio_unittest/sox_io_backend/save_test.py
+++ b/test/torchaudio_unittest/sox_io_backend/save_test.py
@@ -235,7 +235,7 @@ class TestSave(SaveTestBase):
     @parameterized.expand(list(itertools.product(
         [8000, 16000],
         [1, 2],
-        [None, -4.2, -0.2, 0, 0.2, 96, 128, 160, 192, 224, 256, 320],
+        [-4.2, -0.2, 0, 0.2, 96, 128, 160, 192, 224, 256, 320],
     )), name_func=name_func)
     def test_mp3(self, sample_rate, num_channels, bit_rate):
         """`sox_io_backend.save` can save mp3 format."""


### PR DESCRIPTION
Looks like `sox` command is doing something elaborated for filing the default compression value for `mp3` and cannot find a way to recreate the exact behavior. So removing the test for consistency for default compression value.