### PR TITLE
Fix HF wav2vec2 integration test

### DIFF
--- a/test/torchaudio_unittest/models/wav2vec2/huggingface_intergration_test.py
+++ b/test/torchaudio_unittest/models/wav2vec2/huggingface_intergration_test.py
@@ -86,7 +86,7 @@ class TestHFIntegration(TorchaudioTestCase):
         self.assertEqual(ref, hyp)
         # Feature projection
         x = torch.randn(3, 10, config['conv_dim'][-1])
-        ref = original.wav2vec2.feature_projection(x)
+        ref = original.wav2vec2.feature_projection(x)[0]
         hyp = imported.encoder.feature_projection(x)
         self.assertEqual(ref, hyp)
         # Convolutional Positional Encoder


### PR DESCRIPTION
It seems that the return value of intermediate layer has been changed. 
The fixed assertion is redundant so we can remove it if there are too many changes on transformer side, but let's see how it goes.