### PR TITLE
Melscale torchscript bugfix

### DIFF
--- a/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
@@ -59,9 +59,12 @@ class Transforms(TempDirMixin, TestBaseMixin):
         spec = torch.rand((6, 201))
         self._assert_consistency(T.AmplitudeToDB(), spec)
 
+    def test_MelScale_invalid(self):
+        with self.assertRaises(ValueError):
+            torch.jit.script(T.MelScale())
+
     def test_MelScale(self):
         spec_f = torch.rand((1, 201, 6))
-        self._assert_consistency(T.MelScale(), spec_f)
         self._assert_consistency(T.MelScale(n_stft=201), spec_f)
 
     def test_MelSpectrogram(self):

--- a/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
@@ -61,6 +61,7 @@ class Transforms(TempDirMixin, TestBaseMixin):
 
     def test_MelScale(self):
         spec_f = torch.rand((1, 201, 6))
+        self._assert_consistency(T.MelScale(), spec_f)
         self._assert_consistency(T.MelScale(n_stft=201), spec_f)
 
     def test_MelSpectrogram(self):

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -276,13 +276,23 @@ class MelScale(torch.nn.Module):
         self.f_min = f_min
         self.norm = norm
         self.mel_scale = mel_scale
+        self.n_stft = n_stft
 
         assert f_min <= self.f_max, 'Require f_min: {} < f_max: {}'.format(f_min, self.f_max)
 
-        fb = torch.empty(0) if n_stft is None else F.create_fb_matrix(
+        fb = torch.empty(0) if self.n_stft is None else F.create_fb_matrix(
             n_stft, self.f_min, self.f_max, self.n_mels, self.sample_rate, self.norm,
             self.mel_scale)
         self.register_buffer('fb', fb)
+
+    def __prepare_scriptable__(self):
+        r"""
+        Prepare self to be scripted
+        Returns:
+            MelScale: self
+        """
+        assert self.n_stft is not None, ValueError("n_stft must be provided at construction")
+        return self
 
     def forward(self, specgram: Tensor) -> Tensor:
         r"""


### PR DESCRIPTION
Added a check in __pre_scriptable__ method for MelScale to make that self.n_stft is not None at the time of scripting.

See https://github.com/pytorch/audio/issues/1454 for details.