### PR TITLE
Use custom clean function to clean

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,8 @@ setup(
     packages=find_packages(exclude=["build*", "test*", "torchaudio.csrc*", "third_party*", "build_tools*"]),
     ext_modules=setup_helpers.get_ext_modules(),
     cmdclass={
-        'build_ext': setup_helpers.BuildExtension.with_options(no_python_abi_suffix=True)
+        'build_ext': setup_helpers.BuildExtension.with_options(no_python_abi_suffix=True),
+        'clean': clean,
     },
     install_requires=[pytorch_package_dep],
     zip_safe=False,


### PR DESCRIPTION
This PR makes `python setup.py clean` actually use the custom-defined the clean class.