### PR TITLE
Put output tensor on proper device in `get_whitenoise()`

### DIFF
--- a/test/torchaudio_unittest/common_utils/data_utils.py
+++ b/test/torchaudio_unittest/common_utils/data_utils.py
@@ -140,7 +140,7 @@ def get_spectrogram(
     """
     hop_length = hop_length or n_fft // 4
     win_length = win_length or n_fft
-    window = torch.hann_window(win_length) if window is None else window
+    window = torch.hann_window(win_length, device=waveform.device) if window is None else window
     spec = torch.stft(
         waveform,
         n_fft=n_fft,

--- a/test/torchaudio_unittest/common_utils/data_utils.py
+++ b/test/torchaudio_unittest/common_utils/data_utils.py
@@ -75,6 +75,9 @@ def get_whitenoise(
     tensor.clamp_(-1.0, 1.0)
     if not channels_first:
         tensor = tensor.t()
+
+    tensor = tensor.to(device)
+
     return convert_tensor_encoding(tensor, dtype)
 
 

--- a/test/torchaudio_unittest/functional/librosa_compatibility_test_impl.py
+++ b/test/torchaudio_unittest/functional/librosa_compatibility_test_impl.py
@@ -33,7 +33,7 @@ class Functional(TestBaseMixin):
         n_fft = 400
         win_length = n_fft
         hop_length = n_fft // 4
-        window = torch.hann_window(win_length)
+        window = torch.hann_window(win_length, device=self.device)
         power = 1
         # GriffinLim params
         n_iter = 8


### PR DESCRIPTION
Put the random audio data generated by `get_whitenoise()` utility function onto the proper device, rather than defaulting to cpu.

Additionally, fix any test failures that arise from this change.