### PR TITLE
Add kaiser window support to resampling

### DIFF
--- a/test/torchaudio_unittest/transforms/transforms_test.py
+++ b/test/torchaudio_unittest/transforms/transforms_test.py
@@ -169,9 +169,11 @@ class Tester(common_utils.TorchaudioTestCase):
 
         upsample_rate = sample_rate * 2
         downsample_rate = sample_rate // 2
-        invalid_resample = torchaudio.transforms.Resample(sample_rate, upsample_rate, resampling_method='foo')
+        invalid_resampling_method = 'foo'
 
-        self.assertRaises(ValueError, invalid_resample, waveform)
+        with self.assertRaises(ValueError):
+            torchaudio.transforms.Resample(sample_rate, upsample_rate,
+                                           resampling_method=invalid_resampling_method)
 
         upsample_resample = torchaudio.transforms.Resample(
             sample_rate, upsample_rate, resampling_method='sinc_interpolation')

--- a/torchaudio/compliance/kaldi.py
+++ b/torchaudio/compliance/kaldi.py
@@ -756,7 +756,8 @@ def resample_waveform(waveform: Tensor,
                       orig_freq: float,
                       new_freq: float,
                       lowpass_filter_width: int = 6,
-                      rolloff: float = 0.99) -> Tensor:
+                      rolloff: float = 0.99,
+                      resampling_method: str = "sinc_interpolation") -> Tensor:
     r"""Resamples the waveform at the new frequency.
 
     This is a wrapper around ``torchaudio.functional.resample``.
@@ -773,4 +774,5 @@ def resample_waveform(waveform: Tensor,
     Returns:
         Tensor: The waveform at the new frequency
     """
-    return torchaudio.functional.resample(waveform, orig_freq, new_freq, lowpass_filter_width, rolloff)
+    return torchaudio.functional.resample(waveform, orig_freq, new_freq, lowpass_filter_width,
+                                          rolloff, resampling_method)

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -1327,7 +1327,7 @@ def _get_sinc_resample_kernel(
     new_freq = int(new_freq) // gcd
 
     if resampling_method == "kaiser_window" and beta is None:
-        beta = 6.
+        beta = 14.769656459379492
 
     assert lowpass_filter_width > 0
     kernels = []

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -1320,6 +1320,9 @@ def _get_sinc_resample_kernel(
             "https://github.com/pytorch/audio/issues/1487."
         )
 
+    if resampling_method not in ['sinc_interpolation', 'kaiser_window']:
+        raise ValueError('Invalid resampling method: {}'.format(resampling_method))
+
     orig_freq = int(orig_freq) // gcd
     new_freq = int(new_freq) // gcd
 

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -663,6 +663,7 @@ class Resample(torch.nn.Module):
             but less efficient. We suggest around 4 to 10 for normal use. (Default: ``6``)
         rolloff (float, optional): The roll-off frequency of the filter, as a fraction of the Nyquist.
             Lower values reduce anti-aliasing, but also reduce some of the highest frequencies. (Default: ``0.99``)
+        beta (float, optional): The shape parameter used for kaiser window.
     """
 
     def __init__(self,
@@ -671,7 +672,7 @@ class Resample(torch.nn.Module):
                  resampling_method: str = 'sinc_interpolation',
                  lowpass_filter_width: int = 6,
                  rolloff: float = 0.99,
-                 **kwargs) -> None:
+                 beta: Optional[float] = None) -> None:
         super(Resample, self).__init__()
 
         self.orig_freq = orig_freq
@@ -686,7 +687,7 @@ class Resample(torch.nn.Module):
 
         self.kernel, self.width = _get_sinc_resample_kernel(self.orig_freq, self.new_freq, self.gcd,
                                                             self.lowpass_filter_width, self.rolloff,
-                                                            self.resampling_method, **kwargs)
+                                                            self.resampling_method, beta)
 
     def forward(self, waveform: Tensor) -> Tensor:
         r"""

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -682,9 +682,6 @@ class Resample(torch.nn.Module):
         self.lowpass_filter_width = lowpass_filter_width
         self.rolloff = rolloff
 
-        if self.resampling_method not in ['sinc_interpolation', 'kaiser_window']:
-            raise ValueError('Invalid resampling method: {}'.format(self.resampling_method))
-
         self.kernel, self.width = _get_sinc_resample_kernel(self.orig_freq, self.new_freq, self.gcd,
                                                             self.lowpass_filter_width, self.rolloff,
                                                             self.resampling_method, beta)


### PR DESCRIPTION
Add kaiser window as an option for resampling
Jupyter notebook of some results [kaiser_resampling__1_.pdf](https://github.com/pytorch/audio/files/6497164/kaiser_resampling__1_.pdf)


cc #1487 

