### PR TITLE
Add warning for non-integer resampling frequencies

### DIFF
--- a/test/torchaudio_unittest/functional/functional_impl.py
+++ b/test/torchaudio_unittest/functional/functional_impl.py
@@ -261,16 +261,17 @@ class Functional(TestBaseMixin):
 
     def test_resample_no_warning(self):
         sample_rate = 44100
-        waveform = get_whitenoise(sample_rate=sample_rate)
+        waveform = get_whitenoise(sample_rate=sample_rate, duration=0.1)
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            F.resample(waveform, sample_rate, sample_rate / 2)
+            F.resample(waveform, float(sample_rate), sample_rate / 2.)
         assert len(w) == 0
 
     def test_resample_warning(self):
+        """resample should throw a warning if an input frequency is not of an integer value"""
         sample_rate = 44100
-        waveform = get_whitenoise(sample_rate=sample_rate)
+        waveform = get_whitenoise(sample_rate=sample_rate, duration=0.1)
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")

--- a/test/torchaudio_unittest/functional/functional_impl.py
+++ b/test/torchaudio_unittest/functional/functional_impl.py
@@ -9,7 +9,7 @@ import torchaudio.functional as F
 from parameterized import parameterized
 from scipy import signal
 
-from torchaudio_unittest.common_utils import TestBaseMixin, get_sinusoid, nested_params
+from torchaudio_unittest.common_utils import TestBaseMixin, get_sinusoid, nested_params, get_whitenoise
 
 
 class Functional(TestBaseMixin):
@@ -258,6 +258,30 @@ class Functional(TestBaseMixin):
             F.mask_along_axis_iid(specgrams, mask_param, mask_value, axis)
 
             self.assertEqual(specgrams, specgrams_copy)
+
+    def test_resample_no_warning(self):
+        sample_rate = 44100
+        waveform = get_whitenoise(sample_rate=sample_rate)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            F.resample(waveform, sample_rate, sample_rate / 2)
+        assert len(w) == 0
+
+    def test_resample_warning(self):
+        sample_rate = 44100
+        waveform = get_whitenoise(sample_rate=sample_rate)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            F.resample(waveform, sample_rate, 5512.5)
+        assert len(w) == 1
+
+
+class FunctionalComplex(TestBaseMixin):
+    complex_dtype = None
+    real_dtype = None
+    device = None
 
     @nested_params(
         [0.5, 1.01, 1.3],

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -1389,12 +1389,15 @@ def resample(
 
     if not (int(orig_freq) == orig_freq and int(new_freq) == new_freq):
         warnings.warn(
-            "Non-integer frequencies are cast to integers and may result in poor resampling quality."
-            "The algorithm is dependent on the integer ratio between `orig_freq` and `new_freq`,"
-            "so please manually convert frequencies to integer values that maintain the ratio"
-            "prior to passing them into the function"
-            "Example: To downsample a 44100 hz waveform by a factor of 8, you can use"
-            "`orig_freq=8` and `new_freq=1` instead of `orig_freq=44100` and `new_freq=5512.5`"
+            "Non-integer frequencies are being cast to ints and may result in poor resampling quality "
+            "because the underlying algorithm requires an integer ratio between `orig_freq` and `new_freq`. "
+            "Using non-integer valued frequencies will throw an error in the next release. "
+            "To work around this issue, manually convert both frequencies to integer values "
+            "that maintain their resampling rate ratio before passing them into the function "
+            "Example: To downsample a 44100 hz waveform by a factor of 8, use "
+            "`orig_freq=8` and `new_freq=1` instead of `orig_freq=44100` and `new_freq=5512.5` "
+            "For more information or to leave feedback about this change, please refer to "
+            "https://github.com/pytorch/audio/issues/1487."
         )
 
     orig_freq = int(orig_freq)

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -1387,6 +1387,16 @@ def resample(
 
     assert orig_freq > 0.0 and new_freq > 0.0
 
+    if not (int(orig_freq) == orig_freq and int(new_freq) == new_freq):
+        warnings.warn(
+            "Non-integer frequencies are cast to integers and may result in poor resampling quality."
+            "The algorithm is dependent on the integer ratio between `orig_freq` and `new_freq`,"
+            "so please manually convert frequencies to integer values that maintain the ratio"
+            "prior to passing them into the function"
+            "Example: To downsample a 44100 hz waveform by a factor of 8, you can use"
+            "`orig_freq=8` and `new_freq=1` instead of `orig_freq=44100` and `new_freq=5512.5`"
+        )
+
     orig_freq = int(orig_freq)
     new_freq = int(new_freq)
     gcd = math.gcd(orig_freq, new_freq)


### PR DESCRIPTION
Add warning and suggestion when the frequency inputs to the resample function are not integer values

cc #1487