### PR TITLE
Add Pathlib support for 'apply_effects_file'

### DIFF
--- a/test/torchaudio_unittest/sox_effect/sox_effect_test.py
+++ b/test/torchaudio_unittest/sox_effect/sox_effect_test.py
@@ -105,8 +105,8 @@ class TestSoxEffectsFile(TempDirMixin, PytorchTestCase):
         load_params("sox_effect_test_args.json"),
         name_func=lambda f, i, p: f'{f.__name__}_{i}_{p.args[0]["effects"][0][0]}',
     )
-    def test_apply_effects_str(self, args):
-        """`apply_effects_file` should return identical data as sox command when file path is given as a string"""
+    def test_apply_effects(self, args):
+        """`apply_effects_file` should return identical data as sox command"""
         dtype = 'int32'
         channels_first = True
         effects = args['effects']
@@ -128,18 +128,14 @@ class TestSoxEffectsFile(TempDirMixin, PytorchTestCase):
         assert sr == expected_sr
         self.assertEqual(found, expected)
 
-    @parameterized.expand(
-        load_params("sox_effect_test_args.json"),
-        name_func=lambda f, i, p: f'{f.__name__}_{i}_{p.args[0]["effects"][0][0]}',
-    )
     def test_apply_effects_path(self, args):
         """`apply_effects_file` should return identical data as sox command when file path is given as a Path Object"""
         dtype = 'int32'
         channels_first = True
-        effects = args['effects']
-        num_channels = args.get("num_channels", 2)
-        input_sr = args.get("input_sample_rate", 8000)
-        output_sr = args.get("output_sample_rate")
+        effects = "hilbert"
+        num_channels = 2
+        input_sr = 8000
+        output_sr = 8000
 
         input_path = self.get_temp_path('input.wav')
         reference_path = self.get_temp_path('reference.wav')

--- a/test/torchaudio_unittest/sox_effect/sox_effect_test.py
+++ b/test/torchaudio_unittest/sox_effect/sox_effect_test.py
@@ -105,7 +105,7 @@ class TestSoxEffectsFile(TempDirMixin, PytorchTestCase):
         load_params("sox_effect_test_args.json"),
         name_func=lambda f, i, p: f'{f.__name__}_{i}_{p.args[0]["effects"][0][0]}',
     )
-    def test_apply_effects(self, args):
+    def test_apply_effects_str(self, args):
         """`apply_effects_file` should return identical data as sox command"""
         dtype = 'int32'
         channels_first = True
@@ -128,11 +128,11 @@ class TestSoxEffectsFile(TempDirMixin, PytorchTestCase):
         assert sr == expected_sr
         self.assertEqual(found, expected)
 
-    def test_apply_effects_path(self, args):
+    def test_apply_effects_path(self):
         """`apply_effects_file` should return identical data as sox command when file path is given as a Path Object"""
         dtype = 'int32'
         channels_first = True
-        effects = "hilbert"
+        effects = [["hilbert"]]
         num_channels = 2
         input_sr = 8000
         output_sr = 8000

--- a/torchaudio/sox_effects/sox_effects.py
+++ b/torchaudio/sox_effects/sox_effects.py
@@ -1,4 +1,3 @@
-import os
 from typing import List, Tuple, Union
 from pathlib import Path
 
@@ -251,6 +250,6 @@ def apply_effects_file(
         >>>     pass
     """
     # Get string representation of 'path' in case Path object is passed
-    path = os.fspath(path)
+    path = str(path)
     signal = torch.ops.torchaudio.sox_effects_apply_effects_file(path, effects, normalize, channels_first)
     return signal.get_tensor(), signal.get_sample_rate()

--- a/torchaudio/sox_effects/sox_effects.py
+++ b/torchaudio/sox_effects/sox_effects.py
@@ -1,4 +1,6 @@
-from typing import List, Tuple
+import os
+from typing import List, Tuple, Union
+from pathlib import Path
 
 import torch
 
@@ -153,7 +155,7 @@ def apply_effects_tensor(
 
 @_mod_utils.requires_module('torchaudio._torchaudio')
 def apply_effects_file(
-        path: str,
+        path: Union[str, Path],
         effects: List[List[str]],
         normalize: bool = True,
         channels_first: bool = True,
@@ -169,7 +171,7 @@ def apply_effects_file(
         rate and leave samples untouched.
 
     Args:
-        path (str): Path to the audio file.
+        path (str or Path): Path to the audio file.
         effects (List[List[str]]): List of effects.
         normalize (bool):
             When ``True``, this function always return ``float32``, and sample values are
@@ -247,5 +249,7 @@ def apply_effects_file(
         >>> for batch in loader:
         >>>     pass
     """
+    # Get string representation of 'path' in case Path object is passed
+    path = os.fspath(path)
     signal = torch.ops.torchaudio.sox_effects_apply_effects_file(path, effects, normalize, channels_first)
     return signal.get_tensor(), signal.get_sample_rate()

--- a/torchaudio/sox_effects/sox_effects.py
+++ b/torchaudio/sox_effects/sox_effects.py
@@ -155,7 +155,7 @@ def apply_effects_tensor(
 
 @_mod_utils.requires_module('torchaudio._torchaudio')
 def apply_effects_file(
-        path: Union[str, Path],
+        path: str,
         effects: List[List[str]],
         normalize: bool = True,
         channels_first: bool = True,
@@ -171,7 +171,8 @@ def apply_effects_file(
         rate and leave samples untouched.
 
     Args:
-        path (str or Path): Path to the audio file.
+        path (str or pathlib.Path): Path to the audio file. This function also handles ``pathlib.Path`` objects, but is
+            annotated as ``str`` for TorchScript compiler compatibility.
         effects (List[List[str]]): List of effects.
         normalize (bool):
             When ``True``, this function always return ``float32``, and sample values are


### PR DESCRIPTION
Relates to #950 

For unit test copied the test for , I copied the existing one and passed Path object .
Didn't do any factoring as it fetching parameters of test case

