### PR TITLE
Temporarily disable fileobj

### DIFF
--- a/.circleci/unittest/linux/scripts/run_test.sh
+++ b/.circleci/unittest/linux/scripts/run_test.sh
@@ -17,4 +17,4 @@ declare -a args=(
 )
 
 cd test
-pytest "${args[@]}" torchaudio_unittest
+pytest "${args[@]}" torchaudio_unittest -k "not fileobj"


### PR DESCRIPTION
Test for file-like object support is causing segmentation fault.
This is impacting PRs so disable it temporarily.