### PR TITLE
remove checkout step from upload

### DIFF
--- a/.circleci/build_docs/commit_docs.sh
+++ b/.circleci/build_docs/commit_docs.sh
@@ -5,7 +5,7 @@ set -ex
 
 if [ "$2" == "" ]; then
     echo call as "$0" "<src>" "<target branch>"
-    echo where src is the built documentation and
+    echo where src is the root of the built documentation git checkout and
     echo branch should be "master" or "1.7" or so
     exit 1
 fi
@@ -15,14 +15,15 @@ target=$2
 
 echo "committing docs from ${src} to ${target}"
 
+pushd $src
 git checkout gh-pages
 mkdir -p ./"${target}"
 rm -rf ./"${target}"/*
-cp -r "${src}/build/html/"* ./"$target"
+cp -r "${src}/docs/build/html/"* ./"$target"
 if [ "${target}" == "master" ]; then
     mkdir -p ./_static
     rm -rf ./_static/*
-    cp -r "${src}/build/html/_static/"* ./_static
+    cp -r "${src}/docs/build/html/_static/"* ./_static
     git add --all ./_static || true
 fi
 git add --all ./"${target}" || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -662,7 +662,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/workspace
-      - designate_upload_channel
       - checkout
       - run:
           name: Install pytorch-audio
@@ -671,7 +670,7 @@ jobs:
           name: Build docs
           command: .circleci/build_docs/build_docs.sh
       - persist_to_workspace:
-          root: docs
+          root: ./
           paths:
             - "*"
 
@@ -683,7 +682,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/workspace
-      - designate_upload_channel
       - run:
           name: Generate netrc
           command: |
@@ -694,13 +692,15 @@ jobs:
               login pytorchbot
               password ${GITHUB_PYTORCHBOT_TOKEN}
             DONE
-      - checkout
       - run:
           name: Upload docs
           command: |
+            # Don't use "checkout" step since it uses ssh, which cannot git push
+            # https://circleci.com/docs/2.0/configuration-reference/#checkout
             set -ex
             echo $PWD
             ls ~/workspace
+            ls ~/workspace/doc
             tag=${CIRCLE_TAG:1:5}
             target=${tag:-master}
             .circleci/build_docs/commit_docs.sh ~/workspace $target

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -662,7 +662,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/workspace
-      - designate_upload_channel
       - checkout
       - run:
           name: Install pytorch-audio
@@ -671,7 +670,7 @@ jobs:
           name: Build docs
           command: .circleci/build_docs/build_docs.sh
       - persist_to_workspace:
-          root: docs
+          root: ./
           paths:
             - "*"
 
@@ -683,7 +682,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/workspace
-      - designate_upload_channel
       - run:
           name: Generate netrc
           command: |
@@ -694,13 +692,15 @@ jobs:
               login pytorchbot
               password ${GITHUB_PYTORCHBOT_TOKEN}
             DONE
-      - checkout
       - run:
           name: Upload docs
           command: |
+            # Don't use "checkout" step since it uses ssh, which cannot git push
+            # https://circleci.com/docs/2.0/configuration-reference/#checkout
             set -ex
             echo $PWD
             ls ~/workspace
+            ls ~/workspace/doc
             tag=${CIRCLE_TAG:1:5}
             target=${tag:-master}
             .circleci/build_docs/commit_docs.sh ~/workspace $target


### PR DESCRIPTION
Continuation of gh-1049, gh-1041, gh-1034, gh-1031, gh-1006 to automate the docs build and push the result to the gh-pages branch. We cannot use the checkout step since it will force push-via-ssh, which will fail. Instead re-use the git checkout from the `build_docs` step.

Also remove the "designate_upload_channel" step which is for uploading wheels, which is not necessary here.