### PR TITLE
Using Path and glob instead of walk_files

### DIFF
--- a/torchaudio/datasets/librispeech.py
+++ b/torchaudio/datasets/librispeech.py
@@ -125,7 +125,7 @@ class LIBRISPEECH(Dataset):
                 extract_archive(archive)
 
         walker = sorted([str(p.stem) for p in Path(self._path).glob('*/*/*' + self._ext_audio)])
-        self._walker.sort()
+        self._walker = walker.sort()
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, int, int, int]:
         """Load the n-th sample from the dataset.

--- a/torchaudio/datasets/librispeech.py
+++ b/torchaudio/datasets/librispeech.py
@@ -125,7 +125,7 @@ class LIBRISPEECH(Dataset):
                     download_url(url, root, hash_value=checksum)
                 extract_archive(archive)
 
-        walker = sorted([str(p.stem) for p in Path(self._path).glob('*/*/*'+self._ext_audio)])
+        walker = sorted([str(p.stem) for p in Path(self._path).glob('*/*/*' + self._ext_audio)])
         self._walker = list(walker)
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, int, int, int]:

--- a/torchaudio/datasets/librispeech.py
+++ b/torchaudio/datasets/librispeech.py
@@ -124,9 +124,7 @@ class LIBRISPEECH(Dataset):
                     download_url(url, root, hash_value=checksum)
                 extract_archive(archive)
 
-        walker = [str(p.stem) for p in Path(self._path).glob('*/*/*' + self._ext_audio)]
-        walker.sort()
-        self._walker = walker
+        self._walker = sorted(str(p.stem) for p in Path(self._path).glob('*/*/*' + self._ext_audio))
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, int, int, int]:
         """Load the n-th sample from the dataset.

--- a/torchaudio/datasets/librispeech.py
+++ b/torchaudio/datasets/librispeech.py
@@ -8,7 +8,6 @@ from torch.utils.data import Dataset
 from torchaudio.datasets.utils import (
     download_url,
     extract_archive,
-    walk_files,
 )
 
 URL = "train-clean-100"

--- a/torchaudio/datasets/librispeech.py
+++ b/torchaudio/datasets/librispeech.py
@@ -124,7 +124,7 @@ class LIBRISPEECH(Dataset):
                     download_url(url, root, hash_value=checksum)
                 extract_archive(archive)
 
-        walker = sorted([str(p.stem) for p in Path(self._path).glob('*/*/*' + self._ext_audio)])
+        walker = [str(p.stem) for p in Path(self._path).glob('*/*/*' + self._ext_audio)]
         self._walker = walker.sort()
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, int, int, int]:

--- a/torchaudio/datasets/librispeech.py
+++ b/torchaudio/datasets/librispeech.py
@@ -125,9 +125,7 @@ class LIBRISPEECH(Dataset):
                     download_url(url, root, hash_value=checksum)
                 extract_archive(archive)
 
-        walker = walk_files(
-            self._path, suffix=self._ext_audio, prefix=False, remove_suffix=True
-        )
+        walker = sorted([str(p.stem) for p in Path(self._path).glob('*/*/*'+self._ext_audio)])
         self._walker = list(walker)
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, int, int, int]:

--- a/torchaudio/datasets/librispeech.py
+++ b/torchaudio/datasets/librispeech.py
@@ -125,7 +125,8 @@ class LIBRISPEECH(Dataset):
                 extract_archive(archive)
 
         walker = [str(p.stem) for p in Path(self._path).glob('*/*/*' + self._ext_audio)]
-        self._walker = walker.sort()
+        walker.sort()
+        self._walker = walker
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, int, int, int]:
         """Load the n-th sample from the dataset.

--- a/torchaudio/datasets/librispeech.py
+++ b/torchaudio/datasets/librispeech.py
@@ -126,7 +126,7 @@ class LIBRISPEECH(Dataset):
                 extract_archive(archive)
 
         walker = sorted([str(p.stem) for p in Path(self._path).glob('*/*/*' + self._ext_audio)])
-        self._walker = list(walker)
+        self._walker.sort()
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, int, int, int]:
         """Load the n-th sample from the dataset.

--- a/torchaudio/datasets/libritts.py
+++ b/torchaudio/datasets/libritts.py
@@ -125,7 +125,7 @@ class LIBRITTS(Dataset):
                     download_url(url, root, hash_value=checksum)
                 extract_archive(archive)
 
-        walker = sorted([str(p.stem) for p in Path(self._path).glob('*/*/*' + self._ext_audio)])
+        walker = [str(p.stem) for p in Path(self._path).glob('*/*/*' + self._ext_audio)]
         self._walker = walker.sort()
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, str, int, int, str]:

--- a/torchaudio/datasets/libritts.py
+++ b/torchaudio/datasets/libritts.py
@@ -126,7 +126,7 @@ class LIBRITTS(Dataset):
                 extract_archive(archive)
 
         walker = sorted([str(p.stem) for p in Path(self._path).glob('*/*/*' + self._ext_audio)])
-        self._walker.sort()
+        self._walker = walker.sort()
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, str, int, int, str]:
         """Load the n-th sample from the dataset.

--- a/torchaudio/datasets/libritts.py
+++ b/torchaudio/datasets/libritts.py
@@ -126,7 +126,8 @@ class LIBRITTS(Dataset):
                 extract_archive(archive)
 
         walker = [str(p.stem) for p in Path(self._path).glob('*/*/*' + self._ext_audio)]
-        self._walker = walker.sort()
+        walker.sort()
+        self._walker = walker
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, str, int, int, str]:
         """Load the n-th sample from the dataset.

--- a/torchaudio/datasets/libritts.py
+++ b/torchaudio/datasets/libritts.py
@@ -125,9 +125,7 @@ class LIBRITTS(Dataset):
                     download_url(url, root, hash_value=checksum)
                 extract_archive(archive)
 
-        walker = [str(p.stem) for p in Path(self._path).glob('*/*/*' + self._ext_audio)]
-        walker.sort()
-        self._walker = walker
+        self._walker = sorted(str(p.stem) for p in Path(self._path).glob('*/*/*' + self._ext_audio))
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, str, int, int, str]:
         """Load the n-th sample from the dataset.

--- a/torchaudio/datasets/libritts.py
+++ b/torchaudio/datasets/libritts.py
@@ -125,7 +125,7 @@ class LIBRITTS(Dataset):
                     download_url(url, root, hash_value=checksum)
                 extract_archive(archive)
 
-        walker = sorted([str(p.stem) for p in Path(lt_data._path).glob('*/*/*' + self._ext_audio)])
+        walker = sorted([str(p.stem) for p in Path(self._path).glob('*/*/*' + self._ext_audio)])
         self._walker = list(walker)
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, str, int, int, str]:

--- a/torchaudio/datasets/libritts.py
+++ b/torchaudio/datasets/libritts.py
@@ -126,7 +126,7 @@ class LIBRITTS(Dataset):
                 extract_archive(archive)
 
         walker = sorted([str(p.stem) for p in Path(self._path).glob('*/*/*' + self._ext_audio)])
-        self._walker = list(walker)
+        self._walker.sort()
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, str, int, int, str]:
         """Load the n-th sample from the dataset.

--- a/torchaudio/datasets/libritts.py
+++ b/torchaudio/datasets/libritts.py
@@ -8,7 +8,6 @@ from torch.utils.data import Dataset
 from torchaudio.datasets.utils import (
     download_url,
     extract_archive,
-    walk_files,
 )
 
 URL = "train-clean-100"
@@ -126,9 +125,7 @@ class LIBRITTS(Dataset):
                     download_url(url, root, hash_value=checksum)
                 extract_archive(archive)
 
-        walker = walk_files(
-            self._path, suffix=self._ext_audio, prefix=False, remove_suffix=True
-        )
+        walker = sorted([str(p.stem) for p in Path(lt_data._path).glob('*/*/*' + self._ext_audio)])
         self._walker = list(walker)
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, str, int, int, str]:

--- a/torchaudio/datasets/speechcommands.py
+++ b/torchaudio/datasets/speechcommands.py
@@ -109,7 +109,8 @@ class SPEECHCOMMANDS(Dataset):
             self._walker = _load_list(self._path, "testing_list.txt")
         elif subset == "training":
             excludes = set(_load_list(self._path, "validation_list.txt", "testing_list.txt"))
-            walker = sorted([str(p) for p in Path(self._path).glob('*/*.wav')])
+            walker = [str(p) for p in Path(self._path).glob('*/*.wav')]
+            walker.sort()
             self._walker = [
                 w for w in walker
                 if HASH_DIVIDER in w
@@ -117,7 +118,8 @@ class SPEECHCOMMANDS(Dataset):
                 and os.path.normpath(w) not in excludes
             ]
         else:
-            walker = sorted([str(p) for p in Path(self._path).glob('*/*.wav')])
+            walker = [str(p) for p in Path(self._path).glob('*/*.wav')]
+            walker.sort()
             self._walker = [w for w in walker if HASH_DIVIDER in w and EXCEPT_FOLDER not in w]
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, str, int]:

--- a/torchaudio/datasets/speechcommands.py
+++ b/torchaudio/datasets/speechcommands.py
@@ -109,8 +109,7 @@ class SPEECHCOMMANDS(Dataset):
             self._walker = _load_list(self._path, "testing_list.txt")
         elif subset == "training":
             excludes = set(_load_list(self._path, "validation_list.txt", "testing_list.txt"))
-            walker = [str(p) for p in Path(self._path).glob('*/*.wav')]
-            walker.sort()
+            walker = sorted(str(p) for p in Path(self._path).glob('*/*.wav'))
             self._walker = [
                 w for w in walker
                 if HASH_DIVIDER in w
@@ -118,8 +117,7 @@ class SPEECHCOMMANDS(Dataset):
                 and os.path.normpath(w) not in excludes
             ]
         else:
-            walker = [str(p) for p in Path(self._path).glob('*/*.wav')]
-            walker.sort()
+            walker = sorted(str(p) for p in Path(self._path).glob('*/*.wav'))
             self._walker = [w for w in walker if HASH_DIVIDER in w and EXCEPT_FOLDER not in w]
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, str, int]:

--- a/torchaudio/datasets/speechcommands.py
+++ b/torchaudio/datasets/speechcommands.py
@@ -7,8 +7,7 @@ from torch.utils.data import Dataset
 from torch import Tensor
 from torchaudio.datasets.utils import (
     download_url,
-    extract_archive,
-    walk_files
+    extract_archive
 )
 
 FOLDER_IN_ARCHIVE = "SpeechCommands"
@@ -110,7 +109,7 @@ class SPEECHCOMMANDS(Dataset):
             self._walker = _load_list(self._path, "testing_list.txt")
         elif subset == "training":
             excludes = set(_load_list(self._path, "validation_list.txt", "testing_list.txt"))
-            walker = walk_files(self._path, suffix=".wav", prefix=True)
+            walker = sorted([str(p) for p in Path(self._path).glob('*/*.wav')])
             self._walker = [
                 w for w in walker
                 if HASH_DIVIDER in w
@@ -118,7 +117,7 @@ class SPEECHCOMMANDS(Dataset):
                 and os.path.normpath(w) not in excludes
             ]
         else:
-            walker = walk_files(self._path, suffix=".wav", prefix=True)
+            walker = sorted([str(p) for p in Path(self._path).glob('*/*.wav')])
             self._walker = [w for w in walker if HASH_DIVIDER in w and EXCEPT_FOLDER not in w]
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, str, int]:

--- a/torchaudio/datasets/speechcommands.py
+++ b/torchaudio/datasets/speechcommands.py
@@ -7,7 +7,7 @@ from torch.utils.data import Dataset
 from torch import Tensor
 from torchaudio.datasets.utils import (
     download_url,
-    extract_archive
+    extract_archive,
 )
 
 FOLDER_IN_ARCHIVE = "SpeechCommands"

--- a/torchaudio/datasets/yesno.py
+++ b/torchaudio/datasets/yesno.py
@@ -8,8 +8,7 @@ from torch import Tensor
 from torch.utils.data import Dataset
 from torchaudio.datasets.utils import (
     download_url,
-    extract_archive,
-    walk_files
+    extract_archive
 )
 
 URL = "http://www.openslr.org/resources/1/waves_yesno.tar.gz"
@@ -85,9 +84,7 @@ class YESNO(Dataset):
                 "Dataset not found. Please use `download=True` to download it."
             )
 
-        walker = walk_files(
-            self._path, suffix=self._ext_audio, prefix=False, remove_suffix=True
-        )
+        walker = sorted([str(p.stem) for p in Path(self._path).glob('*.wav')])
         self._walker = list(walker)
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, List[int]]:

--- a/torchaudio/datasets/yesno.py
+++ b/torchaudio/datasets/yesno.py
@@ -84,7 +84,7 @@ class YESNO(Dataset):
                 "Dataset not found. Please use `download=True` to download it."
             )
 
-        walker = sorted([str(p.stem) for p in Path(self._path).glob('*.wav')])
+        walker = sorted([str(p.stem) for p in Path(self._path).glob('*.' + self._ext_audio)])
         self._walker = list(walker)
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, List[int]]:

--- a/torchaudio/datasets/yesno.py
+++ b/torchaudio/datasets/yesno.py
@@ -85,7 +85,7 @@ class YESNO(Dataset):
             )
 
         walker = sorted([str(p.stem) for p in Path(self._path).glob('*' + self._ext_audio)])
-        self._walker.sort()
+        self._walker = walker.sort()
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, List[int]]:
         """Load the n-th sample from the dataset.

--- a/torchaudio/datasets/yesno.py
+++ b/torchaudio/datasets/yesno.py
@@ -8,7 +8,7 @@ from torch import Tensor
 from torch.utils.data import Dataset
 from torchaudio.datasets.utils import (
     download_url,
-    extract_archive
+    extract_archive,
 )
 
 URL = "http://www.openslr.org/resources/1/waves_yesno.tar.gz"

--- a/torchaudio/datasets/yesno.py
+++ b/torchaudio/datasets/yesno.py
@@ -84,9 +84,7 @@ class YESNO(Dataset):
                 "Dataset not found. Please use `download=True` to download it."
             )
 
-        walker = [str(p.stem) for p in Path(self._path).glob('*' + self._ext_audio)]
-        walker.sort()
-        self._walker = walker
+        self._walker = sorted(str(p.stem) for p in Path(self._path).glob('*' + self._ext_audio))
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, List[int]]:
         """Load the n-th sample from the dataset.

--- a/torchaudio/datasets/yesno.py
+++ b/torchaudio/datasets/yesno.py
@@ -84,7 +84,7 @@ class YESNO(Dataset):
                 "Dataset not found. Please use `download=True` to download it."
             )
 
-        walker = sorted([str(p.stem) for p in Path(self._path).glob('*' + self._ext_audio)])
+        walker = [str(p.stem) for p in Path(self._path).glob('*' + self._ext_audio)]
         self._walker = walker.sort()
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, List[int]]:

--- a/torchaudio/datasets/yesno.py
+++ b/torchaudio/datasets/yesno.py
@@ -85,7 +85,7 @@ class YESNO(Dataset):
             )
 
         walker = sorted([str(p.stem) for p in Path(self._path).glob('*' + self._ext_audio)])
-        self._walker = list(walker)
+        self._walker.sort()
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, List[int]]:
         """Load the n-th sample from the dataset.

--- a/torchaudio/datasets/yesno.py
+++ b/torchaudio/datasets/yesno.py
@@ -84,7 +84,7 @@ class YESNO(Dataset):
                 "Dataset not found. Please use `download=True` to download it."
             )
 
-        walker = sorted([str(p.stem) for p in Path(self._path).glob('*.' + self._ext_audio)])
+        walker = sorted([str(p.stem) for p in Path(self._path).glob('*' + self._ext_audio)])
         self._walker = list(walker)
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, List[int]]:

--- a/torchaudio/datasets/yesno.py
+++ b/torchaudio/datasets/yesno.py
@@ -85,7 +85,8 @@ class YESNO(Dataset):
             )
 
         walker = [str(p.stem) for p in Path(self._path).glob('*' + self._ext_audio)]
-        self._walker = walker.sort()
+        walker.sort()
+        self._walker = walker
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, List[int]]:
         """Load the n-th sample from the dataset.


### PR DESCRIPTION
Hello @vincentqb,

I wanted to take an initial stab at this. I have made a minor modification for 

- [x] yesno
- [x] librispeech
- [x] libritts
- [x] speechcommands

Looks like `tedlium`, `ljspeech` and `vctk` (VCTK_092) don't have `walk_files`

cc https://github.com/pytorch/audio/issues/1051