### PR TITLE
Update the way to access libsox global config

### DIFF
--- a/torchaudio/csrc/pybind/sox/effects.cpp
+++ b/torchaudio/csrc/pybind/sox/effects.cpp
@@ -48,14 +48,16 @@ std::tuple<torch::Tensor, int64_t> apply_effects_fileobj(
   // the whole audio data are fetched.
   //
   // * This can be changed with `torchaudio.utils.sox_utils.set_buffer_size`.
-  const auto capacity = [](&){
+  const auto capacity = [&]() {
     // NOTE:
-    // Use the abstraction provided by `libtorchaudio` to access the global config defined by libsox.
-    // Directly using `sox_get_globals` function will end up retrieving the static variable defined
-    // in `_torchaudio`, which is not correct.
+    // Use the abstraction provided by `libtorchaudio` to access the global
+    // config defined by libsox. Directly using `sox_get_globals` function will
+    // end up retrieving the static variable defined in `_torchaudio`, which is
+    // not correct.
     const auto bufsiz = get_buffer_size();
     const size_t kDefaultCapacityInBytes = 256;
-    return (bufsiz > kDefaultCapacityInBytes) ? bufsiz : kDefaultCapacityInBytes;
+    return (bufsiz > kDefaultCapacityInBytes) ? bufsiz
+                                              : kDefaultCapacityInBytes;
   }();
   std::string buffer(capacity, '\0');
   auto* in_buf = const_cast<char*>(buffer.data());

--- a/torchaudio/csrc/pybind/sox/effects.cpp
+++ b/torchaudio/csrc/pybind/sox/effects.cpp
@@ -48,8 +48,15 @@ std::tuple<torch::Tensor, int64_t> apply_effects_fileobj(
   // the whole audio data are fetched.
   //
   // * This can be changed with `torchaudio.utils.sox_utils.set_buffer_size`.
-  auto capacity =
-      (sox_get_globals()->bufsiz > 256) ? sox_get_globals()->bufsiz : 256;
+  const auto capacity = [](&){
+    // NOTE:
+    // Use the abstraction provided by `libtorchaudio` to access the global config defined by libsox.
+    // Directly using `sox_get_globals` function will end up retrieving the static variable defined
+    // in `_torchaudio`, which is not correct.
+    const auto bufsiz = get_buffer_size();
+    const size_t kDefaultCapacityInBytes = 256;
+    return (bufsiz > kDefaultCapacityInBytes) ? bufsiz : kDefaultCapacityInBytes;
+  }();
   std::string buffer(capacity, '\0');
   auto* in_buf = const_cast<char*>(buffer.data());
   auto num_read = read_fileobj(&fileobj, capacity, in_buf);

--- a/torchaudio/csrc/pybind/sox/io.cpp
+++ b/torchaudio/csrc/pybind/sox/io.cpp
@@ -36,14 +36,16 @@ std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_fileobj(
   //
   // See:
   // https://xiph.org/vorbis/doc/Vorbis_I_spec.html
-  const auto capacity = [&](){
+  const auto capacity = [&]() {
     // NOTE:
-    // Use the abstraction provided by `libtorchaudio` to access the global config defined by libsox.
-    // Directly using `sox_get_globals` function will end up retrieving the static variable defined
-    // in `_torchaudio`, which is not correct.
+    // Use the abstraction provided by `libtorchaudio` to access the global
+    // config defined by libsox. Directly using `sox_get_globals` function will
+    // end up retrieving the static variable defined in `_torchaudio`, which is
+    // not correct.
     const auto bufsiz = get_buffer_size();
     const size_t kDefaultCapacityInBytes = 4096;
-    return (bufsiz > kDefaultCapacityInBytes) ? bufsiz : kDefaultCapacityInBytes;
+    return (bufsiz > kDefaultCapacityInBytes) ? bufsiz
+                                              : kDefaultCapacityInBytes;
   }();
   std::string buffer(capacity, '\0');
   auto* buf = const_cast<char*>(buffer.data());

--- a/torchaudio/csrc/pybind/sox/io.cpp
+++ b/torchaudio/csrc/pybind/sox/io.cpp
@@ -36,10 +36,15 @@ std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_fileobj(
   //
   // See:
   // https://xiph.org/vorbis/doc/Vorbis_I_spec.html
-  const int kDefaultCapacityInBytes = 4096;
-  auto capacity = (sox_get_globals()->bufsiz > kDefaultCapacityInBytes)
-      ? sox_get_globals()->bufsiz
-      : kDefaultCapacityInBytes;
+  const auto capacity = [&](){
+    // NOTE:
+    // Use the abstraction provided by `libtorchaudio` to access the global config defined by libsox.
+    // Directly using `sox_get_globals` function will end up retrieving the static variable defined
+    // in `_torchaudio`, which is not correct.
+    const auto bufsiz = get_buffer_size();
+    const size_t kDefaultCapacityInBytes = 4096;
+    return (bufsiz > kDefaultCapacityInBytes) ? bufsiz : kDefaultCapacityInBytes;
+  }();
   std::string buffer(capacity, '\0');
   auto* buf = const_cast<char*>(buffer.data());
   auto num_read = read_fileobj(&fileobj, capacity, buf);


### PR DESCRIPTION
Preparation for splitting `libtorchaudio` and `_torchaudio`.

When two libraries are compiled separately, and each code does
`#include <sox.h>` independently, two copies of libsox's static global
variables (`sox_globals_t`) are created.

Our code should be referring to the same instance. To achieve this,
`_torchaudio` should be accessing the global variable defined in
`libtorchaudio` via the custom utility functions, and it should not
directly use `sox_get_globals`.