### PR TITLE
Fix test dependency typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ export PATH="<path_to_torchaudio>/third_party/install/bin:${PATH}"
 The following dependencies are also needed for testing:
 
 ```bash
-pip install typing pytest scipy numpy parametrized
+pip install typing pytest scipy numpy parameterized
 ```
 
 ## Development Process


### PR DESCRIPTION
Seems like there's a typo in `CONTRIBUTING.md` - tests depend on `parameterized`, not `parametrized`