### PR TITLE
Fixing clang-format version to what PyTorch uses.

### DIFF
--- a/.circleci/torchscript_bc_test/common.sh
+++ b/.circleci/torchscript_bc_test/common.sh
@@ -59,9 +59,6 @@ install_release() {
 install_build_dependencies() {
     printf "* Installing torchaudio dependencies except PyTorch - (Python: %s)\n" "$1"
     conda env update -q --file "${_this_dir}/environment.yml" --prune
-    if [ "${_os}" == Linux ]; then
-        pip install clang-format
-    fi
 }
 
 build_master() {

--- a/.circleci/unittest/linux/scripts/run_style_checks.sh
+++ b/.circleci/unittest/linux/scripts/run_style_checks.sh
@@ -20,9 +20,9 @@ if [ "${status}" -ne 0 ]; then
 fi
 
 printf "\x1b[34mRunning clang-format: "
-clang-format --version
+./clang-format --version
 printf "\x1b[0m\n"
-git-clang-format origin/master
+git-clang-format --binary ./clang-format origin/master
 git diff --exit-code
 status=$?
 exit_status="$((exit_status+status))"

--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -38,7 +38,9 @@ conda activate "${env_dir}"
 printf "* Installing dependencies (except PyTorch)\n"
 conda env update --file "${this_dir}/environment.yml" --prune
 if [ "${os}" == Linux ] ; then
-    pip install clang-format
+    clangformat_path="${root_dir}/clang-format"
+    curl https://oss-clang-format.s3.us-east-2.amazonaws.com/linux64/clang-format-linux64 -o "${clangformat_path}"
+    chmod +x "${clangformat_path}"
 fi
 
 # 4. Buld codecs


### PR DESCRIPTION
In [Vision-2372](https://github.com/pytorch/vision/issues/2372) we fixed the clang-format version. @mthrok [proposed](https://github.com/pytorch/vision/pull/2872#issuecomment-714495595) to do the same in audio.