### PR TITLE
Add SpeechCommands train/valid/test split

### DIFF
--- a/test/torchaudio_unittest/datasets/speechcommands_test.py
+++ b/test/torchaudio_unittest/datasets/speechcommands_test.py
@@ -112,8 +112,8 @@ class TestSpeechCommands(TempDirMixin, TorchaudioTestCase):
 
         assert num_samples == len(self.samples)
 
-    def testSpeechCommandsSplit(self):
-        dataset = speechcommands.SPEECHCOMMANDS(self.root_dir, split="testing")
+    def testSpeechCommandsSubset(self):
+        dataset = speechcommands.SPEECHCOMMANDS(self.root_dir, subset="testing")
         print(dataset._path)
 
         num_samples = 0

--- a/test/torchaudio_unittest/datasets/speechcommands_test.py
+++ b/test/torchaudio_unittest/datasets/speechcommands_test.py
@@ -107,7 +107,22 @@ class TestSpeechCommands(TempDirMixin, TorchaudioTestCase):
 
     def testSpeechCommands(self):
         dataset = speechcommands.SPEECHCOMMANDS(self.root_dir)
-        print(dataset._path)
+
+        num_samples = 0
+        for i, (data, sample_rate, label, speaker_id, utterance_number) in enumerate(
+            dataset
+        ):
+            self.assertEqual(data, self.samples[i][0], atol=5e-5, rtol=1e-8)
+            assert sample_rate == self.samples[i][1]
+            assert label == self.samples[i][2]
+            assert speaker_id == self.samples[i][3]
+            assert utterance_number == self.samples[i][4]
+            num_samples += 1
+
+        assert num_samples == len(self.samples)
+
+    def testSpeechCommandsNone(self):
+        dataset = speechcommands.SPEECHCOMMANDS(self.root_dir, subset=None)
 
         num_samples = 0
         for i, (data, sample_rate, label, speaker_id, utterance_number) in enumerate(
@@ -169,3 +184,11 @@ class TestSpeechCommands(TempDirMixin, TorchaudioTestCase):
             num_samples += 1
 
         assert num_samples == len(self.test_samples)
+
+    def testSpeechCommandsSum(self):
+        dataset_all = speechcommands.SPEECHCOMMANDS(self.root_dir)
+        dataset_train = speechcommands.SPEECHCOMMANDS(self.root_dir, subset="training")
+        dataset_valid = speechcommands.SPEECHCOMMANDS(self.root_dir, subset="validation")
+        dataset_test = speechcommands.SPEECHCOMMANDS(self.root_dir, subset="testing")
+
+        assert len(dataset_train) + len(dataset_valid) + len(dataset_test) == len(dataset_all)

--- a/test/torchaudio_unittest/datasets/speechcommands_test.py
+++ b/test/torchaudio_unittest/datasets/speechcommands_test.py
@@ -96,15 +96,14 @@ class TestSpeechCommands(TempDirMixin, TorchaudioTestCase):
                             utterance,
                         )
                         cls.samples.append(sample)
-                        label_filename = os.path.join(label, filename)
-                        if 2 <= j < 4:
-                            valid.write(f'{label_filename}\n')
-                            cls.valid_samples.append(sample)
-                        elif 4 <= j < 6:
-                            test.write(f'{label_filename}\n')
-                            cls.test_samples.append(sample)
-                        else:
+                        if j < 2:
                             cls.train_samples.append(sample)
+                        elif j < 4:
+                            valid.write(f'{label}/{filename}\n')
+                            cls.valid_samples.append(sample)
+                        elif j < 6:
+                            test.write(f'{label}/{filename}\n')
+                            cls.test_samples.append(sample)
 
     def testSpeechCommands(self):
         dataset = speechcommands.SPEECHCOMMANDS(self.root_dir)
@@ -141,7 +140,6 @@ class TestSpeechCommands(TempDirMixin, TorchaudioTestCase):
 
     def testSpeechCommandsSubsetValid(self):
         dataset = speechcommands.SPEECHCOMMANDS(self.root_dir, subset="validation")
-        print(dataset._path)
 
         num_samples = 0
         for i, (data, sample_rate, label, speaker_id, utterance_number) in enumerate(
@@ -156,9 +154,8 @@ class TestSpeechCommands(TempDirMixin, TorchaudioTestCase):
 
         assert num_samples == len(self.valid_samples)
 
-    def testSpeechCommandsSubset(self):
+    def testSpeechCommandsSubsetTest(self):
         dataset = speechcommands.SPEECHCOMMANDS(self.root_dir, subset="testing")
-        print(dataset._path)
 
         num_samples = 0
         for i, (data, sample_rate, label, speaker_id, utterance_number) in enumerate(

--- a/test/torchaudio_unittest/datasets/speechcommands_test.py
+++ b/test/torchaudio_unittest/datasets/speechcommands_test.py
@@ -53,11 +53,12 @@ class TestSpeechCommands(TempDirMixin, TorchaudioTestCase):
 
     root_dir = None
     samples = []
+    train_samples = []
     valid_samples = []
     test_samples = []
 
     @classmethod
-    def setUp(cls):
+    def setUpClass(cls):
         cls.root_dir = cls.get_base_temp_dir()
         dataset_dir = os.path.join(
             cls.root_dir, speechcommands.FOLDER_IN_ARCHIVE, speechcommands.URL
@@ -102,6 +103,8 @@ class TestSpeechCommands(TempDirMixin, TorchaudioTestCase):
                         elif 4 <= j < 6:
                             test.write(f'{label_filename}\n')
                             cls.test_samples.append(sample)
+                        else:
+                            cls.train_samples.append(sample)
 
     def testSpeechCommands(self):
         dataset = speechcommands.SPEECHCOMMANDS(self.root_dir)
@@ -119,6 +122,22 @@ class TestSpeechCommands(TempDirMixin, TorchaudioTestCase):
             num_samples += 1
 
         assert num_samples == len(self.samples)
+
+    def testSpeechCommandsSubsetTrain(self):
+        dataset = speechcommands.SPEECHCOMMANDS(self.root_dir, subset="training")
+
+        num_samples = 0
+        for i, (data, sample_rate, label, speaker_id, utterance_number) in enumerate(
+            dataset
+        ):
+            self.assertEqual(data, self.train_samples[i][0], atol=5e-5, rtol=1e-8)
+            assert sample_rate == self.train_samples[i][1]
+            assert label == self.train_samples[i][2]
+            assert speaker_id == self.train_samples[i][3]
+            assert utterance_number == self.train_samples[i][4]
+            num_samples += 1
+
+        assert num_samples == len(self.train_samples)
 
     def testSpeechCommandsSubsetValid(self):
         dataset = speechcommands.SPEECHCOMMANDS(self.root_dir, subset="validation")

--- a/test/torchaudio_unittest/datasets/speechcommands_test.py
+++ b/test/torchaudio_unittest/datasets/speechcommands_test.py
@@ -63,33 +63,37 @@ class TestSpeechCommands(TempDirMixin, TorchaudioTestCase):
         os.makedirs(dataset_dir, exist_ok=True)
         sample_rate = 16000  # 16kHz sample rate
         seed = 0
-        for label in LABELS:
-            path = os.path.join(dataset_dir, label)
-            os.makedirs(path, exist_ok=True)
-            for j in range(2):
-                # generate hash ID for speaker
-                speaker = "{:08x}".format(j)
+        txt_file = os.path.join(dataset_dir, "testing_list.txt")
+        with open(txt_file, "w") as txt:
+            for label in LABELS:
+                path = os.path.join(dataset_dir, label)
+                os.makedirs(path, exist_ok=True)
+                for j in range(2):
+                    # generate hash ID for speaker
+                    speaker = "{:08x}".format(j)
 
-                for utterance in range(3):
-                    filename = f"{speaker}{speechcommands.HASH_DIVIDER}{utterance}.wav"
-                    file_path = os.path.join(path, filename)
-                    seed += 1
-                    data = get_whitenoise(
-                        sample_rate=sample_rate,
-                        duration=0.01,
-                        n_channels=1,
-                        dtype="int16",
-                        seed=seed,
-                    )
-                    save_wav(file_path, data, sample_rate)
-                    sample = (
-                        normalize_wav(data),
-                        sample_rate,
-                        label,
-                        speaker,
-                        utterance,
-                    )
-                    cls.samples.append(sample)
+                    for utterance in range(3):
+                        filename = f"{speaker}{speechcommands.HASH_DIVIDER}{utterance}.wav"
+                        file_path = os.path.join(path, filename)
+                        seed += 1
+                        data = get_whitenoise(
+                            sample_rate=sample_rate,
+                            duration=0.01,
+                            n_channels=1,
+                            dtype="int16",
+                            seed=seed,
+                        )
+                        save_wav(file_path, data, sample_rate)
+                        sample = (
+                            normalize_wav(data),
+                            sample_rate,
+                            label,
+                            speaker,
+                            utterance,
+                        )
+                        cls.samples.append(sample)
+                        label_filename = os.path.join(label, filename)
+                        txt.write(f'{label_filename}\n')
 
     def testSpeechCommands(self):
         dataset = speechcommands.SPEECHCOMMANDS(self.root_dir)
@@ -107,3 +111,20 @@ class TestSpeechCommands(TempDirMixin, TorchaudioTestCase):
             num_samples += 1
 
         assert num_samples == len(self.samples)
+
+    def testSpeechCommandsSplit(self):
+        dataset = speechcommands.SPEECHCOMMANDS(self.root_dir, split="testing")
+        print(dataset._path)
+
+        num_samples = 0
+        for i, (data, sample_rate, label, speaker_id, utterance_number) in enumerate(
+            dataset
+        ):
+            self.assertEqual(data, self.samples[i][0], atol=5e-5, rtol=1e-8)
+            assert sample_rate == self.samples[i][1]
+            assert label == self.samples[i][2]
+            assert speaker_id == self.samples[i][3]
+            assert utterance_number == self.samples[i][4]
+            num_samples += 1
+
+        assert len(dataset) == len(self.samples)

--- a/torchaudio/datasets/speechcommands.py
+++ b/torchaudio/datasets/speechcommands.py
@@ -98,9 +98,13 @@ class SPEECHCOMMANDS(Dataset):
             walker = validation_list
         elif split == "testing":
             walker = testing_list
-        else:
+        elif split in ["training", "all"]:
             walker = walk_files(self._path, suffix=".wav", prefix=True)
             walker = filter(lambda w: HASH_DIVIDER in w and EXCEPT_FOLDER not in w, walker)
+        else:
+            raise ValueError(
+                f'Expected "split" to be one of "all, "training", "validation", "testing", but got "f{split}".'
+            )
 
         if split == "training":
             walker = filter(

--- a/torchaudio/datasets/speechcommands.py
+++ b/torchaudio/datasets/speechcommands.py
@@ -22,6 +22,15 @@ _CHECKSUMS = {
 }
 
 
+def _load_list(root, *filenames):
+    output = []
+    for filename in filenames:
+        filepath = os.path.join(root, filename)
+        with open(filepath) as fileobj:
+            output += [os.path.normpath(os.path.join(root, line.strip())) for line in fileobj]
+    return output
+
+
 def load_speechcommands_item(filepath: str, path: str) -> Tuple[Tensor, int, str, str, int]:
     relpath = os.path.relpath(filepath, path)
     label, filename = os.path.split(relpath)
@@ -90,20 +99,12 @@ class SPEECHCOMMANDS(Dataset):
                     download_url(url, root, hash_value=checksum, hash_type="md5")
                 extract_archive(archive, self._path)
 
-        def _load_list(*filenames):
-            output = []
-            for filename in filenames:
-                filepath = os.path.join(self._path, filename)
-                with open(filepath) as fileobj:
-                    output += [os.path.normpath(os.path.join(self._path, line.strip())) for line in fileobj]
-            return output
-
         if subset == "validation":
-            self._walker = _load_list("validation_list.txt")
+            self._walker = _load_list(self._path, "validation_list.txt")
         elif subset == "testing":
-            self._walker = _load_list("testing_list.txt")
+            self._walker = _load_list(self._path, "testing_list.txt")
         elif subset == "training":
-            excludes = set(_load_list("validation_list.txt", "testing_list.txt"))
+            excludes = set(_load_list(self._path, "validation_list.txt", "testing_list.txt"))
             walker = walk_files(self._path, suffix=".wav", prefix=True)
             self._walker = [
                 w for w in walker

--- a/torchaudio/datasets/speechcommands.py
+++ b/torchaudio/datasets/speechcommands.py
@@ -58,7 +58,7 @@ class SPEECHCOMMANDS(Dataset):
                  url: str = URL,
                  folder_in_archive: str = FOLDER_IN_ARCHIVE,
                  download: bool = False,
-                 subset: str = None,
+                 subset: Optional[str] = None,
                  ) -> None:
 
         assert subset is None or subset in ["training", "validation", "testing"], (

--- a/torchaudio/datasets/speechcommands.py
+++ b/torchaudio/datasets/speechcommands.py
@@ -59,7 +59,8 @@ class SPEECHCOMMANDS(Dataset):
             Whether to download the dataset if it is not found at root path. (default: ``False``).
         subset (Optional[str]):
             Select a subset of the dataset [None, "training", "validation", "testing"]. None means
-            the whole dataset. (default: ``None``)
+            the whole dataset. "validation" and "testing" are defined in "validation_list.txt" and
+            "testing_list.txt", respectively, and "training" is the rest. (default: ``None``)
     """
 
     def __init__(self,

--- a/torchaudio/datasets/speechcommands.py
+++ b/torchaudio/datasets/speechcommands.py
@@ -95,7 +95,7 @@ class SPEECHCOMMANDS(Dataset):
             for filename in filenames:
                 filepath = os.path.join(self._path, filename)
                 with open(filepath) as fileobj:
-                    output += [os.path.join(self._path, line.strip()) for line in fileobj]
+                    output += [os.path.normpath(os.path.join(self._path, line.strip())) for line in fileobj]
             return output
 
         if subset == "validation":
@@ -105,7 +105,12 @@ class SPEECHCOMMANDS(Dataset):
         elif subset == "training":
             excludes = set(_load_list("validation_list.txt", "testing_list.txt"))
             walker = walk_files(self._path, suffix=".wav", prefix=True)
-            self._walker = [w for w in walker if HASH_DIVIDER in w and EXCEPT_FOLDER not in w and w not in excludes]
+            self._walker = [
+                w for w in walker
+                if HASH_DIVIDER in w
+                and EXCEPT_FOLDER not in w
+                and os.path.normpath(w) not in excludes
+            ]
         else:
             walker = walk_files(self._path, suffix=".wav", prefix=True)
             self._walker = [w for w in walker if HASH_DIVIDER in w and EXCEPT_FOLDER not in w]


### PR DESCRIPTION
Add SpeechCommands train/valid/test split. This follows the convention established in [gtzan](https://github.com/pytorch/audio/blob/master/torchaudio/datasets/gtzan.py#L1014).