### PR TITLE
Update AudioMetaData docstring with encoding values

### DIFF
--- a/torchaudio/backend/common.py
+++ b/torchaudio/backend/common.py
@@ -16,8 +16,8 @@ class AudioMetaData:
             * ``PCM_U``: Unsigned integer linear PCM
             * ``PCM_F``: Floating point linear PCM
             * ``FLAC``: Flac, Free Lossless Audio Codec
-            * ``ULAW``: Mu-law, [wikipedia]
-            * ``ALAW``: A-law [wikipedia]
+            * ``ULAW``: Mu-law
+            * ``ALAW``: A-law
             * ``MP3`` : MP3, MPEG-1 Audio Layer III
             * ``VORBIS``: OGG Vorbis
             * ``AMR_WB``: Adaptive Multi-Rate

--- a/torchaudio/backend/common.py
+++ b/torchaudio/backend/common.py
@@ -19,10 +19,10 @@ class AudioMetaData:
             * ``ULAW``: Mu-law, [wikipedia]
             * ``ALAW``: A-law [wikipedia]
             * ``MP3`` : MP3, MPEG-1 Audio Layer III
-            * ``VORBIS``: OGG Vorbis [xiph.org]
-            * ``AMR_WB``: Adaptive Multi-Rate [wikipedia]
-            * ``AMR_NB``: Adaptive Multi-Rate Wideband [wikipedia]
-            * ``OPUS``: Opus [opus-codec.org]
+            * ``VORBIS``: OGG Vorbis
+            * ``AMR_WB``: Adaptive Multi-Rate
+            * ``AMR_NB``: Adaptive Multi-Rate Wideband
+            * ``OPUS``: Opus
             * ``UNKNOWN`` : None of above
     """
     def __init__(

--- a/torchaudio/backend/common.py
+++ b/torchaudio/backend/common.py
@@ -23,7 +23,7 @@ class AudioMetaData:
             * ``AMR_WB``: Adaptive Multi-Rate [wikipedia]
             * ``AMR_NB``: Adaptive Multi-Rate Wideband [wikipedia]
             * ``OPUS``: Opus [opus-codec.org]
-            * ``UNKNOWN`` : None of avobe
+            * ``UNKNOWN`` : None of above
     """
     def __init__(
             self,

--- a/torchaudio/backend/common.py
+++ b/torchaudio/backend/common.py
@@ -9,7 +9,21 @@ class AudioMetaData:
     :ivar int num_channels: The number of channels
     :ivar int bits_per_sample: The number of bits per sample. This is 0 for lossy formats,
         or when it cannot be accurately inferred.
-    :ivar str encoding: Audio encoding.
+    :ivar str encoding: Audio encoding
+        The values encoding can take are one of the following:
+
+            * ``PCM_S``: Signed integer linear PCM
+            * ``PCM_U``: Unsigned integer linear PCM
+            * ``PCM_F``: Floating point linear PCM
+            * ``FLAC``: Flac, Free Lossless Audio Codec
+            * ``ULAW``: Mu-law, [wikipedia]
+            * ``ALAW``: A-law [wikipedia]
+            * ``MP3`` : MP3, MPEG-1 Audio Layer III
+            * ``VORBIS``: OGG Vorbis [xiph.org]
+            * ``AMR_WB``: Adaptive Multi-Rate [wikipedia]
+            * ``AMR_NB``: Adaptive Multi-Rate Wideband [wikipedia]
+            * ``OPUS``: Opus [opus-codec.org]
+            * ``UNKNOWN`` : None of avobe
     """
     def __init__(
             self,


### PR DESCRIPTION
Question: I think the docstring is leaking Sphinx tags. Should we remove them?