### PR TITLE
Add support for loading mp3 files without extension to "sox_io" backend

### DIFF
--- a/test/torchaudio_unittest/common_utils/sox_utils.py
+++ b/test/torchaudio_unittest/common_utils/sox_utils.py
@@ -1,4 +1,5 @@
 import subprocess
+import warnings
 
 
 def get_encoding(dtype):
@@ -27,8 +28,7 @@ def gen_audio_file(
 ):
     """Generate synthetic audio file with `sox` command."""
     if path.endswith('.wav'):
-        raise RuntimeError(
-            'Use get_wav_data and save_wav to generate wav file for accurate result.')
+        warnings.warn('Use get_wav_data and save_wav to generate wav file for accurate result.')
     command = [
         'sox',
         '-V3',  # verbose

--- a/test/torchaudio_unittest/soundfile_backend/load_test.py
+++ b/test/torchaudio_unittest/soundfile_backend/load_test.py
@@ -1,4 +1,4 @@
-import itertools
+import os
 from unittest.mock import patch
 
 import torch
@@ -263,3 +263,39 @@ class TestLoad(LoadTestBase):
     def test_flac(self, dtype, sample_rate, num_channels, channels_first):
         """`soundfile_backend.load` can load flac format correctly."""
         self.assert_flac(dtype, sample_rate, num_channels, channels_first)
+
+
+@skipIfNoModule("soundfile")
+class TestLoadFormat(TempDirMixin, PytorchTestCase):
+    """Given `format` parameter, `so.load` can load files without extension"""
+    original = None
+    path = None
+
+    def _make_file(self, format_):
+        sample_rate = 8000
+        path_with_ext = self.get_temp_path(f'test.{format_}')
+        data = get_wav_data('float32', num_channels=2).numpy().T
+        soundfile.write(path_with_ext, data, sample_rate)
+        expected = soundfile.read(path_with_ext, dtype='float32')[0].T
+        path = os.path.splitext(path_with_ext)[0]
+        os.rename(path_with_ext, path)
+        return path, expected
+
+    def _test_format(self, format_):
+        """Providing format allows to read file without extension"""
+        path, expected = self._make_file(format_)
+        found, _ = soundfile_backend.load(path)
+        self.assertEqual(found, expected)
+
+    @parameterized.expand([
+        ('WAV', ), ('wav', ),
+    ])
+    def test_wav(self, format_):
+        self._test_format(format_)
+
+    @parameterized.expand([
+        ('FLAC', ), ('flac',),
+    ])
+    @skipIfFormatNotSupported("FLAC")
+    def test_flac(self, format_):
+        self._test_format(format_)

--- a/test/torchaudio_unittest/sox_io_backend/load_test.py
+++ b/test/torchaudio_unittest/sox_io_backend/load_test.py
@@ -1,3 +1,4 @@
+import os
 import itertools
 
 from torchaudio.backend import sox_io_backend
@@ -272,7 +273,7 @@ class TestLoadParams(TempDirMixin, PytorchTestCase):
         super().setUp()
         sample_rate = 8000
         self.original = get_wav_data('float32', num_channels=2)
-        self.path = self.get_temp_path('test.wave')
+        self.path = self.get_temp_path('test.wav')
         save_wav(self.path, self.original, sample_rate)
 
     @parameterized.expand(list(itertools.product(
@@ -291,3 +292,28 @@ class TestLoadParams(TempDirMixin, PytorchTestCase):
         found, _ = sox_io_backend.load(self.path, channels_first=channels_first)
         expected = self.original if channels_first else self.original.transpose(1, 0)
         self.assertEqual(found, expected)
+
+
+@skipIfNoExec('sox')
+@skipIfNoExtension
+class TestLoadExtensionLess(TempDirMixin, PytorchTestCase):
+    """Given `format` parameter, `sox_io_backend.load` can load files without extension"""
+    original = None
+    path = None
+
+    def _make_file(self, format_):
+        sample_rate = 8000
+        path = self.get_temp_path(f'test.{format_}')
+        sox_utils.gen_audio_file(f'{path}', sample_rate, num_channels=2)
+        self.original = sox_io_backend.load(path)[0]
+        self.path = os.path.splitext(path)[0]
+        os.rename(path, self.path)
+
+    @parameterized.expand([
+        ('WAV', ), ('wav', ), ('MP3', ), ('mp3', ), ('FLAC', ), ('flac',),
+    ], name_func=name_func)
+    def test_format(self, format_):
+        """Providing format allows to read file without extension"""
+        self._make_file(format_)
+        found, _ = sox_io_backend.load(self.path)
+        self.assertEqual(found, self.original)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -76,6 +76,7 @@ ExternalProject_Add(libsox
   DOWNLOAD_DIR ${ARCHIVE_DIR}
   URL https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2.tar.bz2
   URL_HASH SHA256=81a6956d4330e75b5827316e44ae381e6f1e8928003c6aa45896da9041ea149c
+  PATCH_COMMAND patch -p0 < ${CMAKE_CURRENT_SOURCE_DIR}/patch/libsox.patch
   # OpenMP is by default compiled against GNU OpenMP, which conflicts with the version of OpenMP that PyTorch uses.
   # See https://github.com/pytorch/audio/pull/1026
   CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build_codec_helper.sh ${CMAKE_CURRENT_SOURCE_DIR}/src/libsox/configure ${COMMON_ARGS} --with-lame --with-flac --with-mad --with-oggvorbis --without-alsa --without-coreaudio --without-png --without-oss --without-sndfile --with-opus --disable-openmp

--- a/third_party/patch/libsox.patch
+++ b/third_party/patch/libsox.patch
@@ -1,0 +1,24 @@
+--- src/formats.c	2014-10-27 02:55:50.000000000 +0000
++++ src/formats_new.c	2020-11-18 19:14:17.398689371 +0000
+@@ -91,6 +91,21 @@
+ 
+   if (ext && !strcasecmp(ext, "snd"))
+   CHECK(sndr  , 7, 1, ""     , 0,  2, "\0")
++
++#if defined HAVE_MP3 && (defined STATIC_MP3 || !defined HAVE_LIBLTDL)
++  // http://www.mp3-tech.org/programmer/frame_header.html
++  // Check the first two bytes are
++  // expected             1111_1111 111X_X01X
++  // mask         \xEEE6 (1111_1111 1110_0110)
++  // masked value \xEEE2 (1111_1111 1110_0010)
++  if (len >= 2 && !memcmp(data, "\xFF", 1)) {
++    unsigned char second_byte = data[1];
++    unsigned char mask = 0xE6;
++    unsigned char expected = 0xE2;
++    if ((second_byte & mask) == expected)
++      return "mp3";
++  }
++#endif
+   #undef CHECK
+ 
+ #if HAVE_MAGIC


### PR DESCRIPTION
When it comes to `mp3` format detection, `libsox` only depends on the file extension. (See #1040)
This PR adds header-based format detection to `mp3`.

Relates to #1040 
~Should go to `0.7.1` release.~ Will ask users to test with nightly build.