### PR TITLE
Add additional guard to libsndfile

### DIFF
--- a/torchaudio/_internal/module_utils.py
+++ b/torchaudio/_internal/module_utils.py
@@ -76,6 +76,30 @@ def requires_kaldi():
             return wrapped
     return decorator
 
+def is_soundfile_available():
+    if not is_module_available('soundfile'): return False
+    try:
+        import soundfile
+    except OSError as os_error:
+        if str(os_error).find("sndfile library not found") != -1:
+            raise RuntimeError("""soundfile requires libsndfile to be installed. Try install it via:
+$conda install -c conda-forge libsndfile """)
+            return False
+        else:
+            raise os_error
+    return True
+
+def requires_soundfile():
+    if is_soundfile_available():
+        def decorator(func):
+            return func
+    else:
+        def decorator(func):
+            @wraps(func)
+            def wrapped(*args, **kwargs):
+                raise RuntimeError(f'{func.__module__}.{func.__name__} requires soundfile')
+            return wrapped
+    return decorator
 
 def is_sox_available():
     return is_module_available('torchaudio._torchaudio') and torch.ops.torchaudio.is_sox_available()

--- a/torchaudio/_internal/module_utils.py
+++ b/torchaudio/_internal/module_utils.py
@@ -80,22 +80,19 @@ def requires_kaldi():
 def _check_soundfile_importable():
     if not is_module_available('soundfile'):
         return False
-    else:
-        try:
-            import soundfile    # noqa: F401
-            return True
-        except OSError:
-            raise RuntimeError("""Failed to import soundfile, most likely it's
-because the required dependency libsndfile not installed yet, try install it:
-$conda install -c conda-forge libsndfile """)
-            return False
+    try:
+        import soundfile    # noqa: F401
+        return True
+    except Exception:
+        warnings.warn("Failed to import soundfile. 'soundfile' backend is not available.")
+        return False
 
 
 _is_soundfile_importable = _check_soundfile_importable()
 
 
 def is_soundfile_available():
-    return is_module_available('soundfile') and _is_soundfile_importable
+    return _is_soundfile_importable
 
 
 def requires_soundfile():

--- a/torchaudio/_internal/module_utils.py
+++ b/torchaudio/_internal/module_utils.py
@@ -95,7 +95,7 @@ _is_soundfile_importable = _check_soundfile_importable()
 
 
 def is_soundfile_available():
-        return is_module_available('soundfile') and _is_soundfile_importable
+    return is_module_available('soundfile') and _is_soundfile_importable
 
 
 def requires_soundfile():

--- a/torchaudio/_internal/module_utils.py
+++ b/torchaudio/_internal/module_utils.py
@@ -76,10 +76,12 @@ def requires_kaldi():
             return wrapped
     return decorator
 
+
 def is_soundfile_available():
-    if not is_module_available('soundfile'): return False
+    if not is_module_available('soundfile'):
+        return False
     try:
-        import soundfile
+        import soundfile # noqa: F401
     except OSError as os_error:
         if str(os_error).find("sndfile library not found") != -1:
             raise RuntimeError("""soundfile requires libsndfile to be installed. Try install it via:
@@ -88,6 +90,7 @@ $conda install -c conda-forge libsndfile """)
         else:
             raise os_error
     return True
+
 
 def requires_soundfile():
     if is_soundfile_available():
@@ -100,6 +103,7 @@ def requires_soundfile():
                 raise RuntimeError(f'{func.__module__}.{func.__name__} requires soundfile')
             return wrapped
     return decorator
+
 
 def is_sox_available():
     return is_module_available('torchaudio._torchaudio') and torch.ops.torchaudio.is_sox_available()

--- a/torchaudio/_internal/module_utils.py
+++ b/torchaudio/_internal/module_utils.py
@@ -77,19 +77,25 @@ def requires_kaldi():
     return decorator
 
 
-def is_soundfile_available():
+def _check_soundfile_importable():
     if not is_module_available('soundfile'):
         return False
-    try:
-        import soundfile    # noqa: F401
-    except OSError as os_error:
-        if str(os_error).find("sndfile library not found") != -1:
-            raise RuntimeError("""soundfile requires libsndfile to be installed. Try install it via:
+    else:
+        try:
+            import soundfile    # noqa: F401
+            return True
+        except OSError:
+            raise RuntimeError("""Failed to import soundfile, most likely it's
+because the required dependency libsndfile not installed yet, try install it:
 $conda install -c conda-forge libsndfile """)
             return False
-        else:
-            raise os_error
-    return True
+
+
+_is_soundfile_importable = _check_soundfile_importable()
+
+
+def is_soundfile_available():
+        return is_module_available('soundfile') and _is_soundfile_importable
 
 
 def requires_soundfile():

--- a/torchaudio/_internal/module_utils.py
+++ b/torchaudio/_internal/module_utils.py
@@ -81,7 +81,7 @@ def is_soundfile_available():
     if not is_module_available('soundfile'):
         return False
     try:
-        import soundfile # noqa: F401
+        import soundfile    # noqa: F401
     except OSError as os_error:
         if str(os_error).find("sndfile library not found") != -1:
             raise RuntimeError("""soundfile requires libsndfile to be installed. Try install it via:

--- a/torchaudio/backend/soundfile_backend.py
+++ b/torchaudio/backend/soundfile_backend.py
@@ -7,9 +7,8 @@ from torchaudio._internal import module_utils as _mod_utils
 from .common import AudioMetaData
 
 
-if _mod_utils.is_module_available("soundfile"):
+if _mod_utils.is_soundfile_available():
     import soundfile
-
 
 # Mapping from soundfile subtype to number of bits per sample.
 # This is mostly heuristical and the value is set to 0 when it is irrelevant
@@ -81,7 +80,7 @@ def _get_encoding(format: str, subtype: str):
     return _SUBTYPE_TO_ENCODING.get(subtype, 'UNKNOWN')
 
 
-@_mod_utils.requires_module("soundfile")
+@_mod_utils.requires_soundfile()
 def info(filepath: str, format: Optional[str] = None) -> AudioMetaData:
     """Get signal information of an audio file.
 
@@ -120,7 +119,7 @@ _SUBTYPE2DTYPE = {
 }
 
 
-@_mod_utils.requires_module("soundfile")
+@_mod_utils.requires_soundfile()
 def load(
     filepath: str,
     frame_offset: int = 0,
@@ -299,7 +298,7 @@ def _get_subtype(
     raise ValueError(f"Unsupported format: {format}")
 
 
-@_mod_utils.requires_module("soundfile")
+@_mod_utils.requires_soundfile()
 def save(
     filepath: str,
     src: torch.Tensor,


### PR DESCRIPTION
Summary:

Add additional check of libsndfile when soundfile is needed.
Address https://github.com/pytorch/audio/issues/1687
No functional change

Test steps:
1. Setup
Install soundfile: $ pip install soundfile
delete libsndfile: $ conda remove libsndfile

2. Repro the error
(audio) [bowangbj@devgpu006.pnb1 ~/local/audio] python
Python 3.9.6 (default, Jul 30 2021, 16:35:19) 
[GCC 7.5.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torchaudio
/data/users/bowangbj/audio/torchaudio/_internal/module_utils.py:87: UserWarning: Failed to import soundfile. 'soundfile' backend is not available.
  warnings.warn("Failed to import soundfile. 'soundfile' backend is not available.")
$conda install -c conda-forge libsndfile

3. Fix the error
Follow error msg above to install libsndfile, and import torchaudio, it will succeed.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: