### PR TITLE
Pin MKL to 2021.2.0 (#1655)

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -35,8 +35,15 @@ else
 fi
 printf "Installing PyTorch with %s\n" "${cudatoolkit}"
 (
+    if [ "${os}" == MacOSX ] ; then
+      # TODO: this can be removed as soon as linking issue could be resolved
+      #  see https://github.com/pytorch/pytorch/issues/62424 from details
+      MKL_CONSTRAINT='mkl==2021.2.0'
+    else
+      MKL_CONSTRAINT=''
+    fi
     set -x
-    conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" "pytorch-${UPLOAD_CHANNEL}::pytorch" ${cudatoolkit}
+    conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" $MKL_CONSTRAINT "pytorch-${UPLOAD_CHANNEL}::pytorch" ${cudatoolkit}
 )
 
 # 2. Install torchaudio

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -238,6 +238,11 @@ setup_conda_pytorch_constraint() {
     export CONDA_PYTORCH_BUILD_CONSTRAINT="- pytorch==${PYTORCH_VERSION}${PYTORCH_VERSION_SUFFIX}"
     export CONDA_PYTORCH_CONSTRAINT="- pytorch==${PYTORCH_VERSION}${PYTORCH_VERSION_SUFFIX}"
   fi
+  # TODO: Remove me later, see https://github.com/pytorch/pytorch/issues/62424 for more details
+  if [[ "$(uname)" == Darwin ]]; then
+    # Use less than equal to avoid version conflict in python=3.6 environment
+    export CONDA_EXTRA_BUILD_CONSTRAINT="- mkl<=2021.2.0"
+  fi
 }
 
 # Translate CUDA_VERSION into CUDA_CUDATOOLKIT_CONSTRAINT

--- a/packaging/torchaudio/meta.yaml
+++ b/packaging/torchaudio/meta.yaml
@@ -17,12 +17,13 @@ requirements:
     - cmake
     - ninja
     - defaults::numpy >=1.11
-    {{ environ.get('CONDA_PYTORCH_BUILD_CONSTRAINT') }}
+    {{ environ.get('CONDA_PYTORCH_BUILD_CONSTRAINT', 'pytorch') }}
+    {{ environ.get('CONDA_EXTRA_BUILD_CONSTRAINT', '') }}
 
   run:
     - python
     - defaults::numpy >=1.11
-    {{ environ.get('CONDA_PYTORCH_CONSTRAINT') }}
+    {{ environ.get('CONDA_PYTORCH_CONSTRAINT', 'pytorch') }}
 
 build:
   string: py{{py}}


### PR DESCRIPTION
* Pin MKL to 2021.2.0

Fixes https://github.com/pytorch/pytorch/issues/62424

* Apply the same  constraint for conda builds

Use less-than-equals constraint to avoid dependency conflicts for
python-3.6 environment