### PR TITLE
feat(docs): navigate with left/right arrow keys

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -125,6 +125,7 @@ html_theme_options = {
     'collapse_navigation': False,
     'display_version': True,
     'logo_only': True,
+    'navigation_with_keys': True
 }
 
 html_logo = '_static/img/pytorch-logo-dark.svg'


### PR DESCRIPTION
Enables docs navigation with left/right arrow keys. It can be useful for the ones who navigate with keyboard a lot.
More info : https://github.com/sphinx-doc/sphinx/pull/2064

You can try here : https://174236-90321822-gh.circle-artifacts.com/0/docs/index.html