### PR TITLE
Shortening lfilter autograd tests input size

### DIFF
--- a/test/torchaudio_unittest/functional/autograd_impl.py
+++ b/test/torchaudio_unittest/functional/autograd_impl.py
@@ -29,7 +29,7 @@ class Autograd(TestBaseMixin):
 
     def test_lfilter_x(self):
         torch.random.manual_seed(2434)
-        x = get_whitenoise(sample_rate=22050, duration=0.025, n_channels=2)
+        x = get_whitenoise(sample_rate=22050, duration=0.01, n_channels=2)
         a = torch.tensor([0.7, 0.2, 0.6])
         b = torch.tensor([0.4, 0.2, 0.9])
         x.requires_grad = True
@@ -37,7 +37,7 @@ class Autograd(TestBaseMixin):
 
     def test_lfilter_a(self):
         torch.random.manual_seed(2434)
-        x = get_whitenoise(sample_rate=22050, duration=0.05, n_channels=2)
+        x = get_whitenoise(sample_rate=22050, duration=0.01, n_channels=2)
         a = torch.tensor([0.7, 0.2, 0.6])
         b = torch.tensor([0.4, 0.2, 0.9])
         a.requires_grad = True
@@ -45,7 +45,7 @@ class Autograd(TestBaseMixin):
 
     def test_lfilter_b(self):
         torch.random.manual_seed(2434)
-        x = get_whitenoise(sample_rate=22050, duration=0.05, n_channels=2)
+        x = get_whitenoise(sample_rate=22050, duration=0.01, n_channels=2)
         a = torch.tensor([0.7, 0.2, 0.6])
         b = torch.tensor([0.4, 0.2, 0.9])
         b.requires_grad = True
@@ -53,14 +53,14 @@ class Autograd(TestBaseMixin):
 
     def test_lfilter_all_inputs(self):
         torch.random.manual_seed(2434)
-        x = get_whitenoise(sample_rate=22050, duration=0.05, n_channels=2)
+        x = get_whitenoise(sample_rate=22050, duration=0.01, n_channels=2)
         a = torch.tensor([0.7, 0.2, 0.6])
         b = torch.tensor([0.4, 0.2, 0.9])
         self.assert_grad(F.lfilter, (x, a, b))
 
     def test_biquad(self):
         torch.random.manual_seed(2434)
-        x = get_whitenoise(sample_rate=22050, duration=0.05, n_channels=2)
+        x = get_whitenoise(sample_rate=22050, duration=0.01, n_channels=1)
         a = torch.tensor([0.7, 0.2, 0.6])
         b = torch.tensor([0.4, 0.2, 0.9])
         self.assert_grad(F.biquad, (x, b[0], b[1], b[2], a[0], a[1], a[2]))
@@ -72,7 +72,7 @@ class Autograd(TestBaseMixin):
     def test_band_biquad(self, central_freq, Q, noise):
         torch.random.manual_seed(2434)
         sr = 22050
-        x = get_whitenoise(sample_rate=sr, duration=0.05, n_channels=2)
+        x = get_whitenoise(sample_rate=sr, duration=0.01, n_channels=1)
         central_freq = torch.tensor(central_freq)
         Q = torch.tensor(Q)
         self.assert_grad(F.band_biquad, (x, sr, central_freq, Q, noise))
@@ -84,7 +84,7 @@ class Autograd(TestBaseMixin):
     def test_bass_biquad(self, central_freq, Q, gain):
         torch.random.manual_seed(2434)
         sr = 22050
-        x = get_whitenoise(sample_rate=sr, duration=0.05, n_channels=2)
+        x = get_whitenoise(sample_rate=sr, duration=0.01, n_channels=1)
         central_freq = torch.tensor(central_freq)
         Q = torch.tensor(Q)
         gain = torch.tensor(gain)
@@ -98,7 +98,7 @@ class Autograd(TestBaseMixin):
     def test_treble_biquad(self, central_freq, Q, gain):
         torch.random.manual_seed(2434)
         sr = 22050
-        x = get_whitenoise(sample_rate=sr, duration=0.05, n_channels=2)
+        x = get_whitenoise(sample_rate=sr, duration=0.01, n_channels=1)
         central_freq = torch.tensor(central_freq)
         Q = torch.tensor(Q)
         gain = torch.tensor(gain)
@@ -110,7 +110,7 @@ class Autograd(TestBaseMixin):
     def test_allpass_biquad(self, central_freq, Q):
         torch.random.manual_seed(2434)
         sr = 22050
-        x = get_whitenoise(sample_rate=sr, duration=0.05, n_channels=2)
+        x = get_whitenoise(sample_rate=sr, duration=0.01, n_channels=1)
         central_freq = torch.tensor(central_freq)
         Q = torch.tensor(Q)
         self.assert_grad(F.allpass_biquad, (x, sr, central_freq, Q))
@@ -121,7 +121,7 @@ class Autograd(TestBaseMixin):
     def test_lowpass_biquad(self, cutoff_freq, Q):
         torch.random.manual_seed(2434)
         sr = 22050
-        x = get_whitenoise(sample_rate=sr, duration=0.05, n_channels=2)
+        x = get_whitenoise(sample_rate=sr, duration=0.01, n_channels=1)
         cutoff_freq = torch.tensor(cutoff_freq)
         Q = torch.tensor(Q)
         self.assert_grad(F.lowpass_biquad, (x, sr, cutoff_freq, Q))
@@ -132,7 +132,7 @@ class Autograd(TestBaseMixin):
     def test_highpass_biquad(self, cutoff_freq, Q):
         torch.random.manual_seed(2434)
         sr = 22050
-        x = get_whitenoise(sample_rate=sr, duration=0.05, n_channels=2)
+        x = get_whitenoise(sample_rate=sr, duration=0.01, n_channels=1)
         cutoff_freq = torch.tensor(cutoff_freq)
         Q = torch.tensor(Q)
         self.assert_grad(F.highpass_biquad, (x, sr, cutoff_freq, Q))
@@ -144,7 +144,7 @@ class Autograd(TestBaseMixin):
     def test_bandpass_biquad(self, central_freq, Q, const_skirt_gain):
         torch.random.manual_seed(2434)
         sr = 22050
-        x = get_whitenoise(sample_rate=sr, duration=0.05, n_channels=2)
+        x = get_whitenoise(sample_rate=sr, duration=0.01, n_channels=1)
         central_freq = torch.tensor(central_freq)
         Q = torch.tensor(Q)
         self.assert_grad(F.bandpass_biquad, (x, sr, central_freq, Q, const_skirt_gain))
@@ -156,7 +156,7 @@ class Autograd(TestBaseMixin):
     def test_equalizer_biquad(self, central_freq, Q, gain):
         torch.random.manual_seed(2434)
         sr = 22050
-        x = get_whitenoise(sample_rate=sr, duration=0.05, n_channels=2)
+        x = get_whitenoise(sample_rate=sr, duration=0.01, n_channels=1)
         central_freq = torch.tensor(central_freq)
         Q = torch.tensor(Q)
         gain = torch.tensor(gain)
@@ -168,7 +168,7 @@ class Autograd(TestBaseMixin):
     def test_bandreject_biquad(self, central_freq, Q):
         torch.random.manual_seed(2434)
         sr = 22050
-        x = get_whitenoise(sample_rate=sr, duration=0.05, n_channels=2)
+        x = get_whitenoise(sample_rate=sr, duration=0.01, n_channels=1)
         central_freq = torch.tensor(central_freq)
         Q = torch.tensor(Q)
         self.assert_grad(F.bandreject_biquad, (x, sr, central_freq, Q))


### PR DESCRIPTION
related to #1441 
Use short input sequences to avoid time out error on ci as `gradcheck` and `gradgradcheck` are very time comsuming.