### PR TITLE
Fixed URLContext response leak

### DIFF
--- a/torchaudio/datasets/utils.py
+++ b/torchaudio/datasets/utils.py
@@ -29,7 +29,8 @@ def stream_url(url: str,
 
     # If we already have the whole file, there is no need to download it again
     req = urllib.request.Request(url, method="HEAD")
-    url_size = int(urllib.request.urlopen(req).info().get("Content-Length", -1))
+    with urllib.request.urlopen(req) as response:
+        url_size = int(response.info().get("Content-Length", -1))
     if url_size == start_byte:
         return
 


### PR DESCRIPTION
This PR fixes an issue pointed out by [Bandit](https://bandit.readthedocs.io/en/latest/) w.r.t. auditing opened URLs for permitted schemes.

Bandit output:
```
>> Issue: [B310:blacklist] Audit url open for permitted schemes. Allowing use of file:/ or custom schemes is often unexpected.
   Severity: Medium   Confidence: High
   Location: ./torchaudio/datasets/utils.py:32
   More Info: https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b310-urllib-urlopen
31          req = urllib.request.Request(url, method="HEAD")
32          url_size = int(urllib.request.urlopen(req).info().get("Content-Length", -1))
33          if url_size == start_byte:
```