### PR TITLE
Remove deprecated load_wav functions from backends

### DIFF
--- a/docs/source/backend.rst
+++ b/docs/source/backend.rst
@@ -6,7 +6,7 @@ torchaudio.backend
 Overview
 ~~~~~~~~
 
-:mod:`torchaudio.backend` module provides implementations for audio file I/O functionalities, which are ``torchaudio.info``, ``torchaudio.load``, ``torchaudio.load_wav`` and ``torchaudio.save``.
+:mod:`torchaudio.backend` module provides implementations for audio file I/O functionalities, which are ``torchaudio.info``, ``torchaudio.load``, and ``torchaudio.save``.
 
 There are currently four implementations available.
 
@@ -14,7 +14,7 @@ There are currently four implementations available.
 * :ref:`"soundfile" <soundfile_backend>` (default on Windows)
 
 .. note::
-   Instead of calling functions in ``torchaudio.backend`` directly, please use ``torchaudio.info``, ``torchaudio.load``, ``torchaudio.load_wav`` and ``torchaudio.save`` with proper backend set with :func:`torchaudio.set_audio_backend`.
+   Instead of calling functions in ``torchaudio.backend`` directly, please use ``torchaudio.info``, ``torchaudio.load``, and ``torchaudio.save`` with proper backend set with :func:`torchaudio.set_audio_backend`.
 
 Availability
 ------------
@@ -58,9 +58,6 @@ load
 
 .. autofunction:: torchaudio.backend.sox_io_backend.load
 
-.. autofunction:: torchaudio.backend.sox_io_backend.load_wav
-
-
 save
 ----
 
@@ -88,9 +85,6 @@ load
 ----
 
 .. autofunction:: torchaudio.backend.soundfile_backend.load
-
-.. autofunction:: torchaudio.backend.soundfile_backend.load_wav
-
 
 save
 ----

--- a/docs/source/torchaudio.rst
+++ b/docs/source/torchaudio.rst
@@ -16,10 +16,6 @@ Refer to :ref:`backend` for the detail.
 
    Load audio file into torch.Tensor object. Refer to :ref:`backend` for the detail.
 
-.. function:: torchaudio.load_wav(filepath: str, ...)
-
-   Load audio file into torch.Tensor, Refer to :ref:`backend` for the detail.
-
 .. function:: torchaudio.save(filepath: str, src: torch.Tensor, sample_rate: int, ...)
 
    Save torch.Tensor object into an audio format. Refer to :ref:`backend` for the detail.

--- a/test/torchaudio_unittest/backend/utils_test.py
+++ b/test/torchaudio_unittest/backend/utils_test.py
@@ -15,7 +15,6 @@ class BackendSwitchMixin:
         else:
             assert torchaudio.get_audio_backend() == self.backend
         assert torchaudio.load == self.backend_module.load
-        assert torchaudio.load_wav == self.backend_module.load_wav
         assert torchaudio.save == self.backend_module.save
         assert torchaudio.info == self.backend_module.info
 

--- a/test/torchaudio_unittest/compliance/generate_fbank_data.py
+++ b/test/torchaudio_unittest/compliance/generate_fbank_data.py
@@ -6,6 +6,7 @@ import subprocess
 import torch
 import torchaudio
 import utils
+from torchaudio_unittest import common_utils
 
 
 def run(exe_path, scp_path, out_dir, wave_len, num_outputs, remove_files, log_level):
@@ -102,7 +103,7 @@ def decode(fn, sound_path, exe_path, scp_path, out_dir):
     # print args for python
     inputs['dither'] = 0.0
     logging.info(inputs)
-    sound, sample_rate = torchaudio.load_wav(sound_path)
+    sound, sample_rate = common_utils.load_wav(sound_path, normalize=False)
     kaldi_output_dict = {k: v for k, v in torchaudio.kaldi_io.read_mat_ark(out_fn)}
     res = torchaudio.compliance.kaldi.fbank(sound, **inputs)
     torch.set_printoptions(precision=10, sci_mode=False)

--- a/test/torchaudio_unittest/compliance_kaldi_test.py
+++ b/test/torchaudio_unittest/compliance_kaldi_test.py
@@ -144,7 +144,7 @@ class Test_Kaldi(common_utils.TempDirMixin, common_utils.TorchaudioTestCase):
             atol (float): absolute tolerance
             rtol (float): relative tolerance
         """
-        sound, sr = torchaudio.load_wav(sound_filepath)
+        sound, sr = common_utils.load_wav(sound_filepath, normalize=False)
         files = self.test_filepaths[filepath_key]
 
         assert len(files) == expected_num_files, \

--- a/torchaudio/backend/no_backend.py
+++ b/torchaudio/backend/no_backend.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Callable, Optional, Tuple, Union
+from typing import Callable, Optional, Tuple, Union
 
 from torch import Tensor
 
@@ -11,10 +11,6 @@ def load(filepath: Union[str, Path],
          num_frames: int = 0,
          offset: int = 0,
          filetype: Optional[str] = None) -> Tuple[Tensor, int]:
-    raise RuntimeError('No audio I/O backend is available.')
-
-
-def load_wav(filepath: Union[str, Path], **kwargs: Any) -> Tuple[Tensor, int]:
     raise RuntimeError('No audio I/O backend is available.')
 
 

--- a/torchaudio/backend/soundfile_backend.py
+++ b/torchaudio/backend/soundfile_backend.py
@@ -424,26 +424,3 @@ def save(
     soundfile.write(
         file=filepath, data=src, samplerate=sample_rate, subtype=subtype, format=format
     )
-
-
-@_mod_utils.requires_module("soundfile")
-@_mod_utils.deprecated('Please use "torchaudio.load".', "0.9.0")
-def load_wav(
-    filepath: str,
-    frame_offset: int = 0,
-    num_frames: int = -1,
-    channels_first: bool = True,
-) -> Tuple[torch.Tensor, int]:
-    """Load wave file.
-
-    This function is defined only for the purpose of compatibility against other backend
-    for simple usecases, such as ``torchaudio.load_wav(filepath)``.
-    The implementation is same as :py:func:`load`.
-    """
-    return load(
-        filepath,
-        frame_offset,
-        num_frames,
-        normalize=False,
-        channels_first=channels_first,
-    )

--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -313,20 +313,3 @@ def save(
         filepath = os.fspath(filepath)
     torch.ops.torchaudio.sox_io_save_audio_file(
         filepath, src, sample_rate, channels_first, compression, format, encoding, bits_per_sample)
-
-
-@_mod_utils.requires_sox()
-@_mod_utils.deprecated('Please use "torchaudio.load".', '0.9.0')
-def load_wav(
-        filepath: str,
-        frame_offset: int = 0,
-        num_frames: int = -1,
-        channels_first: bool = True,
-) -> Tuple[torch.Tensor, int]:
-    """Load wave file.
-
-    This function is defined only for the purpose of compatibility against other backend
-    for simple usecases, such as ``torchaudio.load_wav(filepath)``.
-    The implementation is same as :py:func:`load`.
-    """
-    return load(filepath, frame_offset, num_frames, normalize=False, channels_first=channels_first)

--- a/torchaudio/backend/utils.py
+++ b/torchaudio/backend/utils.py
@@ -53,7 +53,7 @@ def set_audio_backend(backend: Optional[str]):
     else:
         raise NotImplementedError(f'Unexpected backend "{backend}"')
 
-    for func in ['save', 'load', 'load_wav', 'info']:
+    for func in ['save', 'load', 'info']:
         setattr(torchaudio, func, getattr(module, func))
 
 


### PR DESCRIPTION
Testing Steps:

Run entire test suite. 

I am getting one failure locally, but it doesn't look related to these changes. 

<img width="1148" alt="Screen Shot 2021-03-05 at 1 22 47 PM" src="https://user-images.githubusercontent.com/25669348/110157396-1e409180-7db6-11eb-9184-1d181e275e5f.png">

Seems to have to do with imprecision of floating point arithemetic. Let me know if you want me to relax the threshold slightly -- it may be that the tests do not fail on CI build. (edit: I actually don't see the tests running on checks). 

Let me know what you think. Thanks!
 
