### PR TITLE
Support bytes and file-like obj in sox_effects

### DIFF
--- a/test/torchaudio_unittest/soundfile_backend/info_test.py
+++ b/test/torchaudio_unittest/soundfile_backend/info_test.py
@@ -93,3 +93,58 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.sample_rate == sample_rate
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
+
+
+@skipIfNoModule("soundfile")
+class TestFileLikeObject(TempDirMixin, PytorchTestCase):
+    def _test_fileobj(self, ext):
+        """Query audio via file-like object should work"""
+        duration = 2
+        sample_rate = 16000
+        num_channels = 2
+        num_frames = sample_rate * duration
+        path = self.get_temp_path(f'test.{ext}')
+
+        data = torch.randn(num_frames, num_channels).numpy()
+        soundfile.write(path, data, sample_rate)
+
+        with open(path, 'rb') as fileobj:
+            info = soundfile_backend.info(fileobj)
+        assert info.sample_rate == sample_rate
+        assert info.num_frames == num_frames
+        assert info.num_channels == num_channels
+
+    def test_fileobj_wav(self):
+        """Loading audio via file-like object works"""
+        self._test_fileobj('wav')
+
+    @skipIfFormatNotSupported("FLAC")
+    def test_fileobj_flac(self):
+        """Loading audio via file-like object works"""
+        self._test_fileobj('flac')
+
+    def _test_bytes(self, ext):
+        """Query audio via file-like object should work"""
+        duration = 2
+        sample_rate = 16000
+        num_channels = 2
+        num_frames = sample_rate * duration
+        path = self.get_temp_path(f'test.{ext}')
+
+        data = torch.randn(num_frames, num_channels).numpy()
+        soundfile.write(path, data, sample_rate)
+
+        with open(path, 'rb') as file_:
+            info = soundfile_backend.info(file_.read())
+        assert info.sample_rate == sample_rate
+        assert info.num_frames == num_frames
+        assert info.num_channels == num_channels
+
+    def test_bytes_wav(self):
+        """Loading audio via file-like object works"""
+        self._test_bytes('wav')
+
+    @skipIfFormatNotSupported("FLAC")
+    def test_bytes_flac(self):
+        """Loading audio via file-like object works"""
+        self._test_bytes('flac')

--- a/test/torchaudio_unittest/soundfile_backend/load_test.py
+++ b/test/torchaudio_unittest/soundfile_backend/load_test.py
@@ -299,3 +299,53 @@ class TestLoadFormat(TempDirMixin, PytorchTestCase):
     @skipIfFormatNotSupported("FLAC")
     def test_flac(self, format_):
         self._test_format(format_)
+
+
+@skipIfNoModule("soundfile")
+class TestFileLikeObject(TempDirMixin, PytorchTestCase):
+    def _test_fileobj(self, ext):
+        """Loading audio via file-like object works"""
+        sample_rate = 16000
+        path = self.get_temp_path(f'test.{ext}')
+
+        data = get_wav_data('float32', num_channels=2).numpy().T
+        soundfile.write(path, data, sample_rate)
+        expected = soundfile.read(path, dtype='float32')[0].T
+
+        with open(path, 'rb') as fileobj:
+            found, sr = soundfile_backend.load(fileobj)
+        assert sr == sample_rate
+        self.assertEqual(expected, found)
+
+    def test_fileobj_wav(self):
+        """Loading audio via file-like object works"""
+        self._test_fileobj('wav')
+
+    @skipIfFormatNotSupported("FLAC")
+    def test_fileobj_flac(self):
+        """Loading audio via file-like object works"""
+        self._test_fileobj('flac')
+
+    def _test_bytes(self, ext):
+        """Loading audio via bytes works"""
+        sample_rate = 16000
+        path = self.get_temp_path(f'test.{ext}')
+
+        data = get_wav_data('float32', num_channels=2).numpy().T
+        soundfile.write(path, data, sample_rate)
+        expected = soundfile.read(path, dtype='float32')[0].T
+
+        with open(path, 'rb') as fileobj:
+            data = fileobj.read()
+            found, sr = soundfile_backend.load(data)
+        assert sr == sample_rate
+        self.assertEqual(expected, found)
+
+    def _test_bytes_wav(self):
+        """Loading audio via bytes works"""
+        self._test_bytes('wav')
+
+    @skipIfFormatNotSupported("FLAC")
+    def _test_bytes_flac(self):
+        """Loading audio via bytes works"""
+        self._test_bytes('flac')

--- a/torchaudio/backend/_soundfile_backend.py
+++ b/torchaudio/backend/_soundfile_backend.py
@@ -1,4 +1,5 @@
 """The new soundfile backend which will become default in 0.8.0 onward"""
+import io
 from typing import Tuple, Optional
 import warnings
 
@@ -80,8 +81,13 @@ def load(
     ``[-1.0, 1.0]``.
 
     Args:
-        filepath (str or pathlib.Path): Path to audio file.
-            This functionalso handles ``pathlib.Path`` objects, but is annotated as ``str``
+        filepath (str, pathlib.Path, or file-like object):
+            Source of audio data. One of the following types;
+                  * ``str`` or ``pathlib.Path``: file path
+                  * ``bytes``: Audio data in bytes
+                  * ``file-like``: A file-like object with ``read`` method
+                    that returns ``bytes``.
+            This argument is intentionally annotated as only ``str`` for
             for the consistency with "sox_io" backend, which has a restriction on type annotation
             for TorchScript compiler compatiblity.
         frame_offset (int):
@@ -109,6 +115,8 @@ def load(
             integer type, else ``float32`` type. If ``channels_first=True``, it has
             ``[channel, time]`` else ``[time, channel]``.
     """
+    if isinstance(filepath, bytes):
+        filepath = io.BytesIO(filepath)
     with soundfile.SoundFile(filepath, "r") as file_:
         if file_.format != "WAV" or normalize:
             dtype = "float32"

--- a/torchaudio/backend/_soundfile_backend.py
+++ b/torchaudio/backend/_soundfile_backend.py
@@ -17,7 +17,12 @@ def info(filepath: str) -> AudioMetaData:
     """Get signal information of an audio file.
 
     Args:
-        filepath (str or pathlib.Path): Path to audio file.
+        filepath (str, pathlib.Path, bytes or file-like object):
+            Source of audio data. One of the following types;
+                  * ``str`` or ``pathlib.Path``: file path
+                  * ``bytes``: Audio data in bytes.
+                  * ``file-like``: A file-like object with ``read`` method
+                    that returns ``bytes``.
             This functionalso handles ``pathlib.Path`` objects, but is annotated as ``str``
             for the consistency with "sox_io" backend, which has a restriction on type annotation
             for TorchScript compiler compatiblity.
@@ -25,6 +30,8 @@ def info(filepath: str) -> AudioMetaData:
     Returns:
         AudioMetaData: meta data of the given audio.
     """
+    if isinstance(filepath, bytes):
+        filepath = io.BytesIO(filepath)
     sinfo = soundfile.info(filepath)
     return AudioMetaData(sinfo.samplerate, sinfo.frames, sinfo.channels)
 

--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -85,11 +85,14 @@ def load(
 
     Args:
         filepath (str, pathlib.Path, file-like object or bytes):
-            Source of audio data. One of the following types;
+            Source of audio data. When the function is not compiled by TorchScript,
+            (e.g. ``torch.jit.script``), the following types are accepted;
                   * ``str`` or ``pathlib.Path``: file path
                   * ``bytes``: Audio data in bytes
                   * ``file-like``: A file-like object with ``read`` method
                     that returns ``bytes``.
+            When the function is compiled by TorchScript (such as ``torch.jit.script``), then only
+            ``str`` type is allowed.
             This argument is intentionally annotated as only ``str`` for
             TorchScript compiler compatibility.
         frame_offset (int):

--- a/torchaudio/csrc/register.cpp
+++ b/torchaudio/csrc/register.cpp
@@ -47,7 +47,7 @@ TORCH_LIBRARY(torchaudio, m) {
       .def("get_num_channels", &torchaudio::sox_io::SignalInfo::getNumChannels)
       .def("get_num_frames", &torchaudio::sox_io::SignalInfo::getNumFrames);
 
-  m.def("torchaudio::sox_io_get_info", &torchaudio::sox_io::get_info);
+  m.def("torchaudio::sox_io_get_info", &torchaudio::sox_io::get_info_file);
   m.def(
       "torchaudio::sox_io_load_audio_file("
           "str path,"

--- a/torchaudio/csrc/sox.cpp
+++ b/torchaudio/csrc/sox.cpp
@@ -181,6 +181,16 @@ void write_audio_file(
 
 namespace {
 
+using SignalInfo = std::tuple<int64_t, int64_t, int64_t>;
+SignalInfo get_info_bytes(
+    py::bytes src,
+    c10::optional<std::string>& format) {
+  auto bytes = static_cast<std::string>(src);
+  auto info = torchaudio::sox_io::get_info_bytes(bytes, format);
+  return std::make_tuple(
+      info->getSampleRate(), info->getNumFrames(), info->getNumChannels());
+}
+
 std::tuple<torch::Tensor, int64_t> load_audio_bytes(
     py::bytes src,
     c10::optional<int64_t> frame_offset,
@@ -289,5 +299,7 @@ PYBIND11_MODULE(_torchaudio, m) {
       "get_info",
       &torch::audio::get_info,
       "Gets information about an audio file");
+  m.def(
+      "get_info_bytes", &get_info_bytes, "Get information about an audio file");
   m.def("load_audio_bytes", &load_audio_bytes, "Load audio from byte string.");
 }

--- a/torchaudio/csrc/sox.cpp
+++ b/torchaudio/csrc/sox.cpp
@@ -1,4 +1,5 @@
 #include <torchaudio/csrc/sox.h>
+#include <torchaudio/csrc/sox_effects.h>
 #include <torchaudio/csrc/sox_io.h>
 
 #include <algorithm>
@@ -204,6 +205,18 @@ std::tuple<torch::Tensor, int64_t> load_audio_bytes(
   return std::make_tuple(result->getTensor(), result->getSampleRate());
 }
 
+std::tuple<torch::Tensor, int64_t> apply_effects_bytes(
+    py::bytes src,
+    std::vector<std::vector<std::string>> effects,
+    c10::optional<bool>& normalize,
+    c10::optional<bool>& channels_first,
+    c10::optional<std::string>& format) {
+  auto bytes = static_cast<std::string>(src);
+  auto result = torchaudio::sox_effects::apply_effects_bytes(
+      bytes, effects, normalize, channels_first, format);
+  return std::make_tuple(result->getTensor(), result->getSampleRate());
+}
+
 } // namespace
 
 PYBIND11_MODULE(_torchaudio, m) {
@@ -302,4 +315,8 @@ PYBIND11_MODULE(_torchaudio, m) {
   m.def(
       "get_info_bytes", &get_info_bytes, "Get information about an audio file");
   m.def("load_audio_bytes", &load_audio_bytes, "Load audio from byte string.");
+  m.def(
+      "apply_effects_bytes",
+      &apply_effects_bytes,
+      "Decode audio data from byte string and apply sox effects.");
 }

--- a/torchaudio/csrc/sox_effects.h
+++ b/torchaudio/csrc/sox_effects.h
@@ -16,7 +16,14 @@ c10::intrusive_ptr<torchaudio::sox_utils::TensorSignal> apply_effects_tensor(
     std::vector<std::vector<std::string>> effects);
 
 c10::intrusive_ptr<torchaudio::sox_utils::TensorSignal> apply_effects_file(
-    const std::string path,
+    const std::string& path,
+    std::vector<std::vector<std::string>> effects,
+    c10::optional<bool>& normalize,
+    c10::optional<bool>& channels_first,
+    c10::optional<std::string>& format);
+
+c10::intrusive_ptr<torchaudio::sox_utils::TensorSignal> apply_effects_bytes(
+    const std::string& bytes,
     std::vector<std::vector<std::string>> effects,
     c10::optional<bool>& normalize,
     c10::optional<bool>& channels_first,

--- a/torchaudio/csrc/sox_io.h
+++ b/torchaudio/csrc/sox_io.h
@@ -21,8 +21,11 @@ struct SignalInfo : torch::CustomClassHolder {
   int64_t getNumFrames() const;
 };
 
-c10::intrusive_ptr<SignalInfo> get_info(
+c10::intrusive_ptr<SignalInfo> get_info_file(
     const std::string& path,
+    c10::optional<std::string>& format);
+c10::intrusive_ptr<SignalInfo> get_info_bytes(
+    const std::string& bytes,
     c10::optional<std::string>& format);
 
 c10::intrusive_ptr<torchaudio::sox_utils::TensorSignal> load_audio_file(

--- a/torchaudio/csrc/sox_io.h
+++ b/torchaudio/csrc/sox_io.h
@@ -33,6 +33,14 @@ c10::intrusive_ptr<torchaudio::sox_utils::TensorSignal> load_audio_file(
     c10::optional<bool>& channels_first,
     c10::optional<std::string>& format);
 
+c10::intrusive_ptr<torchaudio::sox_utils::TensorSignal> load_audio_bytes(
+    const std::string& bytes,
+    c10::optional<int64_t>& frame_offset,
+    c10::optional<int64_t>& num_frames,
+    c10::optional<bool>& normalize,
+    c10::optional<bool>& channels_first,
+    c10::optional<std::string>& format);
+
 void save_audio_file(
     const std::string& file_name,
     const c10::intrusive_ptr<torchaudio::sox_utils::TensorSignal>& signal,

--- a/torchaudio/csrc/sox_utils.cpp
+++ b/torchaudio/csrc/sox_utils.cpp
@@ -99,9 +99,6 @@ void validate_input_file(const SoxFormat& sf) {
   if (sf->encoding.encoding == SOX_ENCODING_UNKNOWN) {
     throw std::runtime_error("Error loading audio file: unknown encoding.");
   }
-  if (sf->signal.length == 0) {
-    throw std::runtime_error("Error reading audio file: unkown length.");
-  }
 }
 
 void validate_input_tensor(const torch::Tensor tensor) {


### PR DESCRIPTION
After #1114, this PR adds `bytes` and `file-like` object support to `sox_effect.apply_effects_file`.