### PR TITLE
packaging: Always strip version suffix for pytorch

### DIFF
--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -162,13 +162,8 @@ setup_pip_pytorch_version() {
     # Install latest prerelease version of torch, per our nightlies, consistent
     # with the requested cuda version
     pip_install --pre torch -f "https://download.pytorch.org/whl/nightly/${WHEEL_DIR}torch_nightly.html"
-    if [[ "$CUDA_VERSION" == "cpu" ]]; then
-      # CUDA and CPU are ABI compatible on the CPU-only parts, so strip
-      # in this case
-      export PYTORCH_VERSION="$(pip show torch | grep ^Version: | sed 's/Version:  *//' | sed 's/+.\+//')"
-    else
-      export PYTORCH_VERSION="$(pip show torch | grep ^Version: | sed 's/Version:  *//')"
-    fi
+    # CUDA and CPU are ABI compatible on the CPU-only parts, so strip in this case
+    export PYTORCH_VERSION="$(pip show torch | grep ^Version: | sed 's/Version:  *//' | sed 's/+.\+//')"
   else
     pip_install "torch==$PYTORCH_VERSION$PYTORCH_VERSION_SUFFIX" \
       -f https://download.pytorch.org/whl/torch_stable.html \


### PR DESCRIPTION
torchaudio can work with any version of pytorch so let's strip the
pytorch version suffix to denote that

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>