### PR TITLE
Fix third party download cache config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - persist_to_workspace:
           root: third_party
           paths:
-            - archives
+            - sox/archives
 
   binary_linux_wheel:
     <<: *binary_common

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -112,7 +112,7 @@ jobs:
       - persist_to_workspace:
           root: third_party
           paths:
-            - archives
+            - sox/archives
 
   binary_linux_wheel:
     <<: *binary_common


### PR DESCRIPTION
Follow up of #1161. CircleCI cache directory was not updated and this is causing nightly to fail.