### PR TITLE
Refactor text preprocessing tests in Tacotron2 example

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -56,7 +56,7 @@ fi
 (
     set -x
     conda install -y -c conda-forge ${NUMBA_DEV_CHANNEL} 'librosa>=0.8.0' parameterized 'requests>=2.20'
-    pip install kaldi-io SoundFile coverage pytest pytest-cov scipy transformers expecttest
+    pip install kaldi-io SoundFile coverage pytest pytest-cov scipy transformers expecttest unidecode inflect
 )
 # Install fairseq
 git clone https://github.com/pytorch/fairseq

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -44,7 +44,7 @@ fi
 (
     set -x
     conda install -y -c conda-forge ${NUMBA_DEV_CHANNEL} 'librosa>=0.8.0' parameterized 'requests>=2.20'
-    pip install kaldi-io SoundFile coverage pytest pytest-cov scipy transformers expecttest
+    pip install kaldi-io SoundFile coverage pytest pytest-cov scipy transformers expecttest unidecode inflect
 )
 # Install fairseq
 git clone https://github.com/pytorch/fairseq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,8 @@ Optional packages to install if you want to run related tests:
 - `transformers`
 - `fairseq` (it has to be newer than `0.10.2`, so you will need to install from
   source. Commit `e6eddd80` is known to work.)
+- `unidecode` (dependency for testing text preprocessing functions for examples/pipeline_tacotron2)
+- `inflect` (dependency for testing text preprocessing functions for examples/pipeline_tacotron2)
 
 ## Development Process
 

--- a/examples/pipeline_tacotron2/text/numbers.py
+++ b/examples/pipeline_tacotron2/text/numbers.py
@@ -52,7 +52,7 @@ def _expand_dollars_repl_fn(m):
     if len(parts) > 2:
         return match + ' dollars'  # Unexpected format
     dollars = int(parts[0]) if parts[0] else 0
-    if len(parts) > 1 and parts[1] :
+    if len(parts) > 1 and parts[1]:
         if len(parts[1]) == 1:
             # handle the case where we have one digit after the decimal point
             cents = int(parts[1]) * 10

--- a/examples/pipeline_tacotron2/text/numbers.py
+++ b/examples/pipeline_tacotron2/text/numbers.py
@@ -29,67 +29,77 @@ import re
 
 
 _inflect = inflect.engine()
-_comma_number_re = re.compile(r'([0-9][0-9\,]+[0-9])')
-_decimal_number_re = re.compile(r'([0-9]+\.[0-9]+)')
-_pounds_re = re.compile(r'£([0-9\,]*[0-9]+)')
-_dollars_re = re.compile(r'\$([0-9\.\,]*[0-9]+)')
-_ordinal_re = re.compile(r'[0-9]+(st|nd|rd|th)')
-_number_re = re.compile(r'[0-9]+')
 
 
-def _remove_commas(m: re.Match) -> str:
-    return m.group(1).replace(',', '')
+def _remove_commas(text: str) -> str:
+    _comma_number_re = re.compile(r'([0-9][0-9\,]+[0-9])')
+    return re.sub(_comma_number_re, lambda m: m.group(1).replace(',', ''), text)
 
 
-def _expand_decimal_point(m: re.Match) -> str:
-    return m.group(1).replace('.', ' point ')
+def _expand_pounds(text: str) -> str:
+    _pounds_re = re.compile(r'£([0-9\,]*[0-9]+)')
+    return re.sub(_pounds_re, r'\1 pounds', text)
 
 
-def _expand_dollars(m: re.Match) -> str:
-    match = m.group(1)
-    parts = match.split('.')
-    if len(parts) > 2:
-        return match + ' dollars'  # Unexpected format
-    dollars = int(parts[0]) if parts[0] else 0
-    cents = int(parts[1]) if len(parts) > 1 and parts[1] else 0
-    if dollars and cents:
-        dollar_unit = 'dollar' if dollars == 1 else 'dollars'
-        cent_unit = 'cent' if cents == 1 else 'cents'
-        return '%s %s, %s %s' % (dollars, dollar_unit, cents, cent_unit)
-    elif dollars:
-        dollar_unit = 'dollar' if dollars == 1 else 'dollars'
-        return '%s %s' % (dollars, dollar_unit)
-    elif cents:
-        cent_unit = 'cent' if cents == 1 else 'cents'
-        return '%s %s' % (cents, cent_unit)
-    else:
-        return 'zero dollars'
-
-
-def _expand_ordinal(m: re.Match) -> str:
-    return _inflect.number_to_words(m.group(0))
-
-
-def _expand_number(m: re.Match) -> str:
-    num = int(m.group(0))
-    if num > 1000 and num < 3000:
-        if num == 2000:
-            return 'two thousand'
-        elif num > 2000 and num < 2010:
-            return 'two thousand ' + _inflect.number_to_words(num % 100)
-        elif num % 100 == 0:
-            return _inflect.number_to_words(num // 100) + ' hundred'
+def _expand_dollars(text: str) -> str:
+    def _helper_fn(m):
+        match = m.group(1)
+        parts = match.split('.')
+        if len(parts) > 2:
+            return match + ' dollars'  # Unexpected format
+        dollars = int(parts[0]) if parts[0] else 0
+        cents = int(parts[1]) if len(parts) > 1 and parts[1] else 0
+        if dollars and cents:
+            dollar_unit = 'dollar' if dollars == 1 else 'dollars'
+            cent_unit = 'cent' if cents == 1 else 'cents'
+            return '%s %s, %s %s' % (dollars, dollar_unit, cents, cent_unit)
+        elif dollars:
+            dollar_unit = 'dollar' if dollars == 1 else 'dollars'
+            return '%s %s' % (dollars, dollar_unit)
+        elif cents:
+            cent_unit = 'cent' if cents == 1 else 'cents'
+            return '%s %s' % (cents, cent_unit)
         else:
-            return _inflect.number_to_words(num, andword='', zero='oh', group=2).replace(', ', ' ')
-    else:
-        return _inflect.number_to_words(num, andword='')
+            return 'zero dollars'
+
+    _dollars_re = re.compile(r'\$([0-9\.\,]*[0-9]+)')
+    return re.sub(_dollars_re, _helper_fn, text)
+
+
+def _expand_decimal_point(text: str) -> str:
+    _decimal_number_re = re.compile(r'([0-9]+\.[0-9]+)')
+    return re.sub(_decimal_number_re, lambda m: m.group(1).replace('.', ' point '), text)
+
+
+def _expand_ordinal(text: str) -> str:
+    _ordinal_re = re.compile(r'[0-9]+(st|nd|rd|th)')
+    return re.sub(_ordinal_re, lambda m: _inflect.number_to_words(m.group(0)), text)
+
+
+def _expand_number(text: str) -> str:
+    def _helper_fn(m):
+        num = int(m.group(0))
+        if num > 1000 and num < 3000:
+            if num == 2000:
+                return 'two thousand'
+            elif num > 2000 and num < 2010:
+                return 'two thousand ' + _inflect.number_to_words(num % 100)
+            elif num % 100 == 0:
+                return _inflect.number_to_words(num // 100) + ' hundred'
+            else:
+                return _inflect.number_to_words(num, andword='', zero='oh', group=2).replace(', ', ' ')
+        else:
+            return _inflect.number_to_words(num, andword='')
+
+    _number_re = re.compile(r'[0-9]+')
+    return re.sub(_number_re, _helper_fn, text)
 
 
 def normalize_numbers(text: str) -> str:
-    text = re.sub(_comma_number_re, _remove_commas, text)
-    text = re.sub(_pounds_re, r'\1 pounds', text)
-    text = re.sub(_dollars_re, _expand_dollars, text)
-    text = re.sub(_decimal_number_re, _expand_decimal_point, text)
-    text = re.sub(_ordinal_re, _expand_ordinal, text)
-    text = re.sub(_number_re, _expand_number, text)
+    text = _remove_commas(text)
+    text = _expand_pounds(text)
+    text = _expand_dollars(text)
+    text = _expand_decimal_point(text)
+    text = _expand_ordinal(text)
+    text = _expand_number(text)
     return text

--- a/examples/pipeline_tacotron2/text/numbers.py
+++ b/examples/pipeline_tacotron2/text/numbers.py
@@ -29,70 +29,81 @@ import re
 
 
 _inflect = inflect.engine()
+_comma_number_re = re.compile(r'([0-9][0-9\,]+[0-9])')
+_pounds_re = re.compile(r'£([0-9\,]*[0-9]+)')
+_dollars_re = re.compile(r'\$([0-9\.\,]*[0-9]+)')
+_decimal_number_re = re.compile(r'([0-9]+\.[0-9]+)')
+_ordinal_re = re.compile(r'[0-9]+(st|nd|rd|th)')
+_number_re = re.compile(r'[0-9]+')
 
 
 def _remove_commas(text: str) -> str:
-    _comma_number_re = re.compile(r'([0-9][0-9\,]+[0-9])')
     return re.sub(_comma_number_re, lambda m: m.group(1).replace(',', ''), text)
 
 
 def _expand_pounds(text: str) -> str:
-    _pounds_re = re.compile(r'£([0-9\,]*[0-9]+)')
     return re.sub(_pounds_re, r'\1 pounds', text)
 
 
-def _expand_dollars(text: str) -> str:
-    def _helper_fn(m):
-        match = m.group(1)
-        parts = match.split('.')
-        if len(parts) > 2:
-            return match + ' dollars'  # Unexpected format
-        dollars = int(parts[0]) if parts[0] else 0
-        cents = int(parts[1]) if len(parts) > 1 and parts[1] else 0
-        if dollars and cents:
-            dollar_unit = 'dollar' if dollars == 1 else 'dollars'
-            cent_unit = 'cent' if cents == 1 else 'cents'
-            return '%s %s, %s %s' % (dollars, dollar_unit, cents, cent_unit)
-        elif dollars:
-            dollar_unit = 'dollar' if dollars == 1 else 'dollars'
-            return '%s %s' % (dollars, dollar_unit)
-        elif cents:
-            cent_unit = 'cent' if cents == 1 else 'cents'
-            return '%s %s' % (cents, cent_unit)
+def _expand_dollars_repl_fn(m):
+    """The replacement function for expanding dollars."""
+    match = m.group(1)
+    parts = match.split('.')
+    if len(parts) > 2:
+        return match + ' dollars'  # Unexpected format
+    dollars = int(parts[0]) if parts[0] else 0
+    if len(parts) > 1 and parts[1] :
+        if len(parts[1]) == 1:
+            # handle the case where we have one digit after the decimal point
+            cents = int(parts[1]) * 10
         else:
-            return 'zero dollars'
+            cents = int(parts[1])
+    else:
+        cents = 0
+    if dollars and cents:
+        dollar_unit = 'dollar' if dollars == 1 else 'dollars'
+        cent_unit = 'cent' if cents == 1 else 'cents'
+        return '%s %s, %s %s' % (dollars, dollar_unit, cents, cent_unit)
+    elif dollars:
+        dollar_unit = 'dollar' if dollars == 1 else 'dollars'
+        return '%s %s' % (dollars, dollar_unit)
+    elif cents:
+        cent_unit = 'cent' if cents == 1 else 'cents'
+        return '%s %s' % (cents, cent_unit)
+    else:
+        return 'zero dollars'
 
-    _dollars_re = re.compile(r'\$([0-9\.\,]*[0-9]+)')
-    return re.sub(_dollars_re, _helper_fn, text)
+
+def _expand_dollars(text: str) -> str:
+    return re.sub(_dollars_re, _expand_dollars_repl_fn, text)
 
 
 def _expand_decimal_point(text: str) -> str:
-    _decimal_number_re = re.compile(r'([0-9]+\.[0-9]+)')
     return re.sub(_decimal_number_re, lambda m: m.group(1).replace('.', ' point '), text)
 
 
 def _expand_ordinal(text: str) -> str:
-    _ordinal_re = re.compile(r'[0-9]+(st|nd|rd|th)')
     return re.sub(_ordinal_re, lambda m: _inflect.number_to_words(m.group(0)), text)
 
 
-def _expand_number(text: str) -> str:
-    def _helper_fn(m):
-        num = int(m.group(0))
-        if num > 1000 and num < 3000:
-            if num == 2000:
-                return 'two thousand'
-            elif num > 2000 and num < 2010:
-                return 'two thousand ' + _inflect.number_to_words(num % 100)
-            elif num % 100 == 0:
-                return _inflect.number_to_words(num // 100) + ' hundred'
-            else:
-                return _inflect.number_to_words(num, andword='', zero='oh', group=2).replace(', ', ' ')
+def _expand_number_repl_fn(m):
+    """The replacement function for expanding number."""
+    num = int(m.group(0))
+    if num > 1000 and num < 3000:
+        if num == 2000:
+            return 'two thousand'
+        elif num > 2000 and num < 2010:
+            return 'two thousand ' + _inflect.number_to_words(num % 100)
+        elif num % 100 == 0:
+            return _inflect.number_to_words(num // 100) + ' hundred'
         else:
-            return _inflect.number_to_words(num, andword='')
+            return _inflect.number_to_words(num, andword='', zero='oh', group=2).replace(', ', ' ')
+    else:
+        return _inflect.number_to_words(num, andword='')
 
-    _number_re = re.compile(r'[0-9]+')
-    return re.sub(_number_re, _helper_fn, text)
+
+def _expand_number(text: str) -> str:
+    return re.sub(_number_re, _expand_number_repl_fn, text)
 
 
 def normalize_numbers(text: str) -> str:

--- a/test/torchaudio_unittest/example/tacotron2/test_text_preprocessing.py
+++ b/test/torchaudio_unittest/example/tacotron2/test_text_preprocessing.py
@@ -1,11 +1,15 @@
-import unittest
-
 from parameterized import parameterized
 
-from .text_preprocessing import text_to_sequence
+from torchaudio._internal.module_utils import is_module_available
+from torchaudio_unittest.common_utils import TorchaudioTestCase, skipIfNoModule
+
+if is_module_available("unidecode") and is_module_available("inflect"):
+    from pipeline_tacotron2.text.text_preprocessing import text_to_sequence
 
 
-class TestTextPreprocessor(unittest.TestCase):
+@skipIfNoModule("unidecode")
+@skipIfNoModule("inflect")
+class TestTextPreprocessor(TorchaudioTestCase):
 
     @parameterized.expand(
         [

--- a/test/torchaudio_unittest/example/tacotron2/test_text_preprocessing.py
+++ b/test/torchaudio_unittest/example/tacotron2/test_text_preprocessing.py
@@ -5,6 +5,14 @@ from torchaudio_unittest.common_utils import TorchaudioTestCase, skipIfNoModule
 
 if is_module_available("unidecode") and is_module_available("inflect"):
     from pipeline_tacotron2.text.text_preprocessing import text_to_sequence
+    from pipeline_tacotron2.text.numbers import (
+        _remove_commas,
+        _expand_pounds,
+        _expand_dollars,
+        _expand_decimal_point,
+        _expand_ordinal,
+        _expand_number,
+    )
 
 
 @skipIfNoModule("unidecode")
@@ -24,3 +32,66 @@ class TestTextPreprocessor(TorchaudioTestCase):
     def test_text_to_sequence(self, sent, seq):
 
         assert (text_to_sequence(sent) == seq)
+
+    @parameterized.expand(
+        [
+            ["He, she, and I have $1,000", "He, she, and I have $1000"],
+        ]
+    )
+    def test_remove_commas(self, sent, truth):
+
+        assert (_remove_commas(sent) == truth)
+
+    @parameterized.expand(
+        [
+            ["He, she, and I have £1000", "He, she, and I have 1000 pounds"],
+        ]
+    )
+    def test_expand_pounds(self, sent, truth):
+
+        assert (_expand_pounds(sent) == truth)
+
+    @parameterized.expand(
+        [
+            ["He, she, and I have $1000", "He, she, and I have 1000 dollars"],
+            ["He, she, and I have $3000.01", "He, she, and I have 3000 dollars, 1 cent"],
+            ["He has $500.20 and she has $1000.50.",
+             "He has 500 dollars, 20 cents and she has 1000 dollars, 50 cents."],
+        ]
+    )
+    def test_expand_dollars(self, sent, truth):
+
+        assert (_expand_dollars(sent) == truth)
+
+    @parameterized.expand(
+        [
+            ["1000.20", "1000 point 20"],
+            ["1000.1", "1000 point 1"],
+        ]
+    )
+    def test_expand_decimal_point(self, sent, truth):
+
+        assert (_expand_decimal_point(sent) == truth)
+
+    @parameterized.expand(
+        [
+            ["21st centry", "twenty-first centry"],
+            ["20th centry", "twentieth centry"],
+            ["2nd place.", "second place."],
+        ]
+    )
+    def test_expand_ordinal(self, sent, truth):
+
+        assert (_expand_ordinal(sent) == truth)
+        _expand_ordinal,
+
+    @parameterized.expand(
+        [
+            ["100020 dollars.", "one hundred thousand twenty dollars."],
+            ["1234567890!", "one billion, two hundred thirty-four million, "
+                            "five hundred sixty-seven thousand, eight hundred ninety!"],
+        ]
+    )
+    def test_expand_number(self, sent, truth):
+
+        assert (_expand_number(sent) == truth)


### PR DESCRIPTION
The tests for `example/pipeline_tacotron2` are moved to `test/torchaudio_unittest/example/tacotron2` in #1625. This PR also moves the text preprocessing tests into `test/torchaudio_unittest/tacotron2` so it will be run automatically by CI.