### PR TITLE
Remove skipIfRocm from soundfile.save_test test_fileobj_flac

### DIFF
--- a/test/torchaudio_unittest/backend/soundfile/save_test.py
+++ b/test/torchaudio_unittest/backend/soundfile/save_test.py
@@ -11,7 +11,6 @@ from torchaudio_unittest.common_utils import (
     get_wav_data,
     load_wav,
     nested_params,
-    skipIfRocm,
 )
 from .common import (
     fetch_wav_subtype,
@@ -281,7 +280,6 @@ class TestFileObject(TempDirMixin, PytorchTestCase):
         self._test_fileobj('wav')
 
     @skipIfFormatNotSupported("FLAC")
-    @skipIfRocm
     def test_fileobj_flac(self):
         """Saving audio via file-like object works"""
         self._test_fileobj('flac')


### PR DESCRIPTION
Allow the test `soundfile.save_test::TestFileObject:test_fileobj_flac` to run in the Rocm stack.