### PR TITLE
Temporarily pin nightly version on Linux/macOS CPU unittest

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -40,7 +40,7 @@ conda activate "${env_dir}"
 # )
 
 
-if [ "${os}" == MacOSX ] | [ -z "${CUDA_VERSION:-}" ] ; then
+if [ "${os}" == MacOSX ] || [ -z "${CUDA_VERSION:-}" ] ; then
     device="cpu"
 else
     version="$(python -c "print(''.join(\"${CUDA_VERSION}\".split('.')[:2]))")"

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -23,6 +23,9 @@ eval "$("${conda_dir}/bin/conda" shell.bash hook)"
 conda activate "${env_dir}"
 
 # 1. Install PyTorch
+# [2021/06/22 Temporary workaround] Disabling the original installation
+# The orignal, conda-based instartion is working for GPUs, but not for CPUs
+# For CPUs we use pip-based installation
 # if [ -z "${CUDA_VERSION:-}" ] ; then
 #     if [ "${os}" == MacOSX ] ; then
 #         cudatoolkit=''
@@ -39,18 +42,22 @@ conda activate "${env_dir}"
 #     conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" "pytorch-${UPLOAD_CHANNEL}::pytorch" ${cudatoolkit}
 # )
 
-
 if [ "${os}" == MacOSX ] || [ -z "${CUDA_VERSION:-}" ] ; then
     device="cpu"
+    printf "Installing PyTorch with %s\n" "$device}"
+    (
+        set -x
+        pip install --pre torch==1.10.0.dev20210618 -f "https://download.pytorch.org/whl/nightly/${device}/torch_nightly.html"
+    )
 else
-    version="$(python -c "print(''.join(\"${CUDA_VERSION}\".split('.')[:2]))")"
-    device=cu"${version}"
+    version="$(python -c "print('.'.join(\"${CUDA_VERSION}\".split('.')[:2]))")"
+    cudatoolkit="cudatoolkit=${version}"
+    printf "Installing PyTorch with %s\n" "${cudatoolkit}"
+    (
+        set -x
+        conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" "pytorch-${UPLOAD_CHANNEL}::pytorch" ${cudatoolkit}
+    )
 fi
-printf "Installing PyTorch with %s\n" "$device}"
-(
-    set -x
-    pip install --pre torch==1.10.0.dev20210618 -f "https://download.pytorch.org/whl/nightly/${device}/torch_nightly.html"
-)
 
 # 2. Install torchaudio
 printf "* Installing torchaudio\n"

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -23,20 +23,33 @@ eval "$("${conda_dir}/bin/conda" shell.bash hook)"
 conda activate "${env_dir}"
 
 # 1. Install PyTorch
-if [ -z "${CUDA_VERSION:-}" ] ; then
-    if [ "${os}" == MacOSX ] ; then
-        cudatoolkit=''
-    else
-        cudatoolkit="cpuonly"
-    fi
+# if [ -z "${CUDA_VERSION:-}" ] ; then
+#     if [ "${os}" == MacOSX ] ; then
+#         cudatoolkit=''
+#     else
+#         cudatoolkit="cpuonly"
+#     fi
+# else
+#     version="$(python -c "print('.'.join(\"${CUDA_VERSION}\".split('.')[:2]))")"
+#     cudatoolkit="cudatoolkit=${version}"
+# fi
+# printf "Installing PyTorch with %s\n" "${cudatoolkit}"
+# (
+#     set -x
+#     conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" "pytorch-${UPLOAD_CHANNEL}::pytorch" ${cudatoolkit}
+# )
+
+
+if [ "${os}" == MacOSX ] | [ -z "${CUDA_VERSION:-}" ] ; then
+    device="cpu"
 else
-    version="$(python -c "print('.'.join(\"${CUDA_VERSION}\".split('.')[:2]))")"
-    cudatoolkit="cudatoolkit=${version}"
+    version="$(python -c "print(''.join(\"${CUDA_VERSION}\".split('.')[:2]))")"
+    device=cu"${version}"
 fi
-printf "Installing PyTorch with %s\n" "${cudatoolkit}"
+printf "Installing PyTorch with %s\n" "$device}"
 (
     set -x
-    conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" "pytorch-${UPLOAD_CHANNEL}::pytorch" ${cudatoolkit}
+    pip install --pre torch==1.10.0.dev20210618 -f "https://download.pytorch.org/whl/nightly/${device}/torch_nightly.html"
 )
 
 # 2. Install torchaudio


### PR DESCRIPTION
The CMake integration of PyTorch core seems to have some issue after torch==1.10.0.dev20210619.

~While this is being worked on, we resort to PyTorch 1.9 for testing and binary build.~
Update: After https://github.com/pytorch/pytorch/pull/60403 Linux GPU conda is working. I updated the PR to pin Linux/macOS CPU test.
Binary builds and Windows testing are still broken.