### PR TITLE
Increase no_output_timeout to 20m for WinConda

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,6 +258,7 @@ jobs:
       - windows_install_cuda
       - run:
           name: Build conda packages
+          no_output_timeout: 20m
           command: |
             set -ex
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -258,6 +258,7 @@ jobs:
       - windows_install_cuda
       - run:
           name: Build conda packages
+          no_output_timeout: 20m
           command: |
             set -ex
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"


### PR DESCRIPTION
Downloading CUDA-11.1 from conda-forge takes a while
