### PR TITLE
Add subcategories to functional documentation

### DIFF
--- a/docs/source/functional.rst
+++ b/docs/source/functional.rst
@@ -186,44 +186,47 @@ treble_biquad
 vad
 ---
 
+:hidden:`Feature Extractions`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 .. autofunction:: vad
 
 :hidden:`spectrogram`
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 .. autofunction:: spectrogram
 
 :hidden:`griffinlim`
-~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 .. autofunction:: griffinlim
 
 :hidden:`phase_vocoder`
-~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 
 .. autofunction:: phase_vocoder
 
 :hidden:`compute_deltas`
-~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------
 
 .. autofunction:: compute_deltas
 
 :hidden:`detect_pitch_frequency`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------
 
 .. autofunction:: detect_pitch_frequency
 
 :hidden:`sliding_window_cmn`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------
 
 .. autofunction:: sliding_window_cmn
 
 :hidden:`compute_kaldi_pitch`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------
 
 .. autofunction:: compute_kaldi_pitch
 
 :hidden:`spectral_centroid`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------
 
 .. autofunction:: spectral_centroid

--- a/docs/source/functional.rst
+++ b/docs/source/functional.rst
@@ -8,6 +8,75 @@ torchaudio.functional
 
 Functions to perform common audio operations.
 
+:hidden:`Utility`
+~~~~~~~~~~~~~~~~~
+
+amplitude_to_DB
+---------------
+
+.. autofunction:: amplitude_to_DB
+
+DB_to_amplitude
+---------------
+
+.. autofunction:: DB_to_amplitude
+
+create_fb_matrix
+----------------
+
+.. autofunction:: create_fb_matrix
+
+create_dct
+----------
+
+.. autofunction:: create_dct
+
+mask_along_axis
+---------------
+
+.. autofunction:: mask_along_axis
+
+mask_along_axis_iid
+-------------------
+
+.. autofunction:: mask_along_axis_iid
+
+mu_law_encoding
+---------------
+
+.. autofunction:: mu_law_encoding
+
+mu_law_decoding
+---------------
+
+.. autofunction:: mu_law_decoding
+
+apply_codec
+-----------
+
+.. autofunction:: apply_codec
+		  
+:hidden:`Complex Utility`
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Utilities for pseudo complex tensor. This is not for the native complex dtype, such as `cfloat64`, but for tensors with real-value type and have extra dimension at the end for real and imaginary parts.
+
+angle
+-----
+
+.. autofunction:: angle
+
+complex_norm
+------------
+
+.. autofunction:: complex_norm
+
+
+magphase
+--------
+
+.. autofunction:: magphase
+
 :hidden:`Filtering`
 ~~~~~~~~~~~~~~~~~~~
 
@@ -129,65 +198,10 @@ vad
 
 .. autofunction:: griffinlim
 
-:hidden:`amplitude_to_DB`
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autofunction:: amplitude_to_DB
-
-:hidden:`DB_to_amplitude`
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autofunction:: DB_to_amplitude
-
-:hidden:`create_fb_matrix`
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autofunction:: create_fb_matrix
-
-:hidden:`create_dct`
-~~~~~~~~~~~~~~~~~~~~
-
-.. autofunction:: create_dct
-
-:hidden:`mu_law_encoding`
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autofunction:: mu_law_encoding
-
-:hidden:`mu_law_decoding`
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autofunction:: mu_law_decoding
-
-:hidden:`complex_norm`
-~~~~~~~~~~~~~~~~~~~~~~
-
-.. autofunction:: complex_norm
-
-:hidden:`angle`
-~~~~~~~~~~~~~~~
-
-.. autofunction:: angle
-
-:hidden:`magphase`
-~~~~~~~~~~~~~~~~~~
-
-.. autofunction:: magphase
-
 :hidden:`phase_vocoder`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: phase_vocoder
-
-:hidden:`mask_along_axis`
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autofunction:: mask_along_axis
-
-:hidden:`mask_along_axis_iid`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autofunction:: mask_along_axis_iid
 
 :hidden:`compute_deltas`
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -213,8 +227,3 @@ vad
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: spectral_centroid
-
-:hidden:`apply_codec`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autofunction:: apply_codec


### PR DESCRIPTION
Adds subcategory to functional documentation, file `filtering` so that it's easier to see the separation in utilities and feature extractions.