### PR TITLE
.circleci: Bump xcode workers to 9.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
   binary_macos_wheel:
     <<: *binary_common
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
     steps:
       - checkout
       - install_build_tools_macos
@@ -176,7 +176,7 @@ jobs:
   binary_macos_conda:
     <<: *binary_common
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
     steps:
       - checkout
       - install_build_tools_macos
@@ -537,7 +537,7 @@ jobs:
   unittest_macos_cpu:
     <<: *binary_common
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
     resource_class: large
     steps:
       - checkout

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -151,7 +151,7 @@ jobs:
   binary_macos_wheel:
     <<: *binary_common
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
     steps:
       - checkout
       - install_build_tools_macos
@@ -176,7 +176,7 @@ jobs:
   binary_macos_conda:
     <<: *binary_common
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
     steps:
       - checkout
       - install_build_tools_macos
@@ -537,7 +537,7 @@ jobs:
   unittest_macos_cpu:
     <<: *binary_common
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
     resource_class: large
     steps:
       - checkout

--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -1,3 +1,4 @@
+# a comment for these trying times
 channels:
   - conda-forge
   - defaults


### PR DESCRIPTION
Upstream is on 9.4.1 and we were experiencing issues when conda-build
was attempting to check for overlinking and failed out due to some files
not existing in xcode 9.0

Should fix issues for macOS builds

Similar to https://github.com/pytorch/vision/pull/2633

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>