### PR TITLE
Update skipIfNoCuda decorator/Force GPU tests run in GPU CIs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -465,7 +465,7 @@ jobs:
           command: docker run -t --gpus all -e UPLOAD_CHANNEL -e CONDA_CHANNEL_FLAGS -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/install.sh
       - run:
           name: Run tests
-          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
+          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" -e "TORCHAUDIO_TEST_FORCE_CUDA=1" .circleci/unittest/linux/scripts/run_test.sh
       - store_test_results:
           path: test-results
       - store_artifacts:
@@ -500,6 +500,7 @@ jobs:
     environment:
       <<: *environment
       CUDA_VERSION: "10.2"
+      TORCHAUDIO_TEST_FORCE_CUDA: "1"
     steps:
       - checkout
       - designate_upload_channel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -465,7 +465,7 @@ jobs:
           command: docker run -t --gpus all -e UPLOAD_CHANNEL -e CONDA_CHANNEL_FLAGS -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/install.sh
       - run:
           name: Run tests
-          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" -e "TORCHAUDIO_TEST_FORCE_CUDA=1" .circleci/unittest/linux/scripts/run_test.sh
+          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "TORCHAUDIO_TEST_FORCE_CUDA=1" "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -500,7 +500,6 @@ jobs:
     environment:
       <<: *environment
       CUDA_VERSION: "10.2"
-      TORCHAUDIO_TEST_FORCE_CUDA: "1"
     steps:
       - checkout
       - designate_upload_channel

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -465,7 +465,7 @@ jobs:
           command: docker run -t --gpus all -e UPLOAD_CHANNEL -e CONDA_CHANNEL_FLAGS -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/install.sh
       - run:
           name: Run tests
-          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
+          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" -e "TORCHAUDIO_TEST_FORCE_CUDA=1" .circleci/unittest/linux/scripts/run_test.sh
       - store_test_results:
           path: test-results
       - store_artifacts:
@@ -500,6 +500,7 @@ jobs:
     environment:
       <<: *environment
       CUDA_VERSION: "10.2"
+      TORCHAUDIO_TEST_FORCE_CUDA: "1"
     steps:
       - checkout
       - designate_upload_channel

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -465,7 +465,7 @@ jobs:
           command: docker run -t --gpus all -e UPLOAD_CHANNEL -e CONDA_CHANNEL_FLAGS -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/install.sh
       - run:
           name: Run tests
-          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD "${image_name}" -e "TORCHAUDIO_TEST_FORCE_CUDA=1" .circleci/unittest/linux/scripts/run_test.sh
+          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "TORCHAUDIO_TEST_FORCE_CUDA=1" "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -500,7 +500,6 @@ jobs:
     environment:
       <<: *environment
       CUDA_VERSION: "10.2"
-      TORCHAUDIO_TEST_FORCE_CUDA: "1"
     steps:
       - checkout
       - designate_upload_channel

--- a/test/torchaudio_unittest/common_utils/case_utils.py
+++ b/test/torchaudio_unittest/common_utils/case_utils.py
@@ -104,7 +104,15 @@ def skipIfNoModule(module, display_name=None):
     return unittest.skipIf(not is_module_available(module), f'"{display_name}" is not available')
 
 
-skipIfNoCuda = unittest.skipIf(not torch.cuda.is_available(), reason='CUDA not available')
+def skipIfNoCuda(test_item):
+    if torch.cuda.is_available():
+        return test_item
+    force_cuda_test = os.environ.get('TORCHAUDIO_TEST_FORCE_CUDA', '0')
+    if force_cuda_test not in ['0', '1']:
+        raise ValueError('"TORCHAUDIO_TEST_FORCE_CUDA" must be either "0" or "1".')
+    if force_cuda_test == '1':
+        raise RuntimeError('"TORCHAUDIO_TEST_FORCE_CUDA" is set but CUDA is not available.')
+    return unittest.skip('CUDA is not available.')(test_item)
 skipIfNoSox = unittest.skipIf(not is_sox_available(), reason='Sox not available')
 skipIfNoKaldi = unittest.skipIf(not is_kaldi_available(), reason='Kaldi not available')
 skipIfRocm = unittest.skipIf(os.getenv('TORCHAUDIO_TEST_WITH_ROCM', '0') == '1',


### PR DESCRIPTION
In response to [https://github.com/pytorch/audio/issues/1552](https://github.com/pytorch/audio/issues/1552)

- Update the skipIfNoCuda decorator to raise an error if the TORCHAUDIO_TEST_FORCE_CUDA variable is set but CUDA is not available
- Update CI to use TORCHAUDIO_TEST_FORCE_CUDA in gpu unittests

