### PR TITLE
Expose USE_CUDA in build

### DIFF
--- a/build_tools/setup_helpers/extension.py
+++ b/build_tools/setup_helpers/extension.py
@@ -38,7 +38,7 @@ _BUILD_SOX = False if platform.system() == 'Windows' else _get_build("BUILD_SOX"
 _BUILD_KALDI = False if platform.system() == 'Windows' else _get_build("BUILD_KALDI", True)
 _BUILD_TRANSDUCER = _get_build("BUILD_TRANSDUCER")
 _USE_ROCM = _get_build("USE_ROCM")
-_USE_CUDA = torch.cuda.is_available()
+_USE_CUDA = _get_build("USE_CUDA", torch.cuda.is_available())
 
 
 def get_ext_modules():


### PR DESCRIPTION
followup: RNNT loss needs to fall back onto CPU if compiled with GPU/USE_CUDA=1 but GPU is not available during run