### PR TITLE
Reformat resample docs

### DIFF
--- a/docs/source/functional.rst
+++ b/docs/source/functional.rst
@@ -56,6 +56,11 @@ apply_codec
 
 .. autofunction:: apply_codec
 
+resample
+--------
+
+.. autofunction:: resample
+
 :hidden:`Complex Utility`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -230,8 +235,3 @@ vad
 ---------------------------
 
 .. autofunction:: spectral_centroid
-
-:hidden:`resample`
----------------------------
-
-.. autofunction:: resample

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -1428,6 +1428,10 @@ def resample(
 
     https://ccrma.stanford.edu/~jos/resample/Theory_Ideal_Bandlimited_Interpolation.html
 
+    Note:
+        ``transforms.Resample`` precomputes and reuses the resampling kernel, so using it will result in
+        more efficient computation if resampling multiple waveforms with the same resampling parameters.
+
     Args:
         waveform (Tensor): The input signal of dimension (..., time)
         orig_freq (float): The original frequency of the signal
@@ -1442,9 +1446,6 @@ def resample(
 
     Returns:
         Tensor: The waveform at the new frequency of dimension (..., time).
-
-    Note: ``transforms.Resample`` precomputes and reuses the resampling kernel, so using it will result in
-    more efficient computation if resampling multiple waveforms with the same resampling parameters.
     """
 
     assert orig_freq > 0.0 and new_freq > 0.0

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -663,6 +663,12 @@ class MuLawDecoding(torch.nn.Module):
 class Resample(torch.nn.Module):
     r"""Resample a signal from one frequency to another. A resampling method can be given.
 
+    Note:
+        If resampling on waveforms of higher precision than float32, there may be a small loss of precision
+        because the kernel is cached once as float32. If high precision resampling is important for your application,
+        the functional form will retain higher precision, but run slower because it does not cache the kernel.
+        Alternatively, you could rewrite a transform that caches a higher precision kernel.
+
     Args:
         orig_freq (float, optional): The original frequency of the signal. (Default: ``16000``)
         new_freq (float, optional): The desired frequency. (Default: ``16000``)
@@ -673,11 +679,6 @@ class Resample(torch.nn.Module):
         rolloff (float, optional): The roll-off frequency of the filter, as a fraction of the Nyquist.
             Lower values reduce anti-aliasing, but also reduce some of the highest frequencies. (Default: ``0.99``)
         beta (float or None): The shape parameter used for kaiser window.
-
-        Note: If resampling on waveforms of higher precision than float32, there may be a small loss of precision
-        because the kernel is cached once as float32. If high precision resampling is important for your application,
-        the functional form will retain higher precision, but run slower because it does not cache the kernel.
-        Alternatively, you could rewrite a transform that caches a higher precision kernel.
     """
 
     def __init__(self,


### PR DESCRIPTION
- move `functional.resample` under Utility section
- reformat `Notes:` sections