### PR TITLE
Fix functional_cpu_test test name generation

### DIFF
--- a/test/torchaudio_unittest/functional/functional_cpu_test.py
+++ b/test/torchaudio_unittest/functional/functional_cpu_test.py
@@ -12,7 +12,6 @@ from torchaudio_unittest.common_utils import (
     TorchaudioTestCase,
     skipIfNoSox,
 )
-from torchaudio_unittest.backend.sox_io.common import name_func
 
 from .functional_impl import Lfilter, Spectrogram
 
@@ -249,17 +248,14 @@ class TestApplyCodec(TorchaudioTestCase):
     def test_wave(self):
         self._smoke_test("wav", compression=None, check_num_frames=True)
 
-    @parameterized.expand([(96,), (128,), (160,), (192,), (224,), (256,), (320,)],
-                          name_func=name_func)
+    @parameterized.expand([(96,), (128,), (160,), (192,), (224,), (256,), (320,)])
     def test_mp3(self, compression):
         self._smoke_test("mp3", compression, check_num_frames=False)
 
-    @parameterized.expand([(0,), (1,), (2,), (3,), (4,), (5,), (6,), (7,), (8,)],
-                          name_func=name_func)
+    @parameterized.expand([(0,), (1,), (2,), (3,), (4,), (5,), (6,), (7,), (8,)])
     def test_flac(self, compression):
         self._smoke_test("flac", compression, check_num_frames=False)
 
-    @parameterized.expand([(-1,), (0,), (1,), (2,), (3,), (3.6,), (5,), (10,)],
-                          name_func=name_func)
+    @parameterized.expand([(-1,), (0,), (1,), (2,), (3,), (3.6,), (5,), (10,)])
     def test_vorbis(self, compression):
         self._smoke_test("vorbis", compression, check_num_frames=False)


### PR DESCRIPTION
remove use of `name_func` from `functional_cpu_test.py` to unblock torchaudio import 