### PR TITLE
Publish artifacts on build_docs CircleCI job to get rendered html files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -574,6 +574,9 @@ jobs:
           root: ./
           paths:
             - "*"
+      - store_artifacts:
+          path: ./docs/build/html
+          destination: docs
 
   upload_docs:
     <<: *binary_common

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -574,6 +574,9 @@ jobs:
           root: ./
           paths:
             - "*"
+      - store_artifacts:
+          path: ./docs/build/html
+          destination: docs
 
   upload_docs:
     <<: *binary_common


### PR DESCRIPTION
Addresses https://github.com/pytorch/audio/pull/1316#issuecomment-786345978

Docs are currently built but the artifacts aren't published so they generated html files aren't accessible. This PR fixes that.