### PR TITLE
Remove duplicate --bits parameter while invoking sox

### DIFF
--- a/test/torchaudio_unittest/common_utils/sox_utils.py
+++ b/test/torchaudio_unittest/common_utils/sox_utils.py
@@ -49,8 +49,6 @@ def gen_audio_file(
     ]
     if compression is not None:
         command += ['--compression', str(compression)]
-    if bit_depth is not None:
-        command += ['--bits', str(bit_depth)]
     if encoding is not None:
         command += ['--encoding', str(encoding)]
     command += [


### PR DESCRIPTION
`--bits` is being provided twice by mistake & sox is unable to handle it well & produces a warning.
For example,

```
sox -V3 --no-dither -R --bits 16 --rate 8000 --null --channels 1 --bits 16 --encoding gsm /tmp/tmp08b_xoao/torchaudio_unittest.backend.sox_io.info_test.TestInfo.test_gsm/data.gsm synth 1 sawtooth 1
sox:      SoX v14.4.2

Input File     : '' (null)
Channels       : 1
Sample Rate    : 8000
Precision      : 16-bit
Endian Type    : little
Reverse Nibbles: no
Reverse Bits   : no

sox WARN formats: gsm can't encode GSM to 16-bit
```