### PR TITLE
Issue warning when a Mel filter bank bin is empty

### DIFF
--- a/test/torchaudio_unittest/functional/functional_cpu_test.py
+++ b/test/torchaudio_unittest/functional/functional_cpu_test.py
@@ -21,6 +21,23 @@ class TestLFilterFloat64(Lfilter, common_utils.PytorchTestCase):
     device = torch.device('cpu')
 
 
+class TestCreateFBMatrix(common_utils.TorchaudioTestCase):
+    def test_no_warning_high_n_freq(self):
+        with pytest.warns(None) as w:
+            F.create_fb_matrix(288, 0, 8000, 128, 16000)
+        assert len(w) == 0
+
+    def test_no_warning_low_n_mels(self):
+        with pytest.warns(None) as w:
+            F.create_fb_matrix(201, 0, 8000, 89, 16000)
+        assert len(w) == 0
+
+    def test_warning(self):
+        with pytest.warns(None) as w:
+            F.create_fb_matrix(201, 0, 8000, 128, 16000)
+        assert len(w) == 1
+
+
 class TestComputeDeltas(common_utils.TorchaudioTestCase):
     """Test suite for correctness of compute_deltas"""
     def test_one_channel(self):

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -315,9 +315,9 @@ def create_fb_matrix(
 
     if (fb.max(dim=0).values == 0.).any():
         warnings.warn(
-            "At least one mel filterbank has all zero values."
-            "The value for `n_mels` ({}) may be set too high."
-            "Or, the value for `n_freqs` ({}) may be set too low.".format(n_mels, n_freqs)
+            "At least one mel filterbank has all zero values. "
+            f"The value for `n_mels` ({n_mels}) may be set too high. "
+            f"Or, the value for `n_freqs` ({n_freqs}) may be set too low."
         )
 
     return fb

--- a/torchaudio/functional.py
+++ b/torchaudio/functional.py
@@ -313,6 +313,13 @@ def create_fb_matrix(
         enorm = 2.0 / (f_pts[2:n_mels + 2] - f_pts[:n_mels])
         fb *= enorm.unsqueeze(0)
 
+    if (fb.max(dim=0).values == 0.).any():
+        warnings.warn(
+            "At least one mel filterbank has all zero values."
+            "The value for `n_mels` ({}) may be set too high."
+            "Or, the value for `n_freqs` ({}) may be set too low.".format(n_mels, n_freqs)
+        )
+
     return fb
 
 


### PR DESCRIPTION
The default parameters for creating Mel filterbanks can result in some mel features always being zero.
This PR is to warn that this is occurring.

This resembles the following issue:
https://github.com/librosa/librosa/issues/478

The unit tests can be run as follow:
```
pytest -k TestCreateFBMatrix test/torchaudio_unittest/functional/functional_cpu_test.py
```