### PR TITLE
Add pretrained weights for wavernn

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -88,8 +88,15 @@ WaveRNN
 
   .. automethod:: forward
 
+Factory Functions
+-----------------
+
+wavernn
+-------
+
+.. autofunction:: wavernn
+
 References
 ~~~~~~~~~~
 
 .. footbibliography::
-

--- a/torchaudio/models/__init__.py
+++ b/torchaudio/models/__init__.py
@@ -1,5 +1,5 @@
 from .wav2letter import Wav2Letter
-from .wavernn import WaveRNN, get_pretrained_wavernn
+from .wavernn import WaveRNN, wavernn
 from .conv_tasnet import ConvTasNet
 from .deepspeech import DeepSpeech
 from .wav2vec2 import (
@@ -13,7 +13,7 @@ from .wav2vec2 import (
 __all__ = [
     'Wav2Letter',
     'WaveRNN',
-    'get_pretrained_wavernn',
+    'wavernn',
     'ConvTasNet',
     'DeepSpeech',
     'Wav2Vec2Model',

--- a/torchaudio/models/__init__.py
+++ b/torchaudio/models/__init__.py
@@ -1,5 +1,5 @@
 from .wav2letter import Wav2Letter
-from .wavernn import WaveRNN
+from .wavernn import WaveRNN, wavernn_10k_epochs_8bits_ljspeech
 from .conv_tasnet import ConvTasNet
 from .deepspeech import DeepSpeech
 from .wav2vec2 import (
@@ -13,6 +13,7 @@ from .wav2vec2 import (
 __all__ = [
     'Wav2Letter',
     'WaveRNN',
+    'wavernn_10k_epochs_8bits_ljspeech',
     'ConvTasNet',
     'DeepSpeech',
     'Wav2Vec2Model',

--- a/torchaudio/models/__init__.py
+++ b/torchaudio/models/__init__.py
@@ -1,5 +1,5 @@
 from .wav2letter import Wav2Letter
-from .wavernn import WaveRNN, wavernn_10k_epochs_8bits_ljspeech
+from .wavernn import WaveRNN, get_pretrained_wavernn
 from .conv_tasnet import ConvTasNet
 from .deepspeech import DeepSpeech
 from .wav2vec2 import (
@@ -13,7 +13,7 @@ from .wav2vec2 import (
 __all__ = [
     'Wav2Letter',
     'WaveRNN',
-    'wavernn_10k_epochs_8bits_ljspeech',
+    'get_pretrained_wavernn',
     'ConvTasNet',
     'DeepSpeech',
     'Wav2Vec2Model',

--- a/torchaudio/models/_utils.py
+++ b/torchaudio/models/_utils.py
@@ -1,0 +1,8 @@
+try:
+    from torch.hub import load_state_dict_from_url
+except ImportError:
+    from torch.utils.model_zoo import load_url as load_state_dict_from_url
+
+__all__ = [
+    'load_state_dict_from_url',
+]

--- a/torchaudio/models/_utils.py
+++ b/torchaudio/models/_utils.py
@@ -1,8 +1,0 @@
-try:
-    from torch.hub import load_state_dict_from_url
-except ImportError:
-    from torch.utils.model_zoo import load_url as load_state_dict_from_url
-
-__all__ = [
-    'load_state_dict_from_url',
-]

--- a/torchaudio/models/wavernn.py
+++ b/torchaudio/models/wavernn.py
@@ -3,10 +3,7 @@ from typing import List, Tuple, Dict, Any
 import torch
 from torch import Tensor
 from torch import nn
-try:
-    from torch.hub import load_state_dict_from_url
-except ImportError:
-    from torch.utils.model_zoo import load_url as load_state_dict_from_url
+from torch.hub import load_state_dict_from_url
 
 
 __all__ = [
@@ -15,7 +12,7 @@ __all__ = [
     "Stretch2d",
     "UpsampleNetwork",
     "WaveRNN",
-    "get_pretrained_wavernn",
+    "wavernn",
 ]
 
 
@@ -351,25 +348,24 @@ class WaveRNN(nn.Module):
         return x.unsqueeze(1)
 
 
-def get_pretrained_wavernn(checkpoint_name: str, progress: bool = True) -> WaveRNN:
+def wavernn(checkpoint_name: str) -> WaveRNN:
     r"""Get pretrained WaveRNN model.
 
-    Here are the available checkpoints:
-
-    - wavernn_10k_epochs_8bits_ljspeech
-
-        WaveRNN model trained with 10k epochs and 8 bits depth waveform on the LJSpeech dataset.
-        The model is trained using the default parameters and code of the examples/pipeline_wavernn/main.py.
-
     Args:
-        checkpoint_name (str): The name of the checkpoint to load.
-        progress (bool): If True, displays a progress bar of the download to stderr.
+        checkpoint_name (str): The name of the checkpoint to load. Available checkpoints:
+
+            - ``"wavernn_10k_epochs_8bits_ljspeech"``:
+
+                WaveRNN model trained with 10k epochs and 8 bits depth waveform on the LJSpeech dataset.
+                The model is trained using the default parameters and code of the examples/pipeline_wavernn/main.py.
     """
     if checkpoint_name not in _MODEL_CONFIG_AND_URLS:
-        raise ValueError("The checkpoint_name `{}` is not supported.".format(checkpoint_name))
+        raise ValueError(
+            f"Unexpected checkpoint_name: '{checkpoint_name}'. "
+            f"Valid choices are; {list(_MODEL_CONFIG_AND_URLS.keys())}")
 
     url, configs = _MODEL_CONFIG_AND_URLS[checkpoint_name]
     model = WaveRNN(**configs)
-    state_dict = load_state_dict_from_url(url, progress=progress)
+    state_dict = load_state_dict_from_url(url, progress=False)
     model.load_state_dict(state_dict)
     return model

--- a/torchaudio/models/wavernn.py
+++ b/torchaudio/models/wavernn.py
@@ -357,7 +357,9 @@ def wavernn(checkpoint_name: str) -> WaveRNN:
             - ``"wavernn_10k_epochs_8bits_ljspeech"``:
 
                 WaveRNN model trained with 10k epochs and 8 bits depth waveform on the LJSpeech dataset.
-                The model is trained using the default parameters and code of the examples/pipeline_wavernn/main.py.
+                The model is trained using the default parameters and code of the
+                `examples/pipeline_wavernn/main.py
+                <https://github.com/pytorch/audio/tree/master/examples/pipeline_wavernn>`_.
     """
     if checkpoint_name not in _MODEL_CONFIG_AND_URLS:
         raise ValueError(

--- a/torchaudio/models/wavernn.py
+++ b/torchaudio/models/wavernn.py
@@ -3,8 +3,10 @@ from typing import List, Tuple, Dict, Any
 import torch
 from torch import Tensor
 from torch import nn
-
-from ._utils import load_state_dict_from_url
+try:
+    from torch.hub import load_state_dict_from_url
+except ImportError:
+    from torch.utils.model_zoo import load_url as load_state_dict_from_url
 
 
 __all__ = [
@@ -17,7 +19,7 @@ __all__ = [
 ]
 
 
-model_config_and_urls: Dict[str, Tuple[str, Dict[str, Any]]] = {
+_MODEL_CONFIG_AND_URLS: Dict[str, Tuple[str, Dict[str, Any]]] = {
     'wavernn_10k_epochs_8bits_ljspeech': (
         'https://download.pytorch.org/models/audio/wavernn_10k_epochs_8bits_ljspeech.pth',
         {
@@ -363,11 +365,11 @@ def get_pretrained_wavernn(checkpoint_name: str, progress: bool = True) -> WaveR
         checkpoint_name (str): The name of the checkpoint to load.
         progress (bool): If True, displays a progress bar of the download to stderr.
     """
-    if checkpoint_name in model_config_and_urls:
-        url, configs = model_config_and_urls[checkpoint_name]
-        model = WaveRNN(**configs)
-        state_dict = load_state_dict_from_url(url, progress=progress)
-        model.load_state_dict(state_dict)
-        return model
-    else:
-        raise ValueError("The model_name `{}` is not supported.".format(checkpoint_name))
+    if checkpoint_name not in _MODEL_CONFIG_AND_URLS:
+        raise ValueError("The checkpoint_name `{}` is not supported.".format(checkpoint_name))
+
+    url, configs = _MODEL_CONFIG_AND_URLS[checkpoint_name]
+    model = WaveRNN(**configs)
+    state_dict = load_state_dict_from_url(url, progress=progress)
+    model.load_state_dict(state_dict)
+    return model

--- a/torchaudio/models/wavernn.py
+++ b/torchaudio/models/wavernn.py
@@ -1,8 +1,11 @@
-from typing import List, Tuple
+from typing import List, Tuple, Any
 
 import torch
 from torch import Tensor
 from torch import nn
+
+from ._utils import load_state_dict_from_url
+
 
 __all__ = [
     "ResBlock",
@@ -10,7 +13,14 @@ __all__ = [
     "Stretch2d",
     "UpsampleNetwork",
     "WaveRNN",
+    "wavernn_10k_epochs_8bits_ljspeech",
 ]
+
+
+model_urls = {
+    'wavernn_10k_epochs_8bits_ljspeech': 'https://download.pytorch.org/models/'
+                                         'audio/wavernn_10k_epochs_8bits_ljspeech.pth',
+}
 
 
 class ResBlock(nn.Module):
@@ -324,3 +334,37 @@ class WaveRNN(nn.Module):
 
         # bring back channel dimension
         return x.unsqueeze(1)
+
+
+def _wavernn(arch: str, pretrained: bool, progress: bool, **kwargs: Any) -> WaveRNN:
+    model = WaveRNN(**kwargs)
+    if pretrained:
+        state_dict = load_state_dict_from_url(model_urls['wavernn'],
+                                              progress=progress)
+        model.load_state_dict(state_dict)
+    return model
+
+
+def wavernn_10k_epochs_8bits_ljspeech(pretrained: bool = True, progress: bool = True, **kwargs: Any) -> WaveRNN:
+    r"""WaveRNN model trained with 10k epochs and 8 bits depth waveform on the LJSpeech dataset.
+    The model is trained using the default parameters and code of the examples/pipeline_wavernn/main.py.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on LJSpeech
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    n_bits = 8
+    configs = {
+        'upsample_scales': [5, 5, 11],
+        'n_classes': 2 ** n_bits,
+        'hop_length': 275,
+        'n_res_block': 10,
+        'n_rnn': 512,
+        'n_fc': 512,
+        'kernel_size': 5,
+        'n_freq': 80,
+        'n_hidden': 128,
+        'n_output': 128
+    }
+    configs.update(kwargs)
+    return _wavernn("wavernn_10k_epochs_8bits_ljspeech", pretrained=pretrained, progress=progress, **configs)


### PR DESCRIPTION
Closes #776.

Offers pertained weight for WaveRNN with 8 bits waveform mode and trained on LJSpeech.

Following the convention [here](https://github.com/pytorch/vision/blob/master/torchvision/models/alexnet.py#L53).