### PR TITLE
move deprecation from class to class.__init__

### DIFF
--- a/torchaudio/_internal/module_utils.py
+++ b/torchaudio/_internal/module_utils.py
@@ -37,17 +37,26 @@ def requires_module(*modules: str):
     return decorator
 
 
-def deprecated(direction: str, version: Optional[str] = None):
+def deprecated(direction: str,
+               version: Optional[str] = None,
+               name: Optional[str] = None,
+              ):
     """Decorator to add deprecation message
 
     Args:
         direction: Migration steps to be given to users.
+        version: Version deprecation will be completed
+        name: Object name to be deprected, defaults to func.__name__
     """
     def decorator(func):
+        if name:
+            func._warn_name = name
+        else:
+            func._warn_name = func.__name__
         @wraps(func)
         def wrapped(*args, **kwargs):
             message = (
-                f'{func.__module__}.{func.__name__} has been deprecated '
+                f'{func.__module__}.{func._warn_name} has been deprecated '
                 f'and will be removed from {"future" if version is None else version} release. '
                 f'{direction}')
             warnings.warn(message, stacklevel=2)

--- a/torchaudio/sox_effects/sox_effects.py
+++ b/torchaudio/sox_effects/sox_effects.py
@@ -275,7 +275,6 @@ def SoxEffect():
     return _torchaudio.SoxEffect()
 
 
-@_mod_utils.deprecated('Please migrate to `apply_effects_file` or `apply_effects_tensor`.')
 class SoxEffectsChain(object):
     r"""SoX effects chain class.
 
@@ -333,6 +332,8 @@ class SoxEffectsChain(object):
 
     EFFECTS_UNIMPLEMENTED = {"spectrogram", "splice", "noiseprof", "fir"}
 
+    @_mod_utils.deprecated('Please migrate to `apply_effects_file` or '
+                           '`apply_effects_tensor`.', name='SoxEffectsChain')
     def __init__(self,
                  normalization: Union[bool, float, Callable] = True,
                  channels_first: bool = True,


### PR DESCRIPTION
Adding the deprecation decorator turns a class into a function. Move it to the `__init__` method instead. This requires specifying the class name, otherwise the warning prints the `__init__` method. 

Because `@wraps` messes with the local namespace, hide the `name` on a "private" attribute.