### PR TITLE
Replace simple_ctc with Python greedy decoder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,3 @@
 	path = third_party/kaldi/submodule
 	url = https://github.com/kaldi-asr/kaldi
 	ignore = dirty
-[submodule "examples/libtorchaudio/simplectc"]
-	path = examples/libtorchaudio/simplectc
-	url = https://github.com/mthrok/ctcdecode

--- a/examples/libtorchaudio/CMakeLists.txt
+++ b/examples/libtorchaudio/CMakeLists.txt
@@ -14,6 +14,5 @@ message("libtorchaudio CMakeLists: ${TORCH_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
 
 add_subdirectory(../.. libtorchaudio)
-add_subdirectory(simplectc)
 add_subdirectory(augmentation)
 add_subdirectory(speech_recognition)

--- a/examples/libtorchaudio/speech_recognition/CMakeLists.txt
+++ b/examples/libtorchaudio/speech_recognition/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(transcribe transcribe.cpp)
 add_executable(transcribe_list transcribe_list.cpp)
-target_link_libraries(transcribe "${TORCH_LIBRARIES}" "${TORCHAUDIO_LIBRARY}" "${CTCDECODE_LIBRARY}")
-target_link_libraries(transcribe_list "${TORCH_LIBRARIES}" "${TORCHAUDIO_LIBRARY}" "${CTCDECODE_LIBRARY}")
+target_link_libraries(transcribe "${TORCH_LIBRARIES}" "${TORCHAUDIO_LIBRARY}")
+target_link_libraries(transcribe_list "${TORCH_LIBRARIES}" "${TORCHAUDIO_LIBRARY}")
 set_property(TARGET transcribe PROPERTY CXX_STANDARD 14)
 set_property(TARGET transcribe_list PROPERTY CXX_STANDARD 14)

--- a/examples/libtorchaudio/speech_recognition/greedy_decoder.py
+++ b/examples/libtorchaudio/speech_recognition/greedy_decoder.py
@@ -16,17 +16,13 @@ class Decoder(torch.nn.Module):
             str: The resulting transcript
         """
         best_path = torch.argmax(logits, dim=-1)  # [num_seq,]
-        prev = ''
+        best_path = torch.unique_consecutive(best_path, dim=-1)
         hypothesis = ''
         for i in best_path:
             char = self.labels[i]
-            if char == prev:
-                continue
             if char == '<s>':
-                prev = ''
                 continue
-            prev = char
             if char == '|':
                 char = ' '
             hypothesis += char
-        return hypothesis.replace('|', ' ')
+        return hypothesis

--- a/examples/libtorchaudio/speech_recognition/greedy_decoder.py
+++ b/examples/libtorchaudio/speech_recognition/greedy_decoder.py
@@ -1,0 +1,32 @@
+import torch
+
+
+class Decoder(torch.nn.Module):
+    def __init__(self, labels):
+        super().__init__()
+        self.labels = labels
+
+    def forward(self, logits: torch.Tensor) -> str:
+        """Given a sequence logits over labels, get the best path string
+
+        Args:
+            logits (Tensor): Logit tensors. Shape `[num_seq, num_label]`.
+
+        Returns:
+            str: The resulting transcript
+        """
+        best_path = torch.argmax(logits, dim=-1)  # [num_seq,]
+        prev = ''
+        hypothesis = ''
+        for i in best_path:
+            char = self.labels[i]
+            if char == prev:
+                continue
+            if char == '<s>':
+                prev = ''
+                continue
+            prev = char
+            if char == '|':
+                char = ' '
+            hypothesis += char
+        return hypothesis.replace('|', ' ')

--- a/examples/libtorchaudio/speech_recognition/greedy_decoder.py
+++ b/examples/libtorchaudio/speech_recognition/greedy_decoder.py
@@ -20,7 +20,7 @@ class Decoder(torch.nn.Module):
         hypothesis = ''
         for i in best_path:
             char = self.labels[i]
-            if char == '<s>':
+            if char in ['<s>', '<pad>']:
                 continue
             if char == '|':
                 char = ' '


### PR DESCRIPTION
For ASR example with Wav2Vec2, I added some C++ based CTC decoder without language model. This should practically yield the same result as greedy decoding which can be implemented in Python very easily. For the purpose of example, this Python implementation is good enough, and it reduces compilation time and make the example simpler.

TODO:
 - [x] Test the resulting pipeline and ensure WERs are not affected.
     - [x] With `wav2vec_small_960h`, this gets `3.1` for `test-clean` and `7.7` for `test-other` dataset.
     - [x] With `facebook/wav2vec2-base-960h`, this gets `3.1` for `test-clean` and `7.7` for `test-other` dataset.