### PR TITLE
Fix links to documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ processing library. The benefits of Pytorch is be seen in torchaudio through
 having all the computations be through Pytorch operations which makes it easy
 to use and feel like a natural extension.
 
-- [Support audio I/O (Load files, Save files)](http://pytorch.org/audio/)
+- [Support audio I/O (Load files, Save files)](http://pytorch.org/audio/stable/)
   - Load the following formats into a torch Tensor using SoX
     - mp3, wav, aac, ogg, flac, avr, cdda, cvs/vms,
     - aiff, au, amr, mp2, mp4, ac3, avi, wmv,
     - mpeg, ircam and any other format supported by libsox.
-    - [Kaldi (ark/scp)](http://pytorch.org/audio/kaldi_io.html)
-- [Dataloaders for common audio datasets (VCTK, YesNo)](http://pytorch.org/audio/datasets.html)
+    - [Kaldi (ark/scp)](http://pytorch.org/audio/stable/kaldi_io.html)
+- [Dataloaders for common audio datasets (VCTK, YesNo)](http://pytorch.org/audio/stable/datasets.html)
 - Common audio transforms
-    - [Spectrogram, AmplitudeToDB, MelScale, MelSpectrogram, MFCC, MuLawEncoding, MuLawDecoding, Resample](http://pytorch.org/audio/transforms.html)
+    - [Spectrogram, AmplitudeToDB, MelScale, MelSpectrogram, MFCC, MuLawEncoding, MuLawDecoding, Resample](http://pytorch.org/audio/stable/transforms.html)
 - Compliance interfaces: Run code using PyTorch that align with other libraries
-    - [Kaldi: spectrogram, fbank, mfcc, resample_waveform](https://pytorch.org/audio/compliance.kaldi.html)
+    - [Kaldi: spectrogram, fbank, mfcc, resample_waveform](https://pytorch.org/audio/stable/compliance.kaldi.html)
 
 Dependencies
 ------------


### PR DESCRIPTION
The documentation links in the readme 404 (except the top-level documentation link, which redirects). The correct location appears to be under "stable". I've changed them to point to stable.