### PR TITLE
Remove reference_cast in make_boxed_from_unboxed_functor (pytorch/pytorch#51319)

### DIFF
--- a/torchaudio/csrc/sox/effects.cpp
+++ b/torchaudio/csrc/sox/effects.cpp
@@ -93,7 +93,7 @@ std::tuple<torch::Tensor, int64_t> apply_effects_file(
     std::vector<std::vector<std::string>> effects,
     c10::optional<bool> normalize,
     c10::optional<bool> channels_first,
-    c10::optional<std::string> format) {
+    const c10::optional<std::string>& format) {
   // Open input file
   SoxFormat sf(sox_open_read(
       path.c_str(),

--- a/torchaudio/csrc/sox/effects.h
+++ b/torchaudio/csrc/sox/effects.h
@@ -26,7 +26,7 @@ std::tuple<torch::Tensor, int64_t> apply_effects_file(
     std::vector<std::vector<std::string>> effects,
     c10::optional<bool> normalize,
     c10::optional<bool> channels_first,
-    c10::optional<std::string> format);
+    const c10::optional<std::string>& format);
 
 #ifdef TORCH_API_INCLUDE_EXTENSION_H
 

--- a/torchaudio/csrc/sox/io.cpp
+++ b/torchaudio/csrc/sox/io.cpp
@@ -12,7 +12,7 @@ namespace sox_io {
 
 std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_file(
     const std::string& path,
-    c10::optional<std::string> format) {
+    const c10::optional<std::string>& format) {
   SoxFormat sf(sox_open_read(
       path.c_str(),
       /*signal=*/nullptr,
@@ -34,8 +34,8 @@ std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_file(
 namespace {
 
 std::vector<std::vector<std::string>> get_effects(
-    c10::optional<int64_t> frame_offset,
-    c10::optional<int64_t> num_frames) {
+    const c10::optional<int64_t>& frame_offset,
+    const c10::optional<int64_t>& num_frames) {
   const auto offset = frame_offset.value_or(0);
   if (offset < 0) {
     throw std::runtime_error(
@@ -66,11 +66,11 @@ std::vector<std::vector<std::string>> get_effects(
 
 std::tuple<torch::Tensor, int64_t> load_audio_file(
     const std::string& path,
-    c10::optional<int64_t> frame_offset,
-    c10::optional<int64_t> num_frames,
+    const c10::optional<int64_t>& frame_offset,
+    const c10::optional<int64_t>& num_frames,
     c10::optional<bool> normalize,
     c10::optional<bool> channels_first,
-    c10::optional<std::string> format) {
+    const c10::optional<std::string>& format) {
   auto effects = get_effects(frame_offset, num_frames);
   return torchaudio::sox_effects::apply_effects_file(
       path, effects, normalize, channels_first, format);

--- a/torchaudio/csrc/sox/io.h
+++ b/torchaudio/csrc/sox/io.h
@@ -13,15 +13,15 @@ namespace sox_io {
 
 std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_file(
     const std::string& path,
-    c10::optional<std::string> format);
+    const c10::optional<std::string>& format);
 
 std::tuple<torch::Tensor, int64_t> load_audio_file(
     const std::string& path,
-    c10::optional<int64_t> frame_offset,
-    c10::optional<int64_t> num_frames,
+    const c10::optional<int64_t>& frame_offset,
+    const c10::optional<int64_t>& num_frames,
     c10::optional<bool> normalize,
     c10::optional<bool> channels_first,
-    c10::optional<std::string> format);
+    const c10::optional<std::string>& format);
 
 void save_audio_file(
     const std::string& path,


### PR DESCRIPTION
This PR cherry-picks a0446251ef7c2806fe36c601631fcae54667318d on top of master, by taking into account the changes from #1285

Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/51319

We were going out of our way to accommodate `IValue::to<Tensor>` returning a copy of the inner Tensor. `IValue::toTensor` is capable of returning a reference without copying, so if we use it directly, we can allow kernels that want to take `Tensor &` to do so!
As a bonus, we get reduced build times.
ghstack-source-id: 121378961

Reviewed By: bhosmer

Differential Revision: D26138549

fbshipit-source-id: b0f830527da360c542c815bef2f7e1692615b32a