### PR TITLE
Ensure axis masking operations are not in-place

### DIFF
--- a/test/torchaudio_unittest/functional/functional_impl.py
+++ b/test/torchaudio_unittest/functional/functional_impl.py
@@ -200,6 +200,7 @@ class Functional(TestBaseMixin):
     def test_mask_along_axis(self, shape, mask_param, mask_value, axis):
         torch.random.manual_seed(42)
         specgram = torch.randn(*shape, dtype=self.dtype, device=self.device)
+        specgram_copy = specgram.clone()
         mask_specgram = F.mask_along_axis(specgram, mask_param, mask_value, axis)
 
         other_axis = 1 if axis == 2 else 2
@@ -211,11 +212,13 @@ class Functional(TestBaseMixin):
 
         assert mask_specgram.size() == specgram.size()
         assert num_masked_columns < mask_param
+        self.assertEqual(specgram, specgram_copy)
 
     @parameterized.expand(list(itertools.product([100], [0., 30.], [2, 3])))
     def test_mask_along_axis_iid(self, mask_param, mask_value, axis):
         torch.random.manual_seed(42)
         specgrams = torch.randn(4, 2, 1025, 400, dtype=self.dtype, device=self.device)
+        specgrams_copy = specgrams.clone()
 
         mask_specgrams = F.mask_along_axis_iid(specgrams, mask_param, mask_value, axis)
 
@@ -226,6 +229,7 @@ class Functional(TestBaseMixin):
 
         assert mask_specgrams.size() == specgrams.size()
         assert (num_masked_columns < mask_param).sum() == num_masked_columns.numel()
+        self.assertEqual(specgrams, specgrams_copy)
 
 
 class FunctionalComplex(TestBaseMixin):

--- a/test/torchaudio_unittest/functional/functional_impl.py
+++ b/test/torchaudio_unittest/functional/functional_impl.py
@@ -233,27 +233,31 @@ class Functional(TestBaseMixin):
     def test_mask_along_axis_preserve(self, shape, mask_param, mask_value, axis):
         """mask_along_axis should not alter original input Tensor
 
-        https://github.com/pytorch/audio/issues/1478
+        Test is run 5 times to bound the probability of no masking occurring to 1e-10
+        See https://github.com/pytorch/audio/issues/1478
         """
         torch.random.manual_seed(42)
-        specgram = torch.randn(*shape, dtype=self.dtype, device=self.device)
-        specgram_copy = specgram.clone()
-        F.mask_along_axis(specgram, mask_param, mask_value, axis)
+        for _ in range(5):
+            specgram = torch.randn(*shape, dtype=self.dtype, device=self.device)
+            specgram_copy = specgram.clone()
+            F.mask_along_axis(specgram, mask_param, mask_value, axis)
 
-        self.assertEqual(specgram, specgram_copy)
+            self.assertEqual(specgram, specgram_copy)
 
     @parameterized.expand(list(itertools.product([100], [0., 30.], [2, 3])))
     def test_mask_along_axis_iid_preserve(self, mask_param, mask_value, axis):
         """mask_along_axis_iid should not alter original input Tensor
 
-        https://github.com/pytorch/audio/issues/1478
+        Test is run 5 times to bound the probability of no masking occurring to 1e-10
+        See https://github.com/pytorch/audio/issues/1478
         """
         torch.random.manual_seed(42)
-        specgrams = torch.randn(4, 2, 1025, 400, dtype=self.dtype, device=self.device)
-        specgrams_copy = specgrams.clone()
-        F.mask_along_axis_iid(specgrams, mask_param, mask_value, axis)
+        for _ in range(5):
+            specgrams = torch.randn(4, 2, 1025, 400, dtype=self.dtype, device=self.device)
+            specgrams_copy = specgrams.clone()
+            F.mask_along_axis_iid(specgrams, mask_param, mask_value, axis)
 
-        self.assertEqual(specgrams, specgrams_copy)
+            self.assertEqual(specgrams, specgrams_copy)
 
 
 class FunctionalComplex(TestBaseMixin):

--- a/test/torchaudio_unittest/functional/functional_impl.py
+++ b/test/torchaudio_unittest/functional/functional_impl.py
@@ -200,7 +200,6 @@ class Functional(TestBaseMixin):
     def test_mask_along_axis(self, shape, mask_param, mask_value, axis):
         torch.random.manual_seed(42)
         specgram = torch.randn(*shape, dtype=self.dtype, device=self.device)
-        specgram_copy = specgram.clone()
         mask_specgram = F.mask_along_axis(specgram, mask_param, mask_value, axis)
 
         other_axis = 1 if axis == 2 else 2
@@ -212,13 +211,11 @@ class Functional(TestBaseMixin):
 
         assert mask_specgram.size() == specgram.size()
         assert num_masked_columns < mask_param
-        self.assertEqual(specgram, specgram_copy)
 
     @parameterized.expand(list(itertools.product([100], [0., 30.], [2, 3])))
     def test_mask_along_axis_iid(self, mask_param, mask_value, axis):
         torch.random.manual_seed(42)
         specgrams = torch.randn(4, 2, 1025, 400, dtype=self.dtype, device=self.device)
-        specgrams_copy = specgrams.clone()
 
         mask_specgrams = F.mask_along_axis_iid(specgrams, mask_param, mask_value, axis)
 
@@ -229,6 +226,33 @@ class Functional(TestBaseMixin):
 
         assert mask_specgrams.size() == specgrams.size()
         assert (num_masked_columns < mask_param).sum() == num_masked_columns.numel()
+
+    @parameterized.expand(
+        list(itertools.product([(2, 1025, 400), (1, 201, 100)], [100], [0., 30.], [1, 2]))
+    )
+    def test_mask_along_axis_preserve(self, shape, mask_param, mask_value, axis):
+        """mask_along_axis should not alter original input Tensor
+
+        https://github.com/pytorch/audio/issues/1478
+        """
+        torch.random.manual_seed(42)
+        specgram = torch.randn(*shape, dtype=self.dtype, device=self.device)
+        specgram_copy = specgram.clone()
+        F.mask_along_axis(specgram, mask_param, mask_value, axis)
+
+        self.assertEqual(specgram, specgram_copy)
+
+    @parameterized.expand(list(itertools.product([100], [0., 30.], [2, 3])))
+    def test_mask_along_axis_iid_preserve(self, mask_param, mask_value, axis):
+        """mask_along_axis_iid should not alter original input Tensor
+
+        https://github.com/pytorch/audio/issues/1478
+        """
+        torch.random.manual_seed(42)
+        specgrams = torch.randn(4, 2, 1025, 400, dtype=self.dtype, device=self.device)
+        specgrams_copy = specgrams.clone()
+        F.mask_along_axis_iid(specgrams, mask_param, mask_value, axis)
+
         self.assertEqual(specgrams, specgrams_copy)
 
 

--- a/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
@@ -13,7 +13,7 @@ from torchaudio_unittest.common_utils import (
 
 
 class Functional(TempDirMixin, TestBaseMixin):
-    """Implements test for `functinoal` modul that are performed for different devices"""
+    """Implements test for `functional` module that are performed for different devices"""
     def _assert_consistency(self, func, tensor, shape_only=False):
         tensor = tensor.to(device=self.device, dtype=self.dtype)
 
@@ -21,8 +21,12 @@ class Functional(TempDirMixin, TestBaseMixin):
         torch.jit.script(func).save(path)
         ts_func = torch.jit.load(path)
 
+        torch.random.manual_seed(40)
         output = func(tensor)
+
+        torch.random.manual_seed(40)
         ts_output = ts_func(tensor)
+
         if shape_only:
             ts_output = ts_output.shape
             output = output.shape

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -783,7 +783,7 @@ def mask_along_axis(
 
     mask_start = (min_value.long()).squeeze()
     mask_end = (min_value.long() + value.long()).squeeze()
-    mask = torch.arange(0, shape[axis], device=specgram.device, dtype=specgram.dtype)
+    mask = torch.arange(0, specgram.shape[axis], device=specgram.device, dtype=specgram.dtype)
     mask = (mask >= mask_start) & (mask < mask_end)
     if axis == 1:
         mask = mask.unsqueeze(-1)


### PR DESCRIPTION
As reported in #1478, `TimeMasking` performs in-place operations that modifies the input tensor. This is also the case for `FrequencyMasking`. 

This PR modifies the algorithm to not perform in-place operations on the input tensor and adds checks in the unit test to ensure that the input tensor is not being changed.

(Resolves #1478)