### PR TITLE
Parameterize librosa compatibility test

### DIFF
--- a/test/torchaudio_unittest/functional/librosa_compatibility_test.py
+++ b/test/torchaudio_unittest/functional/librosa_compatibility_test.py
@@ -46,8 +46,9 @@ class TestFunctional(common_utils.TorchaudioTestCase):
 
         self.assertEqual(ta_out, lr_out, atol=5e-5, rtol=1e-5)
 
-    @parameterized.expand(
-        [
+    @parameterized.expand([
+        param(norm=norm, mel_scale=mel_scale, **p.kwargs)
+        for p in [
             param(),
             param(n_mels=128, sample_rate=44100),
             param(n_mels=128, fmin=2000.0, fmax=5000.0),
@@ -55,24 +56,15 @@ class TestFunctional(common_utils.TorchaudioTestCase):
             param(n_mels=56, fmin=800.0, fmax=900.0),
             param(n_mels=56, fmin=1900.0, fmax=900.0),
             param(n_mels=10, fmin=1900.0, fmax=900.0),
-            param(mel_scale="slaney"),
-            param(n_mels=128, sample_rate=44100, mel_scale="slaney"),
-            param(n_mels=128, fmin=2000.0, fmax=5000.0, mel_scale="slaney"),
-            param(n_mels=56, fmin=100.0, fmax=9000.0, mel_scale="slaney"),
-            param(n_mels=56, fmin=800.0, fmax=900.0, mel_scale="slaney"),
-            param(n_mels=56, fmin=1900.0, fmax=900.0, mel_scale="slaney"),
-            param(n_mels=10, fmin=1900.0, fmax=900.0, mel_scale="slaney"),
-        ] + ([
-            param(n_mels=128, sample_rate=44100, norm="slaney"),
-            param(n_mels=128, fmin=2000.0, fmax=5000.0, norm="slaney"),
-            param(n_mels=56, fmin=100.0, fmax=9000.0, norm="slaney"),
-            param(n_mels=56, fmin=800.0, fmax=900.0, norm="slaney"),
-            param(n_mels=56, fmin=1900.0, fmax=900.0, norm="slaney"),
-            param(n_mels=10, fmin=1900.0, fmax=900.0, norm="slaney"),
-        ] if StrictVersion(librosa.__version__) >= StrictVersion("0.7.2") else [])
-    )
+        ]
+        for norm in [None, 'slaney']
+        for mel_scale in ['htk', 'slaney']
+    ])
     def test_create_fb(self, n_mels=40, sample_rate=22050, n_fft=2048,
                        fmin=0.0, fmax=8000.0, norm=None, mel_scale="htk"):
+        if (norm == "slaney" and StrictVersion(librosa.__version__) < StrictVersion("0.7.2")):
+            self.skipTest('Test is known to fail with older versions of librosa.')
+
         librosa_fb = librosa.filters.mel(sr=sample_rate,
                                          n_fft=n_fft,
                                          n_mels=n_mels,

--- a/test/torchaudio_unittest/functional/librosa_compatibility_test.py
+++ b/test/torchaudio_unittest/functional/librosa_compatibility_test.py
@@ -62,14 +62,14 @@ class TestFunctional(common_utils.TorchaudioTestCase):
             param(n_mels=56, fmin=800.0, fmax=900.0, mel_scale="slaney"),
             param(n_mels=56, fmin=1900.0, fmax=900.0, mel_scale="slaney"),
             param(n_mels=10, fmin=1900.0, fmax=900.0, mel_scale="slaney"),
-        ] + [
+        ] + ([
             param(n_mels=128, sample_rate=44100, norm="slaney"),
             param(n_mels=128, fmin=2000.0, fmax=5000.0, norm="slaney"),
             param(n_mels=56, fmin=100.0, fmax=9000.0, norm="slaney"),
             param(n_mels=56, fmin=800.0, fmax=900.0, norm="slaney"),
             param(n_mels=56, fmin=1900.0, fmax=900.0, norm="slaney"),
             param(n_mels=10, fmin=1900.0, fmax=900.0, norm="slaney"),
-        ] if StrictVersion(librosa.__version__) >= StrictVersion("0.7.2") else []
+        ] if StrictVersion(librosa.__version__) >= StrictVersion("0.7.2") else [])
     )
     def test_create_fb(self, n_mels=40, sample_rate=22050, n_fft=2048,
                        fmin=0.0, fmax=8000.0, norm=None, mel_scale="htk"):

--- a/test/torchaudio_unittest/functional/librosa_compatibility_test.py
+++ b/test/torchaudio_unittest/functional/librosa_compatibility_test.py
@@ -3,7 +3,7 @@ import unittest
 from distutils.version import StrictVersion
 
 import torch
-from parameterized import parameterized
+from parameterized import parameterized, param
 
 import torchaudio.functional as F
 from torchaudio._internal.module_utils import is_module_available
@@ -46,15 +46,33 @@ class TestFunctional(common_utils.TorchaudioTestCase):
 
         self.assertEqual(ta_out, lr_out, atol=5e-5, rtol=1e-5)
 
-    def _test_create_fb(
-        self, n_mels=40,
-        sample_rate=22050,
-        n_fft=2048,
-        fmin=0.0,
-        fmax=8000.0,
-        norm=None,
-        mel_scale="htk",
-    ):
+    @parameterized.expand(
+        [
+            param(),
+            param(n_mels=128, sample_rate=44100),
+            param(n_mels=128, fmin=2000.0, fmax=5000.0),
+            param(n_mels=56, fmin=100.0, fmax=9000.0),
+            param(n_mels=56, fmin=800.0, fmax=900.0),
+            param(n_mels=56, fmin=1900.0, fmax=900.0),
+            param(n_mels=10, fmin=1900.0, fmax=900.0),
+            param(mel_scale="slaney"),
+            param(n_mels=128, sample_rate=44100, mel_scale="slaney"),
+            param(n_mels=128, fmin=2000.0, fmax=5000.0, mel_scale="slaney"),
+            param(n_mels=56, fmin=100.0, fmax=9000.0, mel_scale="slaney"),
+            param(n_mels=56, fmin=800.0, fmax=900.0, mel_scale="slaney"),
+            param(n_mels=56, fmin=1900.0, fmax=900.0, mel_scale="slaney"),
+            param(n_mels=10, fmin=1900.0, fmax=900.0, mel_scale="slaney"),
+        ] + [
+            param(n_mels=128, sample_rate=44100, norm="slaney"),
+            param(n_mels=128, fmin=2000.0, fmax=5000.0, norm="slaney"),
+            param(n_mels=56, fmin=100.0, fmax=9000.0, norm="slaney"),
+            param(n_mels=56, fmin=800.0, fmax=900.0, norm="slaney"),
+            param(n_mels=56, fmin=1900.0, fmax=900.0, norm="slaney"),
+            param(n_mels=10, fmin=1900.0, fmax=900.0, norm="slaney"),
+        ] if StrictVersion(librosa.__version__) >= StrictVersion("0.7.2") else []
+    )
+    def test_create_fb(self, n_mels=40, sample_rate=22050, n_fft=2048,
+                       fmin=0.0, fmax=8000.0, norm=None, mel_scale="htk"):
         librosa_fb = librosa.filters.mel(sr=sample_rate,
                                          n_fft=n_fft,
                                          n_mels=n_mels,
@@ -73,30 +91,6 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         for i_mel_bank in range(n_mels):
             self.assertEqual(
                 fb[:, i_mel_bank], torch.tensor(librosa_fb[i_mel_bank]), atol=1e-4, rtol=1e-5)
-
-    def test_create_fb(self):
-        self._test_create_fb()
-        self._test_create_fb(n_mels=128, sample_rate=44100)
-        self._test_create_fb(n_mels=128, fmin=2000.0, fmax=5000.0)
-        self._test_create_fb(n_mels=56, fmin=100.0, fmax=9000.0)
-        self._test_create_fb(n_mels=56, fmin=800.0, fmax=900.0)
-        self._test_create_fb(n_mels=56, fmin=1900.0, fmax=900.0)
-        self._test_create_fb(n_mels=10, fmin=1900.0, fmax=900.0)
-        self._test_create_fb(mel_scale="slaney")
-        self._test_create_fb(n_mels=128, sample_rate=44100, mel_scale="slaney")
-        self._test_create_fb(n_mels=128, fmin=2000.0, fmax=5000.0, mel_scale="slaney")
-        self._test_create_fb(n_mels=56, fmin=100.0, fmax=9000.0, mel_scale="slaney")
-        self._test_create_fb(n_mels=56, fmin=800.0, fmax=900.0, mel_scale="slaney")
-        self._test_create_fb(n_mels=56, fmin=1900.0, fmax=900.0, mel_scale="slaney")
-        self._test_create_fb(n_mels=10, fmin=1900.0, fmax=900.0, mel_scale="slaney")
-        if StrictVersion(librosa.__version__) < StrictVersion("0.7.2"):
-            return
-        self._test_create_fb(n_mels=128, sample_rate=44100, norm="slaney")
-        self._test_create_fb(n_mels=128, fmin=2000.0, fmax=5000.0, norm="slaney")
-        self._test_create_fb(n_mels=56, fmin=100.0, fmax=9000.0, norm="slaney")
-        self._test_create_fb(n_mels=56, fmin=800.0, fmax=900.0, norm="slaney")
-        self._test_create_fb(n_mels=56, fmin=1900.0, fmax=900.0, norm="slaney")
-        self._test_create_fb(n_mels=10, fmin=1900.0, fmax=900.0, norm="slaney")
 
     def test_amplitude_to_DB(self):
         spec = torch.rand((6, 201))


### PR DESCRIPTION
Closes #1346 

I've parameterized the `test_create_fb` test, as mentioned in #1346:

> We'd like to use parameterized for the functional librosa compatibility test [here](https://github.com/pytorch/audio/blob/master/test/torchaudio_unittest/functional/librosa_compatibility_test.py#L77). This will make it easier to know which option is failing.
> 
> cc [comment](https://github.com/pytorch/audio/pull/593/files#r585724895)