### PR TITLE
Add encoding attribte to info

### DIFF
--- a/test/torchaudio_unittest/sox_io_backend/info_test.py
+++ b/test/torchaudio_unittest/sox_io_backend/info_test.py
@@ -27,6 +27,14 @@ if _mod_utils.is_module_available("requests"):
     import requests
 
 
+_DTYPE_TO_ENCODING = {
+    'float32': 'PCM_F',
+    'int32': 'PCM_S',
+    'int16': 'PCM_S',
+    'uint8': 'PCM_U',
+}
+
+
 @skipIfNoExec('sox')
 @skipIfNoExtension
 class TestInfo(TempDirMixin, PytorchTestCase):
@@ -46,6 +54,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
         assert info.bits_per_sample == sox_utils.get_bit_depth(dtype)
+        assert info.encoding == _DTYPE_TO_ENCODING[dtype]
 
     @parameterized.expand(list(itertools.product(
         ['float32', 'int32', 'int16', 'uint8'],
@@ -63,6 +72,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
         assert info.bits_per_sample == sox_utils.get_bit_depth(dtype)
+        assert info.encoding == _DTYPE_TO_ENCODING[dtype]
 
     @parameterized.expand(list(itertools.product(
         [8000, 16000],
@@ -83,6 +93,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         # assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
         assert info.bits_per_sample == 0  # bit_per_sample is irrelevant for compressed formats
+        assert info.encoding == "MP3"
 
     @parameterized.expand(list(itertools.product(
         [8000, 16000],
@@ -102,6 +113,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
         assert info.bits_per_sample == 24  # FLAC standard
+        assert info.encoding == "FLAC"
 
     @parameterized.expand(list(itertools.product(
         [8000, 16000],
@@ -121,6 +133,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
         assert info.bits_per_sample == 0  # bit_per_sample is irrelevant for compressed formats
+        assert info.encoding == "VORBIS"
 
     @parameterized.expand(list(itertools.product(
         [8000, 16000],
@@ -137,6 +150,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
         assert info.bits_per_sample == bits_per_sample
+        assert info.encoding == "PCM_S"
 
     @parameterized.expand(list(itertools.product(
         ['float32', 'int32', 'int16', 'uint8'],
@@ -156,6 +170,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
         assert info.bits_per_sample == bits_per_sample
+        assert info.encoding == "PCM_U" if dtype == 'uint8' else "PCM_S"
 
     def test_amr_nb(self):
         """`sox_io_backend.info` can check amr-nb file correctly"""
@@ -171,6 +186,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
         assert info.bits_per_sample == 0
+        assert info.encoding == "AMR_NB"
 
 
 @skipIfNoExtension
@@ -188,6 +204,7 @@ class TestInfoOpus(PytorchTestCase):
         assert info.num_frames == 32768
         assert info.num_channels == num_channels
         assert info.bits_per_sample == 0  # bit_per_sample is irrelevant for compressed formats
+        assert info.encoding == "OPUS"
 
 
 @skipIfNoExtension
@@ -206,6 +223,7 @@ class TestLoadWithoutExtension(PytorchTestCase):
         sinfo = sox_io_backend.info(path, format="mp3")
         assert sinfo.sample_rate == 16000
         assert sinfo.bits_per_sample == 0  # bit_per_sample is irrelevant for compressed formats
+        assert sinfo.encoding == "MP3"
 
 
 @skipIfNoExtension

--- a/test/torchaudio_unittest/sox_io_backend/info_test.py
+++ b/test/torchaudio_unittest/sox_io_backend/info_test.py
@@ -205,6 +205,40 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.bits_per_sample == 0
         assert info.encoding == "AMR_NB"
 
+    def test_ulaw(self):
+        """`sox_io_backend.info` can check ulaw file correctly"""
+        duration = 1
+        num_channels = 1
+        sample_rate = 8000
+        path = self.get_temp_path('data.wav')
+        sox_utils.gen_audio_file(
+            path, sample_rate=sample_rate, num_channels=num_channels,
+            bit_depth=8, encoding='u-law',
+            duration=duration)
+        info = sox_io_backend.info(path)
+        assert info.sample_rate == sample_rate
+        assert info.num_frames == sample_rate * duration
+        assert info.num_channels == num_channels
+        assert info.bits_per_sample == 8
+        assert info.encoding == "ULAW"
+
+    def test_alaw(self):
+        """`sox_io_backend.info` can check ulaw file correctly"""
+        duration = 1
+        num_channels = 1
+        sample_rate = 8000
+        path = self.get_temp_path('data.wav')
+        sox_utils.gen_audio_file(
+            path, sample_rate=sample_rate, num_channels=num_channels,
+            bit_depth=8, encoding='a-law',
+            duration=duration)
+        info = sox_io_backend.info(path)
+        assert info.sample_rate == sample_rate
+        assert info.num_frames == sample_rate * duration
+        assert info.num_channels == num_channels
+        assert info.bits_per_sample == 8
+        assert info.encoding == "ALAW"
+
 
 @skipIfNoExtension
 class TestInfoOpus(PytorchTestCase):

--- a/test/torchaudio_unittest/sox_io_backend/info_test.py
+++ b/test/torchaudio_unittest/sox_io_backend/info_test.py
@@ -28,7 +28,7 @@ if _mod_utils.is_module_available("requests"):
     import requests
 
 
-def _get_encoding(ext, dtype):
+def get_encoding(ext, dtype):
     exts = {
         'mp3',
         'flac',
@@ -43,7 +43,7 @@ def _get_encoding(ext, dtype):
     return ext.upper() if ext in exts else encodings[dtype]
 
 
-def _get_bits_per_sample(ext, dtype):
+def get_bits_per_sample(ext, dtype):
     bits_per_samples = {
         'flac': 24,
         'mp3': 0,
@@ -71,7 +71,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
         assert info.bits_per_sample == sox_utils.get_bit_depth(dtype)
-        assert info.encoding == _get_encoding('wav', dtype)
+        assert info.encoding == get_encoding('wav', dtype)
 
     @parameterized.expand(list(itertools.product(
         ['float32', 'int32', 'int16', 'uint8'],
@@ -89,7 +89,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
         assert info.bits_per_sample == sox_utils.get_bit_depth(dtype)
-        assert info.encoding == _get_encoding('wav', dtype)
+        assert info.encoding == get_encoding('wav', dtype)
 
     @parameterized.expand(list(itertools.product(
         [8000, 16000],
@@ -187,7 +187,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
         assert info.bits_per_sample == bits_per_sample
-        assert info.encoding == _get_encoding("amb", dtype)
+        assert info.encoding == get_encoding("amb", dtype)
 
     def test_amr_nb(self):
         """`sox_io_backend.info` can check amr-nb file correctly"""
@@ -239,7 +239,7 @@ class TestLoadWithoutExtension(PytorchTestCase):
         path = get_asset_path("mp3_without_ext")
         sinfo = sox_io_backend.info(path, format="mp3")
         assert sinfo.sample_rate == 16000
-        assert sinfo.num_frames == 0
+        assert sinfo.num_frames == 81216
         assert sinfo.num_channels == 1
         assert sinfo.bits_per_sample == 0  # bit_per_sample is irrelevant for compressed formats
         assert sinfo.encoding == "MP3"
@@ -303,14 +303,14 @@ class TestFileObject(FileObjTestBase, PytorchTestCase):
         num_channels = 2
         sinfo = self._query_fileobj(ext, dtype, sample_rate, num_channels, num_frames)
 
-        bits_per_sample = _get_bits_per_sample(ext, dtype)
+        bits_per_sample = get_bits_per_sample(ext, dtype)
         num_frames = 0 if ext in ['mp3', 'vorbis'] else num_frames
 
         assert sinfo.sample_rate == sample_rate
         assert sinfo.num_channels == num_channels
         assert sinfo.num_frames == num_frames
         assert sinfo.bits_per_sample == bits_per_sample
-        assert sinfo.encoding == _get_encoding(ext, dtype)
+        assert sinfo.encoding == get_encoding(ext, dtype)
 
     @parameterized.expand([
         ('wav', "float32"),
@@ -329,14 +329,14 @@ class TestFileObject(FileObjTestBase, PytorchTestCase):
         num_channels = 2
         sinfo = self._query_bytesio(ext, dtype, sample_rate, num_channels, num_frames)
 
-        bits_per_sample = _get_bits_per_sample(ext, dtype)
+        bits_per_sample = get_bits_per_sample(ext, dtype)
         num_frames = 0 if ext in ['mp3', 'vorbis'] else num_frames
 
         assert sinfo.sample_rate == sample_rate
         assert sinfo.num_channels == num_channels
         assert sinfo.num_frames == num_frames
         assert sinfo.bits_per_sample == bits_per_sample
-        assert sinfo.encoding == _get_encoding(ext, dtype)
+        assert sinfo.encoding == get_encoding(ext, dtype)
 
     @parameterized.expand([
         ('wav', "float32"),
@@ -355,14 +355,14 @@ class TestFileObject(FileObjTestBase, PytorchTestCase):
         num_channels = 2
         sinfo = self._query_bytesio(ext, dtype, sample_rate, num_channels, num_frames)
 
-        bits_per_sample = _get_bits_per_sample(ext, dtype)
+        bits_per_sample = get_bits_per_sample(ext, dtype)
         num_frames = 0 if ext in ['mp3', 'vorbis'] else num_frames
 
         assert sinfo.sample_rate == sample_rate
         assert sinfo.num_channels == num_channels
         assert sinfo.num_frames == num_frames
         assert sinfo.bits_per_sample == bits_per_sample
-        assert sinfo.encoding == _get_encoding(ext, dtype)
+        assert sinfo.encoding == get_encoding(ext, dtype)
 
     @parameterized.expand([
         ('wav', "float32"),
@@ -381,14 +381,14 @@ class TestFileObject(FileObjTestBase, PytorchTestCase):
         num_channels = 2
         sinfo = self._query_tarfile(ext, dtype, sample_rate, num_channels, num_frames)
 
-        bits_per_sample = _get_bits_per_sample(ext, dtype)
+        bits_per_sample = get_bits_per_sample(ext, dtype)
         num_frames = 0 if ext in ['mp3', 'vorbis'] else num_frames
 
         assert sinfo.sample_rate == sample_rate
         assert sinfo.num_channels == num_channels
         assert sinfo.num_frames == num_frames
         assert sinfo.bits_per_sample == bits_per_sample
-        assert sinfo.encoding == _get_encoding(ext, dtype)
+        assert sinfo.encoding == get_encoding(ext, dtype)
 
 
 @skipIfNoExtension
@@ -421,11 +421,11 @@ class TestFileObjectHttp(HttpServerMixin, FileObjTestBase, PytorchTestCase):
         num_channels = 2
         sinfo = self._query_http(ext, dtype, sample_rate, num_channels, num_frames)
 
-        bits_per_sample = _get_bits_per_sample(ext, dtype)
+        bits_per_sample = get_bits_per_sample(ext, dtype)
         num_frames = 0 if ext in ['mp3', 'vorbis'] else num_frames
 
         assert sinfo.sample_rate == sample_rate
         assert sinfo.num_channels == num_channels
         assert sinfo.num_frames == num_frames
         assert sinfo.bits_per_sample == bits_per_sample
-        assert sinfo.encoding == _get_encoding(ext, dtype)
+        assert sinfo.encoding == get_encoding(ext, dtype)

--- a/torchaudio/backend/common.py
+++ b/torchaudio/backend/common.py
@@ -14,12 +14,21 @@ class AudioMetaData:
     :ivar int num_channels: The number of channels
     :ivar int bits_per_sample: The number of bits per sample. This is 0 for lossy formats,
         or when it cannot be accurately inferred.
+    :ivar str encoding: Audio encoding.
     """
-    def __init__(self, sample_rate: int, num_frames: int, num_channels: int, bits_per_sample: int):
+    def __init__(
+            self,
+            sample_rate: int,
+            num_frames: int,
+            num_channels: int,
+            bits_per_sample: int,
+            encoding: str,
+    ):
         self.sample_rate = sample_rate
         self.num_frames = num_frames
         self.num_channels = num_channels
         self.bits_per_sample = bits_per_sample
+        self.encoding = encoding
 
 
 @_mod_utils.deprecated('Please migrate to `AudioMetaData`.', '0.9.0')

--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -17,17 +17,15 @@ def _info(
         format: Optional[str] = None,
 ) -> AudioMetaData:
     if hasattr(filepath, 'read'):
-        sinfo = torchaudio._torchaudio.get_info_fileobj(
-            filepath, format)
-        sample_rate, num_channels, num_frames, bits_per_sample = sinfo
-        return AudioMetaData(
-            sample_rate, num_frames, num_channels, bits_per_sample)
+        sinfo = torchaudio._torchaudio.get_info_fileobj(filepath, format)
+        return AudioMetaData(*sinfo)
     sinfo = torch.ops.torchaudio.sox_io_get_info(os.fspath(filepath), format)
     return AudioMetaData(
         sinfo.get_sample_rate(),
         sinfo.get_num_frames(),
         sinfo.get_num_channels(),
         sinfo.get_bits_per_sample(),
+        sinfo.get_encoding(),
     )
 
 
@@ -69,7 +67,8 @@ def info(
         sinfo.get_sample_rate(),
         sinfo.get_num_frames(),
         sinfo.get_num_channels(),
-        sinfo.get_bits_per_sample())
+        sinfo.get_bits_per_sample(),
+        sinfo.get_encoding())
 
 
 @_mod_utils.requires_module('torchaudio._torchaudio')

--- a/torchaudio/csrc/sox/io.cpp
+++ b/torchaudio/csrc/sox/io.cpp
@@ -14,11 +14,13 @@ SignalInfo::SignalInfo(
     const int64_t sample_rate_,
     const int64_t num_channels_,
     const int64_t num_frames_,
-    const int64_t bits_per_sample_)
+    const int64_t bits_per_sample_,
+    const std::string encoding_)
     : sample_rate(sample_rate_),
       num_channels(num_channels_),
       num_frames(num_frames_),
-      bits_per_sample(bits_per_sample_){};
+      bits_per_sample(bits_per_sample_),
+      encoding(encoding_){};
 
 int64_t SignalInfo::getSampleRate() const {
   return sample_rate;
@@ -35,6 +37,45 @@ int64_t SignalInfo::getNumFrames() const {
 int64_t SignalInfo::getBitsPerSample() const {
   return bits_per_sample;
 }
+
+std::string SignalInfo::getEncoding() const {
+  return encoding;
+}
+
+namespace {
+
+std::string get_encoding(sox_encoding_t encoding) {
+  switch (encoding) {
+    case SOX_ENCODING_UNKNOWN:
+      return "UNKNOWN";
+    case SOX_ENCODING_SIGN2:
+      return "PCM_S";
+    case SOX_ENCODING_UNSIGNED:
+      return "PCM_U";
+    case SOX_ENCODING_FLOAT:
+      return "PCM_F";
+    case SOX_ENCODING_FLAC:
+      return "FLAC";
+    case SOX_ENCODING_ULAW:
+      return "ULAW";
+    case SOX_ENCODING_ALAW:
+      return "ALAW";
+    case SOX_ENCODING_MP3:
+      return "MP3";
+    case SOX_ENCODING_VORBIS:
+      return "VORBIS";
+    case SOX_ENCODING_AMR_WB:
+      return "AMR_WB";
+    case SOX_ENCODING_AMR_NB:
+      return "AMR_NB";
+    case SOX_ENCODING_OPUS:
+      return "OPUS";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+} // namespace
 
 c10::intrusive_ptr<SignalInfo> get_info_file(
     const std::string& path,
@@ -53,7 +94,8 @@ c10::intrusive_ptr<SignalInfo> get_info_file(
       static_cast<int64_t>(sf->signal.rate),
       static_cast<int64_t>(sf->signal.channels),
       static_cast<int64_t>(sf->signal.length / sf->signal.channels),
-      static_cast<int64_t>(sf->encoding.bits_per_sample));
+      static_cast<int64_t>(sf->encoding.bits_per_sample),
+      get_encoding(sf->encoding.encoding));
 }
 
 namespace {
@@ -157,7 +199,7 @@ void save_audio_file(
 
 #ifdef TORCH_API_INCLUDE_EXTENSION_H
 
-std::tuple<int64_t, int64_t, int64_t, int64_t> get_info_fileobj(
+std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_fileobj(
     py::object fileobj,
     c10::optional<std::string>& format) {
   // Prepare in-memory file object
@@ -202,9 +244,10 @@ std::tuple<int64_t, int64_t, int64_t, int64_t> get_info_fileobj(
 
   return std::make_tuple(
       static_cast<int64_t>(sf->signal.rate),
-      static_cast<int64_t>(sf->signal.channels),
       static_cast<int64_t>(sf->signal.length / sf->signal.channels),
-      static_cast<int64_t>(sf->encoding.bits_per_sample));
+      static_cast<int64_t>(sf->signal.channels),
+      static_cast<int64_t>(sf->encoding.bits_per_sample),
+      get_encoding(sf->encoding.encoding));
 }
 
 std::tuple<torch::Tensor, int64_t> load_audio_fileobj(

--- a/torchaudio/csrc/sox/io.h
+++ b/torchaudio/csrc/sox/io.h
@@ -16,16 +16,19 @@ struct SignalInfo : torch::CustomClassHolder {
   int64_t num_channels;
   int64_t num_frames;
   int64_t bits_per_sample;
+  std::string encoding;
 
   SignalInfo(
       const int64_t sample_rate_,
       const int64_t num_channels_,
       const int64_t num_frames_,
-      const int64_t bits_per_sample_);
+      const int64_t bits_per_sample_,
+      const std::string encoding_);
   int64_t getSampleRate() const;
   int64_t getNumChannels() const;
   int64_t getNumFrames() const;
   int64_t getBitsPerSample() const;
+  std::string getEncoding() const;
 };
 
 c10::intrusive_ptr<SignalInfo> get_info_file(
@@ -51,7 +54,7 @@ void save_audio_file(
 
 #ifdef TORCH_API_INCLUDE_EXTENSION_H
 
-std::tuple<int64_t, int64_t, int64_t, int64_t> get_info_fileobj(
+std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_fileobj(
     py::object fileobj,
     c10::optional<std::string>& format);
 

--- a/torchaudio/csrc/sox/register.cpp
+++ b/torchaudio/csrc/sox/register.cpp
@@ -45,7 +45,8 @@ TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
       .def("get_num_frames", &torchaudio::sox_io::SignalInfo::getNumFrames)
       .def(
           "get_bits_per_sample",
-          &torchaudio::sox_io::SignalInfo::getBitsPerSample);
+          &torchaudio::sox_io::SignalInfo::getBitsPerSample)
+      .def("get_encoding", &torchaudio::sox_io::SignalInfo::getEncoding);
 
   m.def("torchaudio::sox_io_get_info", &torchaudio::sox_io::get_info_file);
   m.def(


### PR DESCRIPTION
This PR adds `encoding` attribute to the `AudioMetaData` class and make `info` function returns `encoding` as well.
In the legacy backend implementations, this information was available in sox backend, but in new backends, we do not expose the native structure of libsox directly, so we use `str` class to represent the encoding. See #1184 for the specification.

Resolves #1184 