### PR TITLE
packaging: Use cpu directory by default

### DIFF
--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -32,7 +32,7 @@ setup_cuda() {
   # First, compute version suffixes.  By default, assume no version suffixes
   export VERSION_SUFFIX=""
   export PYTORCH_VERSION_SUFFIX=""
-  export WHEEL_DIR=""
+  export WHEEL_DIR="cpu/"
   # Wheel builds need suffixes (but not if they're on OS X, which never has suffix)
   if [[ "$BUILD_TYPE" == "wheel" ]] && [[ "$(uname)" != Darwin ]]; then
     # The default CUDA has no suffix


### PR DESCRIPTION
Default to using the `cpu` directory since the base one is not reliable

similar to https://github.com/pytorch/text/pull/981

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>