### PR TITLE
fix: dataset-root and dataset-folder-in-archive flag is empty

### DIFF
--- a/examples/pipeline_wav2letter/README.md
+++ b/examples/pipeline_wav2letter/README.md
@@ -4,8 +4,13 @@ This is an example pipeline for speech recognition using a greedy or Viterbi CTC
 
 More information about each command line parameters is available with the `--help` option. An example can be invoked as follows.
 ```
+DATASET_ROOT = <Top>/<level>/<folder>
+DATASET_FOLDER_IN_ARCHIVE =  'LibriSpeech'
+
 python main.py \
     --reduce-lr-valid \
+    --dataset-root "${DATASET_ROOT}" \
+    --dataset-folder-in-archive "${DATASET_FOLDER_IN_ARCHIVE}" \
     --dataset-train train-clean-100 train-clean-360 train-other-500 \
     --dataset-valid dev-clean \
     --batch-size 128 \
@@ -15,7 +20,6 @@ python main.py \
     --clip-grad 0. \
     --gamma .99 \
     --hop-length 160 \
-    --n-hidden-channels 2000 \
     --win-length 400 \
     --n-bins 13 \
     --normalize \


### PR DESCRIPTION
In line [151-160](https://github.com/pytorch/audio/blob/master/examples/pipeline_wav2letter/main.py#L151) and Line [437](https://github.com/pytorch/audio/blob/fb3ef9ba427acd7db3084f988ab55169fab14854/examples/pipeline_wav2letter/main.py#L437) of main.py, the default value of `dataset-root` and `dataset-folder-in-archive` will be None, which prevents `main.py` from knowing where the dataset is actually in the computer and loading it.

Moreover, `n-hidden-channels 2000` has not been defined in `main.py`, so it needs to be removed.

Erro log:

```bash
python main.py \
    --reduce-lr-valid \
    --dataset-train train-clean-100 train-clean-360 train-other-500 \
    --dataset-valid dev-clean \
    --batch-size 128 \
    --learning-rate .6 \
    --momentum .8 \
    --weight-decay .00001 \
    --clip-grad 0. \
    --gamma .99 \
    --hop-length 160 \
    --win-length 400 \
    --n-bins 13 \
    --normalize \
    --optimizer adadelta \
    --scheduler reduceonplateau \                                         
    --epochs 30

/home/hoangtnm/anaconda3/envs/dl/lib/python3.7/site-packages/torchaudio/backend/utils.py:54: UserWarning: "sox" backend is being deprecated. The default backend will be changed to "sox_io" backend in 0.8.0 and "sox" backend will be removed in 0.9.0. Please migrate to "sox_io" backend. Please refer to https://github.com/pytorch/audio/issues/903 for the detail.
  '"sox" backend is being deprecated. '
INFO:root:Namespace(batch_size=128, checkpoint='', clip_grad=0.0, dataset_folder_in_archive=None, dataset_root=None, dataset_train=['train-clean-100', 'train-clean-360', 'train-other-500'], dataset_valid=['dev-clean'], decoder='greedy', distributed=False, epochs=30, eps=1e-08, freq_mask=0, gamma=0.99, hop_length=160, jit=False, learning_rate=0.6, momentum=0.8, n_bins=13, normalize=True, optimizer='adadelta', progress_bar=False, reduce_lr_valid=True, rho=0.95, scheduler='reduceonplateau', seed=0, start_epoch=0, time_mask=0, type='mfcc', weight_decay=1e-05, win_length=400, workers=0, world_size=8)
INFO:root:Start time: 2020-11-28 21:18:22.337478
/home/hoangtnm/anaconda3/envs/dl/lib/python3.7/site-packages/torchaudio/backend/utils.py:64: UserWarning: The interface of "soundfile" backend is planned to change in 0.8.0 to match that of "sox_io" backend and the current interface will be removed in 0.9.0. To use the new interface, do `torchaudio.USE_SOUNDFILE_LEGACY_INTERFACE = False` before setting the backend to "soundfile". Please refer to https://github.com/pytorch/audio/issues/903 for the detail.
  'The interface of "soundfile" backend is planned to change in 0.8.0 to '
Traceback (most recent call last):
  File "main.py", line 670, in <module>
    spawn_main(main, args)
  File "main.py", line 663, in spawn_main
    main(0, args)
  File "main.py", line 454, in main
    root=args.dataset_root,
  File "/media/aiteam/DATA/workspace/hoangtnm/audio/examples/pipeline_wav2letter/src/datasets.py", line 65, in split_process_vlsp2020asr
    return tuple(create(dataset) for dataset in datasets)
  File "/media/aiteam/DATA/workspace/hoangtnm/audio/examples/pipeline_wav2letter/src/datasets.py", line 65, in <genexpr>
    return tuple(create(dataset) for dataset in datasets)
  File "/media/aiteam/DATA/workspace/hoangtnm/audio/examples/pipeline_wav2letter/src/datasets.py", line 57, in create
    for tag, transform in zip(tags, transform_list)
  File "/media/aiteam/DATA/workspace/hoangtnm/audio/examples/pipeline_wav2letter/src/datasets.py", line 57, in <listcomp>
    for tag, transform in zip(tags, transform_list)
  File "/media/aiteam/DATA/workspace/hoangtnm/audio/examples/pipeline_wav2letter/src/datasets.py", line 15, in __init__
    self._path = os.path.join(root, url)
  File "/home/hoangtnm/anaconda3/envs/dl/lib/python3.7/posixpath.py", line 80, in join
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```