### PR TITLE
Fix encoding of CMUDict data reading

### DIFF
--- a/torchaudio/datasets/cmudict.py
+++ b/torchaudio/datasets/cmudict.py
@@ -148,7 +148,7 @@ class CMUDict(Dataset):
         with open(os.path.join(self._root_path, basename_symbols), "r") as text:
             self._symbols = [line.strip() for line in text.readlines()]
 
-        with open(os.path.join(self._root_path, basename), "r") as text:
+        with open(os.path.join(self._root_path, basename), "r", encoding='latin-1') as text:
             self._dictionary = _parse_dictionary(text.readlines(),
                                                  exclude_punctuations=self.exclude_punctuations)
 


### PR DESCRIPTION
It appears that there will be an error for the current `torchaudio.datasets.CMUDict` due to using the wrong data loading encoding. According to [this](https://github.com/NVIDIA/DeepLearningExamples/blob/master/PyTorch/SpeechSynthesis/Tacotron2/tacotron2/text/cmudict.py#L23), we should use `latin-1` as the encoding method for loading CMUDict data.