### PR TITLE
Fix doc commit script 2

### DIFF
--- a/.circleci/build_docs/commit_docs.sh
+++ b/.circleci/build_docs/commit_docs.sh
@@ -17,13 +17,16 @@ set -ex
 echo "committing docs from ${src} to ${target}"
 
 git checkout gh-pages
-rm -rf docs/$target/*
-cp -r ${src}/build/html/* docs/$target
+mkdir -p ./$target
+rm -rf ./$target/*
+cp -r ${src}/build/html/* ./$target
 if [ "$target" == "master" ]; then
-    rm -rf docs/_static/*
-    cp -r ${src}/build/html/_static/* docs/_static
+    mkdir -p ./_static
+    rm -rf ./_static/*
+    cp -r ${src}/build/html/_static/* ./_static
+    git add ./_static || true
 fi
-git add docs || true
+git add ./$target || true
 git config user.email "soumith+bot@pytorch.org"
 git config user.name "pytorchbot"
 # If there aren't changes, don't make a commit; push is no-op


### PR DESCRIPTION
The fix in #1034 got a little further in the [document commit job](https://app.circleci.com/pipelines/github/pytorch/audio/3893/workflows/23a3e829-9592-499a-8445-acf0884f0179/jobs/117250), but there was another mistake: the documentation lives in the top-level directory not inside `docs`. This PR should fix it. Also fix for first-time creation of the directories if they do not exist.