### PR TITLE
Removed check_length from validate_input_file()

### DIFF
--- a/torchaudio/csrc/sox/effects.cpp
+++ b/torchaudio/csrc/sox/effects.cpp
@@ -204,7 +204,7 @@ std::tuple<torch::Tensor, int64_t> apply_effects_fileobj(
       /*filetype=*/format.has_value() ? format.value().c_str() : nullptr));
 
   // In case of streamed data, length can be 0
-  validate_input_file(sf, /*check_length=*/false);
+  validate_input_file(sf);
 
   // Prepare output buffer
   std::vector<sox_sample_t> out_buffer;

--- a/torchaudio/csrc/sox/io.cpp
+++ b/torchaudio/csrc/sox/io.cpp
@@ -170,7 +170,7 @@ std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_fileobj(
       /*filetype=*/format.has_value() ? format.value().c_str() : nullptr));
 
   // In case of streamed data, length can be 0
-  validate_input_file(sf, /*check_length=*/false);
+  validate_input_file(sf);
 
   return std::make_tuple(
       static_cast<int64_t>(sf->signal.rate),

--- a/torchaudio/csrc/sox/utils.cpp
+++ b/torchaudio/csrc/sox/utils.cpp
@@ -81,15 +81,12 @@ void SoxFormat::close() {
   }
 }
 
-void validate_input_file(const SoxFormat& sf, bool check_length) {
+void validate_input_file(const SoxFormat& sf) {
   if (static_cast<sox_format_t*>(sf) == nullptr) {
     throw std::runtime_error("Error loading audio file: failed to open file.");
   }
   if (sf->encoding.encoding == SOX_ENCODING_UNKNOWN) {
     throw std::runtime_error("Error loading audio file: unknown encoding.");
-  }
-  if (check_length && sf->signal.length == 0) {
-    throw std::runtime_error("Error reading audio file: unknown length.");
   }
 }
 

--- a/torchaudio/csrc/sox/utils.h
+++ b/torchaudio/csrc/sox/utils.h
@@ -56,7 +56,7 @@ struct SoxFormat {
 
 ///
 /// Verify that input file is found, has known encoding, and not empty
-void validate_input_file(const SoxFormat& sf, bool check_length = true);
+void validate_input_file(const SoxFormat& sf);
 
 ///
 /// Verify that input Tensor is 2D, CPU and either uin8, int16, int32 or float32


### PR DESCRIPTION
Some audio formats like `gsm` does not have valid frame numbers when opened. But `libsox` can properly handle these audios, so checking if `length > 0` is not necessary and too strict.