### PR TITLE
Add GSM format support to sox_io's save function (#1275)

### DIFF
--- a/test/torchaudio_unittest/backend/sox_io/save_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/save_test.py
@@ -310,6 +310,13 @@ class SaveTest(SaveTestBase):
         self.assert_save_consistency(
             "amr-nb", compression=bit_rate, num_channels=1, test_mode=test_mode)
 
+    @nested_params(
+        ["path", "fileobj", "bytesio"],
+    )
+    def test_save_gsm(self, test_mode):
+        self.assert_save_consistency(
+            "gsm", test_mode=test_mode)
+
     @parameterized.expand([
         ("wav", "PCM_S", 16),
         ("mp3", ),

--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -195,7 +195,7 @@ def save(
             When ``filepath`` argument is file-like object, this argument is required.
 
             Valid values are ``"wav"``, ``"mp3"``, ``"ogg"``, ``"vorbis"``, ``"amr-nb"``,
-            ``"amb"``, ``"flac"`` and ``"sph"``.
+            ``"amb"``, ``"flac"``, ``"sph"`` and ``"gsm"``.
         encoding (str, optional): Changes the encoding for the supported formats.
             This argument is effective only for supported formats, cush as ``"wav"``, ``""amb"``
             and ``"sph"``. Valid values are;
@@ -290,6 +290,9 @@ def save(
 
     ``"amr-nb"``
         Bitrate ranging from 4.75 kbit/s to 12.2 kbit/s. Default: 4.75 kbit/s
+
+    ``"gsm"``
+        Lossy Speech Compression, CPU intensive.
 
     Note:
         To save into formats that ``libsox`` does not handle natively, (such as ``"mp3"``,

--- a/torchaudio/csrc/sox/types.cpp
+++ b/torchaudio/csrc/sox/types.cpp
@@ -20,6 +20,8 @@ Format get_format_from_string(const std::string& format) {
     return Format::AMB;
   if (format == "sph")
     return Format::SPHERE;
+  if (format == "gsm")
+    return Format::GSM;
   std::ostringstream stream;
   stream << "Internal Error: unexpected format value: " << format;
   throw std::runtime_error(stream.str());

--- a/torchaudio/csrc/sox/types.h
+++ b/torchaudio/csrc/sox/types.h
@@ -15,6 +15,7 @@ enum class Format {
   AMR_WB,
   AMB,
   SPHERE,
+  GSM,
 };
 
 Format get_format_from_string(const std::string& format);

--- a/torchaudio/csrc/sox/utils.cpp
+++ b/torchaudio/csrc/sox/utils.cpp
@@ -378,6 +378,14 @@ std::tuple<sox_encoding_t, unsigned> get_save_encoding(
           throw std::runtime_error(
               "sph does not support encoding: " + encoding.value());
       }
+    case Format::GSM:
+      if (enc != Encoding::NOT_PROVIDED)
+        throw std::runtime_error("gsm does not support `encoding` option.");
+      if (bps != BitDepth::NOT_PROVIDED)
+        throw std::runtime_error(
+            "gsm does not support `bits_per_sample` option.");
+      return std::make_tuple<>(SOX_ENCODING_GSM, 16);
+
     default:
       throw std::runtime_error("Unsupported format: " + format);
   }
@@ -409,6 +417,8 @@ unsigned get_precision(const std::string filetype, caffe2::TypeMeta dtype) {
   if (filetype == "amr-nb") {
     return 16;
   }
+  if (filetype == "gsm")
+    return 16;
   throw std::runtime_error("Unsupported file type: " + filetype);
 }
 


### PR DESCRIPTION
(cherry picked from commit 490a53e5601bd71dfddbb3789958f5a18a08f475)