### PR TITLE
DOC: Remove git tag from 0.9.0 pages titles

### DIFF
--- a/0.9.0/_modules/index.html
+++ b/0.9.0/_modules/index.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Overview: module code &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>Overview: module code &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/backend/common.html
+++ b/0.9.0/_modules/torchaudio/backend/common.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.backend.common &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.backend.common &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/backend/soundfile_backend.html
+++ b/0.9.0/_modules/torchaudio/backend/soundfile_backend.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.backend.soundfile_backend &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.backend.soundfile_backend &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/backend/sox_io_backend.html
+++ b/0.9.0/_modules/torchaudio/backend/sox_io_backend.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.backend.sox_io_backend &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.backend.sox_io_backend &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/backend/utils.html
+++ b/0.9.0/_modules/torchaudio/backend/utils.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.backend.utils &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.backend.utils &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/compliance/kaldi.html
+++ b/0.9.0/_modules/torchaudio/compliance/kaldi.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.compliance.kaldi &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.compliance.kaldi &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/datasets/cmuarctic.html
+++ b/0.9.0/_modules/torchaudio/datasets/cmuarctic.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.datasets.cmuarctic &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.datasets.cmuarctic &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/datasets/commonvoice.html
+++ b/0.9.0/_modules/torchaudio/datasets/commonvoice.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.datasets.commonvoice &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.datasets.commonvoice &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/datasets/gtzan.html
+++ b/0.9.0/_modules/torchaudio/datasets/gtzan.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.datasets.gtzan &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.datasets.gtzan &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/datasets/librispeech.html
+++ b/0.9.0/_modules/torchaudio/datasets/librispeech.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.datasets.librispeech &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.datasets.librispeech &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/datasets/libritts.html
+++ b/0.9.0/_modules/torchaudio/datasets/libritts.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.datasets.libritts &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.datasets.libritts &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/datasets/ljspeech.html
+++ b/0.9.0/_modules/torchaudio/datasets/ljspeech.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.datasets.ljspeech &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.datasets.ljspeech &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/datasets/speechcommands.html
+++ b/0.9.0/_modules/torchaudio/datasets/speechcommands.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.datasets.speechcommands &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.datasets.speechcommands &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/datasets/tedlium.html
+++ b/0.9.0/_modules/torchaudio/datasets/tedlium.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.datasets.tedlium &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.datasets.tedlium &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/datasets/vctk.html
+++ b/0.9.0/_modules/torchaudio/datasets/vctk.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.datasets.vctk &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.datasets.vctk &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/datasets/yesno.html
+++ b/0.9.0/_modules/torchaudio/datasets/yesno.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.datasets.yesno &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.datasets.yesno &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/functional/filtering.html
+++ b/0.9.0/_modules/torchaudio/functional/filtering.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.functional.filtering &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.functional.filtering &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/functional/functional.html
+++ b/0.9.0/_modules/torchaudio/functional/functional.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.functional.functional &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.functional.functional &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/kaldi_io.html
+++ b/0.9.0/_modules/torchaudio/kaldi_io.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.kaldi_io &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.kaldi_io &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/models/conv_tasnet.html
+++ b/0.9.0/_modules/torchaudio/models/conv_tasnet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.models.conv_tasnet &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.models.conv_tasnet &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/models/deepspeech.html
+++ b/0.9.0/_modules/torchaudio/models/deepspeech.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.models.deepspeech &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.models.deepspeech &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/models/wav2letter.html
+++ b/0.9.0/_modules/torchaudio/models/wav2letter.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.models.wav2letter &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.models.wav2letter &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/models/wav2vec2/model.html
+++ b/0.9.0/_modules/torchaudio/models/wav2vec2/model.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.models.wav2vec2.model &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.models.wav2vec2.model &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/models/wav2vec2/utils/import_fairseq.html
+++ b/0.9.0/_modules/torchaudio/models/wav2vec2/utils/import_fairseq.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.models.wav2vec2.utils.import_fairseq &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.models.wav2vec2.utils.import_fairseq &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/models/wav2vec2/utils/import_huggingface.html
+++ b/0.9.0/_modules/torchaudio/models/wav2vec2/utils/import_huggingface.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.models.wav2vec2.utils.import_huggingface &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.models.wav2vec2.utils.import_huggingface &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/models/wavernn.html
+++ b/0.9.0/_modules/torchaudio/models/wavernn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.models.wavernn &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.models.wavernn &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/sox_effects/sox_effects.html
+++ b/0.9.0/_modules/torchaudio/sox_effects/sox_effects.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.sox_effects.sox_effects &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.sox_effects.sox_effects &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/transforms.html
+++ b/0.9.0/_modules/torchaudio/transforms.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.transforms &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.transforms &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/_modules/torchaudio/utils/sox_utils.html
+++ b/0.9.0/_modules/torchaudio/utils/sox_utils.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.utils.sox_utils &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.utils.sox_utils &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/backend.html
+++ b/0.9.0/backend.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.backend &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.backend &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/compliance.kaldi.html
+++ b/0.9.0/compliance.kaldi.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.compliance.kaldi &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.compliance.kaldi &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/datasets.html
+++ b/0.9.0/datasets.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.datasets &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.datasets &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/functional.html
+++ b/0.9.0/functional.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.functional &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.functional &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/genindex.html
+++ b/0.9.0/genindex.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Index &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>Index &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/index.html
+++ b/0.9.0/index.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/kaldi_io.html
+++ b/0.9.0/kaldi_io.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.kaldi_io &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.kaldi_io &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/models.html
+++ b/0.9.0/models.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.models &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.models &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/py-modindex.html
+++ b/0.9.0/py-modindex.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Python Module Index &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>Python Module Index &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/search.html
+++ b/0.9.0/search.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Search &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>Search &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/sox_effects.html
+++ b/0.9.0/sox_effects.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.sox_effects &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.sox_effects &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/torchaudio.html
+++ b/0.9.0/torchaudio.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/transforms.html
+++ b/0.9.0/transforms.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.transforms &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.transforms &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   

--- a/0.9.0/utils.html
+++ b/0.9.0/utils.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchaudio.utils &mdash; Torchaudio 0.9.0a0+1437208 documentation</title>
+  <title>torchaudio.utils &mdash; Torchaudio 0.9.0 documentation</title>
   
 
   


### PR DESCRIPTION
The page titles (what you see when you hover over the page's tab in the browser) still had the git tag.

`for f in $(find . -name "*.html"); do sed -i -e"s/0\.9\.0a0+1437208/0.9.0/" $f; done`