### PR TITLE
Add autograd tests for TimeMasking/FrequencyMasking

### DIFF
--- a/test/torchaudio_unittest/transforms/autograd_test_impl.py
+++ b/test/torchaudio_unittest/transforms/autograd_test_impl.py
@@ -132,8 +132,15 @@ class AutogradTestMixin(TestBaseMixin):
         spectrogram = get_spectrogram(
             get_whitenoise(sample_rate=sample_rate, duration=0.05, n_channels=2),
             n_fft=n_fft, power=1)
+        spectrogram2 = get_spectrogram(
+            # Add second white noise with another seed, so they are different
+            get_whitenoise(sample_rate=sample_rate, duration=0.05, n_channels=2, seed=31),
+            n_fft=n_fft, power=1)
         deterministic_transform = _DeterministicWrapper(masking_transform(400))
+        deterministic_transform_iid = _DeterministicWrapper(masking_transform(400, True))
+
         self.assert_grad(deterministic_transform, [spectrogram])
+        self.assert_grad(deterministic_transform_iid, [spectrogram + spectrogram2])
 
     def test_spectral_centroid(self):
         sample_rate = 8000

--- a/test/torchaudio_unittest/transforms/autograd_test_impl.py
+++ b/test/torchaudio_unittest/transforms/autograd_test_impl.py
@@ -125,14 +125,15 @@ class AutogradTestMixin(TestBaseMixin):
         waveform = get_whitenoise(sample_rate=8000, duration=0.05, n_channels=2)
         self.assert_grad(transform, [waveform], nondet_tol=1e-10)
 
-    def test_time_masking(self):
+    @parameterized.expand([(T.TimeMasking,), (T.FrequencyMasking,)])
+    def test_masking(self, masking_transform):
         sample_rate = 8000
         n_fft = 400
         spectrogram = get_spectrogram(
             get_whitenoise(sample_rate=sample_rate, duration=0.05, n_channels=2),
             n_fft=n_fft, power=1)
-        transform = T.TimeMasking(400)
-        self.assert_grad(transform, [spectrogram])
+        deterministic_transform = _DeterministicWrapper(masking_transform(400))
+        self.assert_grad(deterministic_transform, [spectrogram])
 
     def test_spectral_centroid(self):
         sample_rate = 8000

--- a/test/torchaudio_unittest/transforms/autograd_test_impl.py
+++ b/test/torchaudio_unittest/transforms/autograd_test_impl.py
@@ -145,7 +145,8 @@ class AutogradTestMixin(TestBaseMixin):
             for i in range(3)
         ]
 
-        batch = torch.cat(specs)
+        batch = torch.stack(specs)
+        assert batch.ndim == 4
         deterministic_transform = _DeterministicWrapper(masking_transform(400, True))
         self.assert_grad(deterministic_transform, [batch])
 

--- a/test/torchaudio_unittest/transforms/autograd_test_impl.py
+++ b/test/torchaudio_unittest/transforms/autograd_test_impl.py
@@ -125,6 +125,15 @@ class AutogradTestMixin(TestBaseMixin):
         waveform = get_whitenoise(sample_rate=8000, duration=0.05, n_channels=2)
         self.assert_grad(transform, [waveform], nondet_tol=1e-10)
 
+    def test_time_masking(self):
+        sample_rate = 8000
+        n_fft = 400
+        spectrogram = get_spectrogram(
+            get_whitenoise(sample_rate=sample_rate, duration=0.05, n_channels=2),
+            n_fft=n_fft, power=1)
+        transform = T.TimeMasking(400)
+        self.assert_grad(transform, [spectrogram])
+
     def test_spectral_centroid(self):
         sample_rate = 8000
         transform = T.SpectralCentroid(sample_rate=sample_rate)


### PR DESCRIPTION
Context: #1414

I combined these two transforms in one test because they're actually the same [`_AxisMasking` transform](https://github.com/pytorch/audio/blob/c2740644ee31d29861d3d9977a43af1e71779054/torchaudio/transforms.py#L856), but just on different axis. I even thought of testing the `_AxisMasking` directly, but decided against it because it's not part of the API.

Test fails without the `_DeterministicWrapper` likely due to random behaviour [here](https://github.com/pytorch/audio/blob/c2740644ee31d29861d3d9977a43af1e71779054/torchaudio/functional/functional.py#L792).