### PR TITLE
Remove VAD from batch consistency tests

### DIFF
--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -197,22 +197,6 @@ class TestFunctional(common_utils.TorchaudioTestCase):
             F.sliding_window_cmn, spectrogram, center=center,
             norm_vars=norm_vars)
 
-    def test_vad_from_file(self):
-        filepath = common_utils.get_asset_path("vad-go-stereo-44100.wav")
-        waveform, sample_rate = common_utils.load_wav(filepath)
-        # Each channel is slightly offset - we can use this to create a batch
-        # with different items.
-        batch = waveform.view(2, 1, -1)
-        self.assert_batch_consistency(F.vad, batch, sample_rate=sample_rate)
-
-    def test_vad_different_items(self):
-        """Separate test to ensure VAD consistency with differing items."""
-        sample_rate = 44100
-        torch.manual_seed(0)
-        waveforms = torch.rand(self.batch_size, 2, 100) - 0.5
-        self.assert_batch_consistency(
-            F.vad, waveforms, sample_rate=sample_rate)
-
     @common_utils.skipIfNoKaldi
     def test_compute_kaldi_pitch(self):
         sample_rate = 44100


### PR DESCRIPTION
As mentioned in #1348 and #1449, the VAD function trims the input tensor to the first instance of voice activity on any channel or item. Trimming batches this way may be undesirable as the item with earliest activity will dominate, but either way, the batch behaviour does not match the itemwise behaviour.

The functional VAD batch consistency tests currently pass out of coincidence, but they specify incorrect behaviour. This PR removes these tests.

Closes #1449