### PR TITLE
Remove residuals for removed modules

### DIFF
--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -32,12 +32,4 @@ __all__ = [
     'list_audio_backends',
     'get_audio_backend',
     'set_audio_backend',
-    'save_encinfo',
-    'sox_signalinfo_t',
-    'sox_encodinginfo_t',
-    'get_sox_option_t',
-    'get_sox_encoding_t',
-    'get_sox_bool',
-    'SignalInfo',
-    'EncodingInfo',
 ]


### PR DESCRIPTION
removed the following items from `__all__`

    'save_encinfo',
    'sox_signalinfo_t',
    'sox_encodinginfo_t',
    'get_sox_option_t',
    'get_sox_encoding_t',
    'get_sox_bool',
    'SignalInfo',
    'EncodingInfo',
  