### PR TITLE
ci: Remove mentions of conda-forge for Python 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,7 @@ commands:
           name: Adding CONDA_CHANNEL_FLAGS to BASH_ENV
           command: |
               CONDA_CHANNEL_FLAGS=""
-              if [[ "${PYTHON_VERSION}" = *3.9* ]]; then
-                echo "export CONDA_CHANNEL_FLAGS=-c=conda-forge" >> ${BASH_ENV}
-              fi
+              # formerly used to add conda-forge flags for Python 3.9, reserving the mechanism for future python upgrades
 
 binary_common: &binary_common
   parameters:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -52,9 +52,7 @@ commands:
           name: Adding CONDA_CHANNEL_FLAGS to BASH_ENV
           command: |
               CONDA_CHANNEL_FLAGS=""
-              if [[ "${PYTHON_VERSION}" = *3.9* ]]; then
-                echo "export CONDA_CHANNEL_FLAGS=-c=conda-forge" >> ${BASH_ENV}
-              fi
+              # formerly used to add conda-forge flags for Python 3.9, reserving the mechanism for future python upgrades
 
 binary_common: &binary_common
   parameters:

--- a/.circleci/torchscript_bc_test/environment.yml
+++ b/.circleci/torchscript_bc_test/environment.yml
@@ -1,5 +1,4 @@
 channels:
-  - conda-forge
   - defaults
 dependencies:
   - flake8

--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -1,5 +1,4 @@
 channels:
-  - conda-forge
   - defaults
 dependencies:
   - flake8

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -231,10 +231,6 @@ setup_conda_pytorch_constraint() {
   else
     export CONDA_CHANNEL_FLAGS="${CONDA_CHANNEL_FLAGS} -c pytorch -c pytorch-test -c pytorch-nightly"
   fi
-  # Some dependencies for Python 3.9 are only on conda-forge
-  if [[ "${PYTHON_VERSION}" = "3.9" ]]; then
-    export CONDA_CHANNEL_FLAGS="${CONDA_CHANNEL_FLAGS} -c conda-forge"
-  fi
   if [[ "$CU_VERSION" == cpu ]]; then
     export CONDA_PYTORCH_BUILD_CONSTRAINT="- pytorch==$PYTORCH_VERSION${PYTORCH_VERSION_SUFFIX}"
     export CONDA_PYTORCH_CONSTRAINT="- pytorch==$PYTORCH_VERSION"


### PR DESCRIPTION
No longer needed for Python 3.9

Relates to https://github.com/pytorch/vision/pull/4082

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>