### PR TITLE
Make removal version explicit for sox deprecations

### DIFF
--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -37,7 +37,8 @@ except ImportError:
 
 @_mod_utils.deprecated(
     "Please remove the function call to initialize_sox. "
-    "Resource initialization is now automatically handled.")
+    "Resource initialization is now automatically handled.",
+    "0.8.0")
 def initialize_sox():
     """Initialize sox effects.
 
@@ -50,7 +51,8 @@ def initialize_sox():
     "Please remove the function call to torchaudio.shutdown_sox. "
     "Resource clean up is now automatically handled. "
     "In the unlikely event that you need to manually shutdown sox, "
-    "please use torchaudio.sox_effects.shutdown_sox_effects.")
+    "please use torchaudio.sox_effects.shutdown_sox_effects.",
+    "0.8.0")
 def shutdown_sox():
     """Shutdown sox effects.
 

--- a/torchaudio/sox_effects/sox_effects.py
+++ b/torchaudio/sox_effects/sox_effects.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Callable, List, Optional, Tuple, Union
 
 import torch
@@ -275,7 +276,6 @@ def SoxEffect():
     return _torchaudio.SoxEffect()
 
 
-@_mod_utils.deprecated('Please migrate to `apply_effects_file` or `apply_effects_tensor`.', "0.8.0")
 class SoxEffectsChain(object):
     r"""SoX effects chain class.
 
@@ -339,6 +339,11 @@ class SoxEffectsChain(object):
                  out_siginfo: Any = None,
                  out_encinfo: Any = None,
                  filetype: str = "raw") -> None:
+        warnings.warn(
+            'torchaudio.sox_effects.SoxEffectsChain has been deprecated and '
+            'will be removed from 0.8.0 release. '
+            'Please migrate to `apply_effects_file` or `apply_effects_tensor`.'
+        )
         self.input_file: Optional[str] = None
         self.chain: List[str] = []
         self.MAX_EFFECT_OPTS = 20

--- a/torchaudio/sox_effects/sox_effects.py
+++ b/torchaudio/sox_effects/sox_effects.py
@@ -260,7 +260,7 @@ def apply_effects_file(
 
 
 @_mod_utils.requires_module('torchaudio._torchaudio')
-@_mod_utils.deprecated('Please migrate to `apply_effects_file` or `apply_effects_tensor`.')
+@_mod_utils.deprecated('Please migrate to `apply_effects_file` or `apply_effects_tensor`.', "0.8.0")
 def SoxEffect():
     r"""Create an object for passing sox effect information between python and c++
 
@@ -275,7 +275,7 @@ def SoxEffect():
     return _torchaudio.SoxEffect()
 
 
-@_mod_utils.deprecated('Please migrate to `apply_effects_file` or `apply_effects_tensor`.')
+@_mod_utils.deprecated('Please migrate to `apply_effects_file` or `apply_effects_tensor`.', "0.8.0")
 class SoxEffectsChain(object):
     r"""SoX effects chain class.
 


### PR DESCRIPTION
Make the sox deprecations explicit about the future version, at which they are removed.

@mattip I was working on updating deprecation decorators and took the opportunity to solve the issue you were facing. Not sure how doc works are organized, but when we build versioned docs and if we are building it from `release/0.7`, then it will be reflected.