### PR TITLE
Support file-like object in save func

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,7 +411,6 @@ jobs:
           paths:
             - conda
             - env
-            - third_party/install
       - run:
           name: Install torchaudio
           command: .circleci/unittest/linux/scripts/install.sh
@@ -456,7 +455,6 @@ jobs:
           paths:
             - conda
             - env
-            - third_party/install
       - run:
           name: Install torchaudio
           command: docker run -t --gpus all -e UPLOAD_CHANNEL -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/install.sh
@@ -569,7 +567,6 @@ jobs:
           paths:
             - conda
             - env
-            - third_party/install
       - run:
           name: Install torchaudio
           command: .circleci/unittest/linux/scripts/install.sh
@@ -606,7 +603,6 @@ jobs:
           paths:
             - conda
             - env
-            - third_party/install
       - run:
           name: Run style check
           command: .circleci/unittest/linux/scripts/run_style_checks.sh

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -411,7 +411,6 @@ jobs:
           paths:
             - conda
             - env
-            - third_party/install
       - run:
           name: Install torchaudio
           command: .circleci/unittest/linux/scripts/install.sh
@@ -456,7 +455,6 @@ jobs:
           paths:
             - conda
             - env
-            - third_party/install
       - run:
           name: Install torchaudio
           command: docker run -t --gpus all -e UPLOAD_CHANNEL -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/install.sh
@@ -569,7 +567,6 @@ jobs:
           paths:
             - conda
             - env
-            - third_party/install
       - run:
           name: Install torchaudio
           command: .circleci/unittest/linux/scripts/install.sh
@@ -606,7 +603,6 @@ jobs:
           paths:
             - conda
             - env
-            - third_party/install
       - run:
           name: Run style check
           command: .circleci/unittest/linux/scripts/run_style_checks.sh

--- a/test/torchaudio_unittest/sox_io_backend/save_test.py
+++ b/test/torchaudio_unittest/sox_io_backend/save_test.py
@@ -456,7 +456,7 @@ class TestFileObject(SaveTestBase):
         with open(res_path, 'wb') as fileobj:
             sox_io_backend.save(
                 fileobj, data, channels_first=channels_first,
-                sample_rate=sample_rate, compression=compression)
+                sample_rate=sample_rate, compression=compression, format=ext)
 
         expected_data, _ = sox_io_backend.load(ref_path)
         data, sr = sox_io_backend.load(res_path)

--- a/test/torchaudio_unittest/sox_io_backend/save_test.py
+++ b/test/torchaudio_unittest/sox_io_backend/save_test.py
@@ -1,3 +1,4 @@
+import io
 import itertools
 
 from torchaudio.backend import sox_io_backend
@@ -417,3 +418,88 @@ class TestSaveParams(TempDirMixin, PytorchTestCase):
         sox_io_backend.save(path, data, 8000)
 
         self.assertEqual(data, expected)
+
+
+@skipIfNoExtension
+@skipIfNoExec('sox')
+class TestFileObject(SaveTestBase):
+    """
+    We campare the result of file-like object input against file path input because
+    `save` function is rigrously tested for file path inputs to match libsox's result,
+    """
+    @parameterized.expand([
+        ('wav', None),
+        ('mp3', 128),
+        ('mp3', 320),
+        ('flac', 0),
+        ('flac', 5),
+        ('flac', 8),
+        ('vorbis', -1),
+        ('vorbis', 10),
+        ('amb', None),
+    ])
+    def test_fileobj(self, ext, compression):
+        """Saving audio to file object returns the same result as via file path."""
+        sample_rate = 16000
+        dtype = 'float32'
+        num_channels = 2
+        num_frames = 16000
+        channels_first = True
+
+        data = get_wav_data(dtype, num_channels, num_frames=num_frames)
+
+        ref_path = self.get_temp_path(f'reference.{ext}')
+        res_path = self.get_temp_path(f'test.{ext}')
+        sox_io_backend.save(
+            ref_path, data, channels_first=channels_first,
+            sample_rate=sample_rate, compression=compression)
+        with open(res_path, 'wb') as fileobj:
+            sox_io_backend.save(
+                fileobj, data, channels_first=channels_first,
+                sample_rate=sample_rate, compression=compression)
+
+        expected_data, _ = sox_io_backend.load(ref_path)
+        data, sr = sox_io_backend.load(res_path)
+
+        assert sample_rate == sr
+        self.assertEqual(expected_data, data)
+
+    @parameterized.expand([
+        ('wav', None),
+        ('mp3', 128),
+        ('mp3', 320),
+        ('flac', 0),
+        ('flac', 5),
+        ('flac', 8),
+        ('vorbis', -1),
+        ('vorbis', 10),
+        ('amb', None),
+    ])
+    def test_bytesio(self, ext, compression):
+        """Saving audio to BytesIO object returns the same result as via file path."""
+        sample_rate = 16000
+        dtype = 'float32'
+        num_channels = 2
+        num_frames = 16000
+        channels_first = True
+
+        data = get_wav_data(dtype, num_channels, num_frames=num_frames)
+
+        ref_path = self.get_temp_path(f'reference.{ext}')
+        res_path = self.get_temp_path(f'test.{ext}')
+        sox_io_backend.save(
+            ref_path, data, channels_first=channels_first,
+            sample_rate=sample_rate, compression=compression)
+        fileobj = io.BytesIO()
+        sox_io_backend.save(
+            fileobj, data, channels_first=channels_first,
+            sample_rate=sample_rate, compression=compression, format=ext)
+        fileobj.seek(0)
+        with open(res_path, 'wb') as file_:
+            file_.write(fileobj.read())
+
+        expected_data, _ = sox_io_backend.load(ref_path)
+        data, sr = sox_io_backend.load(res_path)
+
+        assert sample_rate == sr
+        self.assertEqual(expected_data, data)

--- a/torchaudio/backend/_soundfile_backend.py
+++ b/torchaudio/backend/_soundfile_backend.py
@@ -1,11 +1,10 @@
 """The new soundfile backend which will become default in 0.8.0 onward"""
-import os
 from typing import Tuple, Optional
 import warnings
 
 import torch
 from torchaudio._internal import module_utils as _mod_utils
-from .common import AudioMetaData, get_ext
+from .common import AudioMetaData
 
 
 if _mod_utils.is_module_available("soundfile"):
@@ -181,11 +180,12 @@ def save(
             '`save` function of "soundfile" backend does not support "compression" parameter. '
             "The argument is silently ignored."
         )
-
-    try:
-        ext = get_ext(filepath, format)
-    except Exception:
-        raise RuntimeError('Cannot detect the output format. Provide `format` argument.') from None
+    if hasattr(filepath, 'write'):
+        if format is None:
+            raise RuntimeError('`format` is required when saving to file object.')
+        ext = format
+    else:
+        ext = str(filepath).split(".")[-1].lower()
 
     if ext != "wav":
         subtype = None

--- a/torchaudio/backend/common.py
+++ b/torchaudio/backend/common.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any, Optional
 
 from torchaudio._internal import module_utils as _mod_utils
@@ -18,22 +17,6 @@ class AudioMetaData:
         self.sample_rate = sample_rate
         self.num_frames = num_frames
         self.num_channels = num_channels
-
-
-def get_ext(
-        src: Any,
-        format: Optional[str]):
-    """Get the file extension from either the given format or target file information
-
-    Args:
-        src (path-like object or file-like object): Target file.
-        format (optional, str): format provided by user.
-    """
-    if format is not None:
-        return format.lower()
-    if hasattr(src, 'name'):
-        src = src.name
-    return os.path.splitext(src)[-1][1:].lower()
 
 
 @_mod_utils.deprecated('Please migrate to `AudioMetaData`.', '0.9.0')

--- a/torchaudio/backend/common.py
+++ b/torchaudio/backend/common.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Optional
 
 from torchaudio._internal import module_utils as _mod_utils
@@ -17,6 +18,22 @@ class AudioMetaData:
         self.sample_rate = sample_rate
         self.num_frames = num_frames
         self.num_channels = num_channels
+
+
+def get_ext(
+        src: Any,
+        format: Optional[str]):
+    """Get the file extension from either the given format or target file information
+
+    Args:
+        src (path-like object or file-like object): Target file.
+        format (optional, str): format provided by user.
+    """
+    if format is not None:
+        return format.lower()
+    if hasattr(src, 'name'):
+        src = src.name
+    return os.path.splitext(src)[-1][1:].lower()
 
 
 @_mod_utils.deprecated('Please migrate to `AudioMetaData`.', '0.9.0')

--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -7,7 +7,7 @@ from torchaudio._internal import (
 )
 
 import torchaudio
-from .common import AudioMetaData, get_ext
+from .common import AudioMetaData
 
 
 @_mod_utils.requires_module('torchaudio._torchaudio')
@@ -143,16 +143,14 @@ def _save(
         compression: Optional[float] = None,
         format: Optional[str] = None,
 ):
-    try:
-        ext = get_ext(filepath, format)
-    except Exception:
-        raise RuntimeError('Cannot detect the output format. Provide `format` argument.') from None
     if hasattr(filepath, 'write'):
+        if format is None:
+            raise RuntimeError('`format` is required when saving to file object.')
         torchaudio._torchaudio.save_audio_fileobj(
-            filepath, src, sample_rate, channels_first, compression, ext)
+            filepath, src, sample_rate, channels_first, compression, format)
     else:
         torch.ops.torchaudio.sox_io_save_audio_file(
-            os.fspath(filepath), src, sample_rate, channels_first, compression, ext)
+            os.fspath(filepath), src, sample_rate, channels_first, compression, format)
 
 
 @_mod_utils.requires_module('torchaudio._torchaudio')

--- a/torchaudio/csrc/pybind.cpp
+++ b/torchaudio/csrc/pybind.cpp
@@ -100,4 +100,8 @@ PYBIND11_MODULE(_torchaudio, m) {
       "load_audio_fileobj",
       &torchaudio::sox_io::load_audio_fileobj,
       "Load audio from file object.");
+  m.def(
+      "save_audio_fileobj",
+      &torchaudio::sox_io::save_audio_fileobj,
+      "Save audio to file obj.");
 }

--- a/torchaudio/csrc/sox/effects.cpp
+++ b/torchaudio/csrc/sox/effects.cpp
@@ -59,8 +59,8 @@ c10::intrusive_ptr<TensorSignal> apply_effects_tensor(
   // Create SoxEffectsChain
   const auto dtype = in_tensor.dtype();
   torchaudio::sox_effects_chain::SoxEffectsChain chain(
-      /*input_encoding=*/get_encodinginfo("wav", dtype, 0.),
-      /*output_encoding=*/get_encodinginfo("wav", dtype, 0.));
+      /*input_encoding=*/get_encodinginfo("wav", dtype),
+      /*output_encoding=*/get_encodinginfo("wav", dtype));
 
   // Prepare output buffer
   std::vector<sox_sample_t> out_buffer;
@@ -112,7 +112,7 @@ c10::intrusive_ptr<TensorSignal> apply_effects_file(
   // Create and run SoxEffectsChain
   torchaudio::sox_effects_chain::SoxEffectsChain chain(
       /*input_encoding=*/sf->encoding,
-      /*output_encoding=*/get_encodinginfo("wav", dtype, 0.));
+      /*output_encoding=*/get_encodinginfo("wav", dtype));
 
   chain.addInputFile(sf);
   for (const auto& effect : effects) {
@@ -193,7 +193,7 @@ std::tuple<torch::Tensor, int64_t> apply_effects_fileobj(
   const auto dtype = get_dtype(sf->encoding.encoding, sf->signal.precision);
   torchaudio::sox_effects_chain::SoxEffectsChain chain(
       /*input_encoding=*/sf->encoding,
-      /*output_encoding=*/get_encodinginfo("wav", dtype, 0.));
+      /*output_encoding=*/get_encodinginfo("wav", dtype));
   chain.addInputFileObj(sf, in_buf, in_buffer_size, &fileobj);
   for (const auto& effect : effects) {
     chain.addEffect(effect);

--- a/torchaudio/csrc/sox/effects_chain.h
+++ b/torchaudio/csrc/sox/effects_chain.h
@@ -46,6 +46,12 @@ class SoxEffectsChain {
       uint64_t buffer_size,
       py::object* fileobj);
 
+  void addOutputFileObj(
+      sox_format_t* sf,
+      char** buffer,
+      size_t* buffer_size,
+      py::object* fileobj);
+
 #endif // TORCH_API_INCLUDE_EXTENSION_H
 };
 

--- a/torchaudio/csrc/sox/io.cpp
+++ b/torchaudio/csrc/sox/io.cpp
@@ -215,6 +215,7 @@ void save_audio_fileobj(
   chain.addOutputFileObj(sf, &buffer.ptr, &buffer.size, &fileobj);
   chain.run();
 
+  // Closing the sox_format_t is necessary for flushing the last chunk to the buffer
   sf.close();
 
   fileobj.attr("write")(py::bytes(buffer.ptr, buffer.size));

--- a/torchaudio/csrc/sox/io.h
+++ b/torchaudio/csrc/sox/io.h
@@ -38,9 +38,12 @@ c10::intrusive_ptr<torchaudio::sox_utils::TensorSignal> load_audio_file(
     c10::optional<std::string>& format);
 
 void save_audio_file(
-    const std::string& file_name,
-    const c10::intrusive_ptr<torchaudio::sox_utils::TensorSignal>& signal,
-    const double compression = 0.);
+    const std::string& path,
+    torch::Tensor tensor,
+    int64_t sample_rate,
+    bool channels_first,
+    c10::optional<double> compression,
+    c10::optional<std::string> format);
 
 #ifdef TORCH_API_INCLUDE_EXTENSION_H
 
@@ -51,6 +54,14 @@ std::tuple<torch::Tensor, int64_t> load_audio_fileobj(
     c10::optional<bool>& normalize,
     c10::optional<bool>& channels_first,
     c10::optional<std::string>& format);
+
+void save_audio_fileobj(
+    py::object fileobj,
+    torch::Tensor tensor,
+    int64_t sample_rate,
+    bool channels_first,
+    c10::optional<double> compression,
+    std::string filetype);
 
 #endif // TORCH_API_INCLUDE_EXTENSION_H
 

--- a/torchaudio/csrc/sox/utils.h
+++ b/torchaudio/csrc/sox/utils.h
@@ -61,6 +61,8 @@ struct SoxFormat {
   sox_format_t* operator->() const noexcept;
   operator sox_format_t*() const noexcept;
 
+  void close();
+
  private:
   sox_format_t* fd_;
 };
@@ -118,8 +120,12 @@ sox_signalinfo_t get_signalinfo(
 /// Get sox_encofinginfo_t for saving audoi file
 sox_encodinginfo_t get_encodinginfo(
     const std::string filetype,
+    const caffe2::TypeMeta dtype);
+
+sox_encodinginfo_t get_encodinginfo(
+    const std::string filetype,
     const caffe2::TypeMeta dtype,
-    const double compression);
+    c10::optional<double>& compression);
 
 } // namespace sox_utils
 } // namespace torchaudio


### PR DESCRIPTION
This adds file object support to `save` function.

Also this PR disables TP binary cache, as it seems to cause an occasional build error.

See #1115 