### PR TITLE
Remove unused helper function

### DIFF
--- a/torchaudio/csrc/sox/utils.cpp
+++ b/torchaudio/csrc/sox/utils.cpp
@@ -141,24 +141,6 @@ caffe2::TypeMeta get_dtype(
   return c10::scalarTypeToTypeMeta(dtype);
 }
 
-caffe2::TypeMeta get_dtype_from_str(const std::string dtype) {
-  const auto tgt_dtype = [&]() {
-    if (dtype == "uint8")
-      return torch::kUInt8;
-    else if (dtype == "int16")
-      return torch::kInt16;
-    else if (dtype == "int32")
-      return torch::kInt32;
-    else if (dtype == "float32")
-      return torch::kFloat32;
-    else if (dtype == "float64")
-      return torch::kFloat64;
-    else
-      throw std::runtime_error("Unsupported dtype");
-  }();
-  return c10::scalarTypeToTypeMeta(tgt_dtype);
-}
-
 torch::Tensor convert_to_tensor(
     sox_sample_t* buffer,
     const int32_t num_samples,

--- a/torchaudio/csrc/sox/utils.h
+++ b/torchaudio/csrc/sox/utils.h
@@ -68,8 +68,6 @@ caffe2::TypeMeta get_dtype(
     const sox_encoding_t encoding,
     const unsigned precision);
 
-caffe2::TypeMeta get_dtype_from_str(const std::string dtype);
-
 ///
 /// Convert sox_sample_t buffer to uint8/int16/int32/float32 Tensor
 /// NOTE: This function might modify the values in the input buffer to


### PR DESCRIPTION
Removed unused helper function "get_dtype_from_str". 
To test, ran  `pytest torchaudio_unittest` after running `BUILD_SOX=1 MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ python setup.py develop`.  I saw no changes in # of failures before and after the change. 

`=================================== 1285 failed, 1193 passed, 2754 skipped, 1 xfailed, 22 warnings in 336.89s (0:05:36) ====================================`

