### PR TITLE
Update version setup.py for LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ binary_common: &binary_common
     build_version:
       description: "version number of release binary; by default, build a nightly"
       type: string
-      default: "0.8.2"
+      default: "0.8.1"
     pytorch_version:
       description: "PyTorch version to build against; by default, use a nightly"
       type: string

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -58,7 +58,7 @@ binary_common: &binary_common
     build_version:
       description: "version number of release binary; by default, build a nightly"
       type: string
-      default: "0.8.2"
+      default: "0.8.1"
     pytorch_version:
       description: "PyTorch version to build against; by default, use a nightly"
       type: string

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ ROOT_DIR = Path(__file__).parent.resolve()
 
 
 # Creating the version file
-version = '0.8.0a0'
+version = '0.8.1'
 sha = 'Unknown'
 
 try:


### PR DESCRIPTION
To test

```
conda install -y pytorch=1.8.1 torchvision=0.9.1 torchaudio=0.8.1 torchtext=0.9.1 cpuonly -c pytorch-lts
```

Then run `python -c "import torchaudio; print(torchaudio.__version__)" `

Output should be `0.8.1`