### PR TITLE
Add documentation for RNN transducer

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,6 +39,7 @@ The :mod:`torchaudio` package consists of I/O, popular datasets and common audio
    compliance.kaldi
    kaldi_io
    utils
+   transducer
    
    
 .. toctree::

--- a/docs/source/transducer.rst
+++ b/docs/source/transducer.rst
@@ -1,0 +1,23 @@
+.. role:: hidden
+    :class: hidden-section
+
+torchaudio.prototype.transducer
+===============================
+
+.. currentmodule:: torchaudio.prototype.transducer
+
+.. note::
+
+    The RNN transducer loss is a prototype feature, see `here <https://pytorch.org/audio>`_ to learn more about the nomenclature. It is only available within the nightlies, and also needs to be imported explicitly using: :code:`from torchaudio.prototype.transducer import rnnt_loss, RNNTLoss`.
+
+rnnt_loss
+---------
+
+.. autofunction:: rnnt_loss
+
+:hidden:`RNNTLoss`
+~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: RNNTLoss
+
+  .. automethod:: forward


### PR DESCRIPTION
Add prototype RNN transducer loss to the documentation. This will need to be guarded off from releases.

<img width="1536" alt="Screen Shot 2021-01-11 at 11 48 48 AM" src="https://user-images.githubusercontent.com/3047868/104212283-07f40600-5403-11eb-9e05-6f3da1a703de.png">

cc #1137