### PR TITLE
torchaudio: Fix c extension compilation

### DIFF
--- a/torchaudio/csrc/sox/effects.cpp
+++ b/torchaudio/csrc/sox/effects.cpp
@@ -91,9 +91,9 @@ std::tuple<torch::Tensor, int64_t> apply_effects_tensor(
 std::tuple<torch::Tensor, int64_t> apply_effects_file(
     const std::string path,
     std::vector<std::vector<std::string>> effects,
-    c10::optional<bool>& normalize,
-    c10::optional<bool>& channels_first,
-    c10::optional<std::string>& format) {
+    c10::optional<bool> normalize,
+    c10::optional<bool> channels_first,
+    c10::optional<std::string> format) {
   // Open input file
   SoxFormat sf(sox_open_read(
       path.c_str(),
@@ -161,9 +161,9 @@ std::tuple<torch::Tensor, int64_t> apply_effects_file(
 std::tuple<torch::Tensor, int64_t> apply_effects_fileobj(
     py::object fileobj,
     std::vector<std::vector<std::string>> effects,
-    c10::optional<bool>& normalize,
-    c10::optional<bool>& channels_first,
-    c10::optional<std::string>& format) {
+    c10::optional<bool> normalize,
+    c10::optional<bool> channels_first,
+    c10::optional<std::string> format) {
   // Prepare the buffer used throughout the lifecycle of SoxEffectChain.
   //
   // For certain format (such as FLAC), libsox keeps reading the content at

--- a/torchaudio/csrc/sox/effects.h
+++ b/torchaudio/csrc/sox/effects.h
@@ -24,18 +24,18 @@ std::tuple<torch::Tensor, int64_t> apply_effects_tensor(
 std::tuple<torch::Tensor, int64_t> apply_effects_file(
     const std::string path,
     std::vector<std::vector<std::string>> effects,
-    c10::optional<bool>& normalize,
-    c10::optional<bool>& channels_first,
-    c10::optional<std::string>& format);
+    c10::optional<bool> normalize,
+    c10::optional<bool> channels_first,
+    c10::optional<std::string> format);
 
 #ifdef TORCH_API_INCLUDE_EXTENSION_H
 
 std::tuple<torch::Tensor, int64_t> apply_effects_fileobj(
     py::object fileobj,
     std::vector<std::vector<std::string>> effects,
-    c10::optional<bool>& normalize,
-    c10::optional<bool>& channels_first,
-    c10::optional<std::string>& format);
+    c10::optional<bool> normalize,
+    c10::optional<bool> channels_first,
+    c10::optional<std::string> format);
 
 #endif // TORCH_API_INCLUDE_EXTENSION_H
 

--- a/torchaudio/csrc/sox/io.cpp
+++ b/torchaudio/csrc/sox/io.cpp
@@ -47,7 +47,7 @@ std::string get_encoding(sox_encoding_t encoding) {
 
 std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_file(
     const std::string& path,
-    c10::optional<std::string>& format) {
+    c10::optional<std::string> format) {
   SoxFormat sf(sox_open_read(
       path.c_str(),
       /*signal=*/nullptr,
@@ -69,8 +69,8 @@ std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_file(
 namespace {
 
 std::vector<std::vector<std::string>> get_effects(
-    c10::optional<int64_t>& frame_offset,
-    c10::optional<int64_t>& num_frames) {
+    c10::optional<int64_t> frame_offset,
+    c10::optional<int64_t> num_frames) {
   const auto offset = frame_offset.value_or(0);
   if (offset < 0) {
     throw std::runtime_error(
@@ -101,11 +101,11 @@ std::vector<std::vector<std::string>> get_effects(
 
 std::tuple<torch::Tensor, int64_t> load_audio_file(
     const std::string& path,
-    c10::optional<int64_t>& frame_offset,
-    c10::optional<int64_t>& num_frames,
-    c10::optional<bool>& normalize,
-    c10::optional<bool>& channels_first,
-    c10::optional<std::string>& format) {
+    c10::optional<int64_t> frame_offset,
+    c10::optional<int64_t> num_frames,
+    c10::optional<bool> normalize,
+    c10::optional<bool> channels_first,
+    c10::optional<std::string> format) {
   auto effects = get_effects(frame_offset, num_frames);
   return torchaudio::sox_effects::apply_effects_file(
       path, effects, normalize, channels_first, format);
@@ -116,10 +116,10 @@ void save_audio_file(
     torch::Tensor tensor,
     int64_t sample_rate,
     bool channels_first,
-    c10::optional<double>& compression,
-    c10::optional<std::string>& format,
-    c10::optional<std::string>& encoding,
-    c10::optional<int64_t>& bits_per_sample) {
+    c10::optional<double> compression,
+    c10::optional<std::string> format,
+    c10::optional<std::string> encoding,
+    c10::optional<int64_t> bits_per_sample) {
   validate_input_tensor(tensor);
 
   const auto filetype = [&]() {
@@ -162,7 +162,7 @@ void save_audio_file(
 
 std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_fileobj(
     py::object fileobj,
-    c10::optional<std::string>& format) {
+    c10::optional<std::string> format) {
   // Prepare in-memory file object
   // When libsox opens a file, it also reads the header.
   // When opening a file there are two functions that might touch FILE* (and the
@@ -213,11 +213,11 @@ std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_fileobj(
 
 std::tuple<torch::Tensor, int64_t> load_audio_fileobj(
     py::object fileobj,
-    c10::optional<int64_t>& frame_offset,
-    c10::optional<int64_t>& num_frames,
-    c10::optional<bool>& normalize,
-    c10::optional<bool>& channels_first,
-    c10::optional<std::string>& format) {
+    c10::optional<int64_t> frame_offset,
+    c10::optional<int64_t> num_frames,
+    c10::optional<bool> normalize,
+    c10::optional<bool> channels_first,
+    c10::optional<std::string> format) {
   auto effects = get_effects(frame_offset, num_frames);
   return torchaudio::sox_effects::apply_effects_fileobj(
       fileobj, effects, normalize, channels_first, format);
@@ -250,10 +250,10 @@ void save_audio_fileobj(
     torch::Tensor tensor,
     int64_t sample_rate,
     bool channels_first,
-    c10::optional<double>& compression,
-    c10::optional<std::string>& format,
-    c10::optional<std::string>& encoding,
-    c10::optional<int64_t>& bits_per_sample) {
+    c10::optional<double> compression,
+    c10::optional<std::string> format,
+    c10::optional<std::string> encoding,
+    c10::optional<int64_t> bits_per_sample) {
   validate_input_tensor(tensor);
 
   if (!format.has_value()) {

--- a/torchaudio/csrc/sox/io.h
+++ b/torchaudio/csrc/sox/io.h
@@ -13,49 +13,49 @@ namespace sox_io {
 
 std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_file(
     const std::string& path,
-    c10::optional<std::string>& format);
+    c10::optional<std::string> format);
 
 std::tuple<torch::Tensor, int64_t> load_audio_file(
     const std::string& path,
-    c10::optional<int64_t>& frame_offset,
-    c10::optional<int64_t>& num_frames,
-    c10::optional<bool>& normalize,
-    c10::optional<bool>& channels_first,
-    c10::optional<std::string>& format);
+    c10::optional<int64_t> frame_offset,
+    c10::optional<int64_t> num_frames,
+    c10::optional<bool> normalize,
+    c10::optional<bool> channels_first,
+    c10::optional<std::string> format);
 
 void save_audio_file(
     const std::string& path,
     torch::Tensor tensor,
     int64_t sample_rate,
     bool channels_first,
-    c10::optional<double>& compression,
-    c10::optional<std::string>& format,
-    c10::optional<std::string>& encoding,
-    c10::optional<int64_t>& bits_per_sample);
+    c10::optional<double> compression,
+    c10::optional<std::string> format,
+    c10::optional<std::string> encoding,
+    c10::optional<int64_t> bits_per_sample);
 
 #ifdef TORCH_API_INCLUDE_EXTENSION_H
 
 std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_fileobj(
     py::object fileobj,
-    c10::optional<std::string>& format);
+    c10::optional<std::string> format);
 
 std::tuple<torch::Tensor, int64_t> load_audio_fileobj(
     py::object fileobj,
-    c10::optional<int64_t>& frame_offset,
-    c10::optional<int64_t>& num_frames,
-    c10::optional<bool>& normalize,
-    c10::optional<bool>& channels_first,
-    c10::optional<std::string>& format);
+    c10::optional<int64_t> frame_offset,
+    c10::optional<int64_t> num_frames,
+    c10::optional<bool> normalize,
+    c10::optional<bool> channels_first,
+    c10::optional<std::string> format);
 
 void save_audio_fileobj(
     py::object fileobj,
     torch::Tensor tensor,
     int64_t sample_rate,
     bool channels_first,
-    c10::optional<double>& compression,
-    c10::optional<std::string>& format,
-    c10::optional<std::string>& encoding,
-    c10::optional<int64_t>& bits_per_sample);
+    c10::optional<double> compression,
+    c10::optional<std::string> format,
+    c10::optional<std::string> encoding,
+    c10::optional<int64_t> bits_per_sample);
 
 #endif // TORCH_API_INCLUDE_EXTENSION_H
 

--- a/torchaudio/csrc/sox/types.cpp
+++ b/torchaudio/csrc/sox/types.cpp
@@ -58,7 +58,7 @@ std::string to_string(Encoding v) {
   }
 }
 
-Encoding get_encoding_from_option(const c10::optional<std::string>& encoding) {
+Encoding get_encoding_from_option(const c10::optional<std::string> encoding) {
   if (!encoding.has_value())
     return Encoding::NOT_PROVIDED;
   std::string v = encoding.value();
@@ -77,7 +77,7 @@ Encoding get_encoding_from_option(const c10::optional<std::string>& encoding) {
   throw std::runtime_error(stream.str());
 }
 
-BitDepth get_bit_depth_from_option(const c10::optional<int64_t>& bit_depth) {
+BitDepth get_bit_depth_from_option(const c10::optional<int64_t> bit_depth) {
   if (!bit_depth.has_value())
     return BitDepth::NOT_PROVIDED;
   int64_t v = bit_depth.value();

--- a/torchaudio/csrc/sox/types.h
+++ b/torchaudio/csrc/sox/types.h
@@ -37,7 +37,7 @@ enum class Encoding {
 };
 
 std::string to_string(Encoding v);
-Encoding get_encoding_from_option(const c10::optional<std::string>& encoding);
+Encoding get_encoding_from_option(const c10::optional<std::string> encoding);
 
 enum class BitDepth : unsigned {
   NOT_PROVIDED = 0,
@@ -48,7 +48,7 @@ enum class BitDepth : unsigned {
   B64 = 64,
 };
 
-BitDepth get_bit_depth_from_option(const c10::optional<int64_t>& bit_depth);
+BitDepth get_bit_depth_from_option(const c10::optional<int64_t> bit_depth);
 
 } // namespace sox_utils
 } // namespace torchaudio

--- a/torchaudio/csrc/sox/utils.cpp
+++ b/torchaudio/csrc/sox/utils.cpp
@@ -297,8 +297,8 @@ std::tuple<sox_encoding_t, unsigned> get_save_encoding_for_wav(
 std::tuple<sox_encoding_t, unsigned> get_save_encoding(
     const std::string& format,
     const caffe2::TypeMeta dtype,
-    const c10::optional<std::string>& encoding,
-    const c10::optional<int64_t>& bits_per_sample) {
+    const c10::optional<std::string> encoding,
+    const c10::optional<int64_t> bits_per_sample) {
   const Format fmt = get_format_from_string(format);
   const Encoding enc = get_encoding_from_option(encoding);
   const BitDepth bps = get_bit_depth_from_option(bits_per_sample);
@@ -479,9 +479,9 @@ sox_encodinginfo_t get_tensor_encodinginfo(caffe2::TypeMeta dtype) {
 sox_encodinginfo_t get_encodinginfo_for_save(
     const std::string& format,
     const caffe2::TypeMeta dtype,
-    const c10::optional<double>& compression,
-    const c10::optional<std::string>& encoding,
-    const c10::optional<int64_t>& bits_per_sample) {
+    const c10::optional<double> compression,
+    const c10::optional<std::string> encoding,
+    const c10::optional<int64_t> bits_per_sample) {
   auto enc = get_save_encoding(format, dtype, encoding, bits_per_sample);
   return sox_encodinginfo_t{
       /*encoding=*/std::get<0>(enc),

--- a/torchaudio/csrc/sox/utils.h
+++ b/torchaudio/csrc/sox/utils.h
@@ -110,9 +110,9 @@ sox_encodinginfo_t get_tensor_encodinginfo(const caffe2::TypeMeta dtype);
 sox_encodinginfo_t get_encodinginfo_for_save(
     const std::string& format,
     const caffe2::TypeMeta dtype,
-    const c10::optional<double>& compression,
-    const c10::optional<std::string>& encoding,
-    const c10::optional<int64_t>& bits_per_sample);
+    const c10::optional<double> compression,
+    const c10::optional<std::string> encoding,
+    const c10::optional<int64_t> bits_per_sample);
 
 #ifdef TORCH_API_INCLUDE_EXTENSION_H
 


### PR DESCRIPTION
After https://github.com/pytorch/pytorch/commit/a9f5e7229e92259bc44eb9898c04eaf200c7f81f was merged into upstream pytorch the passing of
references within torch c extension functions is no longer allowed. This
just removes the reference and passes by value instead.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>