### PR TITLE
Update GPU test image to development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -430,7 +430,7 @@ jobs:
     resource_class: gpu.small
     environment:
       <<: *environment
-      image_name: "pytorch/torchaudio_unittest_base:manylinux-cuda10.1"
+      image_name: pytorch/torchaudio_unittest_base:manylinux-cuda10.1-cudnn7-20201203
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -430,7 +430,7 @@ jobs:
     resource_class: gpu.small
     environment:
       <<: *environment
-      image_name: "pytorch/torchaudio_unittest_base:manylinux-cuda10.1"
+      image_name: pytorch/torchaudio_unittest_base:manylinux-cuda10.1-cudnn7-20201203
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/unittest/linux/docker/build_and_push.sh
+++ b/.circleci/unittest/linux/docker/build_and_push.sh
@@ -7,15 +7,14 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 
+datestr="$(date "+%Y%m%d")"
 if [ "$1" = "cpu" ]; then
     base_image="ubuntu:18.04"
-    image="pytorch/torchaudio_unittest_base:manylinux"
-elif [[ "$1" =~ ^(9.2|10.1)$ ]]; then
-    base_image="nvidia/cuda:$1-runtime-ubuntu18.04"
-    image="pytorch/torchaudio_unittest_base:manylinux-cuda$1"
+    image="pytorch/torchaudio_unittest_base:manylinux-${datestr}"
 else
-    printf "Unexpected <CUDA_VERSION> string: %s" "$1"
-    exit 1;
+    base_image="nvidia/cuda:$1-devel-ubuntu18.04"
+    docker pull "${base_image}"
+    image="pytorch/torchaudio_unittest_base:manylinux-cuda$1-${datestr}"
 fi
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"


### PR DESCRIPTION
Changing the test Docker image for GPU tests to use Nvidia Docker `devel` image. This is necessary for #1187. 