### PR TITLE
Correct notation fluctuation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ the audio domain. By supporting PyTorch, torchaudio follows the same philosophy
 of providing strong GPU acceleration, having a focus on trainable features through
 the autograd system, and having consistent style (tensor names and dimension names).
 Therefore, it is primarily a machine learning library and not a general signal
-processing library. The benefits of Pytorch is be seen in torchaudio through
-having all the computations be through Pytorch operations which makes it easy
+processing library. The benefits of PyTorch is be seen in torchaudio through
+having all the computations be through PyTorch operations which makes it easy
 to use and feel like a natural extension.
 
 - [Support audio I/O (Load files, Save files)](http://pytorch.org/audio/)


### PR DESCRIPTION
Sorry for my sudden PR.

I've just started using this project, and while I was reading the README, I noticed that `PyTorch` and `Pytorch` are not written consistently.

If this is a deliberate change, I apologize for my misunderstanding. 
However, If my understanding is correct, I would like to suggest changing the notation from `Pytorch` to `PyTorch`, just in case.

Thank you very much for your consideration.

Closes #1030