### PR TITLE
fix resample type hint

### DIFF
--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -567,8 +567,8 @@ class Resample(torch.nn.Module):
     """
 
     def __init__(self,
-                 orig_freq: int = 16000,
-                 new_freq: int = 16000,
+                 orig_freq: float = 16000,
+                 new_freq: float = 16000,
                  resampling_method: str = 'sinc_interpolation') -> None:
         super(Resample, self).__init__()
         self.orig_freq = orig_freq


### PR DESCRIPTION
As indicated in the docstrings, the sample rates would need to be `float`. I also discovered that using `int` can result in an error

```
  File "/Users/faro/repositories/open-unmix-pytorch-dev/env/lib/python3.7/site-packages/torch/nn/modules/module.py", line 722, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/Users/faro/repositories/open-unmix-pytorch-dev/env/lib/python3.7/site-packages/torchaudio/transforms.py", line 596, in forward
    waveform = kaldi.resample_waveform(waveform, self.orig_freq, self.new_freq)
  File "/Users/faro/repositories/open-unmix-pytorch-dev/env/lib/python3.7/site-packages/torchaudio/compliance/kaldi.py", line 930, in resample_waveform
    window_width, lowpass_cutoff, lowpass_filter_width, device, dtype)
  File "/Users/faro/repositories/open-unmix-pytorch-dev/env/lib/python3.7/site-packages/torchaudio/compliance/kaldi.py", line 807, in _get_LR_indices_and_weights
    assert lowpass_cutoff < min(orig_freq, new_freq) / 2
RuntimeError: Integer division of tensors using div or / is no longer supported, and in a future release div will perform true division as in Python 3. Use true_divide or floor_divide (// in Python) instead.

```