### PR TITLE
[ROCm] add rocm wheels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -840,13 +840,6 @@ workflows:
           requires:
           - download_third_parties_nix
       - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:rocm4.1
-          cuda_version: rocm4.1
-          name: binary_linux_conda_py3.6_rocm4.1
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cuda_version: cpu
           name: binary_linux_conda_py3.7_cpu
@@ -864,13 +857,6 @@ workflows:
           conda_docker_image: pytorch/conda-builder:cuda111
           cuda_version: cu111
           name: binary_linux_conda_py3.7_cu111
-          python_version: '3.7'
-          requires:
-          - download_third_parties_nix
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:rocm4.1
-          cuda_version: rocm4.1
-          name: binary_linux_conda_py3.7_rocm4.1
           python_version: '3.7'
           requires:
           - download_third_parties_nix
@@ -896,13 +882,6 @@ workflows:
           requires:
           - download_third_parties_nix
       - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:rocm4.1
-          cuda_version: rocm4.1
-          name: binary_linux_conda_py3.8_rocm4.1
-          python_version: '3.8'
-          requires:
-          - download_third_parties_nix
-      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cuda_version: cpu
           name: binary_linux_conda_py3.9_cpu
@@ -920,13 +899,6 @@ workflows:
           conda_docker_image: pytorch/conda-builder:cuda111
           cuda_version: cu111
           name: binary_linux_conda_py3.9_cu111
-          python_version: '3.9'
-          requires:
-          - download_third_parties_nix
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:rocm4.1
-          cuda_version: rocm4.1
-          name: binary_linux_conda_py3.9_rocm4.1
           python_version: '3.9'
           requires:
           - download_third_parties_nix
@@ -2343,42 +2315,6 @@ workflows:
           requires:
           - nightly_binary_linux_conda_py3.6_cu111_upload
       - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:rocm4.1
-          cuda_version: rocm4.1
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_rocm4.1
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_rocm4.1_upload
-          requires:
-          - nightly_binary_linux_conda_py3.6_rocm4.1
-      - smoke_test_linux_conda:
-          cuda_version: rocm4.1
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_rocm4.1_smoke_test_conda
-          python_version: '3.6'
-          requires:
-          - nightly_binary_linux_conda_py3.6_rocm4.1_upload
-      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cuda_version: cpu
           filters:
@@ -2486,42 +2422,6 @@ workflows:
           python_version: '3.7'
           requires:
           - nightly_binary_linux_conda_py3.7_cu111_upload
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:rocm4.1
-          cuda_version: rocm4.1
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.7_rocm4.1
-          python_version: '3.7'
-          requires:
-          - download_third_parties_nix
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.7_rocm4.1_upload
-          requires:
-          - nightly_binary_linux_conda_py3.7_rocm4.1
-      - smoke_test_linux_conda:
-          cuda_version: rocm4.1
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.7_rocm4.1_smoke_test_conda
-          python_version: '3.7'
-          requires:
-          - nightly_binary_linux_conda_py3.7_rocm4.1_upload
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cuda_version: cpu
@@ -2631,42 +2531,6 @@ workflows:
           requires:
           - nightly_binary_linux_conda_py3.8_cu111_upload
       - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:rocm4.1
-          cuda_version: rocm4.1
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.8_rocm4.1
-          python_version: '3.8'
-          requires:
-          - download_third_parties_nix
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.8_rocm4.1_upload
-          requires:
-          - nightly_binary_linux_conda_py3.8_rocm4.1
-      - smoke_test_linux_conda:
-          cuda_version: rocm4.1
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.8_rocm4.1_smoke_test_conda
-          python_version: '3.8'
-          requires:
-          - nightly_binary_linux_conda_py3.8_rocm4.1_upload
-      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cuda_version: cpu
           filters:
@@ -2774,42 +2638,6 @@ workflows:
           python_version: '3.9'
           requires:
           - nightly_binary_linux_conda_py3.9_cu111_upload
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:rocm4.1
-          cuda_version: rocm4.1
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.9_rocm4.1
-          python_version: '3.9'
-          requires:
-          - download_third_parties_nix
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.9_rocm4.1_upload
-          requires:
-          - nightly_binary_linux_conda_py3.9_rocm4.1
-      - smoke_test_linux_conda:
-          cuda_version: rocm4.1
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.9_rocm4.1_smoke_test_conda
-          python_version: '3.9'
-          requires:
-          - nightly_binary_linux_conda_py3.9_rocm4.1_upload
       - binary_macos_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cuda_version: cpu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -651,6 +651,13 @@ workflows:
           - download_third_parties_nix
           wheel_docker_image: pytorch/manylinux-cuda111
       - binary_linux_wheel:
+          cuda_version: rocm4.1
+          name: binary_linux_wheel_py3.6_rocm4.1
+          python_version: '3.6'
+          requires:
+          - download_third_parties_nix
+          wheel_docker_image: pytorch/manylinux-rocm:4.1
+      - binary_linux_wheel:
           cuda_version: cpu
           name: binary_linux_wheel_py3.7_cpu
           python_version: '3.7'
@@ -670,6 +677,13 @@ workflows:
           requires:
           - download_third_parties_nix
           wheel_docker_image: pytorch/manylinux-cuda111
+      - binary_linux_wheel:
+          cuda_version: rocm4.1
+          name: binary_linux_wheel_py3.7_rocm4.1
+          python_version: '3.7'
+          requires:
+          - download_third_parties_nix
+          wheel_docker_image: pytorch/manylinux-rocm:4.1
       - binary_linux_wheel:
           cuda_version: cpu
           name: binary_linux_wheel_py3.8_cpu
@@ -691,6 +705,13 @@ workflows:
           - download_third_parties_nix
           wheel_docker_image: pytorch/manylinux-cuda111
       - binary_linux_wheel:
+          cuda_version: rocm4.1
+          name: binary_linux_wheel_py3.8_rocm4.1
+          python_version: '3.8'
+          requires:
+          - download_third_parties_nix
+          wheel_docker_image: pytorch/manylinux-rocm:4.1
+      - binary_linux_wheel:
           cuda_version: cpu
           name: binary_linux_wheel_py3.9_cpu
           python_version: '3.9'
@@ -710,6 +731,13 @@ workflows:
           requires:
           - download_third_parties_nix
           wheel_docker_image: pytorch/manylinux-cuda111
+      - binary_linux_wheel:
+          cuda_version: rocm4.1
+          name: binary_linux_wheel_py3.9_rocm4.1
+          python_version: '3.9'
+          requires:
+          - download_third_parties_nix
+          wheel_docker_image: pytorch/manylinux-rocm:4.1
       - binary_macos_wheel:
           cuda_version: cpu
           name: binary_macos_wheel_py3.6_cpu
@@ -812,6 +840,13 @@ workflows:
           requires:
           - download_third_parties_nix
       - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:rocm4.1
+          cuda_version: rocm4.1
+          name: binary_linux_conda_py3.6_rocm4.1
+          python_version: '3.6'
+          requires:
+          - download_third_parties_nix
+      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cuda_version: cpu
           name: binary_linux_conda_py3.7_cpu
@@ -829,6 +864,13 @@ workflows:
           conda_docker_image: pytorch/conda-builder:cuda111
           cuda_version: cu111
           name: binary_linux_conda_py3.7_cu111
+          python_version: '3.7'
+          requires:
+          - download_third_parties_nix
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:rocm4.1
+          cuda_version: rocm4.1
+          name: binary_linux_conda_py3.7_rocm4.1
           python_version: '3.7'
           requires:
           - download_third_parties_nix
@@ -854,6 +896,13 @@ workflows:
           requires:
           - download_third_parties_nix
       - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:rocm4.1
+          cuda_version: rocm4.1
+          name: binary_linux_conda_py3.8_rocm4.1
+          python_version: '3.8'
+          requires:
+          - download_third_parties_nix
+      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cuda_version: cpu
           name: binary_linux_conda_py3.9_cpu
@@ -871,6 +920,13 @@ workflows:
           conda_docker_image: pytorch/conda-builder:cuda111
           cuda_version: cu111
           name: binary_linux_conda_py3.9_cu111
+          python_version: '3.9'
+          requires:
+          - download_third_parties_nix
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:rocm4.1
+          cuda_version: rocm4.1
+          name: binary_linux_conda_py3.9_rocm4.1
           python_version: '3.9'
           requires:
           - download_third_parties_nix
@@ -1218,6 +1274,42 @@ workflows:
           requires:
           - nightly_binary_linux_wheel_py3.6_cu111_upload
       - binary_linux_wheel:
+          cuda_version: rocm4.1
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.6_rocm4.1
+          python_version: '3.6'
+          requires:
+          - download_third_parties_nix
+          wheel_docker_image: pytorch/manylinux-rocm:4.1
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.6_rocm4.1_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.6_rocm4.1
+      - smoke_test_linux_pip:
+          cuda_version: rocm4.1
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.6_rocm4.1_smoke_test_pip
+          python_version: '3.6'
+          requires:
+          - nightly_binary_linux_wheel_py3.6_rocm4.1_upload
+      - binary_linux_wheel:
           cuda_version: cpu
           filters:
             branches:
@@ -1324,6 +1416,42 @@ workflows:
           python_version: '3.7'
           requires:
           - nightly_binary_linux_wheel_py3.7_cu111_upload
+      - binary_linux_wheel:
+          cuda_version: rocm4.1
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.7_rocm4.1
+          python_version: '3.7'
+          requires:
+          - download_third_parties_nix
+          wheel_docker_image: pytorch/manylinux-rocm:4.1
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.7_rocm4.1_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.7_rocm4.1
+      - smoke_test_linux_pip:
+          cuda_version: rocm4.1
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.7_rocm4.1_smoke_test_pip
+          python_version: '3.7'
+          requires:
+          - nightly_binary_linux_wheel_py3.7_rocm4.1_upload
       - binary_linux_wheel:
           cuda_version: cpu
           filters:
@@ -1432,6 +1560,42 @@ workflows:
           requires:
           - nightly_binary_linux_wheel_py3.8_cu111_upload
       - binary_linux_wheel:
+          cuda_version: rocm4.1
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.8_rocm4.1
+          python_version: '3.8'
+          requires:
+          - download_third_parties_nix
+          wheel_docker_image: pytorch/manylinux-rocm:4.1
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.8_rocm4.1_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.8_rocm4.1
+      - smoke_test_linux_pip:
+          cuda_version: rocm4.1
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.8_rocm4.1_smoke_test_pip
+          python_version: '3.8'
+          requires:
+          - nightly_binary_linux_wheel_py3.8_rocm4.1_upload
+      - binary_linux_wheel:
           cuda_version: cpu
           filters:
             branches:
@@ -1538,6 +1702,42 @@ workflows:
           python_version: '3.9'
           requires:
           - nightly_binary_linux_wheel_py3.9_cu111_upload
+      - binary_linux_wheel:
+          cuda_version: rocm4.1
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.9_rocm4.1
+          python_version: '3.9'
+          requires:
+          - download_third_parties_nix
+          wheel_docker_image: pytorch/manylinux-rocm:4.1
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.9_rocm4.1_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.9_rocm4.1
+      - smoke_test_linux_pip:
+          cuda_version: rocm4.1
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.9_rocm4.1_smoke_test_pip
+          python_version: '3.9'
+          requires:
+          - nightly_binary_linux_wheel_py3.9_rocm4.1_upload
       - binary_macos_wheel:
           cuda_version: cpu
           filters:
@@ -2143,6 +2343,42 @@ workflows:
           requires:
           - nightly_binary_linux_conda_py3.6_cu111_upload
       - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:rocm4.1
+          cuda_version: rocm4.1
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.6_rocm4.1
+          python_version: '3.6'
+          requires:
+          - download_third_parties_nix
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.6_rocm4.1_upload
+          requires:
+          - nightly_binary_linux_conda_py3.6_rocm4.1
+      - smoke_test_linux_conda:
+          cuda_version: rocm4.1
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.6_rocm4.1_smoke_test_conda
+          python_version: '3.6'
+          requires:
+          - nightly_binary_linux_conda_py3.6_rocm4.1_upload
+      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cuda_version: cpu
           filters:
@@ -2250,6 +2486,42 @@ workflows:
           python_version: '3.7'
           requires:
           - nightly_binary_linux_conda_py3.7_cu111_upload
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:rocm4.1
+          cuda_version: rocm4.1
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.7_rocm4.1
+          python_version: '3.7'
+          requires:
+          - download_third_parties_nix
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.7_rocm4.1_upload
+          requires:
+          - nightly_binary_linux_conda_py3.7_rocm4.1
+      - smoke_test_linux_conda:
+          cuda_version: rocm4.1
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.7_rocm4.1_smoke_test_conda
+          python_version: '3.7'
+          requires:
+          - nightly_binary_linux_conda_py3.7_rocm4.1_upload
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cuda_version: cpu
@@ -2359,6 +2631,42 @@ workflows:
           requires:
           - nightly_binary_linux_conda_py3.8_cu111_upload
       - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:rocm4.1
+          cuda_version: rocm4.1
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.8_rocm4.1
+          python_version: '3.8'
+          requires:
+          - download_third_parties_nix
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.8_rocm4.1_upload
+          requires:
+          - nightly_binary_linux_conda_py3.8_rocm4.1
+      - smoke_test_linux_conda:
+          cuda_version: rocm4.1
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.8_rocm4.1_smoke_test_conda
+          python_version: '3.8'
+          requires:
+          - nightly_binary_linux_conda_py3.8_rocm4.1_upload
+      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cuda_version: cpu
           filters:
@@ -2466,6 +2774,42 @@ workflows:
           python_version: '3.9'
           requires:
           - nightly_binary_linux_conda_py3.9_cu111_upload
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:rocm4.1
+          cuda_version: rocm4.1
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.9_rocm4.1
+          python_version: '3.9'
+          requires:
+          - download_third_parties_nix
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.9_rocm4.1_upload
+          requires:
+          - nightly_binary_linux_conda_py3.9_rocm4.1
+      - smoke_test_linux_conda:
+          cuda_version: rocm4.1
+          filters:
+            branches:
+              only:
+              - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.9_rocm4.1_smoke_test_conda
+          python_version: '3.9'
+          requires:
+          - nightly_binary_linux_conda_py3.9_rocm4.1_upload
       - binary_macos_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cuda_version: cpu

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -36,7 +36,10 @@ def build_workflows(prefix='', upload=False, filter_branch=None, indentation=6):
         for os_type in ["linux", "macos", "windows"]:
             for python_version in PYTHON_VERSIONS:
                 for cu_version in CU_VERSIONS_DICT[os_type]:
-                    w += build_workflow_pair(btype, os_type, python_version, cu_version, filter_branch, prefix, upload)
+                    if cu_version.startswith("rocm") and btype=="conda":
+                        pass
+                    else:
+                        w += build_workflow_pair(btype, os_type, python_version, cu_version, filter_branch, prefix, upload)
 
     if not filter_branch:
         # Build on every pull request, but upload only on nightly and tags

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -21,7 +21,7 @@ import os.path
 
 
 PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9"]
-CU_VERSIONS_DICT = {"linux": ["cpu", "cu102", "cu111"],
+CU_VERSIONS_DICT = {"linux": ["cpu", "cu102", "cu111","rocm4.1"],
                     "windows": ["cpu", "cu102", "cu111"],
                     "macos": ["cpu"]}
 
@@ -124,8 +124,10 @@ def generate_base_workflow(base_workflow_name, python_version, cu_version, filte
         d['requires'] = ['download_third_parties_nix']
     if btype == 'conda':
         d['conda_docker_image'] = f'pytorch/conda-builder:{cu_version.replace("cu1","cuda1")}'
-    elif cu_version != 'cpu':
+    elif cu_version.startswith('cu'):
         d['wheel_docker_image'] = f'pytorch/manylinux-{cu_version.replace("cu1","cuda1")}'
+    elif cu_version.startswith('rocm'):
+        d["wheel_docker_image"] = f"pytorch/manylinux-rocm:{cu_version[len('rocm'):]}"
 
     if filter_branch:
         d["filters"] = gen_filter_branch_tree(filter_branch)

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -107,6 +107,10 @@ setup_cuda() {
       export FORCE_CUDA=1
       export TORCH_CUDA_ARCH_LIST="3.5;5.0+PTX;6.0;7.0"
       ;;
+    rocm*)
+      export FORCE_CUDA=1
+      export USE_ROCM=1
+      ;;
     cpu)
       ;;
     *)


### PR DESCRIPTION
This PR adds wheels for rocm. It is based on this PR for pytorch vision(https://github.com/pytorch/vision/pull/3575) that adds rocm wheels . 

It works by creating a rocm version of the binary_linux_wheel build jobs that use pytorch/manylinux-rocm instead of manylinux-cuda102.