### PR TITLE
Add style checks on example files on CI

### DIFF
--- a/.circleci/unittest/linux/scripts/run_style_checks.sh
+++ b/.circleci/unittest/linux/scripts/run_style_checks.sh
@@ -29,7 +29,7 @@ set +e
 exit_status=0
 
 printf "\x1b[34mRunning flake8:\x1b[0m\n"
-flake8 torchaudio test build_tools/setup_helpers docs/source/conf.py
+flake8 torchaudio test build_tools/setup_helpers docs/source/conf.py examples
 status=$?
 exit_status="$((exit_status+status))"
 if [ "${status}" -ne 0 ]; then

--- a/examples/interactive_asr/__init__.py
+++ b/examples/interactive_asr/__init__.py
@@ -1,1 +1,3 @@
 from . import utils, vad
+
+__all__ = ['utils', 'vad']

--- a/examples/libtorchaudio/speech_recognition/parse_voxforge.py
+++ b/examples/libtorchaudio/speech_recognition/parse_voxforge.py
@@ -11,7 +11,7 @@ example: python parse_voxforge.py voxforge/de/Helge-20150608-aku
     ...
 
 Dataset can be obtained from http://www.repository.voxforge1.org/downloads/de/Trunk/Audio/Main/16kHz_16bit/
-"""
+"""  # noqa: E501
 import os
 import argparse
 from pathlib import Path

--- a/examples/source_separation/conv_tasnet/__init__.py
+++ b/examples/source_separation/conv_tasnet/__init__.py
@@ -2,3 +2,5 @@ from . import (
     train,
     trainer,
 )
+
+__all__ = ['train', 'trainer']

--- a/examples/source_separation/conv_tasnet/train.py
+++ b/examples/source_separation/conv_tasnet/train.py
@@ -63,7 +63,7 @@ def _parse_args(args):
     group.add_argument(
         "--batch-size",
         type=int,
-        help=f"Batch size. (default: 16 // world_size)",
+        help="Batch size. (default: 16 // world_size)",
     )
     group = parser.add_argument_group("Training Options")
     group.add_argument(
@@ -223,7 +223,7 @@ def train(args):
         optimizer.load_state_dict(checkpoint["optimizer"])
     else:
         dist_utils.synchronize_params(
-            str(args.save_dir / f"tmp.pt"), device, model, optimizer
+            str(args.save_dir / "tmp.pt"), device, model, optimizer
         )
 
     lr_scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
@@ -258,7 +258,7 @@ def train(args):
         debug=args.debug,
     )
 
-    log_path = args.save_dir / f"log.csv"
+    log_path = args.save_dir / "log.csv"
     _write_header(log_path, args)
     dist_utils.write_csv_on_master(
         log_path,

--- a/examples/source_separation/utils/__init__.py
+++ b/examples/source_separation/utils/__init__.py
@@ -3,3 +3,5 @@ from . import (
     dist_utils,
     metrics,
 )
+
+__all__ = ['dataset', 'dist_utils', 'metrics']

--- a/examples/source_separation/utils/dataset/__init__.py
+++ b/examples/source_separation/utils/dataset/__init__.py
@@ -1,1 +1,3 @@
 from . import utils, wsj0mix
+
+__all__ = ['utils', 'wsj0mix']

--- a/examples/source_separation/utils/dataset/utils.py
+++ b/examples/source_separation/utils/dataset/utils.py
@@ -43,7 +43,6 @@ def _fix_num_frames(sample: wsj0mix.SampleType, target_num_frames: int, random_s
     return mix, src, mask
 
 
-
 def collate_fn_wsj0mix_train(samples: List[wsj0mix.SampleType], sample_rate, duration):
     target_num_frames = int(duration * sample_rate)
 


### PR DESCRIPTION
I've also fixed the flake8 errors.

Here is an copy of the original errors:
```bash
interactive_asr/__init__.py:1:1: F401 '.utils' imported but unused
interactive_asr/__init__.py:1:1: F401 '.vad' imported but unused
libtorchaudio/speech_recognition/parse_voxforge.py:10:121: E501 line too long (126 > 120 characters)
libtorchaudio/simplectc/tests/test_decode.py:77:1: W293 blank line contains whitespace
libtorchaudio/simplectc/tests/test_decode.py:160:121: E501 line too long (136 > 120 characters)
libtorchaudio/simplectc/setup.py:7:1: F401 'setuptools.find_packages' imported but unused
libtorchaudio/simplectc/simple_ctc/__init__.py:28:1: F401 '.decoder.BeamSearchDecoder' imported but unused
source_separation/utils/dataset/__init__.py:1:1: F401 '.utils' imported but unused
source_separation/utils/dataset/__init__.py:1:1: F401 '.wsj0mix' imported but unused
source_separation/utils/dataset/utils.py:47:1: E303 too many blank lines (3)
source_separation/utils/__init__.py:1:1: F401 '.dataset' imported but unused
source_separation/utils/__init__.py:1:1: F401 '.dist_utils' imported but unused
source_separation/utils/__init__.py:1:1: F401 '.metrics' imported but unused
source_separation/conv_tasnet/__init__.py:1:1: F401 '.train' imported but unused
source_separation/conv_tasnet/__init__.py:1:1: F401 '.trainer' imported but unused
source_separation/conv_tasnet/train.py:66:14: F541 f-string is missing placeholders
source_separation/conv_tasnet/train.py:226:33: F541 f-string is missing placeholders
source_separation/conv_tasnet/train.py:261:32: F541 f-string is missing placeholders
```

For the error in [this file](https://github.com/pytorch/audio/pull/1667/files#diff-97285e039304ae145ce4e47cd4254e4bfce89d98ed81bd51fcb3f362e835c5d7R14) I chose to ignore since `de5-001\t/datasets/voxforge/de/guenter-20140214-afn/wav/de5-001.wav\tES SOLL ETWA FÜNFZIGTAUSEND VERSCHIEDENE SORTEN GEBEN` seems to be a whole line itself, and I am not sure where to cutoff.