### PR TITLE
Make HTTP fetch test more reliable

### DIFF
--- a/test/torchaudio_unittest/common_utils/case_utils.py
+++ b/test/torchaudio_unittest/common_utils/case_utils.py
@@ -52,14 +52,15 @@ class HttpServerMixin(TempDirMixin):
     The server is up through the execution of all the test suite defined under the subclass.
     """
     _proc = None
-    _port = 8000
+    _port = 20576
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls._proc = subprocess.Popen(
             ['python', '-m', 'http.server', f'{cls._port}'],
-            cwd=cls.get_base_temp_dir())
+            cwd=cls.get_base_temp_dir(),
+            stderr=subprocess.DEVNULL)  # Disable server-side error log because it is confusing
         time.sleep(1.0)
 
     @classmethod

--- a/test/torchaudio_unittest/common_utils/case_utils.py
+++ b/test/torchaudio_unittest/common_utils/case_utils.py
@@ -52,7 +52,7 @@ class HttpServerMixin(TempDirMixin):
     The server is up through the execution of all the test suite defined under the subclass.
     """
     _proc = None
-    _port = 20576
+    _port = 8000
 
     @classmethod
     def setUpClass(cls):
@@ -61,7 +61,7 @@ class HttpServerMixin(TempDirMixin):
             ['python', '-m', 'http.server', f'{cls._port}'],
             cwd=cls.get_base_temp_dir(),
             stderr=subprocess.DEVNULL)  # Disable server-side error log because it is confusing
-        time.sleep(1.0)
+        time.sleep(2.0)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Since the update of Xcode, some of HTTP tests are failing on macOS, due to `reqests.get` fails to establish a connection to local server. 

Attempted fix
 - [did not work]Changing port from 8000 to 20576.
 - ✅ Increase start up wait time from 1.0 to 2.0.
