### PR TITLE
Fixed seg fault caused by passing random effect to apply_effects_tensor

### DIFF
--- a/torchaudio/csrc/sox/effects_chain.cpp
+++ b/torchaudio/csrc/sox/effects_chain.cpp
@@ -258,7 +258,13 @@ void SoxEffectsChain::addEffect(const std::vector<std::string> effect) {
     throw std::runtime_error(stream.str());
   }
 
-  SoxEffect e(sox_create_effect(sox_find_effect(name.c_str())));
+  auto returned_effect = sox_find_effect(name.c_str());
+  if (!returned_effect) {
+    std::ostringstream stream;
+    stream << "Unsupported effect: " << name;
+    throw std::runtime_error(stream.str());
+  }
+  SoxEffect e(sox_create_effect(returned_effect));
   const auto num_options = num_args - 1;
 
   std::vector<char*> opts;


### PR DESCRIPTION
Fixes https://github.com/pytorch/audio/issues/1223.

```
>>> import torchaudio
################################################################################
### WARNING, path does not exist: KALDI_ROOT=/mnt/matylda5/iveselyk/Tools/kaldi-trunk
###          (please add 'export KALDI_ROOT=<your_path>' in your $HOME/.profile)
###          (or run as: KALDI_ROOT=<your_path> python <your_script>.py)
################################################################################

>>> effects = [['gain', '-n'], ['pitch', '1'], ['rate', '16000'], ['foo', '1']]
>>> waveform, sample_rate = torchaudio.load('knu1.mp3')
>>> waveform2, sample_rate2 = torchaudio.sox_effects.apply_effects_tensor(waveform, sample_rate, effects, channels_first=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/prabhatroy/Documents/pytorch/audio/torchaudio/sox_effects/sox_effects.py", line 153, in apply_effects_tensor
    tensor, sample_rate, effects, channels_first)
RuntimeError: Unsupported effect: foo
>>> 

```