### PR TITLE
PoC: Use UninitializedBuffer for resampling kernel cache

### DIFF
--- a/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
@@ -18,6 +18,9 @@ class Transforms(TempDirMixin, TestBaseMixin):
         tensor = tensor.to(device=self.device, dtype=self.dtype)
         transform = transform.to(device=self.device, dtype=self.dtype)
 
+        # Perform dry-run so that UninitializedBuffer/Parameter are materialized
+        transform(tensor)
+
         path = self.get_temp_path('transform.zip')
         torch.jit.script(transform).save(path)
         ts_transform = torch.jit.load(path)


### PR DESCRIPTION
`T.Resample` precomputes and caches resampling kernel for performance improvement.
Currently, the kernel computed at the construction time and is cached with float32 first.
This causes degredation if one wants to perform resampling on float64.

In 0.9.0, we decided to use float32 for initial caching for the sake of minimum disruption
to user experience. (The original implementation computed the kernel on-the-fly on the same
device/dtype of the input Tensor, but most of use cases we are aware of are CPU/float32.)
We are now asking users to use `.to` to move the Module to the appropriate device/dtype.
But if users are using float64, this is numerically BC-breaking.
For DL application this might be fine, but for sound engineering, it might be not.

This PR adopts `LazyModuleMixin` and `UninitializedBuffer` so that resampling kernel is
computed and cached at the first forward call, assuming that `T.Resample` object has been
moved to the right `device/dtype`. This resolves the numerical BC-breaking for float64 case.

The downside of this adoptation is that
1. To TorchScript the resulting model, one has to do dry-run so that the kernel buffer is materialized. This is another BC-breaking.
2. It issues `UserWarning: Lazy modules are a new feature under heavy development so changes to the API or functionality can happen at any moment.`.