### PR TITLE
Add autograd test to T.TimeStretch (and F.phase_vocoder)

### DIFF
--- a/test/torchaudio_unittest/transforms/autograd_test_impl.py
+++ b/test/torchaudio_unittest/transforms/autograd_test_impl.py
@@ -36,8 +36,8 @@ class AutogradTestMixin(TestBaseMixin):
     ):
         transform = transform.to(dtype=torch.float64, device=self.device)
 
-        # For the autograd test, float32 and cfloat64 are not good enough
-        # we make sure that all the tensors are of float64 or cfloat128
+        # gradcheck and gradgradcheck only pass if the input tensors are of dtype `torch.double` or 
+        # `torch.cdouble`, when the default eps and tolerance values are used.
         inputs_ = []
         for i in inputs:
             if torch.is_tensor(i):

--- a/test/torchaudio_unittest/transforms/autograd_test_impl.py
+++ b/test/torchaudio_unittest/transforms/autograd_test_impl.py
@@ -36,6 +36,8 @@ class AutogradTestMixin(TestBaseMixin):
     ):
         transform = transform.to(dtype=torch.float64, device=self.device)
 
+        # For the autograd test, float32 and cfloat64 are not good enough
+        # we make sure that all the tensors are of float64 or cfloat128
         inputs_ = []
         for i in inputs:
             if torch.is_tensor(i):
@@ -172,10 +174,10 @@ class AutogradTestMixin(TestBaseMixin):
         waveform = get_whitenoise(sample_rate=40, duration=1, n_channels=2)
         spectrogram = get_spectrogram(waveform, n_fft=n_fft, power=None)
 
-        # 1e-3 is still too close on CPU
+        # 1e-3 is too small (on CPU)
         epsilon = 1e-2
         too_close = spectrogram.abs() < epsilon
-        spectrogram[too_close] = spectrogram[too_close] / spectrogram[too_close].abs()
+        spectrogram[too_close] = epsilon * spectrogram[too_close] / spectrogram[too_close].abs()
         if test_pseudo_complex:
             spectrogram = torch.view_as_real(spectrogram)
         self.assert_grad(transform, [spectrogram])

--- a/test/torchaudio_unittest/transforms/autograd_test_impl.py
+++ b/test/torchaudio_unittest/transforms/autograd_test_impl.py
@@ -154,7 +154,7 @@ class AutogradTestMixin(TestBaseMixin):
         [0.7, 0.8, 0.9, 1.0, 1.3],
         [False, True],
     )
-    def test_timestretch(self, rate, test_pseudo_complex):
+    def test_timestretch_non_zero(self, rate, test_pseudo_complex):
         """Verify that ``T.TimeStretch`` does not fail if it's not close to 0
 
         ``T.TimeStrech`` is not differentiable around 0, so this test checks the differentiability


### PR DESCRIPTION
**UPDATE**
Due to the conversion from cartesian coordinate to polar coordinate, `F.phase_vocoder` (and `T.TimeStretch`) is not differentiable everywhere.

---
Part of #1337 
~Looks like `rate=0.7` is not differentiable to second degree.~
~Let's see what are the value ranges of `rate`, that are differentiable to second degree.~
`T.TimeStretch` manipulates spectrogram in polar coordinate.
The angle conversion from Cartesian to Polar (`atan2(Img, Real)`) does not have a 
nice differentiability around `(x=0, y=0)` and `theta = +/- pi`, therefore `T.TimeStrech` is not differentiable there.

**TODO**
- [x] Check if `rate=0.7` issue happens without complex Tensor adaptation (#1430)
    -> Yes it does. In fact the adaptation of complex Tensor makes the TimeStretch work with rate in range 0.8 ~ 1.3.
    -> Filed the issue for `rate=0.7` pytorch/pytorch#55557