### PR TITLE
Clean up transducer build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ class clean(distutils.command.clean.clean):
         # Remove build directory
         build_dirs = [
             ROOT_DIR / 'build',
-            ROOT_DIR / 'third_party' / 'build',
         ]
         for path in build_dirs:
             if path.exists():

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,9 +1,15 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(torchaudio_third_parties)
-include(ExternalProject)
 
-set(INSTALL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/install)
+option(BUILD_SOX "Build libsox statically")
+option(BUILD_TRANSDUCER "Build transducer")
+
+SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+if (BUILD_SOX)
+include(ExternalProject)
+set(INSTALL_DIR ${CMAKE_INSTALL_PREFIX})
 set(ARCHIVE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/archives)
 set(COMMON_ARGS --quiet --disable-shared --enable-static --prefix=${INSTALL_DIR} --with-pic --disable-dependency-tracking --disable-debug --disable-examples --disable-doc)
 
@@ -88,5 +94,8 @@ ExternalProject_Add(libsox
   # See https://github.com/pytorch/audio/pull/1026
   CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build_codec_helper.sh ${CMAKE_CURRENT_SOURCE_DIR}/src/libsox/configure ${COMMON_ARGS} --with-lame --with-flac --with-mad --with-oggvorbis --without-alsa --without-coreaudio --without-png --without-oss --without-sndfile --with-opus --with-amrwb --with-amrnb --disable-openmp --without-sndio --without-pulseaudio
 )
+endif()
 
+if(BUILD_TRANSDUCER)
 add_subdirectory(transducer)
+endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,9 +3,9 @@ cmake_minimum_required(VERSION 3.5)
 project(torchaudio_third_parties)
 
 option(BUILD_SOX "Build libsox statically")
-option(BUILD_TRANSDUCER "Build transducer")
+option(BUILD_TRANSDUCER "Build transducer statically")
 
-SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 if (BUILD_SOX)
 include(ExternalProject)

--- a/third_party/transducer/CMakeLists.txt
+++ b/third_party/transducer/CMakeLists.txt
@@ -1,20 +1,7 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
-
-PROJECT(rnnt_release)
-
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
-
-IF(APPLE)
-    ADD_DEFINITIONS(-DAPPLE)
-ENDIF()
-
-INCLUDE_DIRECTORIES(submodule/include)
-
-SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
 ADD_DEFINITIONS(-DRNNT_DISABLE_OMP)
 
 IF(APPLE)
+    ADD_DEFINITIONS(-DAPPLE)
     EXEC_PROGRAM(uname ARGS -v  OUTPUT_VARIABLE DARWIN_VERSION)
     STRING(REGEX MATCH "[0-9]+" DARWIN_VERSION ${DARWIN_VERSION})
     MESSAGE(STATUS "DARWIN_VERSION=${DARWIN_VERSION}")
@@ -30,9 +17,11 @@ ELSE()
 ENDIF()
 
 ADD_LIBRARY(warprnnt STATIC submodule/src/rnnt_entrypoint.cpp)
+target_include_directories(warprnnt PUBLIC submodule/include)
+set_target_properties(warprnnt PROPERTIES PUBLIC_HEADER submodule/include/rnnt.h)
 
-INSTALL(TARGETS warprnnt
-        LIBRARY DESTINATION "lib"
-        ARCHIVE DESTINATION "lib")
 
-INSTALL(FILES submodule/include/rnnt.h DESTINATION "submodule/include")
+INSTALL(
+  TARGETS warprnnt
+  ARCHIVE DESTINATION "lib"
+  PUBLIC_HEADER DESTINATION "include")

--- a/torchaudio/csrc/sox/register.cpp
+++ b/torchaudio/csrc/sox/register.cpp
@@ -2,7 +2,7 @@
 #include <torchaudio/csrc/sox/io.h>
 #include <torchaudio/csrc/sox/utils.h>
 
-TORCH_LIBRARY(torchaudio, m) {
+TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
   //////////////////////////////////////////////////////////////////////////////
   // sox_utils.h
   //////////////////////////////////////////////////////////////////////////////
@@ -74,18 +74,4 @@ TORCH_LIBRARY(torchaudio, m) {
   m.def(
       "torchaudio::sox_effects_apply_effects_file",
       &torchaudio::sox_effects::apply_effects_file);
-
-  //////////////////////////////////////////////////////////////////////////////
-  // transducer.cpp
-  //////////////////////////////////////////////////////////////////////////////
-  #ifdef BUILD_TRANSDUCER
-  m.def("rnnt_loss(Tensor acts,"
-                  "Tensor labels,"
-                  "Tensor input_lengths,"
-                  "Tensor label_lengths,"
-                  "Tensor costs,"
-                  "Tensor grads,"
-                  "int blank_label,"
-                  "int num_threads) -> int");
-  #endif
 }

--- a/torchaudio/csrc/transducer.cpp
+++ b/torchaudio/csrc/transducer.cpp
@@ -1,5 +1,3 @@
-#ifdef BUILD_TRANSDUCER
-
 #include <iostream>
 #include <numeric>
 #include <string>
@@ -7,6 +5,8 @@
 
 #include <torch/script.h>
 #include "rnnt.h"
+
+namespace {
 
 int64_t cpu_rnnt_loss(torch::Tensor acts,
                       torch::Tensor labels,
@@ -75,8 +75,19 @@ int64_t cpu_rnnt_loss(torch::Tensor acts,
     return -1;
 }
 
+} // namespace
+
 TORCH_LIBRARY_IMPL(torchaudio, CPU, m) {
-    m.impl("rnnt_loss", &cpu_rnnt_loss);
+  m.impl("rnnt_loss", &cpu_rnnt_loss);
 }
 
-#endif
+TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
+  m.def("rnnt_loss(Tensor acts,"
+                  "Tensor labels,"
+                  "Tensor input_lengths,"
+                  "Tensor label_lengths,"
+                  "Tensor costs,"
+                  "Tensor grads,"
+                  "int blank_label,"
+                  "int num_threads) -> int");
+}


### PR DESCRIPTION
This PR cleans up build process by

* Decoupling the registration of sox and transducer, using `TORCH_LIBRARY_FRAGMENT` macro.
* Instead of linking `libwarprnnt.a` from the build directory use the install directory, where other libsox related libraries are found.

When `BUILD_TRANSDUCER` is false-y value
* Do not build the external transducer
* Do not build the transducer binding (exclude it from the list of sources)

---

Remaining tweak for build (not in this PR)
* move the sox-related stuff to the dedicated directory under `third_directory` #1161 
* CXX11 ABI
* Hide symbols
* Add switch to exclude prototype from package