### PR TITLE
[HOT FIX] Temporarily pin nightly version on Linux GPU unit test

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -47,7 +47,7 @@ if [ "${os}" == MacOSX ] || [ -z "${CUDA_VERSION:-}" ] ; then
 else
     device="$(python -c "print(''.join(\"${CUDA_VERSION}\".split('.')[:2]))")"
 fi
-printf "Installing PyTorch with %s\n" "$device}"
+printf "Installing PyTorch with %s\n" "${device}"
 (
     set -x
     pip install --pre torch==1.10.0.dev20210618 -f "https://download.pytorch.org/whl/nightly/${device}/torch_nightly.html"

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -44,20 +44,14 @@ conda activate "${env_dir}"
 
 if [ "${os}" == MacOSX ] || [ -z "${CUDA_VERSION:-}" ] ; then
     device="cpu"
-    printf "Installing PyTorch with %s\n" "$device}"
-    (
-        set -x
-        pip install --pre torch==1.10.0.dev20210618 -f "https://download.pytorch.org/whl/nightly/${device}/torch_nightly.html"
-    )
 else
-    version="$(python -c "print('.'.join(\"${CUDA_VERSION}\".split('.')[:2]))")"
-    cudatoolkit="cudatoolkit=${version}"
-    printf "Installing PyTorch with %s\n" "${cudatoolkit}"
-    (
-        set -x
-        conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" "pytorch-${UPLOAD_CHANNEL}::pytorch" ${cudatoolkit}
-    )
+    device="$(python -c "print(''.join(\"${CUDA_VERSION}\".split('.')[:2]))")"
 fi
+printf "Installing PyTorch with %s\n" "$device}"
+(
+    set -x
+    pip install --pre torch==1.10.0.dev20210618 -f "https://download.pytorch.org/whl/nightly/${device}/torch_nightly.html"
+)
 
 # 2. Install torchaudio
 printf "* Installing torchaudio\n"

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -45,7 +45,7 @@ conda activate "${env_dir}"
 if [ "${os}" == MacOSX ] || [ -z "${CUDA_VERSION:-}" ] ; then
     device="cpu"
 else
-    device="$(python -c "print(''.join(\"${CUDA_VERSION}\".split('.')[:2]))")"
+    device=cu"$(python -c "print(''.join(\"${CUDA_VERSION}\".split('.')[:2]))")"
 fi
 printf "Installing PyTorch with %s\n" "${device}"
 (


### PR DESCRIPTION
When hot fix was applied in #1598, it was only applied to CPU jobs.
This is because I looked at the nightly build, saw green lights on GPU unit test jobs, 
and thought that GPU jobs were somehow recovered.

It turned out, however, that GPU unit tests were fetching CUDA 10.1 binaries from April.
Because the PyTorch core dropped binary distribution for CUDA 10.1.

The unit test job was updated in #1605 to use CUDA 10.2. The GPU tests are now
picking up the latest nightly and failing because of broken CMake integration as expected.

This PR applies the same hot fix as in #1598 to GPU unit tests, so that they pass.
