### PR TITLE
[BC-Breaking] Default to PCM_16 for flac on soundfile backend

### DIFF
--- a/torchaudio/backend/soundfile_backend.py
+++ b/torchaudio/backend/soundfile_backend.py
@@ -283,7 +283,7 @@ def _get_subtype(
         if encoding:
             raise ValueError("flac does not support encoding.")
         if not bits_per_sample:
-            return "PCM_24"
+            return "PCM_16"
         if bits_per_sample > 24:
             raise ValueError("flac does not support bits_per_sample > 24.")
         return "PCM_S8" if bits_per_sample == 8 else f"PCM_{bits_per_sample}"
@@ -382,8 +382,8 @@ def save(
 
     ``"flac"``
         - 8-bit
-        - 16-bit
-        - 24-bit (default)
+        - 16-bit (default)
+        - 24-bit
 
     ``"ogg"``, ``"vorbis"``
         - Doesn't accept changing configuration.

--- a/torchaudio/backend/soundfile_backend.py
+++ b/torchaudio/backend/soundfile_backend.py
@@ -416,6 +416,9 @@ def save(
 
     if bits_per_sample not in (None, 8, 16, 24, 32, 64):
         raise ValueError("Invalid bits_per_sample.")
+    if bits_per_sample == 24:
+        warnings.warn("Saving audio with 24 bits per sample might warp samples near -1. "
+                      "Using 16 bits per sample might be able to avoid this.")
     subtype = _get_subtype(src.dtype, ext, encoding, bits_per_sample)
 
     # sph is a extension used in TED-LIUM but soundfile does not recognize it as NIST format,


### PR DESCRIPTION
The test for backend/soundfile/save_test.py::TestFileObject::test_fileobj_flac is not working correctly. Please refer to #1592 for more details.

closes #1592 