### PR TITLE
Use parametrize and set random seed in functional batch consistency test 

### DIFF
--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -9,6 +9,13 @@ import torchaudio.functional as F
 from torchaudio_unittest import common_utils
 
 
+def _name_from_args(func, _, params):
+    """Return a parameterized test name, based on parameter values."""
+    return "{}_{}".format(
+        func.__name__,
+        "_".join(str(arg) for arg in params.args))
+
+
 @parameterized_class([
     # Single-item batch isolates problems that come purely from adding a
     # dimension (rather than processing multiple items)
@@ -58,7 +65,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
     @parameterized.expand(list(itertools.product(
         [8000, 16000, 44100],
         [1, 2],
-    )), name_func=lambda f, _, p: f'{f.__name__}_{"_".join(str(arg) for arg in p.args)}')
+    )), name_func=_name_from_args)
     def test_detect_pitch_frequency(self, sample_rate, n_channels):
         # Use different frequencies to ensure each item in the batch returns a
         # different answer.
@@ -183,7 +190,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
     @parameterized.expand(list(itertools.product(
         [True, False],  # center
         [True, False],  # norm_vars
-    )), name_func=lambda f, _, p: f'{f.__name__}_{"_".join(str(arg) for arg in p.args)}')
+    )), name_func=_name_from_args)
     def test_sliding_window_cmn(self, center, norm_vars):
         waveforms = torch.randn(self.batch_size, 2, 1024) - 0.5
         self.assert_batch_consistency(

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -192,9 +192,10 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         [True, False],  # norm_vars
     )), name_func=_name_from_args)
     def test_sliding_window_cmn(self, center, norm_vars):
-        waveforms = torch.randn(self.batch_size, 2, 1024) - 0.5
+        spectrogram = torch.rand(self.batch_size, 2, 1024, 1024) * 200
         self.assert_batch_consistency(
-            F.sliding_window_cmn, waveforms, center=center, norm_vars=norm_vars)
+            F.sliding_window_cmn, spectrogram, center=center,
+            norm_vars=norm_vars)
 
     def test_vad_from_file(self):
         filepath = common_utils.get_asset_path("vad-go-stereo-44100.wav")

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -180,16 +180,14 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         sample_rate = 44100
         self.assert_batch_consistency(F.flanger, waveforms, sample_rate)
 
-    def test_sliding_window_cmn(self):
+    @parameterized.expand(list(itertools.product(
+        [True, False],  # center
+        [True, False],  # norm_vars
+    )), name_func=lambda f, _, p: f'{f.__name__}_{"_".join(str(arg) for arg in p.args)}')
+    def test_sliding_window_cmn(self, center, norm_vars):
         waveforms = torch.randn(self.batch_size, 2, 1024) - 0.5
         self.assert_batch_consistency(
-            F.sliding_window_cmn, waveforms, center=True, norm_vars=True)
-        self.assert_batch_consistency(
-            F.sliding_window_cmn, waveforms, center=True, norm_vars=False)
-        self.assert_batch_consistency(
-            F.sliding_window_cmn, waveforms, center=False, norm_vars=True)
-        self.assert_batch_consistency(
-            F.sliding_window_cmn, waveforms, center=False, norm_vars=False)
+            F.sliding_window_cmn, waveforms, center=center, norm_vars=norm_vars)
 
     def test_vad_from_file(self):
         filepath = common_utils.get_asset_path("vad-go-stereo-44100.wav")

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -192,6 +192,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         [True, False],  # norm_vars
     )), name_func=_name_from_args)
     def test_sliding_window_cmn(self, center, norm_vars):
+        torch.manual_seed(0)
         spectrogram = torch.rand(self.batch_size, 2, 1024, 1024) * 200
         self.assert_batch_consistency(
             F.sliding_window_cmn, spectrogram, center=center,
@@ -208,6 +209,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
     def test_vad_different_items(self):
         """Separate test to ensure VAD consistency with differing items."""
         sample_rate = 44100
+        torch.manual_seed(0)
         waveforms = torch.rand(self.batch_size, 2, 100) - 0.5
         self.assert_batch_consistency(
             F.vad, waveforms, sample_rate=sample_rate)


### PR DESCRIPTION
This PR adds a number of miscellaneous changes to `functional/batch_consistency_test.py` . They are as follows:

- Parameterize `test_sliding_window_cmn` so separate tests are generated  (also extract the test naming function).
- `F.sliding_window_cmn` should take a spectrogram, so replace the wave with a spectrogram. (Related to this, `F.sliding_window_cmn` currently refers to its spectrogram parameter as  [`waveform`](https://github.com/pytorch/audio/blob/master/torchaudio/functional/functional.py#L888). Would you like me to change it to `spec`?)
- Set the manual seed in a couple of places it was missing.
- Tweak the VAD consistency tests by using longer samples for the random test, and using lower thresholds for the file test. **This now causes many of the VAD tests to fail.**

  This has me thinking - if the purpose of `F.vad` is to outright crop the input tensor (not, for example, zero it), shouldn't we expect it to produce different results on a sample vs. a batch? I believe my tweaks just contain the right conditions for that to happen, but I might be misreading. If this is the case, should `F.vad` be removed from the batch consistency tests?

In #1315, @mthrok also [mentioned](https://github.com/pytorch/audio/pull/1315#discussion_r583935701) switching the tensor creation to `get_whitenoise`. I've done this on [another branch](https://github.com/jcaw/audio/compare/batch_consistency_misc_changes...jcaw:switch_to_white_noise) by introducing a new function `get_whitenoise_batch` - I wasn't sure if this was the approach you would prefer so I've left it out for now. (For example, I could perhaps add an optional `n_items` parameter to `get_whitenoise` which returns a batch iff provided, although that seems messy). I can append those changes to this PR too, and introduce a similar `add_spectrogram` function if that's also desirable.