### PR TITLE
Refactor implementation of F.compute_deltas

### DIFF
--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -793,7 +793,7 @@ def compute_deltas(
 
     # pack batch
     shape = specgram.size()
-    specgram = specgram.reshape(1, -1, shape[-1])
+    specgram = specgram.reshape(-1, 1, shape[-1])
 
     assert win_length >= 3
 
@@ -804,9 +804,9 @@ def compute_deltas(
 
     specgram = torch.nn.functional.pad(specgram, (n, n), mode=mode)
 
-    kernel = torch.arange(-n, n + 1, 1, device=device, dtype=dtype).repeat(specgram.shape[1], 1, 1)
+    kernel = torch.arange(-n, n + 1, 1, device=device, dtype=dtype).view(1, 1, -1)
 
-    output = torch.nn.functional.conv1d(specgram, kernel, groups=specgram.shape[1]) / denom
+    output = torch.nn.functional.conv1d(specgram, kernel) / denom
 
     # unpack batch
     output = output.reshape(shape)


### PR DESCRIPTION
Removing the `repeat` function and replacing groups convolution with regular convolution can lower the size of kernel, and is more memory friendly. 
Can also have some performance gain, probably.