### PR TITLE
refactor cmuarctic dataset unittest

### DIFF
--- a/test/torchaudio_unittest/datasets/cmuarctic_test.py
+++ b/test/torchaudio_unittest/datasets/cmuarctic_test.py
@@ -11,6 +11,47 @@ from torchaudio_unittest.common_utils import (
     normalize_wav,
 )
 
+_UTTERANCE = "This is a test utterance."
+
+
+def get_mock_dataset(root_dir):
+    """
+    prepares mocked dataset
+    """
+    mocked_data = []
+    sample_rate = 16000
+    base_dir = os.path.join(root_dir, "ARCTIC", "cmu_us_aew_arctic")
+    txt_dir = os.path.join(base_dir, "etc")
+    os.makedirs(txt_dir, exist_ok=True)
+    txt_file = os.path.join(txt_dir, "txt.done.data")
+    audio_dir = os.path.join(base_dir, "wav")
+    os.makedirs(audio_dir, exist_ok=True)
+
+    seed = 42
+    with open(txt_file, "w") as txt:
+        for c in ["a", "b"]:
+            for i in range(5):
+                utterance_id = f"arctic_{c}{i:04d}"
+                path = os.path.join(audio_dir, f"{utterance_id}.wav")
+                data = get_whitenoise(
+                    sample_rate=sample_rate,
+                    duration=3,
+                    n_channels=1,
+                    dtype="int16",
+                    seed=seed,
+                )
+                save_wav(path, data, sample_rate)
+                sample = (
+                    normalize_wav(data),
+                    sample_rate,
+                    _UTTERANCE,
+                    utterance_id.split("_")[1],
+                )
+                mocked_data.append(sample)
+                txt.write(f'( {utterance_id} "{_UTTERANCE}" )\n')
+                seed += 1
+    return mocked_data
+
 
 class TestCMUARCTIC(TempDirMixin, TorchaudioTestCase):
     backend = "default"
@@ -21,39 +62,7 @@ class TestCMUARCTIC(TempDirMixin, TorchaudioTestCase):
     @classmethod
     def setUpClass(cls):
         cls.root_dir = cls.get_base_temp_dir()
-        sample_rate = 16000
-        utterance = "This is a test utterance."
-
-        base_dir = os.path.join(cls.root_dir, "ARCTIC", "cmu_us_aew_arctic")
-        txt_dir = os.path.join(base_dir, "etc")
-        os.makedirs(txt_dir, exist_ok=True)
-        txt_file = os.path.join(txt_dir, "txt.done.data")
-        audio_dir = os.path.join(base_dir, "wav")
-        os.makedirs(audio_dir, exist_ok=True)
-
-        seed = 42
-        with open(txt_file, "w") as txt:
-            for c in ["a", "b"]:
-                for i in range(5):
-                    utterance_id = f"arctic_{c}{i:04d}"
-                    path = os.path.join(audio_dir, f"{utterance_id}.wav")
-                    data = get_whitenoise(
-                        sample_rate=sample_rate,
-                        duration=3,
-                        n_channels=1,
-                        dtype="int16",
-                        seed=seed,
-                    )
-                    save_wav(path, data, sample_rate)
-                    sample = (
-                        normalize_wav(data),
-                        sample_rate,
-                        utterance,
-                        utterance_id.split("_")[1],
-                    )
-                    cls.samples.append(sample)
-                    txt.write(f'( {utterance_id} "{utterance}" )\n')
-                    seed += 1
+        cls.samples = get_mock_dataset(cls.root_dir)
 
     def _test_cmuarctic(self, dataset):
         n_ite = 0


### PR DESCRIPTION
- [x] refactor [cmuractic](https://github.com/pytorch/audio/blob/71214b48548b1dcb6ebd581dd36a9d0e60af6837/test/torchaudio_unittest/datasets/cmuarctic_test.py#L24-L56) dataset.