### PR TITLE
Adopt native complex dtype in griffnlim

### DIFF
--- a/test/torchaudio_unittest/transforms/autograd_test_impl.py
+++ b/test/torchaudio_unittest/transforms/autograd_test_impl.py
@@ -21,7 +21,7 @@ class _DeterministicWrapper(torch.nn.Module):
         self.transform = transform
 
     def forward(self, input: torch.Tensor):
-        torch.random.manual_seed(0)
+        torch.random.manual_seed(self.seed)
         return self.transform(input)
 
 

--- a/test/torchaudio_unittest/transforms/autograd_test_impl.py
+++ b/test/torchaudio_unittest/transforms/autograd_test_impl.py
@@ -8,6 +8,7 @@ import torchaudio.transforms as T
 from torchaudio_unittest.common_utils import (
     TestBaseMixin,
     get_whitenoise,
+    nested_params,
 )
 
 
@@ -65,14 +66,17 @@ class AutogradTestMixin(TestBaseMixin):
         waveform = get_whitenoise(sample_rate=sample_rate, duration=0.05, n_channels=2)
         self.assert_grad(transform, [waveform], nondet_tol=1e-10)
 
-    @parameterized.expand([(0, ), (0.99, )])
-    def test_griffinlim(self, momentum):
+    @nested_params(
+        [0, 0.99],
+        [False, True],
+    )
+    def test_griffinlim(self, momentum, rand_init):
         n_fft = 400
         n_frames = 5
         n_iter = 3
         spec = torch.rand(n_fft // 2 + 1, n_frames) * n_fft
-        transform = T.GriffinLim(n_fft=n_fft, n_iter=n_iter, momentum=momentum, rand_init=False)
-        self.assert_grad(transform, [spec], nondet_tol=1e-10)
+        transform = T.GriffinLim(n_fft=n_fft, n_iter=n_iter, momentum=momentum, rand_init=rand_init)
+        self.assert_grad(transform, [spec])
 
     @parameterized.expand([(False, ), (True, )])
     def test_mfcc(self, log_mels):

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -130,6 +130,8 @@ def _get_complex_dtype(real_dtype: torch.dtype):
         return torch.cdouble
     if real_dtype == torch.float:
         return torch.cfloat
+    if real_dtype == torch.half:
+        return torch.complex32
     raise ValueError(f'Unexpected dtype {real_dtype}')
 
 


### PR DESCRIPTION
Get rid of pseudo complex type in `F.griffinlim`.

Part of #1337 

`griffinlim` is tested
 - ✅ TorchScript on CPU/CUDA for `float32` and `float64`
 - ✅ `librosa` consistency on CPU
 - ✅ Batch consistency on CPU

**TODO**
 - [x] Autograd test (updated from #1421)
 - [x] Benchmark
 - [x] Remove the hardcoded `cfloat` in the intermediate variable.

## Benchmark

<details><summary>script</summary>

```bash
#!/usr/bin/env bash

OMP_NUM_THREADS=1 numactl --membind 0 --cpubind 0 python -m timeit -s """
import torch
import torchaudio;

batch_size = 32
num_channels = 1
num_freq = 201
num_frames = 400

torch.manual_seed(0);
spec = torch.randn(batch_size, num_channels, num_freq, num_frames, dtype=torch.float32, device='cpu');
griffinlim = torchaudio.transforms.GriffinLim()
""" """
griffinlim(spec)
"""
```

</details>

| device |           master (8d2eeb1)           |                This PR                |
|:------:|:------------------------------------:|:-------------------------------------:|
|    CPU | 1 loop, best of 5: 6.48 sec per loop | 1 loop, best of 5: 3.57 sec per loop  |
|    GPU | 1 loop, best of 5: 128 msec per loop | 1 loop, best of 5: 93.4 msec per loop |