### PR TITLE
Cherry-pick: Temporarily Disable OpenMP support for libsox (#1026)

### DIFF
--- a/test/torchaudio_unittest/sox_effect/dataset_test.py
+++ b/test/torchaudio_unittest/sox_effect/dataset_test.py
@@ -2,6 +2,7 @@ import sys
 import platform
 from unittest import skipIf
 from typing import List, Tuple
+from concurrent.futures import ProcessPoolExecutor
 
 import numpy as np
 import torch
@@ -122,3 +123,36 @@ class TestSoxEffectsDataset(TempDirMixin, PytorchTestCase):
         )
         for batch in loader:
             assert batch.shape == (32, 2, 2 * sample_rate)
+
+
+def speed(path):
+    wav, sample_rate = torchaudio.backend.sox_io_backend.load(path)
+    effects = [
+        ['speed', '1.03756523535464655'],
+        ['rate', f'{sample_rate}'],
+    ]
+    return torchaudio.sox_effects.apply_effects_tensor(wav, sample_rate, effects)[0]
+
+
+@skipIfNoExtension
+class TestProcessPoolExecutor(TempDirMixin, PytorchTestCase):
+    backend = "sox_io"
+
+    def setUp(self):
+        sample_rate = 16000
+        self.flist = []
+        for i in range(10):
+            path = self.get_temp_path(f'{i}.wav')
+            data = get_whitenoise(n_channels=1, sample_rate=sample_rate, duration=1, dtype='float')
+            save_wav(path, data, sample_rate)
+            self.flist.append(path)
+
+    def test_executor(self):
+        """Test that apply_effects_tensor with speed + rate does not crush
+
+        https://github.com/pytorch/audio/issues/1021
+        """
+        executor = ProcessPoolExecutor(1)
+        futures = [executor.submit(speed, path) for path in self.flist]
+        for future in futures:
+            future.result()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -76,5 +76,7 @@ ExternalProject_Add(libsox
   DOWNLOAD_DIR ${ARCHIVE_DIR}
   URL https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2.tar.bz2
   URL_HASH SHA256=81a6956d4330e75b5827316e44ae381e6f1e8928003c6aa45896da9041ea149c
-  CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build_codec_helper.sh ${CMAKE_CURRENT_SOURCE_DIR}/src/libsox/configure ${COMMON_ARGS} --with-lame --with-flac --with-mad --with-oggvorbis --without-alsa --without-coreaudio --without-png --without-oss --without-sndfile --with-opus
+  # OpenMP is by default compiled against GNU OpenMP, which conflicts with the version of OpenMP that PyTorch uses.
+  # See https://github.com/pytorch/audio/pull/1026
+  CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build_codec_helper.sh ${CMAKE_CURRENT_SOURCE_DIR}/src/libsox/configure ${COMMON_ARGS} --with-lame --with-flac --with-mad --with-oggvorbis --without-alsa --without-coreaudio --without-png --without-oss --without-sndfile --with-opus --disable-openmp
 )


### PR DESCRIPTION
Currently `libsox` on Linux is compiled with GPU OpenMP and it interferes with the version PyTorch uses (Intel in case of binary distribution). This PR disables OpenMP support for `libsox`, while we investigate the way to use the same OpenMP as PyTorch's version.