### PR TITLE
[CI] Disable xdist in macOS unittest in CI

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -7,7 +7,6 @@ dependencies:
   - numpy >= 1.11
   - pytest
   - pytest-cov
-  - pytest-xdist
   - codecov
   - librosa>=0.8.0
   - llvmlite==0.31  # See https://github.com/pytorch/audio/pull/766

--- a/.circleci/unittest/linux/scripts/run_test.sh
+++ b/.circleci/unittest/linux/scripts/run_test.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-case "$(uname -s)" in
-    Darwin*) os=MacOSX;;
-    *) os=Linux
-esac
-
-
 eval "$(./conda/bin/conda shell.bash hook)"
 conda activate ./env
 
@@ -15,15 +9,12 @@ python -m torch.utils.collect_env
 export TORCHAUDIO_TEST_FAIL_IF_NO_EXTENSION=1
 export PATH="${PWD}/third_party/install/bin/:${PATH}"
 
-declare -a common_args=(
+declare -a args=(
+    '-v'
     '--cov=torchaudio'
     "--junitxml=${PWD}/test-results/junit.xml"
     '--durations' '20'
 )
-if [ "${os}" == MacOSX ] ; then
-    declare -a args=('-q' '-n' 'auto' '--dist=loadscope')
-else
-    declare -a args=('-v')
-fi
+
 cd test
-pytest "${args[@]}" "${common_args[@]}" torchaudio_unittest
+pytest "${args[@]}" torchaudio_unittest


### PR DESCRIPTION
This reverts commit 1ecbc249b5eed3a2e0e765ac0046e2bf9c231884.

Reason: The macOS CI jobs are stuck with xdist recently.

**Note** some macOS CI unittest jobs are still failing at environment setup which is not caused by this PR and is going to be fixed by a separate PR. 