### PR TITLE
change 0.7.0 documentation to use a version selector

### DIFF
--- a/0.7.0/backend.html
+++ b/0.7.0/backend.html
@@ -185,7 +185,7 @@
               
               
                 <div class="version">
-                  0.7.0
+                  <a href=https://pytorch.org/audio/versions.html>0.7.0  &#x25BC</a>
                 </div>
               
             

--- a/0.7.0/compliance.kaldi.html
+++ b/0.7.0/compliance.kaldi.html
@@ -185,7 +185,7 @@
               
               
                 <div class="version">
-                  0.7.0
+                  <a href=https://pytorch.org/audio/versions.html>0.7.0  &#x25BC</a>
                 </div>
               
             

--- a/0.7.0/datasets.html
+++ b/0.7.0/datasets.html
@@ -185,7 +185,7 @@
               
               
                 <div class="version">
-                  0.7.0
+                  <a href=https://pytorch.org/audio/versions.html>0.7.0  &#x25BC</a>
                 </div>
               
             

--- a/0.7.0/functional.html
+++ b/0.7.0/functional.html
@@ -185,7 +185,7 @@
               
               
                 <div class="version">
-                  0.7.0
+                  <a href=https://pytorch.org/audio/versions.html>0.7.0  &#x25BC</a>
                 </div>
               
             

--- a/0.7.0/genindex.html
+++ b/0.7.0/genindex.html
@@ -184,7 +184,7 @@
               
               
                 <div class="version">
-                  0.7.0
+                  <a href=https://pytorch.org/audio/versions.html>0.7.0  &#x25BC</a>
                 </div>
               
             

--- a/0.7.0/index.html
+++ b/0.7.0/index.html
@@ -184,7 +184,7 @@
               
               
                 <div class="version">
-                  0.7.0
+                  <a href=https://pytorch.org/audio/versions.html>0.7.0  &#x25BC</a>
                 </div>
               
             

--- a/0.7.0/kaldi_io.html
+++ b/0.7.0/kaldi_io.html
@@ -185,7 +185,7 @@
               
               
                 <div class="version">
-                  0.7.0
+                  <a href=https://pytorch.org/audio/versions.html>0.7.0  &#x25BC</a>
                 </div>
               
             

--- a/0.7.0/models.html
+++ b/0.7.0/models.html
@@ -185,7 +185,7 @@
               
               
                 <div class="version">
-                  0.7.0
+                  <a href=https://pytorch.org/audio/versions.html>0.7.0  &#x25BC</a>
                 </div>
               
             

--- a/0.7.0/py-modindex.html
+++ b/0.7.0/py-modindex.html
@@ -186,7 +186,7 @@
               
               
                 <div class="version">
-                  0.7.0
+                  <a href=https://pytorch.org/audio/versions.html>0.7.0  &#x25BC</a>
                 </div>
               
             

--- a/0.7.0/search.html
+++ b/0.7.0/search.html
@@ -183,7 +183,7 @@
               
               
                 <div class="version">
-                  0.7.0
+                  <a href=https://pytorch.org/audio/versions.html>0.7.0  &#x25BC</a>
                 </div>
               
             

--- a/0.7.0/sox_effects.html
+++ b/0.7.0/sox_effects.html
@@ -185,7 +185,7 @@
               
               
                 <div class="version">
-                  0.7.0
+                  <a href=https://pytorch.org/audio/versions.html>0.7.0  &#x25BC</a>
                 </div>
               
             

--- a/0.7.0/torchaudio.html
+++ b/0.7.0/torchaudio.html
@@ -185,7 +185,7 @@
               
               
                 <div class="version">
-                  0.7.0
+                  <a href=https://pytorch.org/audio/versions.html>0.7.0  &#x25BC</a>
                 </div>
               
             

--- a/0.7.0/transforms.html
+++ b/0.7.0/transforms.html
@@ -185,7 +185,7 @@
               
               
                 <div class="version">
-                  0.7.0
+                  <a href=https://pytorch.org/audio/versions.html>0.7.0  &#x25BC</a>
                 </div>
               
             

--- a/0.7.0/utils.html
+++ b/0.7.0/utils.html
@@ -184,7 +184,7 @@
               
               
                 <div class="version">
-                  0.7.0
+                  <a href=https://pytorch.org/audio/versions.html>0.7.0  &#x25BC</a>
                 </div>
               
             


### PR DESCRIPTION
Swap the static text "0.7.0" version for a link to the versions.html page

@brianjo 
