### PR TITLE
Remove gradient variable from RNNT Loss Python code

### DIFF
--- a/torchaudio/prototype/rnnt_loss.py
+++ b/torchaudio/prototype/rnnt_loss.py
@@ -53,7 +53,7 @@ def rnnt_loss(
     if blank < 0:  # reinterpret blank index if blank < 0.
         blank = logits.shape[-1] + blank
 
-    costs, gradients = torch.ops.torchaudio.rnnt_loss(
+    costs, _ = torch.ops.torchaudio.rnnt_loss(
         logits=logits,
         targets=targets,
         logit_lengths=logit_lengths,


### PR DESCRIPTION
`gradients` variable is not accessed in Python code