### PR TITLE
Fix Tacotron2 Postnet forward

### DIFF
--- a/torchaudio/prototype/tacotron2.py
+++ b/torchaudio/prototype/tacotron2.py
@@ -354,13 +354,11 @@ class _Postnet(nn.Module):
             x (Tensor): Tensor with shape (n_batch, ``n_mels``, max of ``mel_specgram_lengths``).
         """
 
-        i = 0
-        for conv in self.convolutions:
+        for i, conv in enumerate(self.convolutions):
             if i < self.n_convs - 1:
                 x = F.dropout(torch.tanh(conv(x)), 0.5, training=self.training)
             else:
                 x = F.dropout(conv(x), 0.5, training=self.training)
-        i += 1
 
         return x
 


### PR DESCRIPTION
I found that there is a glitch at the `__forward__` method of Tacotron2 _Postnet.
The correct implementation to reference is [here](https://github.com/NVIDIA/DeepLearningExamples/blob/5a8521ee05934170ace0243f62e81cd7d7774fbd/PyTorch/SpeechSynthesis/Tacotron2/tacotron2/model.py#L173).