### PR TITLE
Fix .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,32 +1,35 @@
 ---
-# NOTE there must be no spaces before the '-', so put the comma first.
+# NOTE there must be no spaces before the '-' and check name.
+# If you edit this list, please verify list of enabled check with
+#   clang-tidy --list-checks
+InheritParentConfig: true
 Checks: '
-  -*
-  ,bugprone-*
-  ,-bugprone-forward-declaration-namespace
-  ,-bugprone-macro-parentheses
-  ,cppcoreguidelines-*
-  ,-cppcoreguidelines-interfaces-global-init
-  ,-cppcoreguidelines-owning-memory
-  ,-cppcoreguidelines-pro-bounds-array-to-pointer-decay
-  ,-cppcoreguidelines-pro-bounds-constant-array-index
-  ,-cppcoreguidelines-pro-bounds-pointer-arithmetic
-  ,-cppcoreguidelines-pro-type-cstyle-cast
-  ,-cppcoreguidelines-pro-type-reinterpret-cast
-  ,-cppcoreguidelines-pro-type-static-cast-downcast
-  ,-cppcoreguidelines-pro-type-union-access
-  ,-cppcoreguidelines-pro-type-vararg
-  ,-cppcoreguidelines-special-member-functions
-  ,hicpp-exception-baseclass
-  ,hicpp-avoid-goto
-  ,modernize-*
-  ,-modernize-return-braced-init-list
-  ,-modernize-use-auto
-  ,-modernize-use-default-member-init
-  ,-modernize-use-using
-  ,performance-unnecessary-value-param
-  '
-WarningsAsErrors: '*'
+bugprone-*,
+-bugprone-forward-declaration-namespace,
+-bugprone-macro-parentheses,
+-clang-analyzer-*,
+cppcoreguidelines-*,
+-cppcoreguidelines-interfaces-global-init,
+-cppcoreguidelines-owning-memory,
+-cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+-cppcoreguidelines-pro-bounds-constant-array-index,
+-cppcoreguidelines-pro-bounds-pointer-arithmetic,
+-cppcoreguidelines-pro-type-cstyle-cast,
+-cppcoreguidelines-pro-type-reinterpret-cast,
+-cppcoreguidelines-pro-type-static-cast-downcast,
+-cppcoreguidelines-pro-type-union-access,
+-cppcoreguidelines-pro-type-vararg,
+-cppcoreguidelines-special-member-functions,
+-facebook-hte-RelativeInclude,
+hicpp-exception-baseclass,
+hicpp-avoid-goto,
+modernize-*,
+-modernize-return-braced-init-list,
+-modernize-use-auto,
+-modernize-use-default-member-init,
+-modernize-use-using,
+performance-unnecessary-value-param,
+'
 HeaderFilterRegex: 'torchaudio/.*'
 AnalyzeTemporaryDtors: false
 CheckOptions:


### PR DESCRIPTION
This change is same as PR #1401. This is created as the reference PR is unable to be merged in master