### PR TITLE
Add vanilla DeepSpeech model

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -31,3 +31,10 @@ The models subpackage contains definitions of models for addressing common audio
 .. autoclass:: WaveRNN
 
   .. automethod:: forward
+
+:hidden:`DeepSpeech`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: DeepSpeech
+
+  .. automethod:: forward

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -17,6 +17,14 @@ The models subpackage contains definitions of models for addressing common audio
   .. automethod:: forward
 
 
+:hidden:`DeepSpeech`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: DeepSpeech
+
+  .. automethod:: forward
+
+
 :hidden:`Wav2Letter`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -29,12 +37,5 @@ The models subpackage contains definitions of models for addressing common audio
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: WaveRNN
-
-  .. automethod:: forward
-
-:hidden:`DeepSpeech`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: DeepSpeech
 
   .. automethod:: forward

--- a/test/torchaudio_unittest/models_test.py
+++ b/test/torchaudio_unittest/models_test.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 
 import torch
 from parameterized import parameterized
-from torchaudio.models import ConvTasNet, Wav2Letter, WaveRNN, DeepSpeech
+from torchaudio.models import ConvTasNet, DeepSpeech, Wav2Letter, WaveRNN
 from torchaudio.models.wavernn import MelResNet, UpsampleNetwork
 from torchaudio_unittest import common_utils
 

--- a/test/torchaudio_unittest/models_test.py
+++ b/test/torchaudio_unittest/models_test.py
@@ -190,4 +190,4 @@ class TestDeepSpeech(common_utils.TorchaudioTestCase):
         x = torch.rand(batch_size, num_channels, input_length, num_features)
         out = model(x)
 
-        assert out.size() == (input_length, batch_size, num_classes)
+        assert out.size() == (batch_size, input_length, num_classes)

--- a/test/torchaudio_unittest/models_test.py
+++ b/test/torchaudio_unittest/models_test.py
@@ -179,15 +179,15 @@ class TestConvTasNet(common_utils.TorchaudioTestCase):
 class TestDeepSpeech(common_utils.TorchaudioTestCase):
 
     def test_deepspeech(self):
-        batch_size = 2
-        num_features = 1
-        num_channels = 1
-        num_classes = 40
-        input_length = 320
+        n_batch = 2
+        n_feature = 1
+        n_channel = 1
+        n_class = 40
+        n_time = 320
 
-        model = DeepSpeech(in_features=1, num_classes=num_classes)
+        model = DeepSpeech(n_feature=n_feature, n_class=n_class)
 
-        x = torch.rand(batch_size, num_channels, input_length, num_features)
+        x = torch.rand(n_batch, n_channel, n_time, n_feature)
         out = model(x)
 
-        assert out.size() == (batch_size, input_length, num_classes)
+        assert out.size() == (n_batch, n_time, n_class)

--- a/test/torchaudio_unittest/models_test.py
+++ b/test/torchaudio_unittest/models_test.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 
 import torch
 from parameterized import parameterized
-from torchaudio.models import ConvTasNet, Wav2Letter, WaveRNN
+from torchaudio.models import ConvTasNet, Wav2Letter, WaveRNN, DeepSpeech
 from torchaudio.models.wavernn import MelResNet, UpsampleNetwork
 from torchaudio_unittest import common_utils
 
@@ -174,3 +174,20 @@ class TestConvTasNet(common_utils.TorchaudioTestCase):
         output = model(tensor)
 
         assert output.shape == (batch_size, num_sources, num_frames)
+
+
+class TestDeepSpeech(common_utils.TorchaudioTestCase):
+
+    def test_deepspeech(self):
+        batch_size = 2
+        num_features = 1
+        num_channels = 1
+        num_classes = 40
+        input_length = 320
+
+        model = DeepSpeech(in_features=1, num_classes=num_classes)
+
+        x = torch.rand(batch_size, num_channels, input_length, num_features)
+        out = model(x)
+
+        assert out.size() == (input_length, batch_size, num_classes)

--- a/torchaudio/models/__init__.py
+++ b/torchaudio/models/__init__.py
@@ -1,9 +1,11 @@
 from .wav2letter import Wav2Letter
 from .wavernn import WaveRNN
 from .conv_tasnet import ConvTasNet
+from .deepspeech import DeepSpeech
 
 __all__ = [
     'Wav2Letter',
     'WaveRNN',
     'ConvTasNet',
+    'DeepSpeech',
 ]

--- a/torchaudio/models/deepspeech.py
+++ b/torchaudio/models/deepspeech.py
@@ -1,0 +1,88 @@
+import torch
+import torch.nn as nn
+
+__all__ = ["DeepSpeech"]
+
+
+class FullyConnected(nn.Module):
+    """
+    Args:
+        in_features: Number of input features
+        hidden_size: Internal hidden unit size.
+    """
+
+    def __init__(self,
+                 in_features: int,
+                 hidden_size: int,
+                 dropout: float,
+                 relu_max_clip: int = 20) -> None:
+        super(FullyConnected, self).__init__()
+        self.fc = nn.Linear(in_features, hidden_size, bias=True)
+        self.nonlinearity = nn.Sequential(*[
+            nn.ReLU(),
+            nn.Hardtanh(0, relu_max_clip)
+        ])
+        if dropout:
+            self.nonlinearity = nn.Sequential(*[
+                self.nonlinearity,
+                nn.Dropout(dropout)
+            ])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.fc(x)
+        x = self.nonlinearity(x)
+        return x
+
+
+class DeepSpeech(nn.Module):
+    """
+    DeepSpeech model architecture from
+    `"Deep Speech: Scaling up end-to-end speech recognition"`
+    <https://arxiv.org/abs/1412.5567> paper.
+
+    Args:
+        in_features: Number of input features
+        hidden_size: Internal hidden unit size.
+        num_classes: Number of output classes
+    """
+
+    def __init__(self,
+                 in_features: int,
+                 hidden_size: int = 2048,
+                 num_classes: int = 40,
+                 dropout: float = 0.0) -> None:
+        super(DeepSpeech, self).__init__()
+        self.hidden_size = hidden_size
+        self.fc1 = FullyConnected(in_features, hidden_size, dropout)
+        self.fc2 = FullyConnected(hidden_size, hidden_size, dropout)
+        self.fc3 = FullyConnected(hidden_size, hidden_size, dropout)
+        self.bi_rnn = nn.RNN(
+            hidden_size, hidden_size, num_layers=1, nonlinearity='relu', bidirectional=True)
+        self.nonlinearity = nn.ReLU()
+        self.fc4 = FullyConnected(hidden_size, hidden_size, dropout)
+        self.out = nn.Sequential(*[
+            nn.Linear(hidden_size, num_classes),
+            nn.LogSoftmax(dim=2)
+        ])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # N x C x T x F
+        x = self.fc1(x)
+        # N x C x T x H
+        x = self.fc2(x)
+        # N x C x T x H
+        x = self.fc3(x)
+        # N x C x T x H
+        x = x.squeeze(1)
+        # N x T x H
+        x = x.transpose(0, 1)
+        # T x N x H
+        x, _ = self.bi_rnn(x)
+        # The fifth (non-recurrent) layer takes both the forward and backward units as inputs
+        x = x[:, :, :self.hidden_size] + x[:, :, self.hidden_size:]
+        # T x N x H
+        x = self.fc4(x)
+        # T x N x H
+        x = self.out(x)
+        # T x N x num_classes
+        return x

--- a/torchaudio/models/deepspeech.py
+++ b/torchaudio/models/deepspeech.py
@@ -1,10 +1,9 @@
 import torch
-import torch.nn as nn
 
 __all__ = ["DeepSpeech"]
 
 
-class FullyConnected(nn.Module):
+class FullyConnected(torch.nn.Module):
     """
     Args:
         n_feature: Number of input features
@@ -17,7 +16,7 @@ class FullyConnected(nn.Module):
                  dropout: float,
                  relu_max_clip: int = 20) -> None:
         super(FullyConnected, self).__init__()
-        self.fc = nn.Linear(n_feature, n_hidden, bias=True)
+        self.fc = torch.nn.Linear(n_feature, n_hidden, bias=True)
         self.relu_max_clip = relu_max_clip
         self.dropout = dropout
 
@@ -30,7 +29,7 @@ class FullyConnected(nn.Module):
         return x
 
 
-class DeepSpeech(nn.Module):
+class DeepSpeech(torch.nn.Module):
     """
     DeepSpeech model architecture from
     `"Deep Speech: Scaling up end-to-end speech recognition"`
@@ -42,20 +41,23 @@ class DeepSpeech(nn.Module):
         n_class: Number of output classes
     """
 
-    def __init__(self,
-                 n_feature: int,
-                 n_hidden: int = 2048,
-                 n_class: int = 40,
-                 dropout: float = 0.0) -> None:
+    def __init__(
+        self,
+        n_feature: int,
+        n_hidden: int = 2048,
+        n_class: int = 40,
+        dropout: float = 0.0,
+    ) -> None:
         super(DeepSpeech, self).__init__()
         self.n_hidden = n_hidden
         self.fc1 = FullyConnected(n_feature, n_hidden, dropout)
         self.fc2 = FullyConnected(n_hidden, n_hidden, dropout)
         self.fc3 = FullyConnected(n_hidden, n_hidden, dropout)
-        self.bi_rnn = nn.RNN(
-            n_hidden, n_hidden, num_layers=1, nonlinearity='relu', bidirectional=True)
+        self.bi_rnn = torch.nn.RNN(
+            n_hidden, n_hidden, num_layers=1, nonlinearity="relu", bidirectional=True
+        )
         self.fc4 = FullyConnected(n_hidden, n_hidden, dropout)
-        self.out = nn.Linear(n_hidden, n_class)
+        self.out = torch.nn.Linear(n_hidden, n_class)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """

--- a/torchaudio/models/deepspeech.py
+++ b/torchaudio/models/deepspeech.py
@@ -66,6 +66,12 @@ class DeepSpeech(nn.Module):
         ])
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            x (torch.Tensor): Tensor of dimension (batch_size, num_channels, input_length, num_features).
+        Returns:
+            Tensor: Predictor tensor of dimension (input_length, batch_size, number_of_classes).
+        """
         # N x C x T x F
         x = self.fc1(x)
         # N x C x T x H


### PR DESCRIPTION
- Add Documentation related to module models
- Add documentation to model `DeepSpeech`
- Add Unit-test to `DeepSpeech`
- Add model `DeepSpeech` according to its paper [Deep Speech: Scaling up end-to-end speech recognition](https://arxiv.org/abs/1412.5567)

Relates to https://github.com/pytorch/audio/issues/446