### PR TITLE
Add sections to transforms docs

### DIFF
--- a/docs/source/functional.rst
+++ b/docs/source/functional.rst
@@ -197,12 +197,11 @@ treble_biquad
 
 .. autofunction:: treble_biquad
 
-
-vad
----
-
 :hidden:`Feature Extractions`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:hidden:`vad`
+-------------
 
 .. autofunction:: vad
 
@@ -227,7 +226,7 @@ vad
 .. autofunction:: phase_vocoder
 
 :hidden:`pitch_shift`
------------------------
+---------------------
 
 .. autofunction:: pitch_shift
 

--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -8,171 +8,181 @@ torchaudio.transforms
 
 Transforms are common audio transforms. They can be chained together using :class:`torch.nn.Sequential`
 
-
-:hidden:`Spectrogram`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: Spectrogram
-
-  .. automethod:: forward
-
-:hidden:`InverseSpectrogram`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: InverseSpectrogram
-
-  .. automethod:: forward
-
-:hidden:`GriffinLim`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: GriffinLim
-
-  .. automethod:: forward
+:hidden:`Utility`
+~~~~~~~~~~~~~~~~~~
 
 :hidden:`AmplitudeToDB`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 
 .. autoclass:: AmplitudeToDB
 
   .. automethod:: forward
 
 :hidden:`MelScale`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------
 
 .. autoclass:: MelScale
 
   .. automethod:: forward
 
 :hidden:`InverseMelScale`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------
 
 .. autoclass:: InverseMelScale
 
   .. automethod:: forward
 
-
-:hidden:`MelSpectrogram`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: MelSpectrogram
-
-  .. automethod:: forward
-
-:hidden:`MFCC`
-~~~~~~~~~~~~~~
-
-.. autoclass:: MFCC
-
-  .. automethod:: forward
-
-:hidden:`LFCC`
-~~~~~~~~~~~~~~
-
-.. autoclass:: LFCC
-
-  .. automethod:: forward
-
 :hidden:`MuLawEncoding`
-~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 
 .. autoclass:: MuLawEncoding
 
   .. automethod:: forward
 
 :hidden:`MuLawDecoding`
-~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 
 .. autoclass:: MuLawDecoding
 
   .. automethod:: forward
 
 :hidden:`Resample`
-~~~~~~~~~~~~~~~~~~
+------------------
 
 .. autoclass:: Resample
 
   .. automethod:: forward
 
-:hidden:`ComplexNorm`
-~~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: ComplexNorm
-
-  .. automethod:: forward
-
-:hidden:`ComputeDeltas`
-~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: ComputeDeltas
-
-  .. automethod:: forward
-
-:hidden:`TimeStretch`
-~~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: TimeStretch
-
-  .. automethod:: forward
-
-:hidden:`PitchShift`
-~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: PitchShift
-
-  .. automethod:: forward
-
-:hidden:`Fade`
-~~~~~~~~~~~~~~
-
-.. autoclass:: Fade
-
-  .. automethod:: forward
-
 :hidden:`FrequencyMasking`
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------
 
 .. autoclass:: FrequencyMasking
 
   .. automethod:: forward
 
 :hidden:`TimeMasking`
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 .. autoclass:: TimeMasking
 
   .. automethod:: forward
 
+:hidden:`TimeStretch`
+---------------------
+
+.. autoclass:: TimeStretch
+
+  .. automethod:: forward
+
+:hidden:`Fade`
+--------------
+
+.. autoclass:: Fade
+
+  .. automethod:: forward
+
 :hidden:`Vol`
-~~~~~~~~~~~~~
+-------------
 
 .. autoclass:: Vol
 
   .. automethod:: forward
 
+:hidden:`Complex Utility`
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:hidden:`ComplexNorm`
+---------------------
+
+.. autoclass:: ComplexNorm
+
+  .. automethod:: forward
+
+:hidden:`Feature Extractions`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:hidden:`Spectrogram`
+---------------------
+
+.. autoclass:: Spectrogram
+
+  .. automethod:: forward
+
+:hidden:`InverseSpectrogram`
+----------------------------
+
+.. autoclass:: InverseSpectrogram
+
+  .. automethod:: forward
+
+:hidden:`MelSpectrogram`
+------------------------
+
+.. autoclass:: MelSpectrogram
+
+  .. automethod:: forward
+
+:hidden:`GriffinLim`
+--------------------
+
+.. autoclass:: GriffinLim
+
+  .. automethod:: forward
+
+:hidden:`MFCC`
+--------------
+
+.. autoclass:: MFCC
+
+  .. automethod:: forward
+
+:hidden:`LFCC`
+--------------
+
+.. autoclass:: LFCC
+
+  .. automethod:: forward
+
+:hidden:`ComputeDeltas`
+-----------------------
+
+.. autoclass:: ComputeDeltas
+
+  .. automethod:: forward
+
+:hidden:`PitchShift`
+--------------------
+
+.. autoclass:: PitchShift
+
+  .. automethod:: forward
+
 :hidden:`SlidingWindowCmn`
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------
 
 .. autoclass:: SlidingWindowCmn
 
   .. automethod:: forward
 
 :hidden:`SpectralCentroid`
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------
 
 .. autoclass:: SpectralCentroid
 
   .. automethod:: forward
 
 :hidden:`Vad`
-~~~~~~~~~~~~~
+-------------
 
 .. autoclass:: Vad
 
   .. automethod:: forward
 
+:hidden:`Loss`
+~~~~~~~~~~~~~~
+
 :hidden:`RNNTLoss`
-~~~~~~~~~~~~~~~~~~
+------------------
 
 .. autoclass:: RNNTLoss
 


### PR DESCRIPTION
Following discussion from https://github.com/pytorch/audio/pull/1711#discussion_r691372056, add subsections in pytorch docs for transforms similar to functional