### PR TITLE
Fix doc rendering

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx==2.4.4
 -e git+git://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinxcontrib.katex
 matplotlib


### PR DESCRIPTION
Currently there is no version specification for `sphinx` in docs and `pip install -r requirements.txt` would install the version that produces the corrupted rendering for function signatures. This issue is fixed by using `2.4.4`, which is [the same version as PyTorch](https://github.com/pytorch/pytorch/blob/master/docs/requirements.txt#L1)

*Note*: This commit should also go to master branch.

Before

<img width="869" alt="Screen Shot 2020-10-20 at 16 13 47" src="https://user-images.githubusercontent.com/855818/96639147-42ac3d80-12ef-11eb-9a7d-6d7be76d750d.png">

After

<img width="878" alt="Screen Shot 2020-10-20 at 16 00 45" src="https://user-images.githubusercontent.com/855818/96637971-738b7300-12ed-11eb-91ec-8be172dcf9a2.png">
