### PR TITLE
Fix linting

### DIFF
--- a/torchaudio/csrc/pybind/sox/effects.cpp
+++ b/torchaudio/csrc/pybind/sox/effects.cpp
@@ -55,7 +55,7 @@ std::tuple<torch::Tensor, int64_t> apply_effects_fileobj(
     // end up retrieving the static variable defined in `_torchaudio`, which is
     // not correct.
     const auto bufsiz = get_buffer_size();
-    const size_t kDefaultCapacityInBytes = 256;
+    const int64_t kDefaultCapacityInBytes = 256;
     return (bufsiz > kDefaultCapacityInBytes) ? bufsiz
                                               : kDefaultCapacityInBytes;
   }();

--- a/torchaudio/csrc/pybind/sox/effects_chain.cpp
+++ b/torchaudio/csrc/pybind/sox/effects_chain.cpp
@@ -128,7 +128,6 @@ int fileobj_output_flow(
     auto fp = static_cast<FILE*>(sf->fp);
     auto fileobj = priv->fileobj;
     auto buffer = priv->buffer;
-    auto buffer_size = priv->buffer_size;
 
     // Encode chunk
     auto num_samples_written = sox_write(sf, ibuf, *isamp);

--- a/torchaudio/csrc/pybind/sox/io.cpp
+++ b/torchaudio/csrc/pybind/sox/io.cpp
@@ -43,7 +43,7 @@ std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_fileobj(
     // end up retrieving the static variable defined in `_torchaudio`, which is
     // not correct.
     const auto bufsiz = get_buffer_size();
-    const size_t kDefaultCapacityInBytes = 4096;
+    const int64_t kDefaultCapacityInBytes = 4096;
     return (bufsiz > kDefaultCapacityInBytes) ? bufsiz
                                               : kDefaultCapacityInBytes;
   }();


### PR DESCRIPTION
* Fix comparison between signed and unsigned integer expressions

```
../../torchaudio/csrc/pybind/sox/effects.cpp:59:20: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     return (bufsiz > kDefaultCapacityInBytes) ? bufsiz
             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~

../../torchaudio/csrc/pybind/sox/io.cpp:47:20: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     return (bufsiz > kDefaultCapacityInBytes) ? bufsiz
```

* Remove unused variable

```
../../torchaudio/csrc/pybind/sox/effects_chain.cpp:131:10: warning: unused variable ‘buffer_size’ [-Wunused-variable]
     auto buffer_size = priv->buffer_size;
          ^~~~~~~~~~~
```