### PR TITLE
Apply functional batch consistency tests to batches of different items

### DIFF
--- a/test/torchaudio_unittest/common_utils/data_utils.py
+++ b/test/torchaudio_unittest/common_utils/data_utils.py
@@ -68,11 +68,11 @@ def get_whitenoise(
     # so we only fork on CPU, generate values and move the data to the given device
     with torch.random.fork_rng([]):
         torch.random.manual_seed(seed)
-        tensor = torch.randn([int(sample_rate * duration)], dtype=torch.float32, device='cpu')
+        tensor = torch.randn([n_channels, int(sample_rate * duration)],
+                             dtype=torch.float32, device='cpu')
     tensor /= 2.0
     tensor *= scale_factor
     tensor.clamp_(-1.0, 1.0)
-    tensor = tensor.repeat([n_channels, 1])
     if not channels_first:
         tensor = tensor.t()
     return convert_tensor_encoding(tensor, dtype)

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -10,6 +10,8 @@ from torchaudio_unittest import common_utils
 
 
 @parameterized_class([
+    # Single-item batch isolates problems that come purely from adding a
+    # dimension (rather than processing multiple items)
     {"batch_size": 1},
     {"batch_size": 3},
 ])

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -187,11 +187,12 @@ class TestFunctional(common_utils.TorchaudioTestCase):
 
     def test_vad_from_file(self):
         common_utils.set_audio_backend('default')
-        filepath = common_utils.get_asset_path("vad-go-mono-32000.wav")
+        filepath = common_utils.get_asset_path("vad-go-stereo-44100.wav")
         waveform, sample_rate = torchaudio.load(filepath)
-        self.assert_batch_consistency(
-            F.vad, waveform.repeat(self.batch_size, 1, 1),
-            sample_rate=sample_rate)
+        # Each channel is slightly offset - we can use this to create a batch
+        # with different items.
+        batch = waveform.view(2, 1, -1)
+        self.assert_batch_consistency(F.vad, batch, sample_rate=sample_rate)
 
     def test_vad_different_items(self):
         """Separate test to ensure VAD consistency with differing items."""

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -195,6 +195,13 @@ class TestFunctional(common_utils.TorchaudioTestCase):
             F.vad, waveform.unsqueeze(0).repeat(3, 1, 1),
             sample_rate=sample_rate)
 
+    def test_vad_different_items(self):
+        """Separate test to ensure VAD consistency with differing items."""
+        sample_rate = 44100
+        waveforms = torch.rand(3, 2, 100) - 0.5
+        self.assert_batch_consistencies(
+            F.vad, waveforms, sample_rate=sample_rate)
+
     @common_utils.skipIfNoExtension
     def test_compute_kaldi_pitch(self):
         sample_rate = 44100

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -35,7 +35,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         batch_input = batch.clone()
         batch_result = functional(batch_input, *args, **kwargs)
 
-        self.assertEqual(items_input,  batch_input,  rtol=rtol, atol=atol)
+        self.assertEqual(items_input, batch_input, rtol=rtol, atol=atol)
         self.assertEqual(items_result, batch_result, rtol=rtol, atol=atol)
 
     def test_griffinlim(self):
@@ -163,7 +163,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         sample_rate = 44100
         n_channels = 2
         waveform = common_utils.get_whitenoise(
-            sample_rate=sample_rate, n_channels=self.batch_size*n_channels,
+            sample_rate=sample_rate, n_channels=self.batch_size * n_channels,
             duration=1)
         batch = waveform.view(self.batch_size, n_channels, waveform.size(-1))
         self.assert_batch_consistency(F.phaser, batch, sample_rate)
@@ -205,7 +205,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         sample_rate = 44100
         n_channels = 2
         waveform = common_utils.get_whitenoise(
-            sample_rate=sample_rate, n_channels=self.batch_size*n_channels)
+            sample_rate=sample_rate, n_channels=self.batch_size * n_channels)
         batch = waveform.view(self.batch_size, n_channels, waveform.size(-1))
         self.assert_batch_consistency(
             F.compute_kaldi_pitch, batch, sample_rate=sample_rate)

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -190,7 +190,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         filepath = common_utils.get_asset_path("vad-go-mono-32000.wav")
         waveform, sample_rate = torchaudio.load(filepath)
         self.assert_batch_consistency(
-            F.vad, waveform.unsqueeze(0).repeat(self.batch_size, 1, 1),
+            F.vad, waveform.repeat(self.batch_size, 1, 1),
             sample_rate=sample_rate)
 
     def test_vad_different_items(self):

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -4,7 +4,6 @@ import math
 
 from parameterized import parameterized, parameterized_class
 import torch
-import torchaudio
 import torchaudio.functional as F
 
 from torchaudio_unittest import common_utils

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -25,14 +25,17 @@ class TestFunctional(common_utils.TorchaudioTestCase):
 
         # Compute items separately, then batch the result
         torch.random.manual_seed(seed)
+        items_input = batch.clone()
         items_result = torch.stack([
-            functional(batch[i].clone(), *args, **kwargs) for i in range(n)
+            functional(items_input[i], *args, **kwargs) for i in range(n)
         ])
 
         # Batch the input and run
         torch.random.manual_seed(seed)
-        batch_result = functional(batch.clone(), *args, **kwargs)
+        batch_input = batch.clone()
+        batch_result = functional(batch_input, *args, **kwargs)
 
+        self.assertEqual(items_input,  batch_input,  rtol=rtol, atol=atol)
         self.assertEqual(items_result, batch_result, rtol=rtol, atol=atol)
 
     def test_griffinlim(self):

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -192,7 +192,6 @@ class TestFunctional(common_utils.TorchaudioTestCase):
             F.sliding_window_cmn, waveforms, center=False, norm_vars=False)
 
     def test_vad_from_file(self):
-        common_utils.set_audio_backend('default')
         filepath = common_utils.get_asset_path("vad-go-stereo-44100.wav")
         waveform, sample_rate = common_utils.load_wav(filepath)
         # Each channel is slightly offset - we can use this to create a batch

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -188,7 +188,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
     def test_vad_from_file(self):
         common_utils.set_audio_backend('default')
         filepath = common_utils.get_asset_path("vad-go-stereo-44100.wav")
-        waveform, sample_rate = torchaudio.load(filepath)
+        waveform, sample_rate = common_utils.load_wav(filepath)
         # Each channel is slightly offset - we can use this to create a batch
         # with different items.
         batch = waveform.view(2, 1, -1)

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -11,8 +11,9 @@ from torchaudio_unittest import common_utils
 
 
 class TestFunctional(common_utils.TorchaudioTestCase):
-    backend = 'default'
     """Test functions defined in `functional` module"""
+    backend = 'default'
+
     def assert_batch_consistency(
             self, functional, batch, *args, atol=1e-8, rtol=1e-5, seed=42,
             **kwargs):

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -164,7 +164,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         n_channels = 2
         waveform = common_utils.get_whitenoise(
             sample_rate=sample_rate, n_channels=self.batch_size*n_channels,
-            duration=5)
+            duration=1)
         batch = waveform.view(self.batch_size, n_channels, waveform.size(-1))
         self.assert_batch_consistency(F.phaser, batch, sample_rate)
 


### PR DESCRIPTION
The `batch_consistency_test.py` files check that behavior is consistent on batches vs. items, but the current infrastructure does this with batches of identical items. This approach may miss bugs related to data leakage between items within a batch, for example #994.

This PR makes changes `functional/batch_consistency_test.py` so (most) batches are generated with items that are not identical, then the entire batch is passed to the consistency check. Batch sizes are parameterized so tests are generated for single-item and three-item batches. I've also changed the white noise generator to generate different data in each channel (rather than duplicating one wave), and the consistency check now checks both inputs and outputs, to detect inconsistencies with in-place operations.

I am still repeating a single item in a couple of places - with a one-channel signal loaded from disk, and for pitch frequency. Using different frequencies within the same batch may be a more robust way to test pitch frequency.

I haven't touched the root `batch_consistency_test.py` yet, but it seems that this approach could be extended to that file too. Let me know if that sounds sensible.

Closes #1294 