### PR TITLE
Revert "Temporarily disable fileobj tests (#1168)"

### DIFF
--- a/.circleci/unittest/linux/scripts/run_test.sh
+++ b/.circleci/unittest/linux/scripts/run_test.sh
@@ -17,4 +17,4 @@ declare -a args=(
 )
 
 cd test
-pytest "${args[@]}" torchaudio_unittest -k "not fileobj"
+pytest "${args[@]}" torchaudio_unittest


### PR DESCRIPTION
This reverts commit 84966ae132f8c04ede2a9365324388f3948a1841.

The segfault issue which was surely happening on the Friday is now gone. I suspect that it was caused by some specific environment. To get the signal, re-enabling the test again.