### PR TITLE
Update setup.py to remove 2.7 ref

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,9 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: C++",
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Multimedia :: Sound/Audio",
         "Topic :: Scientific/Engineering :: Artificial Intelligence"

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: C++",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Multimedia :: Sound/Audio",


### PR DESCRIPTION
This PR removes alleged support to Python 2.7 in `setup.py`.
Closes  #477