### PR TITLE
Show built doc links directly in PR GUI

### DIFF
--- a/.github/workflows/show_link_to_built_docs.yml
+++ b/.github/workflows/show_link_to_built_docs.yml
@@ -14,3 +14,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-path: 0/docs/index.html
           circleci-jobs: build_docs
+          job-title: See the built docs here!

--- a/.github/workflows/show_link_to_built_docs.yml
+++ b/.github/workflows/show_link_to_built_docs.yml
@@ -1,0 +1,16 @@
+name: Show CI job with links to built docs
+
+on:
+  status
+
+jobs:
+  circleci_artifacts_redirector_job:
+    runs-on: ubuntu-latest
+    name: Run CircleCI artifacts redirector
+    steps:
+      - name: GitHub Action step
+        uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-path: 0/docs/index.html
+          circleci-jobs: build_docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,10 @@ make html
 
 The built docs should now be available in `docs/build/html`
 
+The docs are also automatically built when you submit a PR. The job that
+builds the docs is named `build_docs`. If that job passes, a link to the
+rendered docs will be available in the `build_docs artifact` job.
+
 ## License
 
 By contributing to Torchaudio, you agree that your contributions will be licensed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ The built docs should now be available in `docs/build/html`
 
 The docs are also automatically built when you submit a PR. The job that
 builds the docs is named `build_docs`. If that job passes, a link to the
-rendered docs will be available in the `build_docs artifact` job.
+rendered docs will be available in a job called `See the built docs here!`.
 
 ## License
 


### PR DESCRIPTION
Similar torchvision PR: https://github.com/pytorch/vision/pull/3711


This PR adds a new GitHub action that will automatically add a link to the rendered docs once the `build_docs` job is finished: https://github.com/larsoner/circleci-artifacts-redirector-action

Right now, checking the rendered docs is a bit tedious as one needs to go to the artifacts tab of the `build_docs` job, and then click on the `index.html` file. This will save a few clicks each time and make the rendered docs more obvious to everyone! 

As explained in the link above, this PR needs to be merged in `master` before we can even see whether it works or not (it worked in torchvision: https://github.com/pytorch/vision/pull/3712)