### PR TITLE
Remove twice coded line on __all__

### DIFF
--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -24,7 +24,6 @@ __all__ = [
     "angle",
     "magphase",
     "phase_vocoder",
-    "detect_pitch_frequency",
     'mask_along_axis',
     'mask_along_axis_iid',
     'sliding_window_cmn',


### PR DESCRIPTION
Hi, I found that the function "detect_pitch_frequency" is inserted twice times to list __all__.  [line 1](https://github.com/pytorch/audio/blob/19fc580da97baf179395bb257647c5c25b993e42/torchaudio/functional/functional.py#L19), [line 2](https://github.com/pytorch/audio/blob/19fc580da97baf179395bb257647c5c25b993e42/torchaudio/functional/functional.py#L27) . So I just remove one of them.

`
__all__ = [
    "spectrogram",
    "griffinlim",
    "amplitude_to_DB",
    "DB_to_amplitude",
    "compute_deltas",
    "create_fb_matrix",
    "create_dct",
    "compute_deltas",
    "detect_pitch_frequency",
    "DB_to_amplitude",
    "mu_law_encoding",
    "mu_law_decoding",
    "complex_norm",
    "angle",
    "magphase",
    "phase_vocoder",
    "detect_pitch_frequency",
    'mask_along_axis',
    'mask_along_axis_iid',
    'sliding_window_cmn',
]
`