### PR TITLE
Precompute transforms.Resample kernel

### DIFF
--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -1383,7 +1383,7 @@ def _apply_sinc_resample_kernel(
     # pack batch
     shape = waveform.size()
     waveform = waveform.view(-1, shape[-1])
-    kernel = kernel.to(dtype=waveform.dtype)
+    kernel = kernel.to(device=waveform.device, dtype=waveform.dtype)
 
     num_wavs, length = waveform.shape
     waveform = torch.nn.functional.pad(waveform, (width, width + orig_freq))
@@ -1434,6 +1434,5 @@ def resample(
     gcd = math.gcd(int(orig_freq), int(new_freq))
 
     kernel, width = _get_sinc_resample_kernel(orig_freq, new_freq, gcd, lowpass_filter_width, rolloff)
-    kernel = kernel.to(device=waveform.device)
     resampled = _apply_sinc_resample_kernel(waveform, orig_freq, new_freq, gcd, kernel, width)
     return resampled

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -1383,7 +1383,7 @@ def _apply_sinc_resample_kernel(
     # pack batch
     shape = waveform.size()
     waveform = waveform.view(-1, shape[-1])
-    kernel = kernel.to(device=waveform.device, dtype=waveform.dtype)
+    kernel = kernel.to(dtype=waveform.dtype)
 
     num_wavs, length = waveform.shape
     waveform = torch.nn.functional.pad(waveform, (width, width + orig_freq))
@@ -1434,5 +1434,6 @@ def resample(
     gcd = math.gcd(int(orig_freq), int(new_freq))
 
     kernel, width = _get_sinc_resample_kernel(orig_freq, new_freq, gcd, lowpass_filter_width, rolloff)
+    kernel = kernel.to(device=waveform.device)
     resampled = _apply_sinc_resample_kernel(waveform, orig_freq, new_freq, gcd, kernel, width)
     return resampled

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -8,7 +8,10 @@ import torch
 from torch import Tensor
 from torchaudio import functional as F
 
-from .functional.functional import _get_sinc_resample_kernel
+from .functional.functional import (
+    _get_sinc_resample_kernel,
+    _apply_sinc_resample_kernel,
+)
 
 __all__ = [
     'Spectrogram',
@@ -654,12 +657,15 @@ class Resample(torch.nn.Module):
                  lowpass_filter_width: int = 6,
                  rolloff: float = 0.99) -> None:
         super(Resample, self).__init__()
-        self.orig_freq = orig_freq
-        self.new_freq = new_freq
+        self.orig_freq = int(orig_freq)
+        self.new_freq = int(new_freq)
+        self.gcd = math.gcd(self.orig_freq, self.new_freq)
         self.resampling_method = resampling_method
         self.lowpass_filter_width = lowpass_filter_width
         self.rolloff = rolloff
-        self.kernel = None
+
+        self.kernel, self.width = _get_sinc_resample_kernel(self.orig_freq // self.gcd, self.new_freq // self.gcd,
+                                                            self.lowpass_filter_width, self.rolloff)
 
     def forward(self, waveform: Tensor) -> Tensor:
         r"""
@@ -670,13 +676,8 @@ class Resample(torch.nn.Module):
             Tensor: Output signal of dimension (..., time).
         """
         if self.resampling_method == 'sinc_interpolation':
-            if self.kernel == None:
-                gcd = math.gcd(self.orig_freq, self.new_freq)
-                orig_freq = self.orig_freq // gcd
-                new_freq = self.new_freq // gcd
-                self.kernel, _ = _get_sinc_resample_kernel(orig_freq, new_freq, self.lowpass_filter_width,
-                                                           self.rolloff, waveform.device, waveform.dtype)
-            return F.resample(waveform, self.orig_freq, self.new_freq, self.lowpass_filter_width, self.rolloff, self.kernel)
+            return _apply_sinc_resample_kernel(waveform, self.orig_freq // self.gcd, self.new_freq // self.gcd,
+                                               self.kernel, self.width)
 
         raise ValueError('Invalid resampling method: {}'.format(self.resampling_method))
 

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -651,20 +651,21 @@ class Resample(torch.nn.Module):
     """
 
     def __init__(self,
-                 orig_freq: int = 16000,
-                 new_freq: int = 16000,
+                 orig_freq: float = 16000,
+                 new_freq: float = 16000,
                  resampling_method: str = 'sinc_interpolation',
                  lowpass_filter_width: int = 6,
                  rolloff: float = 0.99) -> None:
         super(Resample, self).__init__()
-        self.orig_freq = int(orig_freq)
-        self.new_freq = int(new_freq)
-        self.gcd = math.gcd(self.orig_freq, self.new_freq)
+
+        self.orig_freq = orig_freq
+        self.new_freq = new_freq
+        self.gcd = math.gcd(int(self.orig_freq), int(self.new_freq))
         self.resampling_method = resampling_method
         self.lowpass_filter_width = lowpass_filter_width
         self.rolloff = rolloff
 
-        self.kernel, self.width = _get_sinc_resample_kernel(self.orig_freq // self.gcd, self.new_freq // self.gcd,
+        self.kernel, self.width = _get_sinc_resample_kernel(self.orig_freq, self.new_freq, self.gcd,
                                                             self.lowpass_filter_width, self.rolloff)
 
     def forward(self, waveform: Tensor) -> Tensor:
@@ -676,7 +677,7 @@ class Resample(torch.nn.Module):
             Tensor: Output signal of dimension (..., time).
         """
         if self.resampling_method == 'sinc_interpolation':
-            return _apply_sinc_resample_kernel(waveform, self.orig_freq // self.gcd, self.new_freq // self.gcd,
+            return _apply_sinc_resample_kernel(waveform, self.orig_freq, self.new_freq, self.gcd,
                                                self.kernel, self.width)
 
         raise ValueError('Invalid resampling method: {}'.format(self.resampling_method))


### PR DESCRIPTION
The kernel used for resampling computations is the same for a given set of resampling parameters, but is currently being recomputed every call to `resample`. To make computation more efficient for `transforms.Resample`, we can precompute the kernel and pass it in to the function instead.

Follow-ups:
- arbitrary source resampling transforms
- [BC-breaking] do not move kernel device and dtype during computation

cc #1487 