### PR TITLE
Replace sox conversion macros with Tensor op

### DIFF
--- a/torchaudio/csrc/sox/effects_chain.cpp
+++ b/torchaudio/csrc/sox/effects_chain.cpp
@@ -108,7 +108,7 @@ int tensor_input_drain(sox_effect_t* effp, sox_sample_t* obuf, size_t* osamp) {
       throw std::runtime_error("Unexpected dtype.");
   }
   // Write to buffer
-  memcpy(obuf, chunk.data_ptr<int32_t>(), *osamp *4);
+  memcpy(obuf, chunk.data_ptr<int32_t>(), *osamp * 4);
   priv->index += *osamp;
   return (priv->index == num_samples) ? SOX_EOF : SOX_SUCCESS;
 }

--- a/torchaudio/csrc/sox/effects_chain.cpp
+++ b/torchaudio/csrc/sox/effects_chain.cpp
@@ -90,7 +90,6 @@ int tensor_input_drain(sox_effect_t* effp, sox_sample_t* obuf, size_t* osamp) {
       break;
     }
     case c10::ScalarType::Int: {
-      chunk = chunk.contiguous();
       break;
     }
     case c10::ScalarType::Short: {
@@ -108,6 +107,7 @@ int tensor_input_drain(sox_effect_t* effp, sox_sample_t* obuf, size_t* osamp) {
       throw std::runtime_error("Unexpected dtype.");
   }
   // Write to buffer
+  chunk = chunk.contiguous();
   memcpy(obuf, chunk.data_ptr<int32_t>(), *osamp * 4);
   priv->index += *osamp;
   return (priv->index == num_samples) ? SOX_EOF : SOX_SUCCESS;

--- a/torchaudio/csrc/sox/effects_chain.cpp
+++ b/torchaudio/csrc/sox/effects_chain.cpp
@@ -84,7 +84,7 @@ int tensor_input_drain(sox_effect_t* effp, sox_sample_t* obuf, size_t* osamp) {
       // Need to convert to 64-bit precision so that
       // values around INT32_MIN/MAX are handled correctly.
       chunk = chunk.to(c10::ScalarType::Double);
-      chunk *= (int)1<<31;
+      chunk *= 2147483648.;
       chunk.clamp_(INT32_MIN, INT32_MAX);
       chunk = chunk.to(c10::ScalarType::Int);
       break;
@@ -95,13 +95,13 @@ int tensor_input_drain(sox_effect_t* effp, sox_sample_t* obuf, size_t* osamp) {
     }
     case c10::ScalarType::Short: {
       chunk = chunk.to(c10::ScalarType::Int);
-      chunk *= (int)1<<16;
+      chunk *= 65536;
       break;
     }
     case c10::ScalarType::Byte: {
       chunk = chunk.to(c10::ScalarType::Int);
       chunk -= 128;
-      chunk *= (int)1<<24;
+      chunk *= 16777216;
       break;
     }
     default:

--- a/torchaudio/csrc/sox/effects_chain.cpp
+++ b/torchaudio/csrc/sox/effects_chain.cpp
@@ -69,49 +69,46 @@ int tensor_input_drain(sox_effect_t* effp, sox_sample_t* obuf, size_t* osamp) {
   *osamp -= *osamp % num_channels;
 
   // Slice the input Tensor
-  const auto tensor_ = [&]() {
+  auto chunk = [&]() {
     auto i_frame = index / num_channels;
     auto num_frames = *osamp / num_channels;
     auto t = (priv->channels_first)
         ? tensor.index({Slice(), Slice(i_frame, i_frame + num_frames)}).t()
         : tensor.index({Slice(i_frame, i_frame + num_frames), Slice()});
-    return t.reshape({-1}).contiguous();
+    return t.reshape({-1});
   }();
 
-  // Convert to sox_sample_t (int32_t) and write to buffer
-  SOX_SAMPLE_LOCALS;
-  switch (tensor_.dtype().toScalarType()) {
+  // Convert to sox_sample_t (int32_t)
+  switch (chunk.dtype().toScalarType()) {
     case c10::ScalarType::Float: {
-      auto ptr = tensor_.data_ptr<float_t>();
-      for (size_t i = 0; i < *osamp; ++i) {
-        obuf[i] = SOX_FLOAT_32BIT_TO_SAMPLE(ptr[i], effp->clips);
-      }
+      // Need to convert to 64-bit precision so that
+      // values around INT32_MIN/MAX are handled correctly.
+      chunk = chunk.to(c10::ScalarType::Double);
+      chunk *= 2147483648.;
+      chunk.clamp_(INT32_MIN, INT32_MAX);
+      chunk = chunk.to(c10::ScalarType::Int);
       break;
     }
     case c10::ScalarType::Int: {
-      auto ptr = tensor_.data_ptr<int32_t>();
-      for (size_t i = 0; i < *osamp; ++i) {
-        obuf[i] = SOX_SIGNED_32BIT_TO_SAMPLE(ptr[i], effp->clips);
-      }
+      chunk = chunk.contiguous();
       break;
     }
     case c10::ScalarType::Short: {
-      auto ptr = tensor_.data_ptr<int16_t>();
-      for (size_t i = 0; i < *osamp; ++i) {
-        obuf[i] = SOX_SIGNED_16BIT_TO_SAMPLE(ptr[i], effp->clips);
-      }
+      chunk = chunk.to(c10::ScalarType::Int);
+      chunk *= 65536;
       break;
     }
     case c10::ScalarType::Byte: {
-      auto ptr = tensor_.data_ptr<uint8_t>();
-      for (size_t i = 0; i < *osamp; ++i) {
-        obuf[i] = SOX_UNSIGNED_8BIT_TO_SAMPLE(ptr[i], effp->clips);
-      }
+      chunk = chunk.to(c10::ScalarType::Int);
+      chunk -= 128;
+      chunk *= 16777216;
       break;
     }
     default:
       throw std::runtime_error("Unexpected dtype.");
   }
+  // Write to buffer
+  memcpy(obuf, chunk.data_ptr<int32_t>(), *osamp *4);
   priv->index += *osamp;
   return (priv->index == num_samples) ? SOX_EOF : SOX_SUCCESS;
 }

--- a/torchaudio/csrc/sox/effects_chain.cpp
+++ b/torchaudio/csrc/sox/effects_chain.cpp
@@ -84,7 +84,7 @@ int tensor_input_drain(sox_effect_t* effp, sox_sample_t* obuf, size_t* osamp) {
       // Need to convert to 64-bit precision so that
       // values around INT32_MIN/MAX are handled correctly.
       chunk = chunk.to(c10::ScalarType::Double);
-      chunk *= 2147483648.;
+      chunk *= (int)1<<31;
       chunk.clamp_(INT32_MIN, INT32_MAX);
       chunk = chunk.to(c10::ScalarType::Int);
       break;
@@ -95,13 +95,13 @@ int tensor_input_drain(sox_effect_t* effp, sox_sample_t* obuf, size_t* osamp) {
     }
     case c10::ScalarType::Short: {
       chunk = chunk.to(c10::ScalarType::Int);
-      chunk *= 65536;
+      chunk *= (int)1<<16;
       break;
     }
     case c10::ScalarType::Byte: {
       chunk = chunk.to(c10::ScalarType::Int);
       chunk -= 128;
-      chunk *= 16777216;
+      chunk *= (int)1<<24;
       break;
     }
     default:


### PR DESCRIPTION
`SOX_SIGNED_16BIT_TO_SAMPLE` and `SOX_SIGNED_32BIT_TO_SAMPLE` uses left shift on signed integers, which is UB.
This PR replaces them (and other sox macros for `uint8` and `float` as well) with Tensor operations.