### PR TITLE
Save/load TorchScript object in test

### DIFF
--- a/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
@@ -44,8 +44,8 @@ class Transforms(TempDirMixin, TestBaseMixin):
         self._assert_consistency(T.AmplitudeToDB(), spec)
 
     def test_MelScale(self):
-        spec_f = torch.rand((1, 6, 201))
-        self._assert_consistency(T.MelScale(), spec_f)
+        spec_f = torch.rand((1, 201, 6))
+        self._assert_consistency(T.MelScale(n_stft=201), spec_f)
 
     def test_MelSpectrogram(self):
         tensor = torch.rand((1, 1000))


### PR DESCRIPTION
This PR adds step to save/load TorchScript object while testing TorchScript compatibility.

Part of #1337 