### PR TITLE
Update xcode version in CI macOS jobs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
     description: "installs tools required to build torchaudio"
     steps:
       - run:
-          name: Install pkg-config
+          name: Install build tools
           command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config wget
           # Disable brew auto update which is very slow
   load_conda_channel_flags:
@@ -162,7 +162,7 @@ jobs:
   binary_macos_wheel:
     <<: *binary_common
     macos:
-      xcode: "9.4.1"
+      xcode: "12.0"
     steps:
       - checkout
       - install_build_tools_macos
@@ -188,7 +188,7 @@ jobs:
   binary_macos_conda:
     <<: *binary_common
     macos:
-      xcode: "9.4.1"
+      xcode: "12.0"
     steps:
       - checkout
       - install_build_tools_macos
@@ -509,7 +509,7 @@ jobs:
   unittest_macos_cpu:
     <<: *binary_common
     macos:
-      xcode: "9.4.1"
+      xcode: "12.0"
     resource_class: large
     steps:
       - checkout

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -42,7 +42,7 @@ commands:
     description: "installs tools required to build torchaudio"
     steps:
       - run:
-          name: Install pkg-config
+          name: Install build tools
           command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config wget
           # Disable brew auto update which is very slow
   load_conda_channel_flags:
@@ -162,7 +162,7 @@ jobs:
   binary_macos_wheel:
     <<: *binary_common
     macos:
-      xcode: "9.4.1"
+      xcode: "12.0"
     steps:
       - checkout
       - install_build_tools_macos
@@ -188,7 +188,7 @@ jobs:
   binary_macos_conda:
     <<: *binary_common
     macos:
-      xcode: "9.4.1"
+      xcode: "12.0"
     steps:
       - checkout
       - install_build_tools_macos
@@ -509,7 +509,7 @@ jobs:
   unittest_macos_cpu:
     <<: *binary_common
     macos:
-      xcode: "9.4.1"
+      xcode: "12.0"
     resource_class: large
     steps:
       - checkout


### PR DESCRIPTION
All macOS CI jobs were failing at `brew`.
The issue was the macOS version `10.13`, which is no longer supported by `brew`.
The macOS version is indirectly controlled by `xcode` version as listed [here](https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions).

Updating the `xcode` to `"12.0"` as in PyTorch core bump macOS version to `10.15` and it resolves the issue.
`Python 3.9` is still failing but it's packaging issue on upstream, which needs to be resolved separately.