### PR TITLE
Ensure resampling identity is unchanged

### DIFF
--- a/test/torchaudio_unittest/functional/functional_impl.py
+++ b/test/torchaudio_unittest/functional/functional_impl.py
@@ -259,6 +259,16 @@ class Functional(TestBaseMixin):
 
             self.assertEqual(specgrams, specgrams_copy)
 
+    @parameterized.expand(list(itertools.product(
+        ["sinc_interpolation", "kaiser_window"],
+        [16000, 44100],
+    )))
+    def test_resample_identity(self, resampling_method, sample_rate):
+        waveform = get_whitenoise(sample_rate=sample_rate, duration=1)
+
+        resampled = F.resample(waveform, sample_rate, sample_rate)
+        self.assertEqual(waveform, resampled)
+
     def test_resample_no_warning(self):
         sample_rate = 44100
         waveform = get_whitenoise(sample_rate=sample_rate, duration=0.1)

--- a/test/torchaudio_unittest/transforms/transforms_test_impl.py
+++ b/test/torchaudio_unittest/transforms/transforms_test_impl.py
@@ -1,3 +1,4 @@
+import itertools
 import warnings
 
 import torch
@@ -8,6 +9,7 @@ from torchaudio_unittest.common_utils import (
     get_whitenoise,
     get_spectrogram,
 )
+from parameterized import parameterized
 
 
 def _get_ratio(mat):
@@ -77,3 +79,14 @@ class TransformsTestBase(TestBaseMixin):
             warnings.simplefilter("always")
             T.MelScale(n_mels=64, sample_rate=8000, n_stft=201)
         assert len(caught_warnings) == 0
+
+    @parameterized.expand(list(itertools.product(
+        ["sinc_interpolation", "kaiser_window"],
+        [16000, 44100],
+    )))
+    def test_resample_identity(self, resampling_method, sample_rate):
+        waveform = get_whitenoise(sample_rate=sample_rate, duration=1)
+
+        resampler = T.Resample(sample_rate, sample_rate)
+        resampled = resampler(waveform)
+        self.assertEqual(waveform, resampled)

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -1449,6 +1449,9 @@ def resample(
 
     assert orig_freq > 0.0 and new_freq > 0.0
 
+    if orig_freq == new_freq:
+        return waveform
+
     gcd = math.gcd(int(orig_freq), int(new_freq))
 
     kernel, width = _get_sinc_resample_kernel(orig_freq, new_freq, gcd, lowpass_filter_width, rolloff,

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -696,10 +696,11 @@ class Resample(torch.nn.Module):
         self.lowpass_filter_width = lowpass_filter_width
         self.rolloff = rolloff
 
-        kernel, self.width = _get_sinc_resample_kernel(self.orig_freq, self.new_freq, self.gcd,
-                                                       self.lowpass_filter_width, self.rolloff,
-                                                       self.resampling_method, beta)
-        self.register_buffer('kernel', kernel)
+        if self.orig_freq != self.new_freq:
+            kernel, self.width = _get_sinc_resample_kernel(self.orig_freq, self.new_freq, self.gcd,
+                                                           self.lowpass_filter_width, self.rolloff,
+                                                           self.resampling_method, beta)
+            self.register_buffer('kernel', kernel)
 
     def forward(self, waveform: Tensor) -> Tensor:
         r"""
@@ -709,6 +710,8 @@ class Resample(torch.nn.Module):
         Returns:
             Tensor: Output signal of dimension (..., time).
         """
+        if self.orig_freq == self.new_freq:
+            return waveform
         return _apply_sinc_resample_kernel(waveform, self.orig_freq, self.new_freq, self.gcd,
                                            self.kernel, self.width)
 


### PR DESCRIPTION
- return the original waveform when original and new sampling rates are the same for resample
- add unit tests for identity case
- remove a unit test that tests compatibility against kaldi's resample, since it is being deprecated