### PR TITLE
Added example for Fade transform

### DIFF
--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -996,6 +996,11 @@ class Fade(torch.nn.Module):
         fade_out_len (int, optional): Length of fade-out (time frames). (Default: ``0``)
         fade_shape (str, optional): Shape of fade. Must be one of: "quarter_sine",
             "half_sine", "linear", "logarithmic", "exponential". (Default: ``"linear"``)
+            
+     Example
+        >>> waveform, sample_rate = torchaudio.load('test.wav', normalize=True)
+        >>> transform = transforms.Fade(fade_in_len=1, fade_out_len=2, fade_shape='linear')
+        >>> faded_waveform = transform(waveform)
     """
 
     def __init__(self,

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -996,8 +996,8 @@ class Fade(torch.nn.Module):
         fade_out_len (int, optional): Length of fade-out (time frames). (Default: ``0``)
         fade_shape (str, optional): Shape of fade. Must be one of: "quarter_sine",
             "half_sine", "linear", "logarithmic", "exponential". (Default: ``"linear"``)
-            
-     Example
+
+    Example
         >>> waveform, sample_rate = torchaudio.load('test.wav', normalize=True)
         >>> transform = transforms.Fade(fade_in_len=sample_rate, fade_out_len=2 * sample_rate, fade_shape='linear')
         >>> faded_waveform = transform(waveform)

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -999,7 +999,7 @@ class Fade(torch.nn.Module):
             
      Example
         >>> waveform, sample_rate = torchaudio.load('test.wav', normalize=True)
-        >>> transform = transforms.Fade(fade_in_len=1, fade_out_len=2, fade_shape='linear')
+        >>> transform = transforms.Fade(fade_in_len=sample_rate, fade_out_len=2 * sample_rate, fade_shape='linear')
         >>> faded_waveform = transform(waveform)
     """
 


### PR DESCRIPTION
Added Example for [Fade Transform](https://pytorch.org/audio/stable/transforms.html#torchaudio.transforms.Fade) as mentioned in [this issue](https://github.com/pytorch/audio/issues/1564).