### PR TITLE
script is not in PWD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -698,10 +698,9 @@ jobs:
             # Don't use "checkout" step since it uses ssh, which cannot git push
             # https://circleci.com/docs/2.0/configuration-reference/#checkout
             set -ex
-            echo $PWD
             tag=${CIRCLE_TAG:1:5}
             target=${tag:-master}
-            .circleci/build_docs/commit_docs.sh ~/workspace $target
+            ~/workspace/.circleci/build_docs/commit_docs.sh ~/workspace $target
 
 workflows:
   build:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -698,10 +698,9 @@ jobs:
             # Don't use "checkout" step since it uses ssh, which cannot git push
             # https://circleci.com/docs/2.0/configuration-reference/#checkout
             set -ex
-            echo $PWD
             tag=${CIRCLE_TAG:1:5}
             target=${tag:-master}
-            .circleci/build_docs/commit_docs.sh ~/workspace $target
+            ~/workspace/.circleci/build_docs/commit_docs.sh ~/workspace $target
 
 workflows:
   build:


### PR DESCRIPTION
Continuation of gh-1093: the script is located in the repo, which is in `~/workspace`.

Is there a way to trigger the nightly build after merging this so the cycles of trial and error can move faster?