### PR TITLE
Remove override CSS

### DIFF
--- a/docs/source/_static/css/override.css
+++ b/docs/source/_static/css/override.css
@@ -1,8 +1,0 @@
-/* Fix for bibtex reference */
-dl.footnote.brackets > dt.label > span.brackets > a.fn-backref {
-    position: inherit
-}
-/* Fix for bibtex back reference */
-dl.footnote.brackets > dt.label > span.fn-backref > a {
-    position: inherit
-}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -137,7 +137,6 @@ html_logo = '_static/img/pytorch-logo-dark.svg'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 html_css_files = [
-    'css/override.css',
     'https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css'
 ]
 


### PR DESCRIPTION
Currently, hyperlinks created inside of PyTorch doc section title are not rendered correctly. (see https://github.com/pytorch/pytorch_sphinx_theme/issues/115)

When I was adding `bibtex` extension, I was placing the bibliography inside of `pytorch.article` (docstring) which suffers from the same rendering issue above. I added `override.css` to workaround this, but later I decided to put all the reference at the bottom of each page, which is outside of `pytorch.article` (docstring), so it no longer suffers from this, and the workaround of override CSS is not necessary.
