### PR TITLE
Add documentation for CMUDict's property

### DIFF
--- a/torchaudio/datasets/cmudict.py
+++ b/torchaudio/datasets/cmudict.py
@@ -169,4 +169,6 @@ class CMUDict(Dataset):
 
     @property
     def symbols(self) -> List[str]:
+        """list[str]: A list of phonemes symbols, such as `AA`, `AE`, `AH`.
+        """
         return self._symbols.copy()


### PR DESCRIPTION
The property doc noe appears [here](https://290922-90321822-gh.circle-artifacts.com/0/docs/datasets.html#torchaudio.datasets.CMUDict.symbols) (which it does not appear [originally](https://pytorch.org/audio/main/datasets.html#torchaudio.datasets.CMUDict)).