### PR TITLE
Improve MelSpectrogram librosa compatibility test

### DIFF
--- a/test/torchaudio_unittest/librosa_compatibility_test.py
+++ b/test/torchaudio_unittest/librosa_compatibility_test.py
@@ -166,13 +166,6 @@ def _load_audio_asset(*asset_paths, **kwargs):
 class TestTransforms(common_utils.TorchaudioTestCase):
     """Test suite for functions in `transforms` module."""
 
-    @staticmethod
-    def _set_up_sound():
-        common_utils.set_audio_backend('default')
-        path = common_utils.get_asset_path('sinewave.wav')
-        sound, sample_rate = common_utils.load_wav(path)
-        sound_librosa = sound.cpu().numpy().squeeze()  # (64000)
-        return sound, sample_rate, sound_librosa
 
     @parameterized.expand([
         param(n_fft=400, hop_length=200, power=2.0),
@@ -181,7 +174,9 @@ class TestTransforms(common_utils.TorchaudioTestCase):
         param(n_fft=200, hop_length=50, power=2.0),
     ])
     def test_spectrogram(self, n_fft, hop_length, power):
-        sound, sample_rate, sound_librosa = self._set_up_sound()
+        sample_rate = 16000
+        sound = common_utils.get_sinusoid(n_channels=1, sample_rate=sample_rate)
+        sound_librosa = sound.cpu().numpy().squeeze()
         spect_transform = torchaudio.transforms.Spectrogram(
             n_fft=n_fft, hop_length=hop_length, power=power)
         out_librosa, _ = librosa.core.spectrum._spectrogram(
@@ -191,7 +186,7 @@ class TestTransforms(common_utils.TorchaudioTestCase):
         self.assertEqual(out_torch, torch.from_numpy(out_librosa), atol=1e-5, rtol=1e-5)
 
     @parameterized.expand([
-        p._replace(kwargs={'norm': norm, **p.kwargs})
+        param(norm=norm, **p.kwargs)
         for p in [
             param(n_fft=400, hop_length=200, n_mels=128),
             param(n_fft=600, hop_length=100, n_mels=128),
@@ -200,7 +195,9 @@ class TestTransforms(common_utils.TorchaudioTestCase):
         for norm in [None, 'slaney']
     ])
     def test_mel_spectrogram(self, n_fft, hop_length, n_mels, norm):
-        sound, sample_rate, sound_librosa = self._set_up_sound()
+        sample_rate = 16000
+        sound = common_utils.get_sinusoid(n_channels=1, sample_rate=sample_rate)
+        sound_librosa = sound.cpu().numpy().squeeze()
         melspect_transform = torchaudio.transforms.MelSpectrogram(
             sample_rate=sample_rate, window_fn=torch.hann_window,
             hop_length=hop_length, n_mels=n_mels, n_fft=n_fft, norm=norm)
@@ -213,7 +210,7 @@ class TestTransforms(common_utils.TorchaudioTestCase):
             torch_mel.type(librosa_mel_tensor.dtype), librosa_mel_tensor, atol=5e-3, rtol=1e-5)
 
     @parameterized.expand([
-        p._replace(kwargs={'norm': norm, **p.kwargs})
+        param(norm=norm, **p.kwargs)
         for p in [
             param(n_fft=400, hop_length=200, power=2.0, n_mels=128),
             param(n_fft=600, hop_length=100, power=2.0, n_mels=128),
@@ -226,7 +223,9 @@ class TestTransforms(common_utils.TorchaudioTestCase):
     def test_s2db(self, n_fft, hop_length, power, n_mels, norm, skip_ci=False):
         if skip_ci and 'CI' in os.environ:
             self.skipTest('Test is known to fail on CI')
-        sound, sample_rate, sound_librosa = self._set_up_sound()
+        sample_rate = 16000
+        sound = common_utils.get_sinusoid(n_channels=1, sample_rate=sample_rate)
+        sound_librosa = sound.cpu().numpy().squeeze()
         spect_transform = torchaudio.transforms.Spectrogram(
             n_fft=n_fft, hop_length=hop_length, power=power)
         out_librosa, _ = librosa.core.spectrum._spectrogram(
@@ -257,13 +256,14 @@ class TestTransforms(common_utils.TorchaudioTestCase):
     @parameterized.expand([
         param(n_fft=400, hop_length=200, n_mels=128, n_mfcc=40),
         param(n_fft=600, hop_length=100, n_mels=128, n_mfcc=20),
-        # NOTE: Test passes offline, but fails on TravisCI (and CircleCI), see #372.
         param(n_fft=200, hop_length=50, n_mels=128, n_mfcc=50, skip_ci=True),
     ])
     def test_mfcc(self, n_fft, hop_length, n_mels, n_mfcc, skip_ci=False):
         if skip_ci and 'CI' in os.environ:
             self.skipTest('Test is known to fail on CI')
-        sound, sample_rate, sound_librosa = self._set_up_sound()
+        sample_rate = 16000
+        sound = common_utils.get_sinusoid(n_channels=1, sample_rate=sample_rate)
+        sound_librosa = sound.cpu().numpy().squeeze()
         librosa_mel = librosa.feature.melspectrogram(
             y=sound_librosa, sr=sample_rate, n_fft=n_fft,
             hop_length=hop_length, n_mels=n_mels, htk=True, norm=None)
@@ -296,7 +296,9 @@ class TestTransforms(common_utils.TorchaudioTestCase):
         param(n_fft=200, hop_length=50),
     ])
     def test_spectral_centroid(self, n_fft, hop_length):
-        sound, sample_rate, sound_librosa = self._set_up_sound()
+        sample_rate = 16000
+        sound = common_utils.get_sinusoid(n_channels=1, sample_rate=sample_rate)
+        sound_librosa = sound.cpu().numpy().squeeze()
         spect_centroid = torchaudio.transforms.SpectralCentroid(
             sample_rate=sample_rate, n_fft=n_fft, hop_length=hop_length)
         out_torch = spect_centroid(sound).squeeze().cpu()

--- a/test/torchaudio_unittest/librosa_compatibility_test.py
+++ b/test/torchaudio_unittest/librosa_compatibility_test.py
@@ -255,11 +255,9 @@ class TestTransforms(common_utils.TorchaudioTestCase):
     @parameterized.expand([
         param(n_fft=400, hop_length=200, n_mels=128, n_mfcc=40),
         param(n_fft=600, hop_length=100, n_mels=128, n_mfcc=20),
-        param(n_fft=200, hop_length=50, n_mels=128, n_mfcc=50, skip_ci=True),
+        param(n_fft=200, hop_length=50, n_mels=128, n_mfcc=50),
     ])
-    def test_mfcc(self, n_fft, hop_length, n_mels, n_mfcc, skip_ci=False):
-        if skip_ci and 'CI' in os.environ:
-            self.skipTest('Test is known to fail on CI')
+    def test_mfcc(self, n_fft, hop_length, n_mels, n_mfcc):
         sample_rate = 16000
         sound = common_utils.get_sinusoid(n_channels=1, sample_rate=sample_rate)
         sound_librosa = sound.cpu().numpy().squeeze()

--- a/test/torchaudio_unittest/librosa_compatibility_test.py
+++ b/test/torchaudio_unittest/librosa_compatibility_test.py
@@ -296,6 +296,10 @@ class TestTransforms(common_utils.TorchaudioTestCase):
             for params in params_list
             for norm in [None, 'slaney']
         ]
+        params_list_skipped = [
+            params for params in params_list
+            if not (params.get('skip_CI') and 'CI' in os.environ)
+        ]
 
         common_utils.set_audio_backend('default')
         path = common_utils.get_asset_path('sinewave.wav')
@@ -312,15 +316,13 @@ class TestTransforms(common_utils.TorchaudioTestCase):
             varnames = test_fn.__code__.co_varnames
             params_list_restricted = [
                 {k: v for k, v in params.items() if k in varnames}
-                for params in params_list
+                for params in params_list_skipped
             ]
             data_dict_restricted = {k: v for k, v in data_dict.items() if k in varnames}
             # restrict to unique parameter combinations
             params_list_unique = [dict(uniq) for uniq in {tuple(sorted(d.items())) for d in params_list_restricted}]
             for params in params_list_unique:
-                with self.subTest(test=test_name, **params):
-                    if params.get('skip_CI') and 'CI' in os.environ:
-                        self.skipTest('Test is known to fail on CI')
+                with self.subTest(msg=test_name, **params):
                     test_fn(**params, **data_dict_restricted)
 
     def test_MelScale(self):

--- a/test/torchaudio_unittest/librosa_compatibility_test.py
+++ b/test/torchaudio_unittest/librosa_compatibility_test.py
@@ -178,7 +178,7 @@ class TestTransforms(common_utils.TorchaudioTestCase):
         param(n_fft=400, hop_length=200, power=2.0),
         param(n_fft=600, hop_length=100, power=2.0),
         param(n_fft=400, hop_length=200, power=3.0),
-        param(n_fft=200, hop_length=50,  power=2.0),
+        param(n_fft=200, hop_length=50, power=2.0),
     ])
     def test_spectrogram(self, n_fft, hop_length, power):
         sound, sample_rate, sound_librosa = self._set_up_sound()
@@ -218,7 +218,7 @@ class TestTransforms(common_utils.TorchaudioTestCase):
             param(n_fft=400, hop_length=200, power=2.0, n_mels=128),
             param(n_fft=600, hop_length=100, power=2.0, n_mels=128),
             param(n_fft=400, hop_length=200, power=3.0, n_mels=128),
-            param(n_fft=200, hop_length=50,  power=2.0, n_mels=128),
+            param(n_fft=200, hop_length=50, power=2.0, n_mels=128),
         ]
         for norm in [None, 'slaney']
     ])
@@ -254,11 +254,11 @@ class TestTransforms(common_utils.TorchaudioTestCase):
     @parameterized.expand([
         param(n_fft=400, hop_length=200, n_mels=128, n_mfcc=40),
         param(n_fft=600, hop_length=100, n_mels=128, n_mfcc=20),
-    ] + ([] if 'CI' in os.environ else [
-        # NOTE: Test passes offline, but fails on TravisCI (and CircleCI), see #372.
-        param(n_fft=200, hop_length=50,  n_mels=128, n_mfcc=50),
-    ]))
-    def test_mfcc(self, n_fft, hop_length, n_mels, n_mfcc):
+        param(n_fft=200, hop_length=50, n_mels=128, n_mfcc=50, skip_ci=True),
+    ])
+    def test_mfcc(self, n_fft, hop_length, n_mels, n_mfcc, skip_ci=False):
+        if skip_ci and 'CI' in os.environ:
+            self.skipTest('Test is known to fail on CI')
         sound, sample_rate, sound_librosa = self._set_up_sound()
         librosa_mel = librosa.feature.melspectrogram(
             y=sound_librosa, sr=sample_rate, n_fft=n_fft,

--- a/test/torchaudio_unittest/librosa_compatibility_test.py
+++ b/test/torchaudio_unittest/librosa_compatibility_test.py
@@ -166,7 +166,6 @@ def _load_audio_asset(*asset_paths, **kwargs):
 class TestTransforms(common_utils.TorchaudioTestCase):
     """Test suite for functions in `transforms` module."""
 
-
     @parameterized.expand([
         param(n_fft=400, hop_length=200, power=2.0),
         param(n_fft=600, hop_length=100, power=2.0),

--- a/test/torchaudio_unittest/librosa_compatibility_test.py
+++ b/test/torchaudio_unittest/librosa_compatibility_test.py
@@ -186,8 +186,7 @@ class TestTransforms(common_utils.TorchaudioTestCase):
         self.assertEqual(
             torch_mel.type(librosa_mel_tensor.dtype), librosa_mel_tensor, atol=5e-3, rtol=1e-5)
 
-    def assert_compatibilities_s2db(self, n_fft, hop_length, power, n_mels, norm,
-                                              sound, sample_rate, sound_librosa):
+    def assert_compatibilities_s2db(self, n_fft, hop_length, power, n_mels, norm, sound, sample_rate, sound_librosa):
         spect_transform = torchaudio.transforms.Spectrogram(
             n_fft=n_fft, hop_length=hop_length, power=power)
         out_librosa, _ = librosa.core.spectrum._spectrogram(
@@ -317,7 +316,7 @@ class TestTransforms(common_utils.TorchaudioTestCase):
             ]
             data_dict_restricted = {k: v for k, v in data_dict.items() if k in varnames}
             # restrict to unique parameter combinations
-            params_list_unique = [dict(uniq) for uniq in set(tuple(sorted(d.items())) for d in params_list_restricted)]
+            params_list_unique = [dict(uniq) for uniq in {tuple(sorted(d.items())) for d in params_list_restricted}]
             for params in params_list_unique:
                 with self.subTest(test=test_name, **params):
                     if params.get('skip_CI') and 'CI' in os.environ:

--- a/test/torchaudio_unittest/librosa_compatibility_test.py
+++ b/test/torchaudio_unittest/librosa_compatibility_test.py
@@ -218,11 +218,14 @@ class TestTransforms(common_utils.TorchaudioTestCase):
             param(n_fft=400, hop_length=200, power=2.0, n_mels=128),
             param(n_fft=600, hop_length=100, power=2.0, n_mels=128),
             param(n_fft=400, hop_length=200, power=3.0, n_mels=128),
-            param(n_fft=200, hop_length=50, power=2.0, n_mels=128),
+            # NOTE: Test passes offline, but fails on TravisCI (and CircleCI), see #372.
+            param(n_fft=200, hop_length=50, power=2.0, n_mels=128, skip_ci=True),
         ]
         for norm in [None, 'slaney']
     ])
-    def test_s2db(self, n_fft, hop_length, power, n_mels, norm):
+    def test_s2db(self, n_fft, hop_length, power, n_mels, norm, skip_ci=False):
+        if skip_ci and 'CI' in os.environ:
+            self.skipTest('Test is known to fail on CI')
         sound, sample_rate, sound_librosa = self._set_up_sound()
         spect_transform = torchaudio.transforms.Spectrogram(
             n_fft=n_fft, hop_length=hop_length, power=power)
@@ -254,6 +257,7 @@ class TestTransforms(common_utils.TorchaudioTestCase):
     @parameterized.expand([
         param(n_fft=400, hop_length=200, n_mels=128, n_mfcc=40),
         param(n_fft=600, hop_length=100, n_mels=128, n_mfcc=20),
+        # NOTE: Test passes offline, but fails on TravisCI (and CircleCI), see #372.
         param(n_fft=200, hop_length=50, n_mels=128, n_mfcc=50, skip_ci=True),
     ])
     def test_mfcc(self, n_fft, hop_length, n_mels, n_mfcc, skip_ci=False):


### PR DESCRIPTION
Resolves #1262 

I've gone off piste from the steps laid out in the issue. Rather than splitting things out as a test and using parameterize, I decided to maintain more control by using unittest.subTest. I wanted to be able to generate lots of different variants, restrict them down to the relevant parameters for each component, and then remove any resultant duplicates (so as to cut down the test time), as well as maintaining the test skip on TravisCI. Trying to do all this in a decorator for parameterize was messy, so hopefully this approach is better. I'm concerned that it might just be over engineered for what you need though, and more difficult to understand than the dumb approach. Let me know what you think, I can drop back to doing the recommended way if you would like.

The change was tested by running:

(cd test && pytest torchaudio_unittest/librosa_compatibility_test.py)