### PR TITLE
Make the version a link to /versions.html

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,8 @@
+{% extends "!layout.html" %}
+
+{% block sidebartitle %}
+    <div class="version">
+      <a href='https://pytorch.org/audio/versions.html'>{{ version }} &#x25BC</a>
+    </div>
+    {% include "searchbox.html" %}
+{% endblock %}


### PR DESCRIPTION
Together with #1272 this will allow selecting between versions of the documentation. Once this is merged and a nightly build pushes docs to master, the version selection will appear on the master docs.

@brianjo 