### PR TITLE
Fixed jinja2 environment autoescape to enable select extensions

### DIFF
--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -15,6 +15,7 @@ https://github.com/pytorch/vision/pull/1321#issuecomment-531033978
 """
 
 import jinja2
+from jinja2 import select_autoescape
 import yaml
 import os.path
 
@@ -213,7 +214,7 @@ if __name__ == "__main__":
     env = jinja2.Environment(
         loader=jinja2.FileSystemLoader(d),
         lstrip_blocks=True,
-        autoescape=False,
+        autoescape=select_autoescape(enabled_extensions=('html', 'xml')),
     )
 
     with open(os.path.join(d, 'config.yml'), 'w') as f:


### PR DESCRIPTION
This PR fixes an issue pointed out by [Bandit](https://bandit.readthedocs.io/en/latest/) w.r.t. using `autoescape=False` with a Jinja2 environment to avoid cross-site scripting vulnerabilities.

Bandit output:
```
>> Issue: [B701:jinja2_autoescape_false] Using jinja2 templates with autoescape=False is dangerous and can lead to XSS. Use autoescape=True or use the select_autoescape function to mitigate XSS vulnerabilities.
   Severity: High   Confidence: High
   Location: ./.circleci/regenerate.py:213
   More Info: https://bandit.readthedocs.io/en/latest/plugins/b701_jinja2_autoescape_false.html
```