### PR TITLE
Fix uninitialised variable in sox/utils.cpp

### DIFF
--- a/torchaudio/csrc/sox/utils.cpp
+++ b/torchaudio/csrc/sox/utils.cpp
@@ -169,7 +169,7 @@ torch::Tensor convert_to_tensor(
     const bool normalize,
     const bool channels_first) {
   torch::Tensor t;
-  uint64_t dummy;
+  uint64_t dummy = 0;
   SOX_SAMPLE_LOCALS;
   if (normalize || dtype == torch::kFloat32) {
     t = torch::empty(


### PR DESCRIPTION
When compiling torchaudio with `-Werror,-Wuninitialized`, we would get compilation errors due to `dummy` not being initialized as follows.

```
 pytorch/audio/torchaudio/csrc/sox/utils.cpp:179:53: error: variable 'dummy' is uninitialized when used here [-Werror,-Wuninitialized]
      ptr[i] = SOX_SAMPLE_TO_FLOAT_32BIT(buffer[i], dummy);
```

This PR fixes it by initializing it to zero.