### PR TITLE
[HOT FIX] Pin nightly version in Windows unit test CI

### DIFF
--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -18,14 +18,25 @@ eval "$("${conda_dir}/Scripts/conda.exe" 'shell.bash' 'hook')"
 conda activate "${env_dir}"
 
 # 1. Install PyTorch
+# if [ -z "${CUDA_VERSION:-}" ] ; then
+#     cudatoolkit="cpuonly"
+# else
+#     version="$(python -c "print('.'.join(\"${CUDA_VERSION}\".split('.')[:2]))")"
+#     cudatoolkit="cudatoolkit=${version}"
+# fi
+# printf "Installing PyTorch with %s\n" "${cudatoolkit}"
+# conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" "pytorch-${UPLOAD_CHANNEL}::pytorch" ${cudatoolkit}
+
 if [ -z "${CUDA_VERSION:-}" ] ; then
-    cudatoolkit="cpuonly"
+    device="cpu"
 else
-    version="$(python -c "print('.'.join(\"${CUDA_VERSION}\".split('.')[:2]))")"
-    cudatoolkit="cudatoolkit=${version}"
+    device=cu"$(python -c "print(''.join(\"${CUDA_VERSION}\".split('.')[:2]))")"
 fi
-printf "Installing PyTorch with %s\n" "${cudatoolkit}"
-conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" "pytorch-${UPLOAD_CHANNEL}::pytorch" ${cudatoolkit}
+printf "Installing PyTorch with %s\n" "${device}"
+(
+    set -x
+    pip install --pre torch==1.10.0.dev20210618 -f "https://download.pytorch.org/whl/nightly/${device}/torch_nightly.html"
+)
 
 # 2. Install torchaudio
 printf "* Installing torchaudio\n"

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -27,6 +27,7 @@ conda activate "${env_dir}"
 # printf "Installing PyTorch with %s\n" "${cudatoolkit}"
 # conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" "pytorch-${UPLOAD_CHANNEL}::pytorch" ${cudatoolkit}
 
+conda install -y nomkl
 if [ -z "${CUDA_VERSION:-}" ] ; then
     device="cpu"
 else


### PR DESCRIPTION
Similar to #1598 and #1606, pin the nightly version on Windows CI while the upstream issue persists.