### PR TITLE
Add GSM encoding support to info

### DIFF
--- a/test/torchaudio_unittest/backend/sox_io/info_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/info_test.py
@@ -221,12 +221,10 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.bits_per_sample == 8
         assert info.encoding == "ALAW"
 
-    @parameterized.expand(list(itertools.product(
-        list(range(1, 17)),
-    )),)
     def test_gsm(self, num_channels):
         """`sox_io_backend.info` can check gsm file correctly"""
         duration = 1
+        num_channels = 1
         sample_rate = 8000
         path = self.get_temp_path('data.gsm')
         sox_utils.gen_audio_file(
@@ -234,10 +232,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
             duration=duration)
         info = sox_io_backend.info(path)
         assert info.sample_rate == sample_rate
-        # TODO: need to confirm if this field should have a 0 value for GSM
-        assert info.num_frames == 0
-        # num_channels is being returned as 1 even if they are 16
-        assert info.num_channels == 1
+        assert info.num_channels == num_channels
         assert info.bits_per_sample == 0
         assert info.encoding == "GSM"
 

--- a/test/torchaudio_unittest/backend/sox_io/info_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/info_test.py
@@ -238,6 +238,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.bits_per_sample == 0
         assert info.encoding == "GSM"
 
+
 @skipIfNoExtension
 class TestInfoOpus(PytorchTestCase):
     @parameterized.expand(list(itertools.product(

--- a/test/torchaudio_unittest/backend/sox_io/info_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/info_test.py
@@ -205,7 +205,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.encoding == "ULAW"
 
     def test_alaw(self):
-        """`sox_io_backend.info` can check ulaw file correctly"""
+        """`sox_io_backend.info` can check alaw file correctly"""
         duration = 1
         num_channels = 1
         sample_rate = 8000
@@ -221,6 +221,22 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.bits_per_sample == 8
         assert info.encoding == "ALAW"
 
+    def test_gsm(self):
+        """`sox_io_backend.info` can check gsm file correctly"""
+        duration = 1
+        num_channels = 1
+        sample_rate = 8000
+        path = self.get_temp_path('data.wav')
+        sox_utils.gen_audio_file(
+            path, sample_rate=sample_rate, num_channels=num_channels,
+            bit_depth=16, encoding='gsm',
+            duration=duration)
+        info = sox_io_backend.info(path)
+        assert info.sample_rate == sample_rate
+        assert info.num_frames == sample_rate * duration
+        assert info.num_channels == num_channels
+        assert info.bits_per_sample == 0
+        assert info.encoding == "GSM"
 
 @skipIfNoExtension
 class TestInfoOpus(PytorchTestCase):

--- a/test/torchaudio_unittest/backend/sox_io/info_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/info_test.py
@@ -221,7 +221,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.bits_per_sample == 8
         assert info.encoding == "ALAW"
 
-    def test_gsm(self, num_channels):
+    def test_gsm(self):
         """`sox_io_backend.info` can check gsm file correctly"""
         duration = 1
         num_channels = 1

--- a/test/torchaudio_unittest/backend/sox_io/info_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/info_test.py
@@ -232,7 +232,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
             duration=duration, bit_depth=16)
         info = sox_io_backend.info(path)
         assert info.sample_rate == sample_rate
-        #TODO: need to confirm if this field should have a 0 value for GSM
+        # TODO: need to confirm if this field should have a 0 value for GSM
         assert info.num_frames == 0
         assert info.num_channels == num_channels
         assert info.bits_per_sample == 0

--- a/test/torchaudio_unittest/backend/sox_io/info_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/info_test.py
@@ -235,6 +235,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.sample_rate == sample_rate
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
+        # The 0 is not a typo
         assert info.bits_per_sample == 0
         assert info.encoding == "GSM"
 

--- a/test/torchaudio_unittest/backend/sox_io/info_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/info_test.py
@@ -221,20 +221,23 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.bits_per_sample == 8
         assert info.encoding == "ALAW"
 
-    def test_gsm(self):
+    @parameterized.expand(list(itertools.product(
+        list(range(1, 17)),
+    )),)
+    def test_gsm(self, num_channels):
         """`sox_io_backend.info` can check gsm file correctly"""
         duration = 1
-        num_channels = 1
         sample_rate = 8000
         path = self.get_temp_path('data.gsm')
         sox_utils.gen_audio_file(
             path, sample_rate=sample_rate, num_channels=num_channels,
-            duration=duration, bit_depth=16)
+            duration=duration)
         info = sox_io_backend.info(path)
         assert info.sample_rate == sample_rate
         # TODO: need to confirm if this field should have a 0 value for GSM
         assert info.num_frames == 0
-        assert info.num_channels == num_channels
+        # num_channels is being returned as 1 even if they are 16
+        assert info.num_channels == 1
         assert info.bits_per_sample == 0
         assert info.encoding == "GSM"
 

--- a/test/torchaudio_unittest/backend/sox_io/info_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/info_test.py
@@ -235,7 +235,6 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.sample_rate == sample_rate
         assert info.num_frames == sample_rate * duration
         assert info.num_channels == num_channels
-        # The 0 is not a typo
         assert info.bits_per_sample == 0
         assert info.encoding == "GSM"
 

--- a/torchaudio/csrc/CMakeLists.txt
+++ b/torchaudio/csrc/CMakeLists.txt
@@ -5,11 +5,11 @@ get_property(TORCHAUDIO_THIRD_PARTIES GLOBAL PROPERTY TORCHAUDIO_THIRD_PARTIES)
 ################################################################################
 set(
   LIBTORCHAUDIO_SOURCES
-  sox/types.cpp
   sox/io.cpp
   sox/utils.cpp
   sox/effects.cpp
   sox/effects_chain.cpp
+  sox/types.cpp
   lfilter.cpp
   )
 

--- a/torchaudio/csrc/CMakeLists.txt
+++ b/torchaudio/csrc/CMakeLists.txt
@@ -5,11 +5,11 @@ get_property(TORCHAUDIO_THIRD_PARTIES GLOBAL PROPERTY TORCHAUDIO_THIRD_PARTIES)
 ################################################################################
 set(
   LIBTORCHAUDIO_SOURCES
+  sox/types.cpp
   sox/io.cpp
   sox/utils.cpp
   sox/effects.cpp
   sox/effects_chain.cpp
-  sox/types.cpp
   lfilter.cpp
   )
 

--- a/torchaudio/csrc/sox/io.cpp
+++ b/torchaudio/csrc/sox/io.cpp
@@ -1,4 +1,4 @@
-#include <sox.h>
+#include <torchaudio/csrc/sox/types.h>
 #include <torchaudio/csrc/sox/effects.h>
 #include <torchaudio/csrc/sox/effects_chain.h>
 #include <torchaudio/csrc/sox/io.h>
@@ -9,41 +9,6 @@ using namespace torchaudio::sox_utils;
 
 namespace torchaudio {
 namespace sox_io {
-
-namespace {
-
-std::string get_encoding(sox_encoding_t encoding) {
-  switch (encoding) {
-    case SOX_ENCODING_UNKNOWN:
-      return "UNKNOWN";
-    case SOX_ENCODING_SIGN2:
-      return "PCM_S";
-    case SOX_ENCODING_UNSIGNED:
-      return "PCM_U";
-    case SOX_ENCODING_FLOAT:
-      return "PCM_F";
-    case SOX_ENCODING_FLAC:
-      return "FLAC";
-    case SOX_ENCODING_ULAW:
-      return "ULAW";
-    case SOX_ENCODING_ALAW:
-      return "ALAW";
-    case SOX_ENCODING_MP3:
-      return "MP3";
-    case SOX_ENCODING_VORBIS:
-      return "VORBIS";
-    case SOX_ENCODING_AMR_WB:
-      return "AMR_WB";
-    case SOX_ENCODING_AMR_NB:
-      return "AMR_NB";
-    case SOX_ENCODING_OPUS:
-      return "OPUS";
-    default:
-      return "UNKNOWN";
-  }
-}
-
-} // namespace
 
 std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_file(
     const std::string& path,

--- a/torchaudio/csrc/sox/io.cpp
+++ b/torchaudio/csrc/sox/io.cpp
@@ -1,8 +1,8 @@
 #include <torchaudio/csrc/sox/effects.h>
 #include <torchaudio/csrc/sox/effects_chain.h>
 #include <torchaudio/csrc/sox/io.h>
-#include <torchaudio/csrc/sox/utils.h>
 #include <torchaudio/csrc/sox/types.h>
+#include <torchaudio/csrc/sox/utils.h>
 
 using namespace torch::indexing;
 using namespace torchaudio::sox_utils;

--- a/torchaudio/csrc/sox/io.cpp
+++ b/torchaudio/csrc/sox/io.cpp
@@ -1,8 +1,8 @@
-#include <torchaudio/csrc/sox/types.h>
 #include <torchaudio/csrc/sox/effects.h>
 #include <torchaudio/csrc/sox/effects_chain.h>
 #include <torchaudio/csrc/sox/io.h>
 #include <torchaudio/csrc/sox/utils.h>
+#include <torchaudio/csrc/sox/types.h>
 
 using namespace torch::indexing;
 using namespace torchaudio::sox_utils;

--- a/torchaudio/csrc/sox/types.cpp
+++ b/torchaudio/csrc/sox/types.cpp
@@ -127,7 +127,7 @@ std::string get_encoding(sox_encoding_t encoding) {
     case SOX_ENCODING_OPUS:
       return "OPUS";
     case SOX_ENCODING_GSM:
-      return "GSM";   
+      return "GSM";
     default:
       return "UNKNOWN";
   }

--- a/torchaudio/csrc/sox/types.cpp
+++ b/torchaudio/csrc/sox/types.cpp
@@ -100,5 +100,38 @@ BitDepth get_bit_depth_from_option(const c10::optional<int64_t>& bit_depth) {
   }
 }
 
+std::string get_encoding(sox_encoding_t encoding) {
+  switch (encoding) {
+    case SOX_ENCODING_UNKNOWN:
+      return "UNKNOWN";
+    case SOX_ENCODING_SIGN2:
+      return "PCM_S";
+    case SOX_ENCODING_UNSIGNED:
+      return "PCM_U";
+    case SOX_ENCODING_FLOAT:
+      return "PCM_F";
+    case SOX_ENCODING_FLAC:
+      return "FLAC";
+    case SOX_ENCODING_ULAW:
+      return "ULAW";
+    case SOX_ENCODING_ALAW:
+      return "ALAW";
+    case SOX_ENCODING_MP3:
+      return "MP3";
+    case SOX_ENCODING_VORBIS:
+      return "VORBIS";
+    case SOX_ENCODING_AMR_WB:
+      return "AMR_WB";
+    case SOX_ENCODING_AMR_NB:
+      return "AMR_NB";
+    case SOX_ENCODING_OPUS:
+      return "OPUS";
+    case SOX_ENCODING_GSM:
+      return "GSM";   
+    default:
+      return "UNKNOWN";
+  }
+}
+
 } // namespace sox_utils
 } // namespace torchaudio

--- a/torchaudio/csrc/sox/types.h
+++ b/torchaudio/csrc/sox/types.h
@@ -1,8 +1,8 @@
 #ifndef TORCHAUDIO_SOX_TYPES_H
 #define TORCHAUDIO_SOX_TYPES_H
 
-#include <torch/script.h>
 #include <sox.h>
+#include <torch/script.h>
 
 namespace torchaudio {
 namespace sox_utils {

--- a/torchaudio/csrc/sox/types.h
+++ b/torchaudio/csrc/sox/types.h
@@ -2,6 +2,7 @@
 #define TORCHAUDIO_SOX_TYPES_H
 
 #include <torch/script.h>
+#include <sox.h>
 
 namespace torchaudio {
 namespace sox_utils {
@@ -49,6 +50,8 @@ enum class BitDepth : unsigned {
 };
 
 BitDepth get_bit_depth_from_option(const c10::optional<int64_t>& bit_depth);
+
+std::string get_encoding(sox_encoding_t encoding);
 
 } // namespace sox_utils
 } // namespace torchaudio


### PR DESCRIPTION
With @mthrok's help, the following tasks were completed in this PR:

1. Added info test for GSM.
2. Moved the function `get_encoding` from `torchaudio/csrc/sox/io.cpp` to `torchaudio/csrc/sox/types.cpp`.