### PR TITLE
Refactor coding style for wavernn example

### DIFF
--- a/examples/pipeline_wavernn/datasets.py
+++ b/examples/pipeline_wavernn/datasets.py
@@ -1,8 +1,6 @@
-import os
 import random
 
 import torch
-import torchaudio
 from torch.utils.data.dataset import random_split
 from torchaudio.datasets import LJSPEECH, LIBRITTS
 from torchaudio.transforms import MuLawEncoding

--- a/examples/pipeline_wavernn/inference.py
+++ b/examples/pipeline_wavernn/inference.py
@@ -1,7 +1,6 @@
 import argparse
 
 import torch
-import torch.nn.functional as F
 import torchaudio
 from torchaudio.transforms import MelSpectrogram
 from torchaudio.models import wavernn

--- a/examples/pipeline_wavernn/main.py
+++ b/examples/pipeline_wavernn/main.py
@@ -1,7 +1,6 @@
 import argparse
 import logging
 import os
-import signal
 from collections import defaultdict
 from datetime import datetime
 from time import time
@@ -9,7 +8,6 @@ from typing import List
 
 import torch
 import torchaudio
-from torch import nn as nn
 from torch.optim import Adam
 from torch.utils.data import DataLoader
 from torchaudio.datasets.utils import bg_iterator

--- a/examples/pipeline_wavernn/wavernn_inference_wrapper.py
+++ b/examples/pipeline_wavernn/wavernn_inference_wrapper.py
@@ -1,16 +1,16 @@
 # *****************************************************************************
 # Copyright (c) 2019 fatchord (https://github.com/fatchord)
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,6 +33,7 @@ from processing import (
     normalized_waveform_to_bits,
     bits_to_normalized_waveform,
 )
+
 
 class WaveRNNInferenceWrapper(torch.nn.Module):
 
@@ -157,7 +158,7 @@ class WaveRNNInferenceWrapper(torch.nn.Module):
             padded[:, :, :t] = x
         else:
             raise ValueError(f"Unexpected side: '{side}'. "
-                            f"Valid choices are 'both', 'before' and 'after'.")
+                             f"Valid choices are 'both', 'before' and 'after'.")
         return padded
 
     def forward(self,
@@ -242,7 +243,7 @@ class WaveRNNInferenceWrapper(torch.nn.Module):
                 output.append(x.squeeze(-1))
             else:
                 raise ValueError(f"Unexpected loss_name: '{loss_name}'. "
-                                f"Valid choices are 'crossentropy'.")
+                                 f"Valid choices are 'crossentropy'.")
 
         output = torch.stack(output).transpose(0, 1).cpu()
 


### PR DESCRIPTION
If flake8 is run in `examples/pipeline_wavernn`, then we will get the following messages:
```bash
datasets.py:1:1: F401 'os' imported but unused
datasets.py:5:1: F401 'torchaudio' imported but unused
inference.py:4:1: F401 'torch.nn.functional as F' imported but unused
main.py:4:1: F401 'signal' imported but unused
main.py:12:1: F401 'torch.nn' imported but unused
wavernn_inference_wrapper.py:3:2: W291 trailing whitespace
wavernn_inference_wrapper.py:10:2: W291 trailing whitespace
wavernn_inference_wrapper.py:13:2: W291 trailing whitespace
wavernn_inference_wrapper.py:37:1: E302 expected 2 blank lines, found 1
wavernn_inference_wrapper.py:160:29: E128 continuation line under-indented for visual indent
wavernn_inference_wrapper.py:245:33: E128 continuation line under-indented for visual indent
```

This PR addresses these coding style warnings.