### PR TITLE
Make sox selective

### DIFF
--- a/test/torchaudio_unittest/backend/sox_io/info_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/info_test.py
@@ -16,8 +16,8 @@ from torchaudio_unittest.common_utils import (
     HttpServerMixin,
     PytorchTestCase,
     skipIfNoExec,
-    skipIfNoExtension,
     skipIfNoModule,
+    skipIfNoSox,
     get_asset_path,
     get_wav_data,
     save_wav,
@@ -33,7 +33,7 @@ if _mod_utils.is_module_available("requests"):
 
 
 @skipIfNoExec('sox')
-@skipIfNoExtension
+@skipIfNoSox
 class TestInfo(TempDirMixin, PytorchTestCase):
     @parameterized.expand(list(itertools.product(
         ['float32', 'int32', 'int16', 'uint8'],
@@ -253,7 +253,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
         assert info.encoding == "PCM_S"
 
 
-@skipIfNoExtension
+@skipIfNoSox
 class TestInfoOpus(PytorchTestCase):
     @parameterized.expand(list(itertools.product(
         ['96k'],
@@ -271,7 +271,7 @@ class TestInfoOpus(PytorchTestCase):
         assert info.encoding == "OPUS"
 
 
-@skipIfNoExtension
+@skipIfNoSox
 class TestLoadWithoutExtension(PytorchTestCase):
     def test_mp3(self):
         """Providing `format` allows to read mp3 without extension
@@ -306,7 +306,7 @@ class FileObjTestBase(TempDirMixin):
         return path
 
 
-@skipIfNoExtension
+@skipIfNoSox
 @skipIfNoExec('sox')
 class TestFileObject(FileObjTestBase, PytorchTestCase):
     def _query_fileobj(self, ext, dtype, sample_rate, num_channels, num_frames):
@@ -438,7 +438,7 @@ class TestFileObject(FileObjTestBase, PytorchTestCase):
         assert sinfo.encoding == get_encoding(ext, dtype)
 
 
-@skipIfNoExtension
+@skipIfNoSox
 @skipIfNoExec('sox')
 @skipIfNoModule("requests")
 class TestFileObjectHttp(HttpServerMixin, FileObjTestBase, PytorchTestCase):

--- a/test/torchaudio_unittest/backend/sox_io/load_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/load_test.py
@@ -11,8 +11,8 @@ from torchaudio_unittest.common_utils import (
     HttpServerMixin,
     PytorchTestCase,
     skipIfNoExec,
-    skipIfNoExtension,
     skipIfNoModule,
+    skipIfNoSox,
     get_asset_path,
     get_wav_data,
     load_wav,
@@ -200,7 +200,7 @@ class LoadTestBase(TempDirMixin, PytorchTestCase):
 
 
 @skipIfNoExec('sox')
-@skipIfNoExtension
+@skipIfNoSox
 class TestLoad(LoadTestBase):
     """Test the correctness of `sox_io_backend.load` for various formats"""
     @parameterized.expand(list(itertools.product(
@@ -332,7 +332,7 @@ class TestLoad(LoadTestBase):
 
 
 @skipIfNoExec('sox')
-@skipIfNoExtension
+@skipIfNoSox
 class TestLoadParams(TempDirMixin, PytorchTestCase):
     """Test the correctness of frame parameters of `sox_io_backend.load`"""
     original = None
@@ -363,7 +363,7 @@ class TestLoadParams(TempDirMixin, PytorchTestCase):
         self.assertEqual(found, expected)
 
 
-@skipIfNoExtension
+@skipIfNoSox
 class TestLoadWithoutExtension(PytorchTestCase):
     def test_mp3(self):
         """Providing format allows to read mp3 without extension
@@ -393,7 +393,7 @@ class CloggedFileObj:
         return ret
 
 
-@skipIfNoExtension
+@skipIfNoSox
 @skipIfNoExec('sox')
 class TestFileObject(TempDirMixin, PytorchTestCase):
     """
@@ -553,7 +553,7 @@ class TestFileObject(TempDirMixin, PytorchTestCase):
         self.assertEqual(expected, found)
 
 
-@skipIfNoExtension
+@skipIfNoSox
 @skipIfNoExec('sox')
 @skipIfNoModule("requests")
 class TestFileObjectHttp(HttpServerMixin, PytorchTestCase):

--- a/test/torchaudio_unittest/backend/sox_io/roundtrip_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/roundtrip_test.py
@@ -7,7 +7,7 @@ from torchaudio_unittest.common_utils import (
     TempDirMixin,
     PytorchTestCase,
     skipIfNoExec,
-    skipIfNoExtension,
+    skipIfNoSox,
     get_wav_data,
 )
 from .common import (
@@ -17,7 +17,7 @@ from .common import (
 
 
 @skipIfNoExec('sox')
-@skipIfNoExtension
+@skipIfNoSox
 class TestRoundTripIO(TempDirMixin, PytorchTestCase):
     """save/load round trip should not degrade data for lossless formats"""
     @parameterized.expand(list(itertools.product(

--- a/test/torchaudio_unittest/backend/sox_io/save_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/save_test.py
@@ -10,7 +10,7 @@ from torchaudio_unittest.common_utils import (
     TorchaudioTestCase,
     PytorchTestCase,
     skipIfNoExec,
-    skipIfNoExtension,
+    skipIfNoSox,
     get_wav_data,
     load_wav,
     save_wav,
@@ -157,7 +157,7 @@ def nested_params(*params):
 
 
 @skipIfNoExec('sox')
-@skipIfNoExtension
+@skipIfNoSox
 class SaveTest(SaveTestBase):
     @nested_params(
         ["path", "fileobj", "bytesio"],
@@ -354,7 +354,7 @@ class SaveTest(SaveTestBase):
 
 
 @skipIfNoExec('sox')
-@skipIfNoExtension
+@skipIfNoSox
 class TestSaveParams(TempDirMixin, PytorchTestCase):
     """Test the correctness of optional parameters of `sox_io_backend.save`"""
     @parameterized.expand([(True, ), (False, )], name_func=name_func)

--- a/test/torchaudio_unittest/backend/sox_io/smoke_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/smoke_test.py
@@ -4,6 +4,7 @@ import unittest
 
 from torchaudio.utils import sox_utils
 from torchaudio.backend import sox_io_backend
+from torchaudio._internal.module_utils import is_sox_available
 from parameterized import parameterized
 
 from torchaudio_unittest.common_utils import (
@@ -16,7 +17,7 @@ from .common import name_func
 
 
 skipIfNoMP3 = unittest.skipIf(
-    not sox_utils.is_sox_available() or
+    not is_sox_available() or
     'mp3' not in sox_utils.list_read_formats() or
     'mp3' not in sox_utils.list_write_formats(),
     '"sox_io" backend does not support MP3')

--- a/test/torchaudio_unittest/backend/sox_io/smoke_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/smoke_test.py
@@ -10,20 +10,20 @@ from parameterized import parameterized
 from torchaudio_unittest.common_utils import (
     TempDirMixin,
     TorchaudioTestCase,
-    skipIfNoExtension,
+    skipIfNoSox,
     get_wav_data,
 )
 from .common import name_func
 
 
 skipIfNoMP3 = unittest.skipIf(
-    not is_module_available('torchaudio._torchaudio') or
+    not sox_utils.is_sox_available() or
     'mp3' not in sox_utils.list_read_formats() or
     'mp3' not in sox_utils.list_write_formats(),
     '"sox_io" backend does not support MP3')
 
 
-@skipIfNoExtension
+@skipIfNoSox
 class SmokeTest(TempDirMixin, TorchaudioTestCase):
     """Run smoke test on various audio format
 
@@ -88,7 +88,7 @@ class SmokeTest(TempDirMixin, TorchaudioTestCase):
         self.run_smoke_test('flac', sample_rate, num_channels, compression=compression_level)
 
 
-@skipIfNoExtension
+@skipIfNoSox
 class SmokeTestFileObj(TorchaudioTestCase):
     """Run smoke test on various audio format
 

--- a/test/torchaudio_unittest/backend/sox_io/smoke_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/smoke_test.py
@@ -4,7 +4,6 @@ import unittest
 
 from torchaudio.utils import sox_utils
 from torchaudio.backend import sox_io_backend
-from torchaudio._internal.module_utils import is_module_available
 from parameterized import parameterized
 
 from torchaudio_unittest.common_utils import (

--- a/test/torchaudio_unittest/backend/sox_io/torchscript_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/torchscript_test.py
@@ -9,7 +9,7 @@ from torchaudio_unittest.common_utils import (
     TempDirMixin,
     TorchaudioTestCase,
     skipIfNoExec,
-    skipIfNoExtension,
+    skipIfNoSox,
     get_wav_data,
     save_wav,
     load_wav,
@@ -45,7 +45,7 @@ def py_save_func(
 
 
 @skipIfNoExec('sox')
-@skipIfNoExtension
+@skipIfNoSox
 class SoxIO(TempDirMixin, TorchaudioTestCase):
     """TorchScript-ability Test suite for `sox_io_backend`"""
     backend = 'sox_io'

--- a/test/torchaudio_unittest/backend/utils_test.py
+++ b/test/torchaudio_unittest/backend/utils_test.py
@@ -25,7 +25,7 @@ class TestBackendSwitch_NoBackend(BackendSwitchMixin, common_utils.TorchaudioTes
     backend_module = torchaudio.backend.no_backend
 
 
-@common_utils.skipIfNoExtension
+@common_utils.skipIfNoSox
 class TestBackendSwitch_SoXIO(BackendSwitchMixin, common_utils.TorchaudioTestCase):
     backend = 'sox_io'
     backend_module = torchaudio.backend.sox_io_backend

--- a/test/torchaudio_unittest/common_utils/__init__.py
+++ b/test/torchaudio_unittest/common_utils/__init__.py
@@ -16,6 +16,7 @@ from .case_utils import (
     skipIfNoExec,
     skipIfNoModule,
     skipIfNoExtension,
+    skipIfNoSox,
     skipIfNoSoxBackend,
 )
 from .wav_utils import (
@@ -30,5 +31,5 @@ from .parameterized_utils import (
 
 __all__ = ['get_asset_path', 'get_whitenoise', 'get_sinusoid', 'set_audio_backend',
            'TempDirMixin', 'HttpServerMixin', 'TestBaseMixin', 'PytorchTestCase', 'TorchaudioTestCase',
-           'skipIfNoCuda', 'skipIfNoExec', 'skipIfNoModule', 'skipIfNoExtension', 'skipIfNoSoxBackend',
-           'get_wav_data', 'normalize_wav', 'load_wav', 'save_wav', 'load_params']
+           'skipIfNoCuda', 'skipIfNoExec', 'skipIfNoModule', 'skipIfNoExtension', 'skipIfNoSox',
+           'skipIfNoSoxBackend', 'get_wav_data', 'normalize_wav', 'load_wav', 'save_wav', 'load_params']

--- a/test/torchaudio_unittest/common_utils/case_utils.py
+++ b/test/torchaudio_unittest/common_utils/case_utils.py
@@ -8,7 +8,10 @@ import unittest
 import torch
 from torch.testing._internal.common_utils import TestCase as PytorchTestCase
 import torchaudio
-from torchaudio._internal.module_utils import is_module_available
+from torchaudio._internal.module_utils import (
+    is_module_available,
+    is_sox_available
+)
 from torchaudio.utils import sox_utils
 
 from .backend_utils import set_audio_backend
@@ -77,7 +80,6 @@ class TestBaseMixin:
 
     def setUp(self):
         super().setUp()
-        # if self.backend != "sox_io" or sox_utils.is_sox_available():
         set_audio_backend(self.backend)
 
 
@@ -97,7 +99,7 @@ def skipIfNoModule(module, display_name=None):
 skipIfNoSoxBackend = unittest.skipIf(
     'sox' not in torchaudio.list_audio_backends(), 'Sox backend not available')
 skipIfNoCuda = unittest.skipIf(not torch.cuda.is_available(), reason='CUDA not available')
-skipIfNoSox = unittest.skipIf(not sox_utils.is_sox_available(), reason='Sox not available')
+skipIfNoSox = unittest.skipIf(not is_sox_available(), reason='Sox not available')
 
 
 def skipIfNoExtension(test_item):

--- a/test/torchaudio_unittest/common_utils/case_utils.py
+++ b/test/torchaudio_unittest/common_utils/case_utils.py
@@ -99,6 +99,7 @@ skipIfNoSoxBackend = unittest.skipIf(
 skipIfNoCuda = unittest.skipIf(not torch.cuda.is_available(), reason='CUDA not available')
 skipIfNoSox = unittest.skipIf(not sox_utils.is_sox_available(), reason='Sox not available')
 
+
 def skipIfNoExtension(test_item):
     if is_module_available('torchaudio._torchaudio'):
         return test_item

--- a/test/torchaudio_unittest/common_utils/case_utils.py
+++ b/test/torchaudio_unittest/common_utils/case_utils.py
@@ -12,7 +12,6 @@ from torchaudio._internal.module_utils import (
     is_module_available,
     is_sox_available
 )
-from torchaudio.utils import sox_utils
 
 from .backend_utils import set_audio_backend
 

--- a/test/torchaudio_unittest/common_utils/case_utils.py
+++ b/test/torchaudio_unittest/common_utils/case_utils.py
@@ -9,6 +9,7 @@ import torch
 from torch.testing._internal.common_utils import TestCase as PytorchTestCase
 import torchaudio
 from torchaudio._internal.module_utils import is_module_available
+from torchaudio.utils import sox_utils
 
 from .backend_utils import set_audio_backend
 
@@ -76,6 +77,7 @@ class TestBaseMixin:
 
     def setUp(self):
         super().setUp()
+        # if self.backend != "sox_io" or sox_utils.is_sox_available():
         set_audio_backend(self.backend)
 
 
@@ -95,7 +97,7 @@ def skipIfNoModule(module, display_name=None):
 skipIfNoSoxBackend = unittest.skipIf(
     'sox' not in torchaudio.list_audio_backends(), 'Sox backend not available')
 skipIfNoCuda = unittest.skipIf(not torch.cuda.is_available(), reason='CUDA not available')
-
+skipIfNoSox = unittest.skipIf(not sox_utils.is_sox_available(), reason='Sox not available')
 
 def skipIfNoExtension(test_item):
     if is_module_available('torchaudio._torchaudio'):

--- a/test/torchaudio_unittest/datasets/tedlium_test.py
+++ b/test/torchaudio_unittest/datasets/tedlium_test.py
@@ -7,6 +7,7 @@ from torchaudio_unittest.common_utils import (
     TorchaudioTestCase,
     get_whitenoise,
     save_wav,
+    skipIfNoSox
 )
 
 from torchaudio.datasets import tedlium
@@ -144,5 +145,6 @@ class TestTedliumSoundfile(Tedlium, TorchaudioTestCase):
 
 
 if platform.system() != "Windows":
+    @skipIfNoSox
     class TestTedliumSoxIO(Tedlium, TorchaudioTestCase):
         backend = "sox_io"

--- a/test/torchaudio_unittest/functional/functional_cpu_test.py
+++ b/test/torchaudio_unittest/functional/functional_cpu_test.py
@@ -10,7 +10,7 @@ import itertools
 from torchaudio_unittest import common_utils
 from torchaudio_unittest.common_utils import (
     TorchaudioTestCase,
-    skipIfNoExtension,
+    skipIfNoSox,
 )
 from torchaudio_unittest.backend.sox_io.common import name_func
 
@@ -220,7 +220,7 @@ class TestMaskAlongAxisIID(common_utils.TorchaudioTestCase):
         assert (num_masked_columns < mask_param).sum() == num_masked_columns.numel()
 
 
-@skipIfNoExtension
+@skipIfNoSox
 class TestApplyCodec(TorchaudioTestCase):
     backend = "sox_io"
 

--- a/test/torchaudio_unittest/sox_effect/dataset_test.py
+++ b/test/torchaudio_unittest/sox_effect/dataset_test.py
@@ -11,7 +11,7 @@ import torchaudio
 from torchaudio_unittest.common_utils import (
     TempDirMixin,
     PytorchTestCase,
-    skipIfNoExtension,
+    skipIfNoSox,
     get_whitenoise,
     save_wav,
 )
@@ -71,7 +71,7 @@ def init_random_seed(worker_id):
     dataset.rng = np.random.RandomState(worker_id)
 
 
-@skipIfNoExtension
+@skipIfNoSox
 @skipIf(
     platform.system() == 'Darwin' and
     sys.version_info.major == 3 and
@@ -134,7 +134,7 @@ def speed(path):
     return torchaudio.sox_effects.apply_effects_tensor(wav, sample_rate, effects)[0]
 
 
-@skipIfNoExtension
+@skipIfNoSox
 class TestProcessPoolExecutor(TempDirMixin, PytorchTestCase):
     backend = "sox_io"
 

--- a/test/torchaudio_unittest/sox_effect/smoke_test.py
+++ b/test/torchaudio_unittest/sox_effect/smoke_test.py
@@ -4,7 +4,7 @@ from parameterized import parameterized
 from torchaudio_unittest.common_utils import (
     TempDirMixin,
     TorchaudioTestCase,
-    skipIfNoExtension,
+    skipIfNoSox,
     get_wav_data,
     get_sinusoid,
     save_wav,
@@ -14,7 +14,7 @@ from .common import (
 )
 
 
-@skipIfNoExtension
+@skipIfNoSox
 class SmokeTest(TempDirMixin, TorchaudioTestCase):
     """Run smoke test on various effects
 

--- a/test/torchaudio_unittest/sox_effect/sox_effect_test.py
+++ b/test/torchaudio_unittest/sox_effect/sox_effect_test.py
@@ -11,7 +11,7 @@ from torchaudio_unittest.common_utils import (
     TempDirMixin,
     HttpServerMixin,
     PytorchTestCase,
-    skipIfNoExtension,
+    skipIfNoSox,
     skipIfNoModule,
     skipIfNoExec,
     get_asset_path,
@@ -31,7 +31,7 @@ if _mod_utils.is_module_available("requests"):
     import requests
 
 
-@skipIfNoExtension
+@skipIfNoSox
 class TestSoxEffects(PytorchTestCase):
     def test_init(self):
         """Calling init_sox_effects multiple times does not crush"""
@@ -39,7 +39,7 @@ class TestSoxEffects(PytorchTestCase):
             sox_effects.init_sox_effects()
 
 
-@skipIfNoExtension
+@skipIfNoSox
 class TestSoxEffectsTensor(TempDirMixin, PytorchTestCase):
     """Test suite for `apply_effects_tensor` function"""
     @parameterized.expand(list(itertools.product(
@@ -91,7 +91,7 @@ class TestSoxEffectsTensor(TempDirMixin, PytorchTestCase):
         self.assertEqual(expected, found)
 
 
-@skipIfNoExtension
+@skipIfNoSox
 class TestSoxEffectsFile(TempDirMixin, PytorchTestCase):
     """Test suite for `apply_effects_file` function"""
     @parameterized.expand(list(itertools.product(
@@ -163,7 +163,7 @@ class TestSoxEffectsFile(TempDirMixin, PytorchTestCase):
         self.assertEqual(found, expected)
 
 
-@skipIfNoExtension
+@skipIfNoSox
 class TestFileFormats(TempDirMixin, PytorchTestCase):
     """`apply_effects_file` gives the same result as sox on various file formats"""
     @parameterized.expand(list(itertools.product(
@@ -256,7 +256,7 @@ class TestFileFormats(TempDirMixin, PytorchTestCase):
         self.assertEqual(found, expected)
 
 
-@skipIfNoExtension
+@skipIfNoSox
 class TestApplyEffectFileWithoutExtension(PytorchTestCase):
     def test_mp3(self):
         """Providing format allows to read mp3 without extension
@@ -275,7 +275,7 @@ class TestApplyEffectFileWithoutExtension(PytorchTestCase):
 
 
 @skipIfNoExec('sox')
-@skipIfNoExtension
+@skipIfNoSox
 class TestFileObject(TempDirMixin, PytorchTestCase):
     @parameterized.expand([
         ('wav', None),
@@ -384,7 +384,7 @@ class TestFileObject(TempDirMixin, PytorchTestCase):
         self.assertEqual(found, expected)
 
 
-@skipIfNoExtension
+@skipIfNoSox
 @skipIfNoExec('sox')
 @skipIfNoModule("requests")
 class TestFileObjectHttp(HttpServerMixin, PytorchTestCase):

--- a/test/torchaudio_unittest/sox_effect/torchscript_test.py
+++ b/test/torchaudio_unittest/sox_effect/torchscript_test.py
@@ -7,7 +7,7 @@ from parameterized import parameterized
 from torchaudio_unittest.common_utils import (
     TempDirMixin,
     PytorchTestCase,
-    skipIfNoExtension,
+    skipIfNoSox,
     get_sinusoid,
     save_wav,
 )
@@ -43,7 +43,7 @@ class SoxEffectFileTransform(torch.nn.Module):
         return sox_effects.apply_effects_file(path, self.effects, self.channels_first)
 
 
-@skipIfNoExtension
+@skipIfNoSox
 class TestTorchScript(TempDirMixin, PytorchTestCase):
     @parameterized.expand(
         load_params("sox_effect_test_args.json"),

--- a/test/torchaudio_unittest/utils/sox_utils_test.py
+++ b/test/torchaudio_unittest/utils/sox_utils_test.py
@@ -2,11 +2,11 @@ from torchaudio.utils import sox_utils
 
 from torchaudio_unittest.common_utils import (
     PytorchTestCase,
-    skipIfNoExtension,
+    skipIfNoSox,
 )
 
 
-@skipIfNoExtension
+@skipIfNoSox
 class TestSoxUtils(PytorchTestCase):
     """Smoke tests for sox_util module"""
     def test_set_seed(self):

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -10,12 +10,8 @@ if (BUILD_SOX)
   add_subdirectory(sox)
   target_include_directories(libsox INTERFACE ${SOX_INCLUDE_DIR})
   target_link_libraries(libsox INTERFACE ${SOX_LIBRARIES})
-else()
-  # If not building and linking libsox statically, then we expect that
-  # sox library and header are found in search path
-  target_link_libraries(libsox INTERFACE -lsox)
+  list(APPEND TORCHAUDIO_THIRD_PARTIES libsox)
 endif()
-list(APPEND TORCHAUDIO_THIRD_PARTIES libsox)
 
 ################################################################################
 # kaldi

--- a/torchaudio/_internal/module_utils.py
+++ b/torchaudio/_internal/module_utils.py
@@ -3,6 +3,8 @@ import importlib.util
 from typing import Optional
 from functools import wraps
 
+import torch
+
 
 def is_module_available(*modules: str) -> bool:
     r"""Returns if a top-level module with :attr:`name` exists *without**
@@ -55,4 +57,21 @@ def deprecated(direction: str, version: Optional[str] = None):
             warnings.warn(message, stacklevel=2)
             return func(*args, **kwargs)
         return wrapped
+    return decorator
+
+
+def is_sox_available():
+    return is_module_available('torchaudio._torchaudio') and torch.ops.torchaudio.is_sox_available()
+
+
+def requires_sox():
+    if is_sox_available():
+        def decorator(func):
+            return func
+    else:
+        def decorator(func):
+            @wraps(func)
+            def wrapped(*args, **kwargs):
+                raise RuntimeError(f'{func.__module__}.{func.__name__} requires sox')
+            return wrapped
     return decorator

--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -5,13 +5,12 @@ import torch
 from torchaudio._internal import (
     module_utils as _mod_utils,
 )
-from torchaudio.utils.sox_utils import requires_sox
 
 import torchaudio
 from .common import AudioMetaData
 
 
-@requires_sox()
+@_mod_utils.requires_sox()
 @_mod_utils.requires_module('torchaudio._torchaudio')
 def info(
         filepath: str,
@@ -56,7 +55,7 @@ def info(
     return AudioMetaData(*sinfo)
 
 
-@requires_sox()
+@_mod_utils.requires_sox()
 @_mod_utils.requires_module('torchaudio._torchaudio')
 def load(
         filepath: str,
@@ -154,7 +153,7 @@ def load(
         filepath, frame_offset, num_frames, normalize, channels_first, format)
 
 
-@requires_sox()
+@_mod_utils.requires_sox()
 @_mod_utils.requires_module('torchaudio._torchaudio')
 def save(
         filepath: str,

--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -10,6 +10,7 @@ from torchaudio.utils.sox_utils import requires_sox
 import torchaudio
 from .common import AudioMetaData
 
+
 @requires_sox()
 @_mod_utils.requires_module('torchaudio._torchaudio')
 def info(

--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -5,11 +5,12 @@ import torch
 from torchaudio._internal import (
     module_utils as _mod_utils,
 )
+from torchaudio.utils.sox_utils import requires_sox
 
 import torchaudio
 from .common import AudioMetaData
 
-
+@requires_sox()
 @_mod_utils.requires_module('torchaudio._torchaudio')
 def info(
         filepath: str,
@@ -54,6 +55,7 @@ def info(
     return AudioMetaData(*sinfo)
 
 
+@requires_sox()
 @_mod_utils.requires_module('torchaudio._torchaudio')
 def load(
         filepath: str,
@@ -151,6 +153,7 @@ def load(
         filepath, frame_offset, num_frames, normalize, channels_first, format)
 
 
+@requires_sox()
 @_mod_utils.requires_module('torchaudio._torchaudio')
 def save(
         filepath: str,

--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -11,7 +11,6 @@ from .common import AudioMetaData
 
 
 @_mod_utils.requires_sox()
-@_mod_utils.requires_module('torchaudio._torchaudio')
 def info(
         filepath: str,
         format: Optional[str] = None,
@@ -56,7 +55,6 @@ def info(
 
 
 @_mod_utils.requires_sox()
-@_mod_utils.requires_module('torchaudio._torchaudio')
 def load(
         filepath: str,
         frame_offset: int = 0,
@@ -154,7 +152,6 @@ def load(
 
 
 @_mod_utils.requires_sox()
-@_mod_utils.requires_module('torchaudio._torchaudio')
 def save(
         filepath: str,
         src: torch.Tensor,

--- a/torchaudio/backend/utils.py
+++ b/torchaudio/backend/utils.py
@@ -7,7 +7,6 @@ from torchaudio._internal.module_utils import (
     is_module_available,
     is_sox_available
 )
-from torchaudio.utils import sox_utils
 from . import (
     no_backend,
     sox_io_backend,

--- a/torchaudio/backend/utils.py
+++ b/torchaudio/backend/utils.py
@@ -3,7 +3,10 @@ import warnings
 from typing import Optional, List
 
 import torchaudio
-from torchaudio._internal.module_utils import is_module_available
+from torchaudio._internal.module_utils import (
+    is_module_available,
+    is_sox_available
+)
 from torchaudio.utils import sox_utils
 from . import (
     no_backend,
@@ -27,7 +30,7 @@ def list_audio_backends() -> List[str]:
     backends = []
     if is_module_available('soundfile'):
         backends.append('soundfile')
-    if sox_utils.is_sox_available():
+    if is_sox_available():
         backends.append('sox_io')
     return backends
 

--- a/torchaudio/backend/utils.py
+++ b/torchaudio/backend/utils.py
@@ -3,10 +3,7 @@ import warnings
 from typing import Optional, List
 
 import torchaudio
-from torchaudio._internal.module_utils import (
-    is_module_available,
-    is_sox_available
-)
+from torchaudio._internal import module_utils as _mod_utils
 from . import (
     no_backend,
     sox_io_backend,
@@ -27,9 +24,9 @@ def list_audio_backends() -> List[str]:
         List[str]: The list of available backends.
     """
     backends = []
-    if is_module_available('soundfile'):
+    if _mod_utils.is_module_available('soundfile'):
         backends.append('soundfile')
-    if is_sox_available():
+    if _mod_utils.is_sox_available():
         backends.append('sox_io')
     return backends
 

--- a/torchaudio/backend/utils.py
+++ b/torchaudio/backend/utils.py
@@ -4,6 +4,7 @@ from typing import Optional, List
 
 import torchaudio
 from torchaudio._internal.module_utils import is_module_available
+from torchaudio.utils import sox_utils
 from . import (
     no_backend,
     sox_io_backend,
@@ -26,7 +27,7 @@ def list_audio_backends() -> List[str]:
     backends = []
     if is_module_available('soundfile'):
         backends.append('soundfile')
-    if is_module_available('torchaudio._torchaudio'):
+    if sox_utils.is_sox_available():
         backends.append('sox_io')
     return backends
 

--- a/torchaudio/csrc/CMakeLists.txt
+++ b/torchaudio/csrc/CMakeLists.txt
@@ -5,11 +5,6 @@ get_property(TORCHAUDIO_THIRD_PARTIES GLOBAL PROPERTY TORCHAUDIO_THIRD_PARTIES)
 ################################################################################
 set(
   LIBTORCHAUDIO_SOURCES
-  sox/io.cpp
-  sox/utils.cpp
-  sox/effects.cpp
-  sox/effects_chain.cpp
-  sox/types.cpp
   lfilter.cpp
   overdrive.cpp
   )
@@ -20,6 +15,18 @@ endif()
 
 if(BUILD_KALDI)
   list(APPEND LIBTORCHAUDIO_SOURCES kaldi.cpp)
+endif()
+
+if(BUILD_SOX)
+  set(
+    SOX_SOURCES
+    sox/io.cpp
+    sox/utils.cpp
+    sox/effects.cpp
+    sox/effects_chain.cpp
+    sox/types.cpp
+  )
+  list(APPEND LIBTORCHAUDIO_SOURCES ${SOX_SOURCES})
 endif()
 
 ################################################################################
@@ -57,10 +64,13 @@ endif()
 # _torchaudio.so
 ################################################################################
 if (BUILD_TORCHAUDIO_PYTHON_EXTENSION)
+  if (BUILD_SOX)
+    list(APPEND LIBTORCHAUDIO_SOURCES pybind.cpp)
+  endif()
+
   add_library(
     _torchaudio
     SHARED
-    pybind.cpp
     ${LIBTORCHAUDIO_SOURCES}
     )
 

--- a/torchaudio/csrc/CMakeLists.txt
+++ b/torchaudio/csrc/CMakeLists.txt
@@ -7,6 +7,7 @@ set(
   LIBTORCHAUDIO_SOURCES
   lfilter.cpp
   overdrive.cpp
+  utils.cpp
   )
 
 if(BUILD_TRANSDUCER)
@@ -64,13 +65,10 @@ endif()
 # _torchaudio.so
 ################################################################################
 if (BUILD_TORCHAUDIO_PYTHON_EXTENSION)
-  if (BUILD_SOX)
-    list(APPEND LIBTORCHAUDIO_SOURCES pybind.cpp)
-  endif()
-
   add_library(
     _torchaudio
     SHARED
+    pybind.cpp
     ${LIBTORCHAUDIO_SOURCES}
     )
 
@@ -85,6 +83,10 @@ if (BUILD_TORCHAUDIO_PYTHON_EXTENSION)
   target_compile_definitions(
     _torchaudio PRIVATE TORCH_API_INCLUDE_EXTENSION_H
   )
+
+  if (BUILD_SOX)
+    target_compile_definitions(_torchaudio PRIVATE INCLUDE_SOX)
+  endif()
 
   target_include_directories(
     _torchaudio

--- a/torchaudio/csrc/pybind.cpp
+++ b/torchaudio/csrc/pybind.cpp
@@ -3,8 +3,10 @@
 #ifdef INCLUDE_SOX
 #include <torchaudio/csrc/sox/effects.h>
 #include <torchaudio/csrc/sox/io.h>
+#endif
 
 PYBIND11_MODULE(_torchaudio, m) {
+#ifdef INCLUDE_SOX
   m.def(
       "get_info_fileobj",
       &torchaudio::sox_io::get_info_fileobj,
@@ -21,7 +23,5 @@ PYBIND11_MODULE(_torchaudio, m) {
       "apply_effects_fileobj",
       &torchaudio::sox_effects::apply_effects_fileobj,
       "Decode audio data from file-like obj and apply effects.");
-}
-#else
-PYBIND11_MODULE(_torchaudio, m) {}
 #endif
+}

--- a/torchaudio/csrc/pybind.cpp
+++ b/torchaudio/csrc/pybind.cpp
@@ -1,4 +1,6 @@
 #include <torch/extension.h>
+
+#ifdef INCLUDE_SOX
 #include <torchaudio/csrc/sox/effects.h>
 #include <torchaudio/csrc/sox/io.h>
 
@@ -20,3 +22,6 @@ PYBIND11_MODULE(_torchaudio, m) {
       &torchaudio::sox_effects::apply_effects_fileobj,
       "Decode audio data from file-like obj and apply effects.");
 }
+#else
+PYBIND11_MODULE(_torchaudio, m) {}
+#endif

--- a/torchaudio/csrc/sox/utils.h
+++ b/torchaudio/csrc/sox/utils.h
@@ -15,8 +15,6 @@ namespace sox_utils {
 // APIs for Python interaction
 ////////////////////////////////////////////////////////////////////////////////
 
-bool is_sox_available();
-
 /// Set sox global options
 void set_seed(const int64_t seed);
 

--- a/torchaudio/csrc/sox/utils.h
+++ b/torchaudio/csrc/sox/utils.h
@@ -15,6 +15,8 @@ namespace sox_utils {
 // APIs for Python interaction
 ////////////////////////////////////////////////////////////////////////////////
 
+bool is_sox_available();
+
 /// Set sox global options
 void set_seed(const int64_t seed);
 

--- a/torchaudio/csrc/utils.cpp
+++ b/torchaudio/csrc/utils.cpp
@@ -1,5 +1,7 @@
 #include <torch/script.h>
 
+namespace torchaudio {
+
 namespace {
 
 bool is_sox_available() {
@@ -15,3 +17,5 @@ bool is_sox_available() {
 TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
   m.def("torchaudio::is_sox_available", &is_sox_available);
 }
+
+} // namespace torchaudio

--- a/torchaudio/csrc/utils.cpp
+++ b/torchaudio/csrc/utils.cpp
@@ -1,0 +1,17 @@
+#include <torch/script.h>
+
+namespace {
+
+bool is_sox_available() {
+#ifdef INCLUDE_SOX
+  return true;
+#else
+  return false;
+#endif
+}
+
+} // namespace
+
+TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
+  m.def("torchaudio::is_sox_available", &is_sox_available);
+}

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -10,6 +10,7 @@ from torch import Tensor
 from torchaudio._internal import (
     module_utils as _mod_utils,
 )
+from torchaudio.utils.sox_utils import requires_sox
 import torchaudio
 
 __all__ = [
@@ -1000,7 +1001,7 @@ def spectral_centroid(
     return (freqs * specgram).sum(dim=freq_dim) / specgram.sum(dim=freq_dim)
 
 
-@_mod_utils.requires_module('torchaudio._torchaudio')
+@requires_sox()
 def apply_codec(
     waveform: Tensor,
     sample_rate: int,

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -7,7 +7,7 @@ from typing import Optional, Tuple
 
 import torch
 from torch import Tensor
-from torchaudio.utils.sox_utils import requires_sox
+from torchaudio._internal import module_utils as _mod_utils
 import torchaudio
 
 __all__ = [
@@ -998,7 +998,7 @@ def spectral_centroid(
     return (freqs * specgram).sum(dim=freq_dim) / specgram.sum(dim=freq_dim)
 
 
-@requires_sox()
+@_mod_utils.requires_sox()
 def apply_codec(
     waveform: Tensor,
     sample_rate: int,

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -7,9 +7,6 @@ from typing import Optional, Tuple
 
 import torch
 from torch import Tensor
-from torchaudio._internal import (
-    module_utils as _mod_utils,
-)
 from torchaudio.utils.sox_utils import requires_sox
 import torchaudio
 

--- a/torchaudio/sox_effects/__init__.py
+++ b/torchaudio/sox_effects/__init__.py
@@ -1,4 +1,4 @@
-from torchaudio.utils import sox_utils
+from torchaudio._internal.module_utils import is_sox_available
 from .sox_effects import (
     init_sox_effects,
     shutdown_sox_effects,
@@ -8,7 +8,7 @@ from .sox_effects import (
 )
 
 
-if sox_utils.is_sox_available():
+if is_sox_available():
     import atexit
     init_sox_effects()
     atexit.register(shutdown_sox_effects)

--- a/torchaudio/sox_effects/__init__.py
+++ b/torchaudio/sox_effects/__init__.py
@@ -1,4 +1,4 @@
-from torchaudio._internal.module_utils import is_sox_available
+from torchaudio._internal import module_utils as _mod_utils
 from .sox_effects import (
     init_sox_effects,
     shutdown_sox_effects,
@@ -8,7 +8,7 @@ from .sox_effects import (
 )
 
 
-if is_sox_available():
+if _mod_utils.is_sox_available():
     import atexit
     init_sox_effects()
     atexit.register(shutdown_sox_effects)

--- a/torchaudio/sox_effects/__init__.py
+++ b/torchaudio/sox_effects/__init__.py
@@ -1,4 +1,4 @@
-from torchaudio._internal import module_utils as _mod_utils
+from torchaudio.utils import sox_utils
 from .sox_effects import (
     init_sox_effects,
     shutdown_sox_effects,
@@ -8,7 +8,7 @@ from .sox_effects import (
 )
 
 
-if _mod_utils.is_module_available('torchaudio._torchaudio'):
+if sox_utils.is_sox_available():
     import atexit
     init_sox_effects()
     atexit.register(shutdown_sox_effects)

--- a/torchaudio/sox_effects/sox_effects.py
+++ b/torchaudio/sox_effects/sox_effects.py
@@ -5,10 +5,10 @@ import torch
 
 import torchaudio
 from torchaudio._internal import module_utils as _mod_utils
-from torchaudio.utils.sox_utils import list_effects, requires_sox
+from torchaudio.utils.sox_utils import list_effects
 
 
-@requires_sox()
+@_mod_utils.requires_sox()
 def init_sox_effects():
     """Initialize resources required to use sox effects.
 
@@ -23,7 +23,7 @@ def init_sox_effects():
     torch.ops.torchaudio.sox_effects_initialize_sox_effects()
 
 
-@requires_sox()
+@_mod_utils.requires_sox()
 def shutdown_sox_effects():
     """Clean up resources required to use sox effects.
 
@@ -37,7 +37,7 @@ def shutdown_sox_effects():
     torch.ops.torchaudio.sox_effects_shutdown_sox_effects()
 
 
-@requires_sox()
+@_mod_utils.requires_sox()
 def effect_names() -> List[str]:
     """Gets list of valid sox effect names
 
@@ -51,7 +51,7 @@ def effect_names() -> List[str]:
     return list(list_effects().keys())
 
 
-@requires_sox()
+@_mod_utils.requires_sox()
 def apply_effects_tensor(
         tensor: torch.Tensor,
         sample_rate: int,
@@ -152,7 +152,7 @@ def apply_effects_tensor(
         tensor, sample_rate, effects, channels_first)
 
 
-@requires_sox()
+@_mod_utils.requires_sox()
 @_mod_utils.requires_module('torchaudio._torchaudio')
 def apply_effects_file(
         path: str,

--- a/torchaudio/sox_effects/sox_effects.py
+++ b/torchaudio/sox_effects/sox_effects.py
@@ -153,7 +153,6 @@ def apply_effects_tensor(
 
 
 @_mod_utils.requires_sox()
-@_mod_utils.requires_module('torchaudio._torchaudio')
 def apply_effects_file(
         path: str,
         effects: List[List[str]],

--- a/torchaudio/sox_effects/sox_effects.py
+++ b/torchaudio/sox_effects/sox_effects.py
@@ -7,6 +7,7 @@ import torchaudio
 from torchaudio._internal import module_utils as _mod_utils
 from torchaudio.utils.sox_utils import list_effects, requires_sox
 
+
 @requires_sox()
 def init_sox_effects():
     """Initialize resources required to use sox effects.

--- a/torchaudio/sox_effects/sox_effects.py
+++ b/torchaudio/sox_effects/sox_effects.py
@@ -5,10 +5,9 @@ import torch
 
 import torchaudio
 from torchaudio._internal import module_utils as _mod_utils
-from torchaudio.utils.sox_utils import list_effects
+from torchaudio.utils.sox_utils import list_effects, requires_sox
 
-
-@_mod_utils.requires_module('torchaudio._torchaudio')
+@requires_sox()
 def init_sox_effects():
     """Initialize resources required to use sox effects.
 
@@ -23,7 +22,7 @@ def init_sox_effects():
     torch.ops.torchaudio.sox_effects_initialize_sox_effects()
 
 
-@_mod_utils.requires_module("torchaudio._torchaudio")
+@requires_sox()
 def shutdown_sox_effects():
     """Clean up resources required to use sox effects.
 
@@ -37,7 +36,7 @@ def shutdown_sox_effects():
     torch.ops.torchaudio.sox_effects_shutdown_sox_effects()
 
 
-@_mod_utils.requires_module('torchaudio._torchaudio')
+@requires_sox()
 def effect_names() -> List[str]:
     """Gets list of valid sox effect names
 
@@ -51,7 +50,7 @@ def effect_names() -> List[str]:
     return list(list_effects().keys())
 
 
-@_mod_utils.requires_module('torchaudio._torchaudio')
+@requires_sox()
 def apply_effects_tensor(
         tensor: torch.Tensor,
         sample_rate: int,
@@ -152,6 +151,7 @@ def apply_effects_tensor(
         tensor, sample_rate, effects, channels_first)
 
 
+@requires_sox()
 @_mod_utils.requires_module('torchaudio._torchaudio')
 def apply_effects_file(
         path: str,

--- a/torchaudio/utils/__init__.py
+++ b/torchaudio/utils/__init__.py
@@ -1,8 +1,8 @@
 from . import (
     sox_utils,
 )
-from torchaudio._internal.module_utils import is_sox_available
+from torchaudio._internal import module_utils as _mod_utils
 
 
-if is_sox_available():
+if _mod_utils.is_sox_available():
     sox_utils.set_verbosity(1)

--- a/torchaudio/utils/__init__.py
+++ b/torchaudio/utils/__init__.py
@@ -2,8 +2,6 @@ from . import (
     sox_utils,
 )
 
-from torchaudio._internal import module_utils as _mod_utils
 
-
-if _mod_utils.is_module_available('torchaudio._torchaudio'):
+if sox_utils.is_sox_available():
     sox_utils.set_verbosity(1)

--- a/torchaudio/utils/__init__.py
+++ b/torchaudio/utils/__init__.py
@@ -1,7 +1,8 @@
 from . import (
     sox_utils,
 )
+from torchaudio._internal.module_utils import is_sox_available
 
 
-if sox_utils.is_sox_available():
+if is_sox_available():
     sox_utils.set_verbosity(1)

--- a/torchaudio/utils/sox_utils.py
+++ b/torchaudio/utils/sox_utils.py
@@ -1,5 +1,4 @@
 from typing import List, Dict
-from functools import wraps
 
 import torch
 from torchaudio._internal import module_utils as _mod_utils

--- a/torchaudio/utils/sox_utils.py
+++ b/torchaudio/utils/sox_utils.py
@@ -1,4 +1,5 @@
 from typing import List, Dict
+from functools import wraps
 
 import torch
 
@@ -6,8 +7,22 @@ from torchaudio._internal import (
     module_utils as _mod_utils,
 )
 
+def is_sox_available():
+    return torch.ops.torchaudio.is_sox_available()
 
-@_mod_utils.requires_module('torchaudio._torchaudio')
+def requires_sox():
+    if is_sox_available():
+        def decorator(func):
+            return func
+    else:
+        def decorator(func):
+            @wraps(func)
+            def wrapped(*args, **kwargs):
+                raise RuntimeError(f'{func.__module__}.{func.__name__} requires sox')
+            return wrapped
+    return decorator
+
+@requires_sox()
 def set_seed(seed: int):
     """Set libsox's PRNG
 
@@ -20,7 +35,7 @@ def set_seed(seed: int):
     torch.ops.torchaudio.sox_utils_set_seed(seed)
 
 
-@_mod_utils.requires_module('torchaudio._torchaudio')
+@requires_sox()
 def set_verbosity(verbosity: int):
     """Set libsox's verbosity
 
@@ -38,7 +53,7 @@ def set_verbosity(verbosity: int):
     torch.ops.torchaudio.sox_utils_set_verbosity(verbosity)
 
 
-@_mod_utils.requires_module('torchaudio._torchaudio')
+@requires_sox()
 def set_buffer_size(buffer_size: int):
     """Set buffer size for sox effect chain
 
@@ -51,7 +66,7 @@ def set_buffer_size(buffer_size: int):
     torch.ops.torchaudio.sox_utils_set_buffer_size(buffer_size)
 
 
-@_mod_utils.requires_module('torchaudio._torchaudio')
+@requires_sox()
 def set_use_threads(use_threads: bool):
     """Set multithread option for sox effect chain
 
@@ -65,7 +80,7 @@ def set_use_threads(use_threads: bool):
     torch.ops.torchaudio.sox_utils_set_use_threads(use_threads)
 
 
-@_mod_utils.requires_module('torchaudio._torchaudio')
+@requires_sox()
 def list_effects() -> Dict[str, str]:
     """List the available sox effect names
 
@@ -75,7 +90,7 @@ def list_effects() -> Dict[str, str]:
     return dict(torch.ops.torchaudio.sox_utils_list_effects())
 
 
-@_mod_utils.requires_module('torchaudio._torchaudio')
+@requires_sox()
 def list_read_formats() -> List[str]:
     """List the supported audio formats for read
 
@@ -85,7 +100,7 @@ def list_read_formats() -> List[str]:
     return torch.ops.torchaudio.sox_utils_list_read_formats()
 
 
-@_mod_utils.requires_module('torchaudio._torchaudio')
+@requires_sox()
 def list_write_formats() -> List[str]:
     """List the supported audio formats for write
 

--- a/torchaudio/utils/sox_utils.py
+++ b/torchaudio/utils/sox_utils.py
@@ -2,26 +2,10 @@ from typing import List, Dict
 from functools import wraps
 
 import torch
+from torchaudio._internal import module_utils as _mod_utils
 
 
-def is_sox_available():
-    return torch.ops.torchaudio.is_sox_available()
-
-
-def requires_sox():
-    if is_sox_available():
-        def decorator(func):
-            return func
-    else:
-        def decorator(func):
-            @wraps(func)
-            def wrapped(*args, **kwargs):
-                raise RuntimeError(f'{func.__module__}.{func.__name__} requires sox')
-            return wrapped
-    return decorator
-
-
-@requires_sox()
+@_mod_utils.requires_sox()
 def set_seed(seed: int):
     """Set libsox's PRNG
 
@@ -34,7 +18,7 @@ def set_seed(seed: int):
     torch.ops.torchaudio.sox_utils_set_seed(seed)
 
 
-@requires_sox()
+@_mod_utils.requires_sox()
 def set_verbosity(verbosity: int):
     """Set libsox's verbosity
 
@@ -52,7 +36,7 @@ def set_verbosity(verbosity: int):
     torch.ops.torchaudio.sox_utils_set_verbosity(verbosity)
 
 
-@requires_sox()
+@_mod_utils.requires_sox()
 def set_buffer_size(buffer_size: int):
     """Set buffer size for sox effect chain
 
@@ -65,7 +49,7 @@ def set_buffer_size(buffer_size: int):
     torch.ops.torchaudio.sox_utils_set_buffer_size(buffer_size)
 
 
-@requires_sox()
+@_mod_utils.requires_sox()
 def set_use_threads(use_threads: bool):
     """Set multithread option for sox effect chain
 
@@ -79,7 +63,7 @@ def set_use_threads(use_threads: bool):
     torch.ops.torchaudio.sox_utils_set_use_threads(use_threads)
 
 
-@requires_sox()
+@_mod_utils.requires_sox()
 def list_effects() -> Dict[str, str]:
     """List the available sox effect names
 
@@ -89,7 +73,7 @@ def list_effects() -> Dict[str, str]:
     return dict(torch.ops.torchaudio.sox_utils_list_effects())
 
 
-@requires_sox()
+@_mod_utils.requires_sox()
 def list_read_formats() -> List[str]:
     """List the supported audio formats for read
 
@@ -99,7 +83,7 @@ def list_read_formats() -> List[str]:
     return torch.ops.torchaudio.sox_utils_list_read_formats()
 
 
-@requires_sox()
+@_mod_utils.requires_sox()
 def list_write_formats() -> List[str]:
     """List the supported audio formats for write
 

--- a/torchaudio/utils/sox_utils.py
+++ b/torchaudio/utils/sox_utils.py
@@ -3,12 +3,10 @@ from functools import wraps
 
 import torch
 
-from torchaudio._internal import (
-    module_utils as _mod_utils,
-)
 
 def is_sox_available():
     return torch.ops.torchaudio.is_sox_available()
+
 
 def requires_sox():
     if is_sox_available():
@@ -21,6 +19,7 @@ def requires_sox():
                 raise RuntimeError(f'{func.__module__}.{func.__name__} requires sox')
             return wrapped
     return decorator
+
 
 @requires_sox()
 def set_seed(seed: int):


### PR DESCRIPTION
support functionality to exclude libsox from C++ extension, so that we can eventually support C++ extension on Windows
- change behavior of `BUILD_SOX=0` to exclude libsox from being built + bound, different from the current implementation (dynamic build if =0)
- construct functions to detect whether or not libsox is built, to appropriately handle functions and unittests requiring sox. previously, this was tested using detection of C++ extension since libsox and extension were always built together, but this will no longer be the case

testing: `pytest torchaudio_unittest` for both `BUILDSOX=0` and `BUILDSOX=1` cases