### PR TITLE
build docs and push to branch in CI

### DIFF
--- a/.circleci/build_docs/build_docs.sh
+++ b/.circleci/build_docs/build_docs.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+eval "$(./conda/bin/conda shell.bash hook)"
+conda activate ./env
+
+pushd doc
+pip install -r requirements.txt
+make html
+popd
+

--- a/.circleci/build_docs/commit_docs.sh
+++ b/.circleci/build_docs/commit_docs.sh
@@ -3,20 +3,25 @@
 set -ex
 
 
-if [ "$1" == "" ]; then
-    echo call as $0 "<target branch>", where branch should be "master" or "1.7" or so
+if [ "$2" == "" ]; then
+    echo call as $0 "<src>" "<target branch>"
+    echo where src is the built documentation and
+    echo branch should be "master" or "1.7" or so
     exit 1
 fi
 
+scr=$1
+target=$2
+
 set -ex
-echo "committing docs to ${target}"
+echo "committing docs from ${stc} to ${target}"
 
 git checkout gh-pages
 rm -rf docs/$target/*
-cp -r doc/build/html/* docs/$target
+cp -r ${src}/build/html/* docs/$target
 if [ $target == "master" ]; then
     rm -rf docs/_static/*
-    cp -r doc/build/html/_static/* docs/_static
+    cp -r ${src}/build/html/_static/* docs/_static
 fi
 git add docs || true
 git config user.email "soumith+bot@pytorch.org"

--- a/.circleci/build_docs/commit_docs.sh
+++ b/.circleci/build_docs/commit_docs.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -ex
+
+
+if [ "$1" == "" ]; then
+    echo call as $0 "<target branch>", where branch should be "master" or "1.7" or so
+    exit 1
+fi
+
+set -ex
+echo "committing docs to ${target}"
+
+git checkout gh-pages
+rm -rf docs/$target/*
+cp -r doc/build/html/* docs/$target
+if [ $target == "master" ]; then
+    rm -rf docs/_static/*
+    cp -r doc/build/html/_static/* docs/_static
+fi
+git add docs || true
+git config user.email "soumith+bot@pytorch.org"
+git config user.name "pytorchbot"
+# If there aren't changes, don't make a commit; push is no-op
+git commit -m "auto-generating sphinx docs" || true
+git push -u origin gh-pages
+
+

--- a/.circleci/build_docs/install_wheels.sh
+++ b/.circleci/build_docs/install_wheels.sh
@@ -1,13 +1,9 @@
-#!/usr/bin/env bash
-
 set -ex
 source ./packaging/pkg_helpers.bash
 export NO_CUDA_PACKAGE=1
 setup_env 0.8.0
 setup_wheel_python
-
-pushd docs
-pip install -r requirements.txt
-make html
-popd
+setup_pip_pytorch_version
+# pytorch is already installed
+pip install --no-deps ~/workspace/torchaudio*
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -650,59 +650,27 @@ jobs:
             .circleci/torchscript_bc_test/setup_master_envs.sh
             .circleci/torchscript_bc_test/validate_objects.sh
   build_docs:
-    <<: *binary_common
-    docker:
-      - image: "pytorch/torchaudio_unittest_base:manylinux"
-    resource_class: medium
+    <<: *smoke_test_common
     steps:
-    - checkout
-    - attach_workspace:
-        at: third_party
-    - designate_upload_channel
-    - generate_cache_key
-    - restore_cache:
-
-        keys:
-          - env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/setup_env.sh" }}-{{ checksum "third_party/CMakeLists.txt" }}-{{ checksum ".cachekey" }}
-
-    - run:
-        name: Setup
-        command: .circleci/unittest/linux/scripts/setup_env.sh
-    - save_cache:
-
-        key: env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/setup_env.sh" }}-{{ checksum "third_party/CMakeLists.txt" }}-{{ checksum ".cachekey" }}
-
-        paths:
-          - conda
-          - env
-          - third_party/build
-          - third_party/install
-          - third_party/src
-    - run:
-        name: Install torchaudio
-        command: .circleci/unittest/linux/scripts/install.sh
-    - run:
-        name: Build docs
-        command: .circleci/unittest/linux/scripts/run_test.sh
-    - run:
-        name: Upload docs
-        command: |
-          tag=${CIRCLE_TAG:1:5}
-          target=${tag:-master}
-          echo "committing docs to ${target}"
-          git checkout gh-pages
-          rm -rf docs/$target/*
-          cp -r doc/build/html/* docs/$target
-          if [ $target == "master" ]; then
-              rm -rf docs/_static/*
-              cp -r doc/build/html/_static/* docs/_static
-          fi
-          git add docs || true
-          git config user.email "soumith+bot@pytorch.org"
-          git config user.name "pytorchbot"
-          # If there aren't changes, don't make a commit; push is no-op
-          git commit -m "auto-generating sphinx docs" || true
-          git push -u origin gh-pages
+      - attach_workspace:
+          at: ~/workspace
+      - designate_upload_channel
+      - run:
+          name: install binaries
+          command: |
+            set -x
+            source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
+            conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch
+            conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
+      - run:
+          name: Build docs
+          command: .circleci/build_docs/build_docs.sh
+      - run:
+          name: Upload docs
+          command: |
+            tag=${CIRCLE_TAG:1:5}
+            target=${tag:-master}
+            .circleci/build_docs/commit_docs.sh $target
 
 workflows:
   build:
@@ -787,9 +755,6 @@ workflows:
           python_version: '3.7'
       - binary_windows_conda:
           name: binary_windows_conda_py3.8
-          python_version: '3.8'
-      - build_docs:
-          name: build_docs
           python_version: '3.8'
   unittest:
     jobs:
@@ -1451,6 +1416,8 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: build_docs
           python_version: '3.8'
+          requires:
+          - nightly_binary_linux_conda_py3.8_upload
   docker_build:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -657,20 +657,18 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/workspace
+      - designate_upload_channel
+      - checkout
       - run:
-          name: Install wheel
-          command: |
-            set -ex
-            echo $PWD
-            ls
-            source ./packaging/pkg_helpers.bash
-            export NO_CUDA_PACKAGE=1
-            setup_env 0.8.0
-            setup_wheel_python()
-            pip install dist/*
+          name: Install pytorch-audio
+          command: .circleci/build_docs/install_wheels.sh
       - run:
           name: Build docs
           command: .circleci/build_docs/build_docs.sh
+      - persist_to_workspace:
+          root: docs
+          paths:
+            - "*"
 
   upload_docs:
     <<: *binary_common
@@ -680,12 +678,17 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/workspace
+      - designate_upload_channel
+      - checkout
       - run:
           name: Upload docs
           command: |
+            set -ex
+            echo $PWD
+            ls ~/workspace
             tag=${CIRCLE_TAG:1:5}
             target=${tag:-master}
-            .circleci/build_docs/commit_docs.sh $target
+            .circleci/build_docs/commit_docs.sh ~/workspace $target
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -649,6 +649,60 @@ jobs:
           command: |
             .circleci/torchscript_bc_test/setup_master_envs.sh
             .circleci/torchscript_bc_test/validate_objects.sh
+  build_docs:
+    <<: *binary_common
+    docker:
+      - image: "pytorch/torchaudio_unittest_base:manylinux"
+    resource_class: medium
+    steps:
+    - checkout
+    - attach_workspace:
+        at: third_party
+    - designate_upload_channel
+    - generate_cache_key
+    - restore_cache:
+
+        keys:
+          - env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/setup_env.sh" }}-{{ checksum "third_party/CMakeLists.txt" }}-{{ checksum ".cachekey" }}
+
+    - run:
+        name: Setup
+        command: .circleci/unittest/linux/scripts/setup_env.sh
+    - save_cache:
+
+        key: env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/setup_env.sh" }}-{{ checksum "third_party/CMakeLists.txt" }}-{{ checksum ".cachekey" }}
+
+        paths:
+          - conda
+          - env
+          - third_party/build
+          - third_party/install
+          - third_party/src
+    - run:
+        name: Install torchaudio
+        command: .circleci/unittest/linux/scripts/install.sh
+    - run:
+        name: Build docs
+        command: .circleci/unittest/linux/scripts/run_test.sh
+    - run:
+        name: Upload docs
+        command: |
+          tag=${CIRCLE_TAG:1:5}
+          target=${tag:-master}
+          echo "committing docs to ${target}"
+          git checkout gh-pages
+          rm -rf docs/$target/*
+          cp -r doc/build/html/* docs/$target
+          if [ $target == "master" ]; then
+              rm -rf docs/_static/*
+              cp -r doc/build/html/_static/* docs/_static
+          fi
+          git add docs || true
+          git config user.email "soumith+bot@pytorch.org"
+          git config user.name "pytorchbot"
+          # If there aren't changes, don't make a commit; push is no-op
+          git commit -m "auto-generating sphinx docs" || true
+          git push -u origin gh-pages
 
 workflows:
   build:
@@ -733,6 +787,9 @@ workflows:
           python_version: '3.7'
       - binary_windows_conda:
           name: binary_windows_conda_py3.8
+          python_version: '3.8'
+      - build_docs:
+          name: build_docs
           python_version: '3.8'
   unittest:
     jobs:
@@ -1385,6 +1442,15 @@ workflows:
           python_version: '3.8'
           requires:
           - nightly_binary_windows_conda_py3.8_upload
+      - build_docs:
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: build_docs
+          python_version: '3.8'
   docker_build:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -650,21 +650,36 @@ jobs:
             .circleci/torchscript_bc_test/setup_master_envs.sh
             .circleci/torchscript_bc_test/validate_objects.sh
   build_docs:
-    <<: *smoke_test_common
+    <<: *binary_common
+    docker:
+      - image: "pytorch/manylinux-cuda100"
+    resource_class: 2xlarge+
     steps:
       - attach_workspace:
           at: ~/workspace
-      - designate_upload_channel
       - run:
-          name: install binaries
+          name: Install wheel
           command: |
-            set -x
-            source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
-            conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch
-            conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
+            set -ex
+            echo $PWD
+            ls
+            source ./packaging/pkg_helpers.bash
+            export NO_CUDA_PACKAGE=1
+            setup_env 0.8.0
+            setup_wheel_python()
+            pip install dist/*
       - run:
           name: Build docs
           command: .circleci/build_docs/build_docs.sh
+
+  upload_docs:
+    <<: *binary_common
+    docker:
+      - image: "pytorch/manylinux-cuda100"
+    resource_class: 2xlarge+
+    steps:
+      - attach_workspace:
+          at: ~/workspace
       - run:
           name: Upload docs
           command: |
@@ -756,6 +771,22 @@ workflows:
       - binary_windows_conda:
           name: binary_windows_conda_py3.8
           python_version: '3.8'
+      - build_docs:
+          name: build_docs
+          python_version: '3.8'
+          requires:
+          - binary_linux_wheel_py3.8
+      - upload_docs:
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: upload_docs
+          python_version: '3.8'
+          requires:
+          - build_docs
   unittest:
     jobs:
       - torchscript_bc_test:
@@ -1407,17 +1438,6 @@ workflows:
           python_version: '3.8'
           requires:
           - nightly_binary_windows_conda_py3.8_upload
-      - build_docs:
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: build_docs
-          python_version: '3.8'
-          requires:
-          - nightly_binary_linux_conda_py3.8_upload
   docker_build:
     triggers:
       - schedule:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -650,21 +650,36 @@ jobs:
             .circleci/torchscript_bc_test/setup_master_envs.sh
             .circleci/torchscript_bc_test/validate_objects.sh
   build_docs:
-    <<: *smoke_test_common
+    <<: *binary_common
+    docker:
+      - image: "pytorch/manylinux-cuda100"
+    resource_class: 2xlarge+
     steps:
       - attach_workspace:
           at: ~/workspace
-      - designate_upload_channel
       - run:
-          name: install binaries
+          name: Install wheel
           command: |
-            set -x
-            source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
-            conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch
-            conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
+            set -ex
+            echo $PWD
+            ls
+            source ./packaging/pkg_helpers.bash
+            export NO_CUDA_PACKAGE=1
+            setup_env 0.8.0
+            setup_wheel_python()
+            pip install dist/*
       - run:
           name: Build docs
           command: .circleci/build_docs/build_docs.sh
+
+  upload_docs:
+    <<: *binary_common
+    docker:
+      - image: "pytorch/manylinux-cuda100"
+    resource_class: 2xlarge+
+    steps:
+      - attach_workspace:
+          at: ~/workspace
       - run:
           name: Upload docs
           command: |

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -650,59 +650,27 @@ jobs:
             .circleci/torchscript_bc_test/setup_master_envs.sh
             .circleci/torchscript_bc_test/validate_objects.sh
   build_docs:
-    <<: *binary_common
-    docker:
-      - image: "pytorch/torchaudio_unittest_base:manylinux"
-    resource_class: medium
+    <<: *smoke_test_common
     steps:
-    - checkout
-    - attach_workspace:
-        at: third_party
-    - designate_upload_channel
-    - generate_cache_key
-    - restore_cache:
-        {% raw %}
-        keys:
-          - env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/setup_env.sh" }}-{{ checksum "third_party/CMakeLists.txt" }}-{{ checksum ".cachekey" }}
-        {% endraw %}
-    - run:
-        name: Setup
-        command: .circleci/unittest/linux/scripts/setup_env.sh
-    - save_cache:
-        {% raw %}
-        key: env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/setup_env.sh" }}-{{ checksum "third_party/CMakeLists.txt" }}-{{ checksum ".cachekey" }}
-        {% endraw %}
-        paths:
-          - conda
-          - env
-          - third_party/build
-          - third_party/install
-          - third_party/src
-    - run:
-        name: Install torchaudio
-        command: .circleci/unittest/linux/scripts/install.sh
-    - run:
-        name: Build docs
-        command: .circleci/unittest/linux/scripts/run_test.sh
-    - run:
-        name: Upload docs
-        command: |
-          tag=${CIRCLE_TAG:1:5}
-          target=${tag:-master}
-          echo "committing docs to ${target}"
-          git checkout gh-pages
-          rm -rf docs/$target/*
-          cp -r doc/build/html/* docs/$target
-          if [ $target == "master" ]; then
-              rm -rf docs/_static/*
-              cp -r doc/build/html/_static/* docs/_static
-          fi
-          git add docs || true
-          git config user.email "soumith+bot@pytorch.org"
-          git config user.name "pytorchbot"
-          # If there aren't changes, don't make a commit; push is no-op
-          git commit -m "auto-generating sphinx docs" || true
-          git push -u origin gh-pages
+      - attach_workspace:
+          at: ~/workspace
+      - designate_upload_channel
+      - run:
+          name: install binaries
+          command: |
+            set -x
+            source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
+            conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch
+            conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
+      - run:
+          name: Build docs
+          command: .circleci/build_docs/build_docs.sh
+      - run:
+          name: Upload docs
+          command: |
+            tag=${CIRCLE_TAG:1:5}
+            target=${tag:-master}
+            .circleci/build_docs/commit_docs.sh $target
 
 workflows:
   build:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -657,20 +657,18 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/workspace
+      - designate_upload_channel
+      - checkout
       - run:
-          name: Install wheel
-          command: |
-            set -ex
-            echo $PWD
-            ls
-            source ./packaging/pkg_helpers.bash
-            export NO_CUDA_PACKAGE=1
-            setup_env 0.8.0
-            setup_wheel_python()
-            pip install dist/*
+          name: Install pytorch-audio
+          command: .circleci/build_docs/install_wheels.sh
       - run:
           name: Build docs
           command: .circleci/build_docs/build_docs.sh
+      - persist_to_workspace:
+          root: docs
+          paths:
+            - "*"
 
   upload_docs:
     <<: *binary_common
@@ -680,12 +678,17 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/workspace
+      - designate_upload_channel
+      - checkout
       - run:
           name: Upload docs
           command: |
+            set -ex
+            echo $PWD
+            ls ~/workspace
             tag=${CIRCLE_TAG:1:5}
             target=${tag:-master}
-            .circleci/build_docs/commit_docs.sh $target
+            .circleci/build_docs/commit_docs.sh ~/workspace $target
 
 workflows:
   build:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -649,6 +649,60 @@ jobs:
           command: |
             .circleci/torchscript_bc_test/setup_master_envs.sh
             .circleci/torchscript_bc_test/validate_objects.sh
+  build_docs:
+    <<: *binary_common
+    docker:
+      - image: "pytorch/torchaudio_unittest_base:manylinux"
+    resource_class: medium
+    steps:
+    - checkout
+    - attach_workspace:
+        at: third_party
+    - designate_upload_channel
+    - generate_cache_key
+    - restore_cache:
+        {% raw %}
+        keys:
+          - env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/setup_env.sh" }}-{{ checksum "third_party/CMakeLists.txt" }}-{{ checksum ".cachekey" }}
+        {% endraw %}
+    - run:
+        name: Setup
+        command: .circleci/unittest/linux/scripts/setup_env.sh
+    - save_cache:
+        {% raw %}
+        key: env-v3-linux-{{ arch }}-py<< parameters.python_version >>-{{ checksum ".circleci/unittest/linux/scripts/setup_env.sh" }}-{{ checksum "third_party/CMakeLists.txt" }}-{{ checksum ".cachekey" }}
+        {% endraw %}
+        paths:
+          - conda
+          - env
+          - third_party/build
+          - third_party/install
+          - third_party/src
+    - run:
+        name: Install torchaudio
+        command: .circleci/unittest/linux/scripts/install.sh
+    - run:
+        name: Build docs
+        command: .circleci/unittest/linux/scripts/run_test.sh
+    - run:
+        name: Upload docs
+        command: |
+          tag=${CIRCLE_TAG:1:5}
+          target=${tag:-master}
+          echo "committing docs to ${target}"
+          git checkout gh-pages
+          rm -rf docs/$target/*
+          cp -r doc/build/html/* docs/$target
+          if [ $target == "master" ]; then
+              rm -rf docs/_static/*
+              cp -r doc/build/html/_static/* docs/_static
+          fi
+          git add docs || true
+          git config user.email "soumith+bot@pytorch.org"
+          git config user.name "pytorchbot"
+          # If there aren't changes, don't make a commit; push is no-op
+          git commit -m "auto-generating sphinx docs" || true
+          git push -u origin gh-pages
 
 workflows:
   build:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -21,6 +21,8 @@ import os.path
 
 PYTHON_VERSIONS = ["3.6", "3.7", "3.8"]
 
+DOC_VERSION = ('linux', '3.8')
+
 
 def build_workflows(prefix='', upload=False, filter_branch=None, indentation=6):
     w = []
@@ -30,6 +32,7 @@ def build_workflows(prefix='', upload=False, filter_branch=None, indentation=6):
             for python_version in PYTHON_VERSIONS:
                 w += build_workflow_pair(btype, os_type, python_version, filter_branch, prefix, upload)
 
+    w += build_doc_job(filter_branch)
     return indent(indentation, w)
 
 
@@ -67,6 +70,16 @@ def build_workflow_pair(btype, os_type, python_version, filter_branch, prefix=''
 
     return w
 
+def build_doc_job(filter_branch):
+    job = {
+        "name": "build_docs",
+        "python_version": "3.8",
+    }
+
+    if filter_branch:
+        job["filters"] = gen_filter_branch_tree(filter_branch)
+    return [{"build_docs": job}]
+
 
 def generate_base_workflow(base_workflow_name, python_version, filter_branch, os_type, btype):
 
@@ -81,7 +94,7 @@ def generate_base_workflow(base_workflow_name, python_version, filter_branch, os
     if filter_branch:
         d["filters"] = gen_filter_branch_tree(filter_branch)
 
-    return {"binary_{os_type}_{btype}".format(os_type=os_type, btype=btype): d}
+    return {f"binary_{os_type}_{btype}": d}
 
 
 def gen_filter_branch_tree(*branches):

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -32,7 +32,8 @@ def build_workflows(prefix='', upload=False, filter_branch=None, indentation=6):
             for python_version in PYTHON_VERSIONS:
                 w += build_workflow_pair(btype, os_type, python_version, filter_branch, prefix, upload)
 
-    w += build_doc_job(filter_branch)
+    if filter_branch == 'nightly':
+        w += build_doc_job(filter_branch)
     return indent(indentation, w)
 
 
@@ -74,6 +75,7 @@ def build_doc_job(filter_branch):
     job = {
         "name": "build_docs",
         "python_version": "3.8",
+        "requires": ["nightly_binary_linux_conda_py3.8_upload",],
     }
 
     if filter_branch:


### PR DESCRIPTION
This creates a job to build docs and push them. The basic idea is to reuse the install part of the ~unittest~ smoke_test jobs, and then do
```
pushd doc
pip install -r requriements.txt
build html
popd
```

Then a separate step commits the built documentation, checks out the gh-pages branch, copies the rendered documentation into the correct directory, commits it, and pushes the result to the branch.

Things I don't understand about the config.yml, I hope I did it right
~- how do the unittest_linux_cpu jobs know not to run if the build job fails? There is no `requires` clause~
- git push hopefully will JustWork when a PR is merged, although it will fail when done on a fork (like when people submit a PR). Should I limit the job to only run on nightly to avoid the problem?