### PR TITLE
remove buggy debug cruft

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -699,8 +699,6 @@ jobs:
             # https://circleci.com/docs/2.0/configuration-reference/#checkout
             set -ex
             echo $PWD
-            ls ~/workspace
-            ls ~/workspace/doc
             tag=${CIRCLE_TAG:1:5}
             target=${tag:-master}
             .circleci/build_docs/commit_docs.sh ~/workspace $target

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -699,8 +699,6 @@ jobs:
             # https://circleci.com/docs/2.0/configuration-reference/#checkout
             set -ex
             echo $PWD
-            ls ~/workspace
-            ls ~/workspace/doc
             tag=${CIRCLE_TAG:1:5}
             target=${tag:-master}
             .circleci/build_docs/commit_docs.sh ~/workspace $target


### PR DESCRIPTION
The nightly task [ran but failed](https://app.circleci.com/pipelines/github/pytorch/audio/4135/workflows/4d0ea223-9e2e-47c4-95b3-3140a60c9f8d/jobs/127799). The debug line to show the contents of `doc` should have been `docs` instead. It did, however confirm the existance of the `docs` directory, so the PR removes the debug cruft so the script hopefully will run to completion.

<details>
<summary>Log output</summary>

```
#!/bin/bash -eo pipefail
# Don't use "checkout" step since it uses ssh, which cannot git push
# https://circleci.com/docs/2.0/configuration-reference/#checkout
set -ex
echo $PWD
ls ~/workspace
ls ~/workspace/doc
tag=${CIRCLE_TAG:1:5}
target=${tag:-master}
.circleci/build_docs/commit_docs.sh ~/workspace $target

+ echo /root/project
/root/project
+ ls /root/workspace
archives	    README.md
build_tools	    requirements.txt
CODE_OF_CONDUCT.md  setup.py
docs		    test
examples	    third_party
LICENSE		    torchaudio
mypy.ini	    torchaudio-0.8.0.dev20201216-cp38-cp38-linux_x86_64.whl
packaging	    tox.ini
+ ls /root/workspace/doc
ls: cannot access /root/workspace/doc: No such file or directory

Exited with code exit status 2

CircleCI received exit code 2
```