### PR TITLE
DOC Fix sphinx warnings and turn warnings into errors

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W  # converts warnings into error
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = torchaudio
 SOURCEDIR     = source

--- a/docs/source/backend.rst
+++ b/docs/source/backend.rst
@@ -157,12 +157,12 @@ You can switch from another backend to the ``"soundfile"`` backend with the foll
     If you are switching from `"soundfile" (legacy interface) <soundfile_legacy_backend>` backend, set ``torchaudio.USE_SOUNDFILE_LEGACY_INTERFACE`` flag **before** switching the backend.
 
 info
-^^^^
+----
 
 .. autofunction:: torchaudio.backend._soundfile_backend.info
 
 load
-^^^^
+----
 
 .. autofunction:: torchaudio.backend._soundfile_backend.load
 
@@ -170,7 +170,7 @@ load
 
 
 save
-^^^^
+----
 
 .. autofunction:: torchaudio.backend._soundfile_backend.save
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -58,6 +58,8 @@ delimiters : [
 '''
 
 napoleon_use_ivar = True
+napoleon_numpy_docstring = False
+napoleon_google_docstring = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/torchaudio/_internal/module_utils.py
+++ b/torchaudio/_internal/module_utils.py
@@ -45,6 +45,7 @@ def deprecated(direction: str, version: Optional[str] = None):
     """
     def decorator(obj):
         # get __init__ if obj is a class, else get the function itself
+        # FIXME: remove when SignalInfo and EncodingInfo are properly removed
         func = getattr(obj, '__init__', obj)
 
         @wraps(func)

--- a/torchaudio/_internal/module_utils.py
+++ b/torchaudio/_internal/module_utils.py
@@ -2,6 +2,7 @@ import warnings
 import importlib.util
 from typing import Optional
 from functools import wraps
+import inspect
 
 
 def is_module_available(*modules: str) -> bool:
@@ -46,7 +47,7 @@ def deprecated(direction: str, version: Optional[str] = None):
     def decorator(obj):
         # get __init__ if obj is a class, else get the function itself
         # FIXME: remove when SignalInfo and EncodingInfo are properly removed
-        func = getattr(obj, '__init__', obj)
+        func = obj.__init__ if inspect.isclass(obj) else obj
 
         @wraps(func)
         def wrapped(*args, **kwargs):

--- a/torchaudio/_internal/module_utils.py
+++ b/torchaudio/_internal/module_utils.py
@@ -2,7 +2,6 @@ import warnings
 import importlib.util
 from typing import Optional
 from functools import wraps
-import inspect
 
 
 def is_module_available(*modules: str) -> bool:

--- a/torchaudio/_internal/module_utils.py
+++ b/torchaudio/_internal/module_utils.py
@@ -44,10 +44,7 @@ def deprecated(direction: str, version: Optional[str] = None):
     Args:
         direction: Migration steps to be given to users.
     """
-    def decorator(obj):
-        # get __init__ if obj is a class, else get the function itself
-        # FIXME: remove when SignalInfo and EncodingInfo are properly removed
-        func = obj.__init__ if inspect.isclass(obj) else obj
+    def decorator(func):
 
         @wraps(func)
         def wrapped(*args, **kwargs):

--- a/torchaudio/_internal/module_utils.py
+++ b/torchaudio/_internal/module_utils.py
@@ -43,7 +43,10 @@ def deprecated(direction: str, version: Optional[str] = None):
     Args:
         direction: Migration steps to be given to users.
     """
-    def decorator(func):
+    def decorator(obj):
+        # get __init__ if obj is a class, else get the function itself
+        func = getattr(obj, '__init__', obj)
+
         @wraps(func)
         def wrapped(*args, **kwargs):
             message = (

--- a/torchaudio/backend/common.py
+++ b/torchaudio/backend/common.py
@@ -1,6 +1,5 @@
 from typing import Any, Optional
-
-from torchaudio._internal import module_utils as _mod_utils
+import warnings
 
 
 class AudioMetaData:
@@ -31,7 +30,6 @@ class AudioMetaData:
         self.encoding = encoding
 
 
-@_mod_utils.deprecated('Please migrate to `AudioMetaData`.', '0.9.0')
 class SignalInfo:
     """One of return types of ``torchaudio.info`` functions.
 
@@ -51,13 +49,18 @@ class SignalInfo:
                  rate: Optional[float] = None,
                  precision: Optional[int] = None,
                  length: Optional[int] = None) -> None:
+        message = (
+            f'{self.__module__}.{self.__class__.__name__} has been deprecated '
+            'and will be removed from 0.9.0 release. '
+            'Please migrate to `AudioMetaData`.'
+        )
+        warnings.warn(message)
         self.channels = channels
         self.rate = rate
         self.precision = precision
         self.length = length
 
 
-@_mod_utils.deprecated('Please migrate to `AudioMetaData`.', '0.9.0')
 class EncodingInfo:
     """One of return types of ``torchaudio.info`` functions.
 
@@ -82,6 +85,12 @@ class EncodingInfo:
                  reverse_nibbles: Any = None,
                  reverse_bits: Any = None,
                  opposite_endian: Optional[bool] = None) -> None:
+        message = (
+            f'{self.__module__}.{self.__class__.__name__} has been deprecated '
+            'and will be removed from 0.9.0 release. '
+            'Please migrate to `AudioMetaData`.'
+        )
+        warnings.warn(message)
         self.encoding = encoding
         self.bits_per_sample = bits_per_sample
         self.compression = compression

--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -22,18 +22,22 @@ def info(
         filepath (path-like object or file-like object):
             Source of audio data. When the function is not compiled by TorchScript,
             (e.g. ``torch.jit.script``), the following types are accepted;
+
                   * ``path-like``: file path
                   * ``file-like``: Object with ``read(size: int) -> bytes`` method,
                     which returns byte string of at most ``size`` length.
+
             When the function is compiled by TorchScript, only ``str`` type is allowed.
 
             Note:
+
                   * When the input type is file-like object, this function cannot
                     get the correct length (``num_samples``) for certain formats,
                     such as ``mp3`` and ``vorbis``.
                     In this case, the value of ``num_samples`` is ``0``.
                   * This argument is intentionally annotated as ``str`` only due to
                     TorchScript compiler compatibility.
+
         format (str, optional):
             Override the format detection with the given format.
             Providing the argument might help when libsox can not infer the format
@@ -103,14 +107,15 @@ def load(
         filepath (path-like object or file-like object):
             Source of audio data. When the function is not compiled by TorchScript,
             (e.g. ``torch.jit.script``), the following types are accepted;
+
                   * ``path-like``: file path
                   * ``file-like``: Object with ``read(size: int) -> bytes`` method,
                     which returns byte string of at most ``size`` length.
+
             When the function is compiled by TorchScript, only ``str`` type is allowed.
 
-            Note:
-                * This argument is intentionally annotated as ``str`` only due to
-                  TorchScript compiler compatibility.
+            Note: This argument is intentionally annotated as ``str`` only due to
+            TorchScript compiler compatibility.
         frame_offset (int):
             Number of frames to skip before start reading data.
         num_frames (int):

--- a/torchaudio/sox_effects/sox_effects.py
+++ b/torchaudio/sox_effects/sox_effects.py
@@ -174,14 +174,16 @@ def apply_effects_file(
     Args:
         path (path-like object or file-like object):
             Source of audio data. When the function is not compiled by TorchScript,
-            (e.g. ``torch.jit.script``), the following types are accepted;
+            (e.g. ``torch.jit.script``), the following types are accepted:
+
                   * ``path-like``: file path
                   * ``file-like``: Object with ``read(size: int) -> bytes`` method,
                     which returns byte string of at most ``size`` length.
+
             When the function is compiled by TorchScript, only ``str`` type is allowed.
-            Note:
-                * This argument is intentionally annotated as ``str`` only for
-                  TorchScript compiler compatibility.
+
+            Note: This argument is intentionally annotated as ``str`` only for
+            TorchScript compiler compatibility.
         effects (List[List[str]]): List of effects.
         normalize (bool):
             When ``True``, this function always return ``float32``, and sample values are


### PR DESCRIPTION
Similar to what was done in `torchvision` https://github.com/pytorch/vision/pull/3290

This PR fixes sphinx warnings and sets the 

```py
napoleon_numpy_docstring = False
napoleon_google_docstring = True
```

for sphinx to issue warnings when the wrong parameter syntax is used.

The warnings are now turned into errors. Note: sphinx will now stop compilation at the first warning/error it sees; if we relied on sphinx>=8, we could use the `--keep-going` option to let it finish.