### PR TITLE
[Doc] Remove sox_effects util from top level module

### DIFF
--- a/docs/source/torchaudio.rst
+++ b/docs/source/torchaudio.rst
@@ -34,10 +34,3 @@ Backend Utilities
 .. autofunction:: get_audio_backend
 
 .. autofunction:: set_audio_backend
-
-Sox Effects Utilities
-~~~~~~~~~~~~~~~~~~~~~
-
-.. autofunction:: initialize_sox
-
-.. autofunction:: shutdown_sox


### PR DESCRIPTION
The sox_effects utilities are removed from top-level module (in [#977](https://github.com/pytorch/audio/pull/977/files#diff-d0f09e250b950133e187b5e43cac6f7693afb38c550b657b604e8c9aa0b1d5e1)), but the documentation was not updated.

**Before:** https://pytorch.org/audio/0.7/torchaudio.html

**After:**
<img width="1469" alt="Screen Shot 2020-11-03 at 15 39 56" src="https://user-images.githubusercontent.com/855818/98038426-1f9f8480-1deb-11eb-811d-5480051c60fc.png">


