### PR TITLE
Do not print CPU info before running tests

### DIFF
--- a/.circleci/unittest/linux/scripts/run_test.sh
+++ b/.circleci/unittest/linux/scripts/run_test.sh
@@ -11,9 +11,7 @@ case "$(uname -s)" in
 esac
 
 python -m torch.utils.collect_env
-if [ "${os}" == Linux ]; then
-    cat /proc/cpuinfo
-fi
+
 export TORCHAUDIO_TEST_FAIL_IF_NO_EXTENSION=1
 export PATH="${PWD}/third_party/install/bin/:${PATH}"
 


### PR DESCRIPTION
This code was added as a part of investigation of inconsistent behavior
of file-like object support. Now the investigation is done and this code
does not provide much insight yet adds a bunch of lines to the log, so
this PR removes it.