### PR TITLE
Fix WaveRNN training example

### DIFF
--- a/examples/pipeline_wavernn/main.py
+++ b/examples/pipeline_wavernn/main.py
@@ -272,6 +272,7 @@ def main(args):
             n_mels=args.n_freq,
             f_min=args.f_min,
             mel_scale='slaney',
+            norm='slaney',
             **melkwargs,
         ),
         NormalizeDB(min_level_db=args.min_level_db, normalization=args.normalization),


### PR DESCRIPTION
We saw that in [this commit](https://github.com/pytorch/audio/commit/e061b268d284a6f43acc44314b83ec6ffe58e91a#diff-a473ab6313da91f82a155edc91015cd96b4867cff38d9dd63bf75dfd411281b3), we ported mel spectrogram from librosa to torchaudio. However this port misses a parameter norm.

[This internal link](https://colab.research.google.com/drive/18d1xOp3x4EEgsa_OIZRYaKB7k_Mig12m?usp=sharing) shows that by adding the `norm='slaney'` parameter to `torchaudio.transforms.MelSpectrogram`, we are able to maintain the original transform (`torchaudio.transforms.Spectrogram` +  `LinearToMel`).