### PR TITLE
fix tag build so it triggers prerequisites

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -686,6 +686,12 @@ workflows:
           wheel_docker_image: pytorch/manylinux-rocm:4.1
       - binary_linux_wheel:
           cuda_version: cpu
+          filters:
+            branches:
+              only:
+              - /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: binary_linux_wheel_py3.8_cpu
           python_version: '3.8'
           requires:
@@ -991,6 +997,12 @@ workflows:
           name: binary_windows_conda_py3.9_cu111
           python_version: '3.9'
       - build_docs:
+          filters:
+            branches:
+              only:
+              - /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: build_docs
           python_version: '3.8'
           requires:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -36,14 +36,20 @@ def build_workflows(prefix='', upload=False, filter_branch=None, indentation=6):
         for os_type in ["linux", "macos", "windows"]:
             for python_version in PYTHON_VERSIONS:
                 for cu_version in CU_VERSIONS_DICT[os_type]:
+                    fb = filter_branch
                     if cu_version.startswith("rocm") and btype=="conda":
-                        pass
-                    else:
-                        w += build_workflow_pair(btype, os_type, python_version, cu_version, filter_branch, prefix, upload)
+                        continue
+                    if not fb and (os_type == 'linux' and
+                                   btype == 'wheel' and
+                                   python_version == '3.8' and
+                                   cu_version == 'cpu'):
+                        # the fields must match the build_docs "requires" dependency
+                        fb = '/.*/'
+                    w += build_workflow_pair(btype, os_type, python_version, cu_version, fb, prefix, upload)
 
     if not filter_branch:
         # Build on every pull request, but upload only on nightly and tags
-        w += build_doc_job(None)
+        w += build_doc_job('/.*/')
         w += upload_doc_job('nightly')
         w += docstring_parameters_sync_job(None)
 


### PR DESCRIPTION
Port pytorch/vision#3998 and pytorch/vision#4053 so that adding a tag will trigger a documentation build-and-upload. The problem was that the upload depends on both the wheel and the build_docs builds, but those did not have the correct filter so they were not running.

Similar to pytorch/text#1332

It would be nice to see this merged before the next tag event, to make sure the docs are now building (the last few tags did not generate docs), although #1568 already generated the 0.9 docs.