### PR TITLE
feat: lfilter with filterbanks support

### DIFF
--- a/test/torchaudio_unittest/functional/autograd_impl.py
+++ b/test/torchaudio_unittest/functional/autograd_impl.py
@@ -61,7 +61,7 @@ class Autograd(TestBaseMixin):
 
     def test_lfilter_filterbanks(self):
         torch.random.manual_seed(2434)
-        x = get_whitenoise(sample_rate=22050, duration=0.01, n_channels=2)
+        x = get_whitenoise(sample_rate=22050, duration=0.01, n_channels=3)
         a = torch.tensor([[0.7, 0.2, 0.6],
                           [0.8, 0.2, 0.9]])
         b = torch.tensor([[0.4, 0.2, 0.9],

--- a/test/torchaudio_unittest/functional/autograd_impl.py
+++ b/test/torchaudio_unittest/functional/autograd_impl.py
@@ -59,6 +59,15 @@ class Autograd(TestBaseMixin):
         b = torch.tensor([0.4, 0.2, 0.9])
         self.assert_grad(F.lfilter, (x, a, b))
 
+    def test_lfilter_filterbanks(self):
+        torch.random.manual_seed(2434)
+        x = get_whitenoise(sample_rate=22050, duration=0.01, n_channels=2)
+        a = torch.tensor([[0.7, 0.2, 0.6],
+                          [0.8, 0.2, 0.9]])
+        b = torch.tensor([[0.4, 0.2, 0.9],
+                          [0.7, 0.2, 0.6]])
+        self.assert_grad(F.lfilter, (x, a, b))
+
     def test_biquad(self):
         torch.random.manual_seed(2434)
         x = get_whitenoise(sample_rate=22050, duration=0.01, n_channels=1)

--- a/test/torchaudio_unittest/functional/functional_impl.py
+++ b/test/torchaudio_unittest/functional/functional_impl.py
@@ -80,6 +80,19 @@ class Functional(TestBaseMixin):
         output_waveform = F.lfilter(waveform, a_coeffs, b_coeffs)
         assert shape == waveform.size() == output_waveform.size()
 
+    @parameterized.expand([
+        ((44100,), (2, 3), (2, 44100)),
+        ((3, 44100), (1, 3), (3, 1, 44100)),
+        ((1, 2, 44100), (3, 3), (1, 2, 3, 44100))
+    ])
+    def test_lfilter_filterbanks_shape(self, input_shape, coeff_shape, target_shape):
+        torch.random.manual_seed(42)
+        waveform = torch.rand(*input_shape, dtype=self.dtype, device=self.device)
+        b_coeffs = torch.rand(*coeff_shape, dtype=self.dtype, device=self.device)
+        a_coeffs = torch.rand(*coeff_shape, dtype=self.dtype, device=self.device)
+        output_waveform = F.lfilter(waveform, a_coeffs, b_coeffs)
+        assert target_shape == output_waveform.size()
+
     def test_lfilter_9th_order_filter_stability(self):
         """
         Validate the precision of lfilter against reference scipy implementation when using high order filter.

--- a/test/torchaudio_unittest/functional/functional_impl.py
+++ b/test/torchaudio_unittest/functional/functional_impl.py
@@ -67,30 +67,21 @@ class Functional(TestBaseMixin):
         assert output_signal.max() > 1
 
     @parameterized.expand([
-        ((44100,),),
-        ((3, 44100),),
-        ((2, 3, 44100),),
-        ((1, 2, 3, 44100),)
+        ((44100,), (4,), (44100,)),
+        ((3, 44100), (4,), (3, 44100,)),
+        ((2, 3, 44100), (4,), (2, 3, 44100,)),
+        ((1, 2, 3, 44100), (4,), (1, 2, 3, 44100,)),
+        ((44100,), (2, 4), (2, 44100)),
+        ((3, 44100), (1, 4), (3, 1, 44100)),
+        ((1, 2, 44100), (3, 4), (1, 2, 3, 44100))
     ])
-    def test_lfilter_shape(self, shape):
-        torch.random.manual_seed(42)
-        waveform = torch.rand(*shape, dtype=self.dtype, device=self.device)
-        b_coeffs = torch.tensor([0, 0, 0, 1], dtype=self.dtype, device=self.device)
-        a_coeffs = torch.tensor([1, 0, 0, 0], dtype=self.dtype, device=self.device)
-        output_waveform = F.lfilter(waveform, a_coeffs, b_coeffs)
-        assert shape == waveform.size() == output_waveform.size()
-
-    @parameterized.expand([
-        ((44100,), (2, 3), (2, 44100)),
-        ((3, 44100), (1, 3), (3, 1, 44100)),
-        ((1, 2, 44100), (3, 3), (1, 2, 3, 44100))
-    ])
-    def test_lfilter_filterbanks_shape(self, input_shape, coeff_shape, target_shape):
+    def test_lfilter_shape(self, input_shape, coeff_shape, target_shape):
         torch.random.manual_seed(42)
         waveform = torch.rand(*input_shape, dtype=self.dtype, device=self.device)
         b_coeffs = torch.rand(*coeff_shape, dtype=self.dtype, device=self.device)
         a_coeffs = torch.rand(*coeff_shape, dtype=self.dtype, device=self.device)
         output_waveform = F.lfilter(waveform, a_coeffs, b_coeffs)
+        assert input_shape == waveform.size()
         assert target_shape == output_waveform.size()
 
     def test_lfilter_9th_order_filter_stability(self):

--- a/torchaudio/functional/filtering.py
+++ b/torchaudio/functional/filtering.py
@@ -941,18 +941,19 @@ def lfilter(
 
     Args:
         waveform (Tensor): audio waveform of dimension of ``(..., time)``.  Must be normalized to -1 to 1.
-        a_coeffs (Tensor): denominator coefficients of difference equation of dimension of ``(*, n_order + 1)``.
-                                Where * is the optional number of filter banks.
+        a_coeffs (Tensor): denominator coefficients of difference equation of dimension of either 
+                                1D with shape ``(num_order + 1)`` or 2D with shape ``(num_filters, num_order + 1)``.
                                 Lower delays coefficients are first, e.g. ``[a0, a1, a2, ...]``.
                                 Must be same size as b_coeffs (pad with 0's as necessary).
-        b_coeffs (Tensor): numerator coefficients of difference equation of dimension of ``(*, n_order + 1)``.
-                                Where * is the optional number of filter banks.
+        b_coeffs (Tensor): numerator coefficients of difference equation of dimension of either 
+                                1D with shape ``(num_order + 1)`` or 2D with shape ``(num_filters, num_order + 1)``.
                                 Lower delays coefficients are first, e.g. ``[b0, b1, b2, ...]``.
                                 Must be same size as a_coeffs (pad with 0's as necessary).
         clamp (bool, optional): If ``True``, clamp the output signal to be in the range [-1, 1] (Default: ``True``)
 
     Returns:
-        Tensor: Waveform with dimension of ``(..., *, time)``.
+        Tensor: Waveform with dimension of either ``(..., num_filters, time)`` if ``a_coeffs`` and ``b_coeffs`` are 2D Tensors, 
+                or ``(..., time)`` otherwise.
     """
     # pack batch
     shape = waveform.size()

--- a/torchaudio/functional/filtering.py
+++ b/torchaudio/functional/filtering.py
@@ -941,19 +941,19 @@ def lfilter(
 
     Args:
         waveform (Tensor): audio waveform of dimension of ``(..., time)``.  Must be normalized to -1 to 1.
-        a_coeffs (Tensor): denominator coefficients of difference equation of dimension of either 
+        a_coeffs (Tensor): denominator coefficients of difference equation of dimension of either
                                 1D with shape ``(num_order + 1)`` or 2D with shape ``(num_filters, num_order + 1)``.
                                 Lower delays coefficients are first, e.g. ``[a0, a1, a2, ...]``.
                                 Must be same size as b_coeffs (pad with 0's as necessary).
-        b_coeffs (Tensor): numerator coefficients of difference equation of dimension of either 
+        b_coeffs (Tensor): numerator coefficients of difference equation of dimension of either
                                 1D with shape ``(num_order + 1)`` or 2D with shape ``(num_filters, num_order + 1)``.
                                 Lower delays coefficients are first, e.g. ``[b0, b1, b2, ...]``.
                                 Must be same size as a_coeffs (pad with 0's as necessary).
         clamp (bool, optional): If ``True``, clamp the output signal to be in the range [-1, 1] (Default: ``True``)
 
     Returns:
-        Tensor: Waveform with dimension of either ``(..., num_filters, time)`` if ``a_coeffs`` and ``b_coeffs`` are 2D Tensors, 
-                or ``(..., time)`` otherwise.
+        Tensor: Waveform with dimension of either ``(..., num_filters, time)`` if ``a_coeffs`` and ``b_coeffs``
+                are 2D Tensors, or ``(..., time)`` otherwise.
     """
     assert a_coeffs.size() == b_coeffs.size()
     assert a_coeffs.ndim <= 2

--- a/torchaudio/functional/filtering.py
+++ b/torchaudio/functional/filtering.py
@@ -962,7 +962,7 @@ def lfilter(
     waveform = waveform.reshape(-1, 1, shape[-1])
     if a_coeffs.ndim > 1:
         shape = shape[:-1] + (a_coeffs.shape[0], shape[-1])
-        waveform = torch.broadcast_to(waveform, a_coeffs)
+        waveform = waveform.repeat(1, a_coeffs.shape[0], 1)
     else:
         a_coeffs = a_coeffs.unsqueeze(0)
         b_coeffs = b_coeffs.unsqueeze(0)

--- a/torchaudio/functional/filtering.py
+++ b/torchaudio/functional/filtering.py
@@ -955,19 +955,18 @@ def lfilter(
         Tensor: Waveform with dimension of either ``(..., num_filters, time)`` if ``a_coeffs`` and ``b_coeffs`` are 2D Tensors, 
                 or ``(..., time)`` otherwise.
     """
-    # pack batch
-    shape = waveform.size()
     assert a_coeffs.size() == b_coeffs.size()
     assert a_coeffs.ndim <= 2
 
-    waveform = waveform.reshape(-1, 1, shape[-1])
     if a_coeffs.ndim > 1:
-        shape = shape[:-1] + (a_coeffs.shape[0], shape[-1])
-        waveform = waveform.repeat(1, a_coeffs.shape[0], 1)
+        waveform = torch.stack([waveform] * a_coeffs.shape[0], -2)
     else:
         a_coeffs = a_coeffs.unsqueeze(0)
         b_coeffs = b_coeffs.unsqueeze(0)
 
+    # pack batch
+    shape = waveform.size()
+    waveform = waveform.reshape(-1, a_coeffs.shape[0], shape[-1])
     output = _lfilter(waveform, a_coeffs, b_coeffs)
 
     if clamp:


### PR DESCRIPTION
resolves #1528 , relates to #1561 

This merge add the ability to apply multiple filters in `F.lfilter`. 
When the input shape is `(..., time)`, if the shape of filter coefficients is `(number_of_filters, filter_order)`, the shape of output will be `(...., number_of_filters, time)`, which is the input shape *plus* one additional dimension from the filters. 


Before feeding to the cpp backend, the python frontend first duplicate the input `number_of_filters`  times and stacking them to form a shape of `(...., number_of_filters, time)`.

The cpp backend assume the shape of `waveform` and  `*_coeffs` are `(batch, number_of_filters, time)` and `(number_of_filters, filter_order)` (before are just `(batch, time)` and `(filter_order,)`). Different filters is applied parallelly at the second dimension of `waveform`.

cc @mthrok 