### PR TITLE
packaging: Ensure we're propagating BUILD_VERSION

### DIFF
--- a/packaging/torchaudio/meta.yaml
+++ b/packaging/torchaudio/meta.yaml
@@ -27,6 +27,8 @@ requirements:
 
 build:
   string: py{{py}}
+  script_env:
+    - BUILD_VERSION
 
 test:
   imports:


### PR DESCRIPTION
BUILD_VERSION gets set by upstream scripts and should be available
whenever we're attempting to build audio in conda environments.

This solves the issue where conda packages appeared to be building a
development version instead of the actual version we were targeting

Closes #1696 

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>