### PR TITLE
remove instructions for building sox from source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,9 +56,7 @@ BUILD_SOX=1 python setup.py develop
 # DEBUG=1 python setup.py develop
 ```
 
-Note: you don't need to use `BUILD_SOX=1` if you have `libsox-dev` installed
-already. If you built sox however, set the `PATH` variable so that the tests
-properly use the newly built `sox` binary:
+If you built sox, set the `PATH` variable so that the tests properly use the newly built `sox` binary:
 
 ```bash
 export PATH="<path_to_torchaudio>/third_party/install/bin:${PATH}"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ to use and feel like a natural extension.
 Dependencies
 ------------
 * PyTorch (See below for the compatible versions)
-* libsox v14.3.2 or above (only required when building from source)
 * [optional] vesis84/kaldi-io-for-python commit cb46cb1f44318a5d04d4941cf39084c5b021241e or above
 
 The following are the corresponding ``torchaudio`` versions and supported Python versions.


### PR DESCRIPTION
remove `BUILD_SOX=0` segment from CONTRIBUTING.md following #1338, which changes the behavior of `BUILD_SOX=0`