### PR TITLE
Remove NumPy dependency from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ Note that nightly build is build on PyTorch's nightly build. Therefore, you need
 **pip**
 
 ```
-pip install numpy
 pip install --pre torchaudio -f https://download.pytorch.org/whl/nightly/torch_nightly.html
 ```
 


### PR DESCRIPTION
PyTorch picks up the correct NumPy version, so it is not necessary to install separately.