### PR TITLE
.circleci: Let numpy get installed as dependency

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -36,7 +36,6 @@ fi
 printf "Installing PyTorch with %s\n" "${cudatoolkit}"
 (
     set -x
-    conda install ${CONDA_CHANNEL_FLAGS:-} -y defaults::numpy
     conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" "pytorch-${UPLOAD_CHANNEL}::pytorch" ${cudatoolkit}
 )
 

--- a/.circleci/unittest/windows/scripts/setup_env.sh
+++ b/.circleci/unittest/windows/scripts/setup_env.sh
@@ -37,9 +37,3 @@ if [ ! -d "${env_dir}" ]; then
     conda create --prefix "${env_dir}" -y python="${PYTHON_VERSION}"
 fi
 conda activate "${env_dir}"
-NUMPY_PIN="1.11"
-if [[ "${PYTHON_VERSION}" = "3.9" ]]; then
-    NUMPY_PIN="1.20"
-fi
-printf "* Installing numpy>=%s\n" "${NUMPY_PIN}\n"
-conda install -y -c conda-forge numpy>="${NUMPY_PIN}"


### PR DESCRIPTION
Numpy is a dependency of pytorch so we should let it get resolved as it
install pytorch

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>