### PR TITLE
Fix fileobj I/O un-deterministic behavior

### DIFF
--- a/third_party/sox/CMakeLists.txt
+++ b/third_party/sox/CMakeLists.txt
@@ -197,6 +197,7 @@ ExternalProject_Add(sox
   URL https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2.tar.bz2
   URL_HASH SHA256=81a6956d4330e75b5827316e44ae381e6f1e8928003c6aa45896da9041ea149c
   CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env ${envs} ${CMAKE_CURRENT_BINARY_DIR}/src/sox/configure ${COMMON_ARGS} ${SOX_OPTIONS}
+  PATCH_COMMAND patch < ${CMAKE_CURRENT_SOURCE_DIR}/patch/sox.patch
   BUILD_BYPRODUCTS ${SOX_LIBRARIES}
   DOWNLOAD_NO_PROGRESS ON
   LOG_DOWNLOAD ON

--- a/third_party/sox/CMakeLists.txt
+++ b/third_party/sox/CMakeLists.txt
@@ -197,7 +197,7 @@ ExternalProject_Add(sox
   URL https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2.tar.bz2
   URL_HASH SHA256=81a6956d4330e75b5827316e44ae381e6f1e8928003c6aa45896da9041ea149c
   CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env ${envs} ${CMAKE_CURRENT_BINARY_DIR}/src/sox/configure ${COMMON_ARGS} ${SOX_OPTIONS}
-  PATCH_COMMAND patch < ${CMAKE_CURRENT_SOURCE_DIR}/patch/sox.patch
+  PATCH_COMMAND patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patch/sox.patch
   BUILD_BYPRODUCTS ${SOX_LIBRARIES}
   DOWNLOAD_NO_PROGRESS ON
   LOG_DOWNLOAD ON

--- a/third_party/sox/patch/sox.patch
+++ b/third_party/sox/patch/sox.patch
@@ -1,7 +1,7 @@
 See https://github.com/pytorch/audio/pull/1297
-diff -ru src/formats.c src/formats.c
---- src/formats.c	2014-10-26 19:55:50.000000000 -0700
-+++ src/formats.c.new	2021-02-22 16:01:02.833144070 -0800
+diff -ru sox/src/formats.c sox/src/formats.c
+--- sox/src/formats.c	2014-10-26 19:55:50.000000000 -0700
++++ sox/src/formats.c	2021-02-22 16:01:02.833144070 -0800
 @@ -333,6 +333,9 @@
    assert(ft);
    if (!ft->fp)

--- a/third_party/sox/patch/sox.patch
+++ b/third_party/sox/patch/sox.patch
@@ -1,6 +1,7 @@
+See https://github.com/pytorch/audio/pull/1297
 diff -ru src/formats.c src/formats.c
 --- src/formats.c	2014-10-26 19:55:50.000000000 -0700
-+++ src/formats.c	2021-02-22 16:01:02.833144070 -0800
++++ src/formats.c.new	2021-02-22 16:01:02.833144070 -0800
 @@ -333,6 +333,9 @@
    assert(ft);
    if (!ft->fp)

--- a/third_party/sox/patch/sox.patch
+++ b/third_party/sox/patch/sox.patch
@@ -1,0 +1,14 @@
+diff -ru src/formats.c src/formats.c
+--- src/formats.c	2014-10-26 19:55:50.000000000 -0700
++++ src/formats.c	2021-02-22 16:01:02.833144070 -0800
+@@ -333,6 +333,9 @@
+   assert(ft);
+   if (!ft->fp)
+     return sox_false;
+-  fstat(fileno((FILE*)ft->fp), &st);
++  int fd = fileno((FILE*)ft->fp);
++  if (fd < 0)
++    return sox_false;
++  fstat(fd, &st);
+   return ((st.st_mode & S_IFMT) == S_IFREG);
+ }

--- a/third_party/sox/patch/sox.patch
+++ b/third_party/sox/patch/sox.patch
@@ -2,7 +2,7 @@ See https://github.com/pytorch/audio/pull/1297
 diff -ru sox/src/formats.c sox/src/formats.c
 --- sox/src/formats.c	2014-10-26 19:55:50.000000000 -0700
 +++ sox/src/formats.c	2021-02-22 16:01:02.833144070 -0800
-@@ -333,6 +333,9 @@
+@@ -333,6 +333,10 @@
    assert(ft);
    if (!ft->fp)
      return sox_false;
@@ -10,6 +10,7 @@ diff -ru sox/src/formats.c sox/src/formats.c
 +  int fd = fileno((FILE*)ft->fp);
 +  if (fd < 0)
 +    return sox_false;
-+  fstat(fd, &st);
++  if (fstat(fd, &st) < 0)
++    return sox_false;
    return ((st.st_mode & S_IFMT) == S_IFREG);
  }


### PR DESCRIPTION
Ever since the file-like object support was added in #1158, the test
was occasionally failing in CI. This PR fixes this.

## What issues are resolved by this PR?

The failing tests exhibit flakiness in the following three areas;
1. `info_test`
For `mp3` and `vorbis` formats, the number of reported frames were most times zero (this is due to the container format), but occasionally, the test reported a correct number. It should be always reporting the same number.
2. `load_test`
The shape of the Tensor loaded with `load` function occasionally had different number of frames than what actually the file has.
3. `save_test`
The saved data occasionally lacked some frames at the end.

## On which environment were the issues happening?
unix system, all Python environment

## What was the cause and what is the fix?
When opening file (for both read and write), `libsox` initializes the dedicated data structure called `sox_format_t`, and set various attributes. One of which is `seekable` and this value is supposed to be `false` for file-like objects. In the investigation https://github.com/pytorch/audio/issues/1229, it turned out that this attribute is occasionally `true` which contributed to the un-deterministic behavior described above. The following code from `libsox` determines if the opened `FILE*` is `seekable`, by simply checking if the associated file descriptor is a regular file. [[src](https://github.com/dmkrepo/libsox/blob/b9dd1a86e71bbd62221904e3e59dfaa9e5e72046/src/formats.c#L329-L338
)]

```c
static sox_bool is_seekable(sox_format_t const * ft)
{
  struct stat st;

  assert(ft);
  if (!ft->fp)
    return sox_false;
  fstat(fileno((FILE*)ft->fp), &st);
  return ((st.st_mode & S_IFMT) == S_IFREG);
}
```

The problem is that `fileno` returns `-1` for the case of file-like object. This is because for file-like object, we use [`sox_open_mem_read`](https://github.com/dmkrepo/libsox/blob/b9dd1a86e71bbd62221904e3e59dfaa9e5e72046/src/formats.c#L617) or [`sox_open_mem_stream_write`](https://github.com/dmkrepo/libsox/blob/b9dd1a86e71bbd62221904e3e59dfaa9e5e72046/src/formats.c#L991), which calls [`fmemopen`](https://github.com/dmkrepo/libsox/blob/b9dd1a86e71bbd62221904e3e59dfaa9e5e72046/src/formats.c#L496) and [`open_memstream`](https://github.com/dmkrepo/libsox/blob/master/src/formats.c#L894) respectively, and the resulting `*FILE` object does not have the associated file descriptor. In this case, `fstat` received `-1` as the file descriptor value and (I guess) the `stat` structure is untouched. Thus the attribute of `st_mode` has an un-initialized value, which result in un-deterministic behavior.

This PR adds patch to check the the value of file descriptor and mark `seekable=false` if it does not have a valid file descriptor.

## How do we know this patch fixes the issue?

I took the detailed note on https://github.com/pytorch/audio/issues/1229. The following script will keep running the tests.

https://github.com/mthrok/audio/blob/10ba189d8bc5f0beb5f7200fcb59778acc490033/debug_fileobj.sh#L1

Before applying the patch, it typically took ~15 mins for one of the tests to fail. After this patch is applied, they do not fail. I kept running the test over night and none of the tests failed.

## TODOs

- [ ] Cherry-pick to `release/0.8`
- [ ] Upstream the patch to sox project
- [ ] Fix in fbcode