### PR TITLE
Add Tacotron2 inference method

### DIFF
--- a/torchaudio/prototype/tacotron2.py
+++ b/torchaudio/prototype/tacotron2.py
@@ -1073,7 +1073,10 @@ class Tacotron2(nn.Module):
 
     @torch.jit.export
     def infer(self, text: Tensor, text_lengths: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
-        r"""Using Tacotron2 for inference. This is generally used for generating mel spectrograms.
+        r"""Using Tacotron2 for inference. The input is a batch of encoded
+        sentences (text) and its corresponding lengths (text_lengths). The
+        output is the generated mel spectrograms, its corresponding lengths, and
+        the attention weights from the decoder.
 
         The input `text` should be padded with zeros to length max of ``text_lengths``.
 


### PR DESCRIPTION
Tacotron2 inference method ported from [nvidia](https://github.com/NVIDIA/DeepLearningExamples/blob/master/PyTorch/SpeechSynthesis/Tacotron2/tacotron2/model.py).
Here are the things that are changed:
- Implemented the `infer` method for Tacotron2
- jit consistency test and output shape test for this `infer` method
- [This line is changed](https://github.com/pytorch/audio/pull/1648#issue-699091717) because `decoder_early_stopping` is by default True and it is an error from the last commit.
- Some of the variable names are also renamed for consistency ([here](https://github.com/pytorch/audio/pull/1648/files#diff-8b8ec57192b9aaeb99a9ec5e709c977771b31b49fe7ddc6704c2128cf161a00eR642) and [here](https://github.com/pytorch/audio/pull/1648/files#diff-001793fb337f116c66a3e7f3869a18012a618ab079df93db381fec0f45b63d9eR137))