### PR TITLE
Add HTK format support to sox_io's save & info

### DIFF
--- a/test/torchaudio_unittest/backend/sox_io/info_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/info_test.py
@@ -205,7 +205,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.encoding == "ULAW"
 
     def test_alaw(self):
-        """`sox_io_backend.info` can check ulaw file correctly"""
+        """`sox_io_backend.info` can check alaw file correctly"""
         duration = 1
         num_channels = 1
         sample_rate = 8000
@@ -221,6 +221,21 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.bits_per_sample == 8
         assert info.encoding == "ALAW"
 
+    def test_htk(self):
+        """`sox_io_backend.info` can check HTK file correctly"""
+        duration = 1
+        num_channels = 1
+        sample_rate = 8000
+        path = self.get_temp_path('data.wav')
+        sox_utils.gen_audio_file(
+            path, sample_rate=sample_rate, num_channels=num_channels,
+            bit_depth=16, duration=duration)
+        info = sox_io_backend.info(path)
+        assert info.sample_rate == sample_rate
+        assert info.num_frames == sample_rate * duration
+        assert info.num_channels == num_channels
+        assert info.bits_per_sample == 16
+        assert info.encoding == "PCM_S"
 
 @skipIfNoExtension
 class TestInfoOpus(PytorchTestCase):

--- a/test/torchaudio_unittest/backend/sox_io/info_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/info_test.py
@@ -226,7 +226,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         duration = 1
         num_channels = 1
         sample_rate = 8000
-        path = self.get_temp_path('data.wav')
+        path = self.get_temp_path('data.htk')
         sox_utils.gen_audio_file(
             path, sample_rate=sample_rate, num_channels=num_channels,
             bit_depth=16, duration=duration)
@@ -236,6 +236,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.num_channels == num_channels
         assert info.bits_per_sample == 16
         assert info.encoding == "PCM_S"
+
 
 @skipIfNoExtension
 class TestInfoOpus(PytorchTestCase):

--- a/test/torchaudio_unittest/backend/sox_io/save_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/save_test.py
@@ -240,8 +240,8 @@ class SaveTest(SaveTestBase):
     @nested_params(
         ["path", "fileobj", "bytesio"],
     )
-    def test_save_hkt(self, test_mode, ):
-        self.assert_save_consistency("hkt", test_mode=test_mode, num_channels=1)
+    def test_save_htk(self, test_mode, ):
+        self.assert_save_consistency("htk", test_mode=test_mode, num_channels=1)
 
     @nested_params(
         ["path", "fileobj", "bytesio"],

--- a/test/torchaudio_unittest/backend/sox_io/save_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/save_test.py
@@ -240,7 +240,7 @@ class SaveTest(SaveTestBase):
     @nested_params(
         ["path", "fileobj", "bytesio"],
     )
-    def test_save_htk(self, test_mode, ):
+    def test_save_htk(self, test_mode):
         self.assert_save_consistency("htk", test_mode=test_mode, num_channels=1)
 
     @nested_params(

--- a/test/torchaudio_unittest/backend/sox_io/save_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/save_test.py
@@ -239,6 +239,12 @@ class SaveTest(SaveTestBase):
 
     @nested_params(
         ["path", "fileobj", "bytesio"],
+    )
+    def test_save_hkt(self, test_mode, ):
+        self.assert_save_consistency("hkt", test_mode=test_mode, num_channels=1)
+
+    @nested_params(
+        ["path", "fileobj", "bytesio"],
         [
             None,
             -1,

--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -296,7 +296,7 @@ def save(
         Lossy Speech Compression, CPU intensive.
 
     ``"htk"``
-        Uses its default single-channel 16-bit PCM format.
+        Uses a default single-channel 16-bit PCM format.
 
     Note:
         To save into formats that ``libsox`` does not handle natively, (such as ``"mp3"``,

--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -195,7 +195,7 @@ def save(
             When ``filepath`` argument is file-like object, this argument is required.
 
             Valid values are ``"wav"``, ``"mp3"``, ``"ogg"``, ``"vorbis"``, ``"amr-nb"``,
-            ``"amb"``, ``"flac"`` and ``"sph"``.
+            ``"amb"``, ``"flac"``, ``"sph"``, and ``"htk"``.
         encoding (str, optional): Changes the encoding for the supported formats.
             This argument is effective only for supported formats, cush as ``"wav"``, ``""amb"``
             and ``"sph"``. Valid values are;
@@ -290,6 +290,9 @@ def save(
 
     ``"amr-nb"``
         Bitrate ranging from 4.75 kbit/s to 12.2 kbit/s. Default: 4.75 kbit/s
+
+    ``"htk"``
+        Uses its default Single channel 16-bit PCM format.
 
     Note:
         To save into formats that ``libsox`` does not handle natively, (such as ``"mp3"``,

--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -292,7 +292,7 @@ def save(
         Bitrate ranging from 4.75 kbit/s to 12.2 kbit/s. Default: 4.75 kbit/s
 
     ``"htk"``
-        Uses its default Single channel 16-bit PCM format.
+        Uses its default single-channel 16-bit PCM format.
 
     Note:
         To save into formats that ``libsox`` does not handle natively, (such as ``"mp3"``,

--- a/torchaudio/csrc/sox/types.cpp
+++ b/torchaudio/csrc/sox/types.cpp
@@ -20,6 +20,8 @@ Format get_format_from_string(const std::string& format) {
     return Format::AMB;
   if (format == "sph")
     return Format::SPHERE;
+  if (format == "htk")
+    return Format::HTK;
   std::ostringstream stream;
   stream << "Internal Error: unexpected format value: " << format;
   throw std::runtime_error(stream.str());

--- a/torchaudio/csrc/sox/types.h
+++ b/torchaudio/csrc/sox/types.h
@@ -15,6 +15,7 @@ enum class Format {
   AMR_WB,
   AMB,
   SPHERE,
+  HTK,
 };
 
 Format get_format_from_string(const std::string& format);

--- a/torchaudio/csrc/sox/utils.cpp
+++ b/torchaudio/csrc/sox/utils.cpp
@@ -424,10 +424,10 @@ unsigned get_precision(const std::string filetype, caffe2::TypeMeta dtype) {
   if (filetype == "amr-nb") {
     return 16;
   }
-  if (filetype == "htk") {
+  if (filetype == "gsm") {
     return 16;
   }
-  if (filetype == "gsm") {
+  if (filetype == "htk") {
     return 16;
   }
   throw std::runtime_error("Unsupported file type: " + filetype);

--- a/torchaudio/csrc/sox/utils.cpp
+++ b/torchaudio/csrc/sox/utils.cpp
@@ -314,6 +314,13 @@ std::tuple<sox_encoding_t, unsigned> get_save_encoding(
         throw std::runtime_error(
             "mp3 does not support `bits_per_sample` option.");
       return std::make_tuple<>(SOX_ENCODING_MP3, 16);
+    case Format::HTK:
+      if (enc != Encoding::NOT_PROVIDED)
+        throw std::runtime_error("htk does not support `encoding` option.");
+      if (bps != BitDepth::NOT_PROVIDED)
+        throw std::runtime_error(
+            "htk does not support `bits_per_sample` option.");
+      return std::make_tuple<>(SOX_ENCODING_SIGN2, 16);
     case Format::VORBIS:
       if (enc != Encoding::NOT_PROVIDED)
         throw std::runtime_error("vorbis does not support `encoding` option.");
@@ -407,6 +414,9 @@ unsigned get_precision(const std::string filetype, caffe2::TypeMeta dtype) {
   if (filetype == "sph")
     return 32;
   if (filetype == "amr-nb") {
+    return 16;
+  }
+  if (filetype == "htk") {
     return 16;
   }
   throw std::runtime_error("Unsupported file type: " + filetype);


### PR DESCRIPTION
With [advice & help](https://github.com/pytorch/audio/pull/1271#issuecomment-780040899) from @mthrok, added `htk` format to sox_io's save function & info test.

htk is a single channel 16-bit PCM format used by HTK, a toolkit for building Hidden Markov Model speech processing tools.