### PR TITLE
Replace pytest's paremeterization with parameterized 

### DIFF
--- a/test/torchaudio_unittest/functional/functional_cpu_test.py
+++ b/test/torchaudio_unittest/functional/functional_cpu_test.py
@@ -125,7 +125,7 @@ class TestDB_to_amplitude(common_utils.TorchaudioTestCase):
 
 class TestComplexNorm(common_utils.TorchaudioTestCase):
     @parameterized.expand(list(itertools.product(
-        [(1, 2, 1025, 400, 2),  (1025, 400, 2)],
+        [(1, 2, 1025, 400, 2), (1025, 400, 2)],
         [1, 2, 0.7]
     )))
     def test_complex_norm(self, shape, power):
@@ -138,7 +138,7 @@ class TestComplexNorm(common_utils.TorchaudioTestCase):
 
 class TestMaskAlongAxis(common_utils.TorchaudioTestCase):
     @parameterized.expand(list(itertools.product(
-        [(2, 1025, 400),  (1, 201, 100)],
+        [(2, 1025, 400), (1, 201, 100)],
         [100],
         [0., 30.],
         [1, 2]
@@ -156,6 +156,7 @@ class TestMaskAlongAxis(common_utils.TorchaudioTestCase):
 
         assert mask_specgram.size() == specgram.size()
         assert num_masked_columns < mask_param
+
 
 class TestMaskAlongAxisIID(common_utils.TorchaudioTestCase):
     @parameterized.expand(list(itertools.product(

--- a/test/torchaudio_unittest/functional/functional_cpu_test.py
+++ b/test/torchaudio_unittest/functional/functional_cpu_test.py
@@ -54,7 +54,7 @@ class TestComputeDeltas(common_utils.TorchaudioTestCase):
         specgram = torch.tensor([[[1.0, 2.0, 3.0, 4.0]]])
         expected = torch.tensor([[[0.5, 1.0, 1.0, 0.5]]])
         computed = F.compute_deltas(specgram, win_length=3)
-        torch.testing.assert_allclose(computed, expected)
+        self.assertEqual(computed, expected)
 
     def test_two_channels(self):
         specgram = torch.tensor([[[1.0, 2.0, 3.0, 4.0],
@@ -62,7 +62,7 @@ class TestComputeDeltas(common_utils.TorchaudioTestCase):
         expected = torch.tensor([[[0.5, 1.0, 1.0, 0.5],
                                   [0.5, 1.0, 1.0, 0.5]]])
         computed = F.compute_deltas(specgram, win_length=3)
-        torch.testing.assert_allclose(computed, expected)
+        self.assertEqual(computed, expected)
 
 
 class TestDetectPitchFrequency(common_utils.TorchaudioTestCase):
@@ -82,7 +82,6 @@ class TestDetectPitchFrequency(common_utils.TorchaudioTestCase):
 
 class TestDB_to_amplitude(common_utils.TorchaudioTestCase):
     def test_DB_to_amplitude(self):
-        torch.random.manual_seed(42)
         # Make some noise
         x = torch.rand(1000)
         spectrogram = torchaudio.transforms.Spectrogram()
@@ -99,13 +98,13 @@ class TestDB_to_amplitude(common_utils.TorchaudioTestCase):
         db = F.amplitude_to_DB(torch.abs(x), multiplier, amin, db_multiplier, top_db=None)
         x2 = F.DB_to_amplitude(db, ref, power)
 
-        torch.testing.assert_allclose(x2, torch.abs(x), atol=5e-5, rtol=1e-5)
+        self.assertEqual(x2, torch.abs(x), atol=5e-5, rtol=1e-5)
 
         # Spectrogram amplitude -> DB -> amplitude
         db = F.amplitude_to_DB(spec, multiplier, amin, db_multiplier, top_db=None)
         x2 = F.DB_to_amplitude(db, ref, power)
 
-        torch.testing.assert_allclose(x2, spec, atol=5e-5, rtol=1e-5)
+        self.assertEqual(x2, spec, atol=5e-5, rtol=1e-5)
 
         # Waveform power -> DB -> power
         multiplier = 10.
@@ -114,13 +113,13 @@ class TestDB_to_amplitude(common_utils.TorchaudioTestCase):
         db = F.amplitude_to_DB(x, multiplier, amin, db_multiplier, top_db=None)
         x2 = F.DB_to_amplitude(db, ref, power)
 
-        torch.testing.assert_allclose(x2, torch.abs(x), atol=5e-5, rtol=1e-5)
+        self.assertEqual(x2, torch.abs(x), atol=5e-5, rtol=1e-5)
 
         # Spectrogram power -> DB -> power
         db = F.amplitude_to_DB(spec, multiplier, amin, db_multiplier, top_db=None)
         x2 = F.DB_to_amplitude(db, ref, power)
 
-        torch.testing.assert_allclose(x2, spec, atol=5e-5, rtol=1e-5)
+        self.assertEqual(x2, spec, atol=5e-5, rtol=1e-5)
 
 
 class TestComplexNorm(common_utils.TorchaudioTestCase):
@@ -133,7 +132,7 @@ class TestComplexNorm(common_utils.TorchaudioTestCase):
         complex_tensor = torch.randn(*shape)
         expected_norm_tensor = complex_tensor.pow(2).sum(-1).pow(power / 2)
         norm_tensor = F.complex_norm(complex_tensor, power)
-        torch.testing.assert_allclose(norm_tensor, expected_norm_tensor, atol=1e-5, rtol=1e-5)
+        self.assertEqual(norm_tensor, expected_norm_tensor, atol=1e-5, rtol=1e-5)
 
 
 class TestMaskAlongAxis(common_utils.TorchaudioTestCase):
@@ -156,7 +155,6 @@ class TestMaskAlongAxis(common_utils.TorchaudioTestCase):
 
         assert mask_specgram.size() == specgram.size()
         assert num_masked_columns < mask_param
-
 
 class TestMaskAlongAxisIID(common_utils.TorchaudioTestCase):
     @parameterized.expand(list(itertools.product(

--- a/test/torchaudio_unittest/functional/functional_cpu_test.py
+++ b/test/torchaudio_unittest/functional/functional_cpu_test.py
@@ -82,6 +82,7 @@ class TestDetectPitchFrequency(common_utils.TorchaudioTestCase):
 
 class TestDB_to_amplitude(common_utils.TorchaudioTestCase):
     def test_DB_to_amplitude(self):
+        torch.random.manual_seed(42)
         # Make some noise
         x = torch.rand(1000)
         spectrogram = torchaudio.transforms.Spectrogram()
@@ -128,7 +129,7 @@ class TestComplexNorm(common_utils.TorchaudioTestCase):
         [1, 2, 0.7]
     )))
     def test_complex_norm(self, shape, power):
-        torch.random.manual_seed(0)
+        torch.random.manual_seed(42)
         complex_tensor = torch.randn(*shape)
         expected_norm_tensor = complex_tensor.pow(2).sum(-1).pow(power / 2)
         norm_tensor = F.complex_norm(complex_tensor, power)
@@ -143,7 +144,7 @@ class TestMaskAlongAxis(common_utils.TorchaudioTestCase):
         [1, 2]
     )))
     def test_mask_along_axis(self, shape, mask_param, mask_value, axis):
-        torch.random.manual_seed(0)
+        torch.random.manual_seed(42)
         specgram = torch.randn(*shape)
         mask_specgram = F.mask_along_axis(specgram, mask_param, mask_value, axis)
 

--- a/test/torchaudio_unittest/functional/functional_cpu_test.py
+++ b/test/torchaudio_unittest/functional/functional_cpu_test.py
@@ -121,16 +121,18 @@ class TestDB_to_amplitude(common_utils.TorchaudioTestCase):
         torch.testing.assert_allclose(x2, spec, atol=5e-5, rtol=1e-5)
 
 
-@pytest.mark.parametrize('complex_tensor', [
-    torch.randn(1, 2, 1025, 400, 2),
-    torch.randn(1025, 400, 2)
-])
-@pytest.mark.parametrize('power', [1, 2, 0.7])
-def test_complex_norm(complex_tensor, power):
-    expected_norm_tensor = complex_tensor.pow(2).sum(-1).pow(power / 2)
-    norm_tensor = F.complex_norm(complex_tensor, power)
+class TestComplexNorm(common_utils.TorchaudioTestCase):
 
-    torch.testing.assert_allclose(norm_tensor, expected_norm_tensor, atol=1e-5, rtol=1e-5)
+    @parameterized.expand([
+        (torch.randn(1, 2, 1025, 400, 2),  1),
+        (torch.randn(1025, 400, 2), 2)
+    ])
+    def test_complex_norm(self, complex_tensor, power):
+        torch.random.manual_seed(42)
+
+        expected_norm_tensor = complex_tensor.pow(2).sum(-1).pow(power / 2)
+        norm_tensor = F.complex_norm(complex_tensor, power)
+        torch.testing.assert_allclose(norm_tensor, expected_norm_tensor, atol=1e-5, rtol=1e-5)
 
 
 @pytest.mark.parametrize('specgram', [

--- a/test/torchaudio_unittest/functional/functional_cpu_test.py
+++ b/test/torchaudio_unittest/functional/functional_cpu_test.py
@@ -156,6 +156,7 @@ class TestMaskAlongAxis(common_utils.TorchaudioTestCase):
         assert mask_specgram.size() == specgram.size()
         assert num_masked_columns < mask_param
 
+
 class TestMaskAlongAxisIID(common_utils.TorchaudioTestCase):
     @parameterized.expand(list(itertools.product(
         [100],

--- a/test/torchaudio_unittest/librosa_compatibility_test.py
+++ b/test/torchaudio_unittest/librosa_compatibility_test.py
@@ -127,7 +127,11 @@ class TestPhaseVocoder(common_utils.TorchaudioTestCase):
         torch.random.manual_seed(42)
         complex_specgrams = torch.randn(*shape)
         complex_specgrams = complex_specgrams.type(torch.float64)
-        phase_advance = torch.linspace(0, np.pi * hop_length, complex_specgrams.shape[-3], dtype=torch.float64)[..., None]
+        phase_advance = torch.linspace(
+            0,
+            np.pi * hop_length,
+            complex_specgrams.shape[-3],
+            dtype=torch.float64)[..., None]
 
         complex_specgrams_stretch = F.phase_vocoder(complex_specgrams, rate=rate, phase_advance=phase_advance)
 
@@ -143,9 +147,10 @@ class TestPhaseVocoder(common_utils.TorchaudioTestCase):
         mono_complex_specgram = complex_specgrams[index].numpy()
         mono_complex_specgram = mono_complex_specgram[..., 0] + \
             mono_complex_specgram[..., 1] * 1j
-        expected_complex_stretch = librosa.phase_vocoder(mono_complex_specgram,
-                                                        rate=rate,
-                                                        hop_length=hop_length)
+        expected_complex_stretch = librosa.phase_vocoder(
+            mono_complex_specgram,
+            rate=rate,
+            hop_length=hop_length)
 
         complex_stretch = complex_specgrams_stretch[index].numpy()
         complex_stretch = complex_stretch[..., 0] + 1j * complex_stretch[..., 1]

--- a/test/torchaudio_unittest/librosa_compatibility_test.py
+++ b/test/torchaudio_unittest/librosa_compatibility_test.py
@@ -155,7 +155,7 @@ class TestPhaseVocoder(common_utils.TorchaudioTestCase):
         complex_stretch = complex_specgrams_stretch[index].numpy()
         complex_stretch = complex_stretch[..., 0] + 1j * complex_stretch[..., 1]
 
-        assert np.allclose(complex_stretch, expected_complex_stretch, atol=1e-5)
+        self.assertEqual(complex_stretch, torch.from_numpy(expected_complex_stretch), atol=1e-5, rtol=1e-5)
 
 
 def _load_audio_asset(*asset_paths, **kwargs):

--- a/test/torchaudio_unittest/librosa_compatibility_test.py
+++ b/test/torchaudio_unittest/librosa_compatibility_test.py
@@ -7,6 +7,8 @@ import torch
 import torchaudio
 import torchaudio.functional as F
 from torchaudio._internal.module_utils import is_module_available
+from parameterized import parameterized
+import itertools
 
 LIBROSA_AVAILABLE = is_module_available('librosa')
 
@@ -111,42 +113,44 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         self.assertEqual(ta_out, lr_out, atol=5e-5, rtol=1e-5)
 
 
-@pytest.mark.parametrize('complex_specgrams', [
-    torch.randn(2, 1025, 400, 2)
-])
-@pytest.mark.parametrize('rate', [0.5, 1.01, 1.3])
-@pytest.mark.parametrize('hop_length', [256])
 @unittest.skipIf(not LIBROSA_AVAILABLE, "Librosa not available")
-def test_phase_vocoder(complex_specgrams, rate, hop_length):
-    # Due to cummulative sum, numerical error in using torch.float32 will
-    # result in bottom right values of the stretched sectrogram to not
-    # match with librosa.
+class TestPhaseVocoder(common_utils.TorchaudioTestCase):
+    @parameterized.expand(list(itertools.product(
+        [(2, 1025, 400, 2)],
+        [0.5, 1.01, 1.3],
+        [256]
+    )))
+    def test_phase_vocoder(self, shape, rate, hop_length):
+        # Due to cummulative sum, numerical error in using torch.float32 will
+        # result in bottom right values of the stretched sectrogram to not
+        # match with librosa.
+        torch.random.manual_seed(42)
+        complex_specgrams = torch.randn(*shape)
+        complex_specgrams = complex_specgrams.type(torch.float64)
+        phase_advance = torch.linspace(0, np.pi * hop_length, complex_specgrams.shape[-3], dtype=torch.float64)[..., None]
 
-    complex_specgrams = complex_specgrams.type(torch.float64)
-    phase_advance = torch.linspace(0, np.pi * hop_length, complex_specgrams.shape[-3], dtype=torch.float64)[..., None]
+        complex_specgrams_stretch = F.phase_vocoder(complex_specgrams, rate=rate, phase_advance=phase_advance)
 
-    complex_specgrams_stretch = F.phase_vocoder(complex_specgrams, rate=rate, phase_advance=phase_advance)
+        # == Test shape
+        expected_size = list(complex_specgrams.size())
+        expected_size[-2] = int(np.ceil(expected_size[-2] / rate))
 
-    # == Test shape
-    expected_size = list(complex_specgrams.size())
-    expected_size[-2] = int(np.ceil(expected_size[-2] / rate))
+        assert complex_specgrams.dim() == complex_specgrams_stretch.dim()
+        assert complex_specgrams_stretch.size() == torch.Size(expected_size)
 
-    assert complex_specgrams.dim() == complex_specgrams_stretch.dim()
-    assert complex_specgrams_stretch.size() == torch.Size(expected_size)
+        # == Test values
+        index = [0] * (complex_specgrams.dim() - 3) + [slice(None)] * 3
+        mono_complex_specgram = complex_specgrams[index].numpy()
+        mono_complex_specgram = mono_complex_specgram[..., 0] + \
+            mono_complex_specgram[..., 1] * 1j
+        expected_complex_stretch = librosa.phase_vocoder(mono_complex_specgram,
+                                                        rate=rate,
+                                                        hop_length=hop_length)
 
-    # == Test values
-    index = [0] * (complex_specgrams.dim() - 3) + [slice(None)] * 3
-    mono_complex_specgram = complex_specgrams[index].numpy()
-    mono_complex_specgram = mono_complex_specgram[..., 0] + \
-        mono_complex_specgram[..., 1] * 1j
-    expected_complex_stretch = librosa.phase_vocoder(mono_complex_specgram,
-                                                     rate=rate,
-                                                     hop_length=hop_length)
+        complex_stretch = complex_specgrams_stretch[index].numpy()
+        complex_stretch = complex_stretch[..., 0] + 1j * complex_stretch[..., 1]
 
-    complex_stretch = complex_specgrams_stretch[index].numpy()
-    complex_stretch = complex_stretch[..., 0] + 1j * complex_stretch[..., 1]
-
-    assert np.allclose(complex_stretch, expected_complex_stretch, atol=1e-5)
+        assert np.allclose(complex_stretch, expected_complex_stretch, atol=1e-5)
 
 
 def _load_audio_asset(*asset_paths, **kwargs):


### PR DESCRIPTION
Made Changes to

- [x] test/torchaudio_unittest/librosa_compatibility_test.py
- [x] test/torchaudio_unittest/functional/functional_cpu_test.py

fixes: #1156 