### PR TITLE
Add bits_per_sample to info

### DIFF
--- a/test/torchaudio_unittest/soundfile_backend/common.py
+++ b/test/torchaudio_unittest/soundfile_backend/common.py
@@ -26,7 +26,7 @@ def skipIfFormatNotSupported(fmt):
         import soundfile
 
         fmts = soundfile.available_formats()
-        return skipIf(fmt not in fmts, f'"{fmt}" is not supported by sondfile')
+        return skipIf(fmt not in fmts, f'"{fmt}" is not supported by soundfile')
     return skipIf(True, '"soundfile" not available.')
 
 

--- a/test/torchaudio_unittest/soundfile_backend/info_test.py
+++ b/test/torchaudio_unittest/soundfile_backend/info_test.py
@@ -1,3 +1,6 @@
+from unittest.mock import patch
+import warnings
+
 import torch
 from torchaudio.backend import _soundfile_backend as soundfile_backend
 from torchaudio._internal import module_utils as _mod_utils
@@ -10,8 +13,6 @@ from torchaudio_unittest.common_utils import (
     save_wav,
 )
 from .common import skipIfFormatNotSupported, parameterize
-
-import pytest
 
 if _mod_utils.is_module_available("soundfile"):
     import soundfile
@@ -104,29 +105,25 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.num_channels == num_channels
         assert info.bits_per_sample == bits_per_sample
 
+    def test_unknown_subtype_warning(self):
+        """soundfile_backend.info issues a warning when the subtype is unknown
 
-def test_unknown_subtype_warning(tmp_path, monkeypatch):
-    """soundfile_backend.info issues a warning when the subtype is unknown
+        This will happen if a new subtype is supported in SoundFile: the _SUBTYPE_TO_BITS_PER_SAMPLE
+        dict should be updated.
+        """
+        dtype, sample_rate, duration, num_channels = 'float32', 16000, 1, 1
+        duration = 1
+        path = self.get_temp_path("data.wav")
+        data = get_wav_data(
+            dtype, num_channels, normalize=False, num_frames=duration * sample_rate
+        )
+        save_wav(path, data, sample_rate=16000)
 
-    This will happen if a new subtype is supported in SoundFile: the _SUBTYPE_TO_BITS_PER_SAMPLE
-    dict should be updated.
-    """
-
-    soundfile_info_original = soundfile.info
-
-    def info_wrapper(filepath):
-        # Wraps soundfile.info and sets the subtype to some unknown value
-        sinfo = soundfile_info_original(filepath)
-        sinfo.subtype = 'SOME_UNKNOWN_SUBTYPE'
-        return sinfo
-
-    monkeypatch.setattr(soundfile, "info", info_wrapper)
-
-    data = get_wav_data(
-        dtype='float32', num_channels=1, normalize=False, num_frames=16000
-    )
-    path = tmp_path / 'data.wav'
-    save_wav(path, data, sample_rate=16000)
-    with pytest.warns(UserWarning, match="subtype is unknown to TorchAudio"):
-        info = soundfile_backend.info(path)
-    assert info.bits_per_sample == 0
+        # We pretend the _SUBTYPE_TO_BITS_PER_SAMPLE dict knows no subtype / is empty.
+        # It's easier to mock the internal dict rather than to mock the entire soundfile.info function
+        with patch.dict(soundfile_backend._SUBTYPE_TO_BITS_PER_SAMPLE, {}, clear=True):
+            with warnings.catch_warnings(record=True) as w:
+                info = soundfile_backend.info(path)
+        assert len(w) == 1
+        assert "subtype is unknown to TorchAudio" in str(w[-1].message)
+        assert info.bits_per_sample == 0

--- a/test/torchaudio_unittest/soundfile_backend/info_test.py
+++ b/test/torchaudio_unittest/soundfile_backend/info_test.py
@@ -66,7 +66,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.sample_rate == sample_rate
         assert info.num_frames == num_frames
         assert info.num_channels == num_channels
-        assert info.bits_per_sample == 24
+        assert info.bits_per_sample == 16
 
     @parameterize([8000, 16000], [1, 2])
     @skipIfFormatNotSupported("OGG")
@@ -82,7 +82,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.sample_rate == sample_rate
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
-        assert info.num_channels == 123  # TODO fix that (can't debug locally)
+        assert info.bits_per_sample == 123  # TODO fix that (can't debug locally)
 
     @parameterize([8000, 16000], [1, 2], [('PCM_24', 24), ('PCM_32', 32)])
     @skipIfFormatNotSupported("NIST")

--- a/test/torchaudio_unittest/soundfile_backend/info_test.py
+++ b/test/torchaudio_unittest/soundfile_backend/info_test.py
@@ -8,7 +8,6 @@ from torchaudio_unittest.common_utils import (
     skipIfNoModule,
     get_wav_data,
     save_wav,
-    sox_utils,
 )
 from .common import skipIfFormatNotSupported, parameterize
 
@@ -22,10 +21,11 @@ if _mod_utils.is_module_available("soundfile"):
 @skipIfNoModule("soundfile")
 class TestInfo(TempDirMixin, PytorchTestCase):
     @parameterize(
-        ["float32", "int32", "int16", "uint8"], [8000, 16000], [1, 2],
+        [("float32", 32), ("int32", 32), ("int16", 16), ("uint8", 8)], [8000, 16000], [1, 2],
     )
-    def test_wav(self, dtype, sample_rate, num_channels):
+    def test_wav(self, dtype_and_bit_depth, sample_rate, num_channels):
         """`soundfile_backend.info` can check wav file correctly"""
+        dtype, bits_per_sample = dtype_and_bit_depth
         duration = 1
         path = self.get_temp_path("data.wav")
         data = get_wav_data(
@@ -36,13 +36,14 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.sample_rate == sample_rate
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
-        assert info.bits_per_sample == sox_utils.get_bit_depth(dtype)
+        assert info.bits_per_sample == bits_per_sample
 
     @parameterize(
-        ["float32", "int32", "int16", "uint8"], [8000, 16000], [4, 8, 16, 32],
+        [("float32", 32), ("int32", 32), ("int16", 16), ("uint8", 8)], [8000, 16000], [1, 2],
     )
-    def test_wav_multiple_channels(self, dtype, sample_rate, num_channels):
+    def test_wav_multiple_channels(self, dtype_and_bit_depth, sample_rate, num_channels):
         """`soundfile_backend.info` can check wav file with channels more than 2 correctly"""
+        dtype, bits_per_sample = dtype_and_bit_depth
         duration = 1
         path = self.get_temp_path("data.wav")
         data = get_wav_data(
@@ -53,7 +54,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.sample_rate == sample_rate
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
-        assert info.bits_per_sample == sox_utils.get_bit_depth(dtype)
+        assert info.bits_per_sample == bits_per_sample
 
     @parameterize([8000, 16000], [1, 2])
     @skipIfFormatNotSupported("FLAC")
@@ -104,30 +105,29 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.num_channels == num_channels
         assert info.bits_per_sample == bits_per_sample
 
-    def test_unknown_subtype_warning(self):
-        """soundfile_backend.info issues a warning when the subtype is unknown
 
-        This will happen if a new subtype is supported in SoundFile: the _SUBTYPE_TO_BITS_PER_SAMPLE
-        dict should be updated.
-        """
+def test_unknown_subtype_warning(tmp_path, monkeypatch):
+    """soundfile_backend.info issues a warning when the subtype is unknown
 
-        soundfile_info_original = soundfile.info
+    This will happen if a new subtype is supported in SoundFile: the _SUBTYPE_TO_BITS_PER_SAMPLE
+    dict should be updated.
+    """
 
-        def info_wrapper(filepath):
-            # Wraps soundfile.info and sets the subtype to some unknown value
-            sinfo = soundfile_info_original(filepath)
-            sinfo.subtype = 'SOME_UNKNOWN_SUBTYPE'
-            return sinfo
+    soundfile_info_original = soundfile.info
 
-        mp = MonkeyPatch()
-        mp.setattr(soundfile, "info", info_wrapper)
+    def info_wrapper(filepath):
+        # Wraps soundfile.info and sets the subtype to some unknown value
+        sinfo = soundfile_info_original(filepath)
+        sinfo.subtype = 'SOME_UNKNOWN_SUBTYPE'
+        return sinfo
 
-        path = self.get_temp_path("data.wav")
-        data = get_wav_data(
-            dtype='float32', num_channels=1, normalize=False, num_frames=16000
-        )
-        save_wav(path, data, sample_rate=16000)
-        with pytest.warns(UserWarning, match="subtype is unknown to TorchAudio"):
-            info = soundfile_backend.info(path)
-        assert info.bits_per_sample == 0
-        mp.undo()
+    monkeypatch.setattr(soundfile, "info", info_wrapper)
+
+    data = get_wav_data(
+        dtype='float32', num_channels=1, normalize=False, num_frames=16000
+    )
+    path = tmp_path / 'data.wav'
+    save_wav(path, data, sample_rate=16000)
+    with pytest.warns(UserWarning, match="subtype is unknown to TorchAudio"):
+        info = soundfile_backend.info(path)
+    assert info.bits_per_sample == 0

--- a/test/torchaudio_unittest/soundfile_backend/info_test.py
+++ b/test/torchaudio_unittest/soundfile_backend/info_test.py
@@ -12,7 +12,6 @@ from torchaudio_unittest.common_utils import (
 from .common import skipIfFormatNotSupported, parameterize
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 
 if _mod_utils.is_module_available("soundfile"):
     import soundfile

--- a/test/torchaudio_unittest/soundfile_backend/info_test.py
+++ b/test/torchaudio_unittest/soundfile_backend/info_test.py
@@ -82,7 +82,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.sample_rate == sample_rate
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
-        assert info.bits_per_sample == 123  # TODO fix that (can't debug locally)
+        assert info.bits_per_sample == 0
 
     @parameterize([8000, 16000], [1, 2], [('PCM_24', 24), ('PCM_32', 32)])
     @skipIfFormatNotSupported("NIST")

--- a/test/torchaudio_unittest/sox_io_backend/info_test.py
+++ b/test/torchaudio_unittest/sox_io_backend/info_test.py
@@ -155,12 +155,13 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         sample_rate = 8000
         path = self.get_temp_path('data.amr-nb')
         sox_utils.gen_audio_file(
-            path, sample_rate=sample_rate, num_channels=num_channels, duration=duration)
+            path, sample_rate=sample_rate, num_channel=num_channels, bit_depth=16,
+            duration=duration)
         info = sox_io_backend.info(path)
         assert info.sample_rate == sample_rate
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
-        assert info.num_channels == num_channels
+        assert info.bits_per_sample == 16
 
 
 @skipIfNoExtension

--- a/test/torchaudio_unittest/sox_io_backend/info_test.py
+++ b/test/torchaudio_unittest/sox_io_backend/info_test.py
@@ -154,16 +154,13 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         num_channels = 1
         sample_rate = 8000
         path = self.get_temp_path('data.amr-nb')
-        bits_per_sample = 16
         sox_utils.gen_audio_file(
-            path, sample_rate=sample_rate, num_channels=num_channels, bit_depth=bits_per_sample,
-            duration=duration)
+            path, sample_rate=sample_rate, num_channels=num_channels, duration=duration)
         info = sox_io_backend.info(path)
         assert info.sample_rate == sample_rate
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
         assert info.num_channels == num_channels
-        assert info.bits_per_sample == bits_per_sample
 
 
 @skipIfNoExtension

--- a/test/torchaudio_unittest/sox_io_backend/info_test.py
+++ b/test/torchaudio_unittest/sox_io_backend/info_test.py
@@ -155,7 +155,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         sample_rate = 8000
         path = self.get_temp_path('data.amr-nb')
         sox_utils.gen_audio_file(
-            path, sample_rate=sample_rate, num_channel=num_channels, bit_depth=16,
+            path, sample_rate=sample_rate, num_channels=num_channels, bit_depth=16,
             duration=duration)
         info = sox_io_backend.info(path)
         assert info.sample_rate == sample_rate

--- a/test/torchaudio_unittest/sox_io_backend/info_test.py
+++ b/test/torchaudio_unittest/sox_io_backend/info_test.py
@@ -161,7 +161,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.sample_rate == sample_rate
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
-        assert info.bits_per_sample == 16
+        assert info.bits_per_sample == 0
 
 
 @skipIfNoExtension

--- a/torchaudio/backend/_soundfile_backend.py
+++ b/torchaudio/backend/_soundfile_backend.py
@@ -66,16 +66,14 @@ def info(filepath: str, format: Optional[str] = None) -> AudioMetaData:
         AudioMetaData: meta data of the given audio.
     """
     sinfo = soundfile.info(filepath)
-    try:
-        bits_per_sample = _SUBTYPE_TO_BITS_PER_SAMPLE[sinfo.subtype]
-    except KeyError:
-        bits_per_sample = 0
+    if sinfo.subtype not in _SUBTYPE_TO_BITS_PER_SAMPLE:
         warnings.warn(
             "The {subtype} subtype is unknown to TorchAudio. As a result, the bits_per_sample "
             "attribute will be set to 0. If you are seeing this warning, please "
             "report by opening an issue on github (after checking for existing/closed ones). "
-            "You may otherwise ignore this warning."
+            "You may otherwise ignore this warning.".format(subtype=sinfo.subtype)
         )
+    bits_per_sample = _SUBTYPE_TO_BITS_PER_SAMPLE.get(sinfo.subtype, 0)
     return AudioMetaData(sinfo.samplerate, sinfo.frames, sinfo.channels, bits_per_sample=bits_per_sample)
 
 

--- a/torchaudio/backend/_soundfile_backend.py
+++ b/torchaudio/backend/_soundfile_backend.py
@@ -68,10 +68,10 @@ def info(filepath: str, format: Optional[str] = None) -> AudioMetaData:
     sinfo = soundfile.info(filepath)
     if sinfo.subtype not in _SUBTYPE_TO_BITS_PER_SAMPLE:
         warnings.warn(
-            "The {subtype} subtype is unknown to TorchAudio. As a result, the bits_per_sample "
+            f"The {sinfo.subtype} subtype is unknown to TorchAudio. As a result, the bits_per_sample "
             "attribute will be set to 0. If you are seeing this warning, please "
             "report by opening an issue on github (after checking for existing/closed ones). "
-            "You may otherwise ignore this warning.".format(subtype=sinfo.subtype)
+            "You may otherwise ignore this warning."
         )
     bits_per_sample = _SUBTYPE_TO_BITS_PER_SAMPLE.get(sinfo.subtype, 0)
     return AudioMetaData(sinfo.samplerate, sinfo.frames, sinfo.channels, bits_per_sample=bits_per_sample)

--- a/torchaudio/backend/_soundfile_backend.py
+++ b/torchaudio/backend/_soundfile_backend.py
@@ -11,6 +11,42 @@ if _mod_utils.is_module_available("soundfile"):
     import soundfile
 
 
+# mapping from soundfile subtype to number of bits per sample.
+# This is mostly heuristical and value is set to 0 when value is irrelevant
+# (lossy formats) or can't be inferred.
+# The dict is inspired from
+# https://github.com/bastibe/python-soundfile/blob/744efb4b01abc72498a96b09115b42a4cabd85e4/soundfile.py#L66-L94
+SUBTYPE_TO_BITS_PER_SAMPLE = {
+    'PCM_S8': 8,  # Signed 8 bit data
+    'PCM_16': 16,  # Signed 16 bit data
+    'PCM_24': 24,  # Signed 24 bit data
+    'PCM_32': 32,  # Signed 32 bit data
+    'PCM_U8': 8,  # Unsigned 8 bit data (WAV and RAW only)
+    'FLOAT': 32,  # 32 bit float data
+    'DOUBLE': 64,  # 64 bit float data
+    'ULAW': 0,  # U-Law encoded.
+    'ALAW': 0,  # A-Law encoded.
+    'IMA_ADPCM': 0,  # IMA ADPCM.
+    'MS_ADPCM': 0,  # Microsoft ADPCM.
+    'GSM610': 0,  # GSM 6.10 encoding.
+    'VOX_ADPCM': 0,  # OKI / Dialogix ADPCM
+    'G721_32': 0,  # 32kbs G721 ADPCM encoding.
+    'G723_24': 0,  # 24kbs G723 ADPCM encoding.
+    'G723_40': 0,  # 40kbs G723 ADPCM encoding.
+    'DWVW_12': 12,  # 12 bit Delta Width Variable Word encoding.
+    'DWVW_16': 16,  # 16 bit Delta Width Variable Word encoding.
+    'DWVW_24': 24,  # 24 bit Delta Width Variable Word encoding.
+    'DWVW_N': 0,  # N bit Delta Width Variable Word encoding.
+    'DPCM_8': 8,  # 8 bit differential PCM (XI only)
+    'DPCM_16': 16,  # 16 bit differential PCM (XI only)
+    'VORBIS': 0,  # Xiph Vorbis encoding.
+    'ALAC_16': 16,  # Apple Lossless Audio Codec (16 bit).
+    'ALAC_20': 20,  # Apple Lossless Audio Codec (20 bit).
+    'ALAC_24': 24,  # Apple Lossless Audio Codec (24 bit).
+    'ALAC_32': 32,  # Apple Lossless Audio Codec (32 bit).
+}
+
+
 @_mod_utils.requires_module("soundfile")
 def info(filepath: str, format: Optional[str] = None) -> AudioMetaData:
     """Get signal information of an audio file.
@@ -27,7 +63,8 @@ def info(filepath: str, format: Optional[str] = None) -> AudioMetaData:
         AudioMetaData: meta data of the given audio.
     """
     sinfo = soundfile.info(filepath)
-    return AudioMetaData(sinfo.samplerate, sinfo.frames, sinfo.channels)
+    bits_per_sample = SUBTYPE_TO_BITS_PER_SAMPLE[sinfo.subtype]
+    return AudioMetaData(sinfo.samplerate, sinfo.frames, sinfo.channels, bits_per_sample=bits_per_sample)
 
 
 _SUBTYPE2DTYPE = {

--- a/torchaudio/backend/_soundfile_backend.py
+++ b/torchaudio/backend/_soundfile_backend.py
@@ -11,9 +11,9 @@ if _mod_utils.is_module_available("soundfile"):
     import soundfile
 
 
-# mapping from soundfile subtype to number of bits per sample.
-# This is mostly heuristical and value is set to 0 when value is irrelevant
-# (lossy formats) or can't be inferred.
+# Mapping from soundfile subtype to number of bits per sample.
+# This is mostly heuristical and the value is set to 0 when it is irrelevant
+# (lossy formats) or when it can't be inferred.
 # The dict is inspired from
 # https://github.com/bastibe/python-soundfile/blob/744efb4b01abc72498a96b09115b42a4cabd85e4/soundfile.py#L66-L94
 SUBTYPE_TO_BITS_PER_SAMPLE = {

--- a/torchaudio/backend/common.py
+++ b/torchaudio/backend/common.py
@@ -12,11 +12,13 @@ class AudioMetaData:
     :ivar int sample_rate: Sample rate
     :ivar int num_frames: The number of frames
     :ivar int num_channels: The number of channels
+    :ivar int bits_per_sample: The number of bits per sample
     """
-    def __init__(self, sample_rate: int, num_frames: int, num_channels: int):
+    def __init__(self, sample_rate: int, num_frames: int, num_channels: int, bits_per_sample: int = 0):
         self.sample_rate = sample_rate
         self.num_frames = num_frames
         self.num_channels = num_channels
+        self.bits_per_sample = bits_per_sample
 
 
 @_mod_utils.deprecated('Please migrate to `AudioMetaData`.', '0.9.0')

--- a/torchaudio/backend/common.py
+++ b/torchaudio/backend/common.py
@@ -14,7 +14,7 @@ class AudioMetaData:
     :ivar int num_channels: The number of channels
     :ivar int bits_per_sample: The number of bits per sample. This is 0 for lossy formats.
     """
-    def __init__(self, sample_rate: int, num_frames: int, num_channels: int, bits_per_sample: int = 0):
+    def __init__(self, sample_rate: int, num_frames: int, num_channels: int, bits_per_sample: int):
         self.sample_rate = sample_rate
         self.num_frames = num_frames
         self.num_channels = num_channels

--- a/torchaudio/backend/common.py
+++ b/torchaudio/backend/common.py
@@ -12,7 +12,8 @@ class AudioMetaData:
     :ivar int sample_rate: Sample rate
     :ivar int num_frames: The number of frames
     :ivar int num_channels: The number of channels
-    :ivar int bits_per_sample: The number of bits per sample. This is 0 for lossy formats.
+    :ivar int bits_per_sample: The number of bits per sample. This is 0 for lossy formats,
+        or when it cannot be accurately inferred.
     """
     def __init__(self, sample_rate: int, num_frames: int, num_channels: int, bits_per_sample: int):
         self.sample_rate = sample_rate

--- a/torchaudio/backend/common.py
+++ b/torchaudio/backend/common.py
@@ -12,7 +12,7 @@ class AudioMetaData:
     :ivar int sample_rate: Sample rate
     :ivar int num_frames: The number of frames
     :ivar int num_channels: The number of channels
-    :ivar int bits_per_sample: The number of bits per sample
+    :ivar int bits_per_sample: The number of bits per sample. This is 0 for lossy formats.
     """
     def __init__(self, sample_rate: int, num_frames: int, num_channels: int, bits_per_sample: int = 0):
         self.sample_rate = sample_rate

--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -32,7 +32,8 @@ def info(
     # Cast to str in case type is `pathlib.Path`
     filepath = str(filepath)
     sinfo = torch.ops.torchaudio.sox_io_get_info(filepath, format)
-    return AudioMetaData(sinfo.get_sample_rate(), sinfo.get_num_frames(), sinfo.get_num_channels())
+    return AudioMetaData(sinfo.get_sample_rate(), sinfo.get_num_frames(), sinfo.get_num_channels(),
+                         sinfo.get_bits_per_sample())
 
 
 @_mod_utils.requires_module('torchaudio._torchaudio')

--- a/torchaudio/csrc/sox/io.cpp
+++ b/torchaudio/csrc/sox/io.cpp
@@ -13,10 +13,12 @@ namespace sox_io {
 SignalInfo::SignalInfo(
     const int64_t sample_rate_,
     const int64_t num_channels_,
-    const int64_t num_frames_)
+    const int64_t num_frames_,
+    const int64_t bits_per_sample_)
     : sample_rate(sample_rate_),
       num_channels(num_channels_),
-      num_frames(num_frames_){};
+      num_frames(num_frames_),
+      bits_per_sample(bits_per_sample_){};
 
 int64_t SignalInfo::getSampleRate() const {
   return sample_rate;
@@ -28,6 +30,10 @@ int64_t SignalInfo::getNumChannels() const {
 
 int64_t SignalInfo::getNumFrames() const {
   return num_frames;
+}
+
+int64_t SignalInfo::getBitsPerSample() const {
+  return bits_per_sample;
 }
 
 c10::intrusive_ptr<SignalInfo> get_info(
@@ -46,7 +52,8 @@ c10::intrusive_ptr<SignalInfo> get_info(
   return c10::make_intrusive<SignalInfo>(
       static_cast<int64_t>(sf->signal.rate),
       static_cast<int64_t>(sf->signal.channels),
-      static_cast<int64_t>(sf->signal.length / sf->signal.channels));
+      static_cast<int64_t>(sf->signal.length / sf->signal.channels),
+      static_cast<int64_t>(sf->encoding.bits_per_sample));
 }
 
 namespace {

--- a/torchaudio/csrc/sox/io.h
+++ b/torchaudio/csrc/sox/io.h
@@ -15,14 +15,17 @@ struct SignalInfo : torch::CustomClassHolder {
   int64_t sample_rate;
   int64_t num_channels;
   int64_t num_frames;
+  int64_t bits_per_sample;
 
   SignalInfo(
       const int64_t sample_rate_,
       const int64_t num_channels_,
-      const int64_t num_frames_);
+      const int64_t num_frames_,
+      const int64_t bits_per_sample_);
   int64_t getSampleRate() const;
   int64_t getNumChannels() const;
   int64_t getNumFrames() const;
+  int64_t getBitsPerSample() const;
 };
 
 c10::intrusive_ptr<SignalInfo> get_info(

--- a/torchaudio/csrc/sox/register.cpp
+++ b/torchaudio/csrc/sox/register.cpp
@@ -42,7 +42,8 @@ TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
   m.class_<torchaudio::sox_io::SignalInfo>("SignalInfo")
       .def("get_sample_rate", &torchaudio::sox_io::SignalInfo::getSampleRate)
       .def("get_num_channels", &torchaudio::sox_io::SignalInfo::getNumChannels)
-      .def("get_num_frames", &torchaudio::sox_io::SignalInfo::getNumFrames);
+      .def("get_num_frames", &torchaudio::sox_io::SignalInfo::getNumFrames)
+      .def("get_bits_per_sample", &torchaudio::sox_io::SignalInfo::getBitsPerSample);
 
   m.def("torchaudio::sox_io_get_info", &torchaudio::sox_io::get_info);
   m.def(


### PR DESCRIPTION
Closes https://github.com/pytorch/audio/issues/1173

This PR adds a `bits_per_sample` attribute to `AudioMetaData` as returned by `info()`, with support for both `sox_io` and `SoundFile`. As SoundFile does not expose the bit depth directly, it is inferred from the `subtype` field as suggested in https://github.com/pytorch/audio/issues/1173.

`bits_per_sample` is left to 0 for lossy formats or when it cannot be inferred.
CC @mthrok 