### PR TITLE
added example for Resampler

### DIFF
--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -643,6 +643,11 @@ class Resample(torch.nn.Module):
             cached as ``torch.float64``. If you use resample with lower precision, then instead of providing this
             providing this argument, please use ``Resample.to(dtype)``, so that the kernel generation is still
             carried out on ``torch.float64``.
+
+    Example
+        >>> waveform, sample_rate = torchaudio.load('test.wav', normalization=True)
+        >>> resampler = transforms.Resample(sample_rate, sample_rate/10)
+        >>> waveform = resampler(waveform)
     """
 
     def __init__(

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -645,9 +645,9 @@ class Resample(torch.nn.Module):
             carried out on ``torch.float64``.
 
     Example
-        >>> waveform, sample_rate = torchaudio.load('test.wav', normalization=True)
-        >>> resampler = transforms.Resample(sample_rate, sample_rate/10)
-        >>> waveform = resampler(waveform)
+        >>> waveform, sample_rate = torchaudio.load('test.wav', normalize=True)
+        >>> transform = transforms.Resample(sample_rate, sample_rate/10)
+        >>> waveform = transform(waveform)
     """
 
     def __init__(


### PR DESCRIPTION
Added example for [Resample](https://pytorch.org/audio/stable/transforms.html#torchaudio.transforms.Resample) as mentioned in [this issue](https://github.com/pytorch/audio/issues/1564)