### PR TITLE
Make buffer size for function info configurable

### DIFF
--- a/test/torchaudio_unittest/common_utils/sox_utils.py
+++ b/test/torchaudio_unittest/common_utils/sox_utils.py
@@ -25,7 +25,7 @@ def get_bit_depth(dtype):
 
 def gen_audio_file(
         path, sample_rate, num_channels,
-        *, encoding=None, bit_depth=None, compression=None, attenuation=None, duration=1,
+        *, encoding=None, bit_depth=None, compression=None, attenuation=None, duration=1, comment_file=None,
 ):
     """Generate synthetic audio file with `sox` command."""
     if path.endswith('.wav'):
@@ -53,6 +53,8 @@ def gen_audio_file(
         command += ['--bits', str(bit_depth)]
     if encoding is not None:
         command += ['--encoding', str(encoding)]
+    if comment_file is not None:
+        command += ['--comment-file', str(comment_file)]
     command += [
         str(path),
         'synth', str(duration),  # synthesizes for the given duration [sec]

--- a/torchaudio/csrc/sox/io.cpp
+++ b/torchaudio/csrc/sox/io.cpp
@@ -161,7 +161,10 @@ std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_fileobj(
   //
   // See:
   // https://xiph.org/vorbis/doc/Vorbis_I_spec.html
-  auto capacity = 4096;
+  const int kDefaultCapacityInBytes = 4096;
+  auto capacity = (sox_get_globals()->bufsiz > kDefaultCapacityInBytes)
+      ? sox_get_globals()->bufsiz
+      : kDefaultCapacityInBytes;
   std::string buffer(capacity, '\0');
   auto* buf = const_cast<char*>(buffer.data());
   auto num_read = read_fileobj(&fileobj, capacity, buf);

--- a/torchaudio/csrc/sox/utils.cpp
+++ b/torchaudio/csrc/sox/utils.cpp
@@ -22,6 +22,10 @@ void set_buffer_size(const int64_t buffer_size) {
   sox_get_globals()->bufsiz = static_cast<size_t>(buffer_size);
 }
 
+int64_t get_buffer_size() {
+  return sox_get_globals()->bufsiz;
+}
+
 std::vector<std::vector<std::string>> list_effects() {
   std::vector<std::vector<std::string>> effects;
   for (const sox_effect_fn_t* fns = sox_get_effect_fns(); *fns; ++fns) {
@@ -538,6 +542,9 @@ TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
   m.def(
       "torchaudio::sox_utils_list_write_formats",
       &torchaudio::sox_utils::list_write_formats);
+  m.def(
+      "torchaudio::sox_utils_get_buffer_size",
+      &torchaudio::sox_utils::get_buffer_size);
 }
 
 } // namespace sox_utils

--- a/torchaudio/csrc/sox/utils.h
+++ b/torchaudio/csrc/sox/utils.h
@@ -24,6 +24,8 @@ void set_use_threads(const bool use_threads);
 
 void set_buffer_size(const int64_t buffer_size);
 
+int64_t get_buffer_size();
+
 std::vector<std::vector<std::string>> list_effects();
 
 std::vector<std::string> list_read_formats();

--- a/torchaudio/utils/sox_utils.py
+++ b/torchaudio/utils/sox_utils.py
@@ -90,3 +90,13 @@ def list_write_formats() -> List[str]:
         List[str]: List of supported audio formats
     """
     return torch.ops.torchaudio.sox_utils_list_write_formats()
+
+
+@_mod_utils.requires_sox()
+def get_buffer_size() -> int:
+    """Get buffer size for sox effect chain
+
+    Returns:
+        int: size in bytes of buffers used for processing audio.
+    """
+    return torch.ops.torchaudio.sox_utils_get_buffer_size()


### PR DESCRIPTION
torchaudio.info currently relies on a buffer of hardcoded size 4KB.
As a consequence, it doesn't work for files with headers larger than 4KB,
which is possible for ogg files, for instance. Here, we make the size of
torchaudio.info's buffer configurable to work for such files.