### PR TITLE
Ignore return_complex when returning real-valued tensor in spectrogram.

### DIFF
--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -73,11 +73,11 @@ def spectrogram(
         onesided (bool, optional): controls whether to return half of results to
             avoid redundancy. Default: ``True``
         return_complex (bool, optional):
-            ``return_complex = True``, this function returns the resulting Tensor in
-            complex dtype, otherwise it returns the resulting Tensor in real dtype with extra
-            dimension for real and imaginary parts. (see ``torch.view_as_real``).
-            When ``power`` is provided, the value must be False, as the resulting
-            Tensor represents real-valued power.
+            Indicates whether the resulting complex-valued Tensor should be represented with
+            native complex dtype, such as `torch.cfloat` and `torch.cdouble`, or real dtype
+            mimicing complex value with an extra dimension for real and imaginary parts.
+            This argument has is only effective when ``power=None``.
+            See also ``torch.view_as_real``.
 
     Returns:
         Tensor: Dimension (..., freq, time), freq is
@@ -91,11 +91,6 @@ def spectrogram(
             "Please refer to https://github.com/pytorch/audio/issues/1337 "
             "for more details about torchaudio's plan to migrate to native complex type."
         )
-
-    if power is not None and return_complex:
-        raise ValueError(
-            'When `power` is provided, the return value is real-valued. '
-            'Therefore, `return_complex` must be False.')
 
     if pad > 0:
         # TODO add "with torch.no_grad():" back when JIT supports it

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -75,8 +75,8 @@ def spectrogram(
         return_complex (bool, optional):
             Indicates whether the resulting complex-valued Tensor should be represented with
             native complex dtype, such as `torch.cfloat` and `torch.cdouble`, or real dtype
-            mimicing complex value with an extra dimension for real and imaginary parts.
-            This argument has is only effective when ``power=None``.
+            mimicking complex value with an extra dimension for real and imaginary parts.
+            This argument is only effective when ``power=None``.
             See also ``torch.view_as_real``.
 
     Returns:

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -60,11 +60,11 @@ class Spectrogram(torch.nn.Module):
         onesided (bool, optional): controls whether to return half of results to
             avoid redundancy Default: ``True``
         return_complex (bool, optional):
-            ``return_complex = True``, this function returns the resulting Tensor in
-            complex dtype, otherwise it returns the resulting Tensor in real dtype with extra
-            dimension for real and imaginary parts. (see ``torch.view_as_real``).
-            When ``power`` is provided, the value must be False, as the resulting
-            Tensor represents real-valued power.
+            Indicates whether the resulting complex-valued Tensor should be represented with
+            native complex dtype, such as `torch.cfloat` and `torch.cdouble`, or real dtype
+            mimicing complex value with an extra dimension for real and imaginary parts.
+            This argument has is only effective when ``power=None``.
+            See also ``torch.view_as_real``.
     """
     __constants__ = ['n_fft', 'win_length', 'hop_length', 'pad', 'power', 'normalized']
 

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -62,8 +62,8 @@ class Spectrogram(torch.nn.Module):
         return_complex (bool, optional):
             Indicates whether the resulting complex-valued Tensor should be represented with
             native complex dtype, such as `torch.cfloat` and `torch.cdouble`, or real dtype
-            mimicing complex value with an extra dimension for real and imaginary parts.
-            This argument has is only effective when ``power=None``.
+            mimicking complex value with an extra dimension for real and imaginary parts.
+            This argument is only effective when ``power=None``.
             See also ``torch.view_as_real``.
     """
     __constants__ = ['n_fft', 'win_length', 'hop_length', 'pad', 'power', 'normalized']


### PR DESCRIPTION
In 0.9.0, we are adding `return_complex=False` to spectrogram operation, so that users can choose whether they receive the resulting complex-valued tensor in pseudo complex tensor (real dtype with an extra dimension for real/imaginary parts) or native complex tensor (torch.cfloat / torch.cdouble).

Spectrogram operation returns raw, complex-valued tensor only when `power=None`. If `power` has some number, it returns the corresponding norm of the raw complex element. (such as power spectrogram) In this case, the value is always represented with real type, and there is no need to represent them in complex number.

The current version (0.9-RC1) checks if `return_complex=True` when `power is not non`. However, this does not align well with the use case. Users expecting power-spectrogram should not worry about this `return_complex` argument, which has its purpose in a different operation mode of `spectrogram` op. Also in #1549, I am switching the default value of `return_complex` to `True` and this means that by default, users who want power spectrogram has to provide `return_complex=False` additionally. This is totally unnecessary and avoidable. Therefore we should only care about the value of `return_complex`, when `power=None` in spectrogram op.