### PR TITLE
Refactor batch consistency test in transforms

### DIFF
--- a/test/torchaudio_unittest/transforms/batch_consistency_test.py
+++ b/test/torchaudio_unittest/transforms/batch_consistency_test.py
@@ -11,35 +11,44 @@ class TestTransforms(common_utils.TorchaudioTestCase):
 
     """Test suite for classes defined in `transforms` module"""
     def test_batch_AmplitudeToDB(self):
-        spec = torch.rand((2, 6, 201))
+        spec = torch.rand((3, 2, 6, 201))
 
         # Single then transform then batch
-        expected = torchaudio.transforms.AmplitudeToDB()(spec).repeat(3, 1, 1)
+        expected = []
+        for i in range(3):
+            expected.append(torchaudio.transforms.AmplitudeToDB()(spec[i]))
+        expected = torch.stack(expected)
 
         # Batch then transform
-        computed = torchaudio.transforms.AmplitudeToDB()(spec.repeat(3, 1, 1))
+        computed = torchaudio.transforms.AmplitudeToDB()(spec)
 
         self.assertEqual(computed, expected)
 
     def test_batch_Resample(self):
-        waveform = torch.randn(2, 2786)
+        waveform = torch.randn(3, 2, 2786)
 
         # Single then transform then batch
-        expected = torchaudio.transforms.Resample()(waveform).repeat(3, 1, 1)
+        expected = []
+        for i in range(3):
+            expected.append(torchaudio.transforms.Resample()(waveform[i]))
+        expected = torch.stack(expected)
 
         # Batch then transform
-        computed = torchaudio.transforms.Resample()(waveform.repeat(3, 1, 1))
+        computed = torchaudio.transforms.Resample()(waveform)
 
         self.assertEqual(computed, expected)
 
     def test_batch_MelScale(self):
-        specgram = torch.randn(2, 201, 256)
+        specgram = torch.randn(3, 2, 201, 256)
 
         # Single then transform then batch
-        expected = torchaudio.transforms.MelScale()(specgram).repeat(3, 1, 1, 1)
+        expected = []
+        for i in range(3):
+            expected.append(torchaudio.transforms.MelScale()(specgram[i]))
+        expected = torch.stack(expected)
 
         # Batch then transform
-        computed = torchaudio.transforms.MelScale()(specgram.repeat(3, 1, 1, 1))
+        computed = torchaudio.transforms.MelScale()(specgram)
 
         # shape = (3, 2, 128, 256)
         self.assertEqual(computed, expected)
@@ -47,13 +56,16 @@ class TestTransforms(common_utils.TorchaudioTestCase):
     def test_batch_InverseMelScale(self):
         n_mels = 32
         n_stft = 5
-        mel_spec = torch.randn(2, n_mels, 32) ** 2
+        mel_spec = torch.randn(3, 2, n_mels, 32) ** 2
 
         # Single then transform then batch
-        expected = torchaudio.transforms.InverseMelScale(n_stft, n_mels)(mel_spec).repeat(3, 1, 1, 1)
+        expected = []
+        for i in range(3):
+            expected.append(torchaudio.transforms.InverseMelScale(n_stft, n_mels)(mel_spec[i]))
+        expected = torch.stack(expected)
 
         # Batch then transform
-        computed = torchaudio.transforms.InverseMelScale(n_stft, n_mels)(mel_spec.repeat(3, 1, 1, 1))
+        computed = torchaudio.transforms.InverseMelScale(n_stft, n_mels)(mel_spec)
 
         # shape = (3, 2, n_mels, 32)
 
@@ -62,90 +74,117 @@ class TestTransforms(common_utils.TorchaudioTestCase):
         self.assertEqual(computed, expected, atol=1.0, rtol=1e-5)
 
     def test_batch_compute_deltas(self):
-        specgram = torch.randn(2, 31, 2786)
+        specgram = torch.randn(3, 2, 31, 2786)
 
         # Single then transform then batch
-        expected = torchaudio.transforms.ComputeDeltas()(specgram).repeat(3, 1, 1, 1)
+        expected = []
+        for i in range(3):
+            expected.append(torchaudio.transforms.ComputeDeltas()(specgram[i]))
+        expected = torch.stack(expected)
 
         # Batch then transform
-        computed = torchaudio.transforms.ComputeDeltas()(specgram.repeat(3, 1, 1, 1))
+        computed = torchaudio.transforms.ComputeDeltas()(specgram)
 
         # shape = (3, 2, 201, 1394)
         self.assertEqual(computed, expected)
 
     def test_batch_mulaw(self):
-        waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=2)
+        waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
+        waveform = waveform.reshape(3, 2, -1)
 
         # Single then transform then batch
-        waveform_encoded = torchaudio.transforms.MuLawEncoding()(waveform)
-        expected = waveform_encoded.unsqueeze(0).repeat(3, 1, 1)
+        expected = []
+        for i in range(3):
+            expected.append(torchaudio.transforms.MuLawEncoding()(waveform[i]))
+        expected = torch.stack(expected)
 
         # Batch then transform
-        waveform_batched = waveform.unsqueeze(0).repeat(3, 1, 1)
-        computed = torchaudio.transforms.MuLawEncoding()(waveform_batched)
+        computed = torchaudio.transforms.MuLawEncoding()(waveform)
 
         # shape = (3, 2, 201, 1394)
         self.assertEqual(computed, expected)
 
         # Single then transform then batch
-        waveform_decoded = torchaudio.transforms.MuLawDecoding()(waveform_encoded)
-        expected = waveform_decoded.unsqueeze(0).repeat(3, 1, 1)
+        expected_decoded = []
+        for i in range(3):
+            expected_decoded.append(torchaudio.transforms.MuLawDecoding()(expected[i]))
+        expected_decoded = torch.stack(expected_decoded)
 
         # Batch then transform
-        computed = torchaudio.transforms.MuLawDecoding()(computed)
+        computed_decoded = torchaudio.transforms.MuLawDecoding()(computed)
 
         # shape = (3, 2, 201, 1394)
-        self.assertEqual(computed, expected)
+        self.assertEqual(computed_decoded, expected_decoded)
 
     def test_batch_spectrogram(self):
-        waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=2)
+        waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
+        waveform = waveform.reshape(3, 2, -1)
 
         # Single then transform then batch
-        expected = torchaudio.transforms.Spectrogram()(waveform).repeat(3, 1, 1, 1)
+        expected = []
+        for i in range(3):
+            expected.append(torchaudio.transforms.Spectrogram()(waveform[i]))
+        expected = torch.stack(expected)
 
         # Batch then transform
-        computed = torchaudio.transforms.Spectrogram()(waveform.repeat(3, 1, 1))
+        computed = torchaudio.transforms.Spectrogram()(waveform)
         self.assertEqual(computed, expected)
 
     def test_batch_inverse_spectrogram(self):
-        waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=2)
+        waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
+        waveform = waveform.reshape(3, 2, -1)
         transform = torchaudio.transforms.Spectrogram(power=None)(waveform)
 
         # Single then transform then batch
-        expected = torchaudio.transforms.InverseSpectrogram()(transform).repeat(3, 1, 1)
+        expected = []
+        for i in range(3):
+            expected.append(torchaudio.transforms.InverseSpectrogram()(transform[i]))
+        expected = torch.stack(expected)
 
         # Batch then transform
-        computed = torchaudio.transforms.InverseSpectrogram()(transform.repeat(3, 1, 1, 1))
+        computed = torchaudio.transforms.InverseSpectrogram()(transform)
         self.assertEqual(computed, expected)
 
     def test_batch_melspectrogram(self):
-        waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=2)
+        waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
+        waveform = waveform.reshape(3, 2, -1)
 
         # Single then transform then batch
-        expected = torchaudio.transforms.MelSpectrogram()(waveform).repeat(3, 1, 1, 1)
+        expected = []
+        for i in range(3):
+            expected.append(torchaudio.transforms.MelSpectrogram()(waveform[i]))
+        expected = torch.stack(expected)
 
         # Batch then transform
-        computed = torchaudio.transforms.MelSpectrogram()(waveform.repeat(3, 1, 1))
+        computed = torchaudio.transforms.MelSpectrogram()(waveform)
         self.assertEqual(computed, expected)
 
     def test_batch_mfcc(self):
-        waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=2)
+        waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
+        waveform = waveform.reshape(3, 2, -1)
 
         # Single then transform then batch
-        expected = torchaudio.transforms.MFCC()(waveform).repeat(3, 1, 1, 1)
+        expected = []
+        for i in range(3):
+            expected.append(torchaudio.transforms.MFCC()(waveform[i]))
+        expected = torch.stack(expected)
 
         # Batch then transform
-        computed = torchaudio.transforms.MFCC()(waveform.repeat(3, 1, 1))
+        computed = torchaudio.transforms.MFCC()(waveform)
         self.assertEqual(computed, expected, atol=1e-4, rtol=1e-5)
 
     def test_batch_lfcc(self):
-        waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=2)
+        waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
+        waveform = waveform.reshape(3, 2, -1)
 
         # Single then transform then batch
-        expected = torchaudio.transforms.LFCC()(waveform).repeat(3, 1, 1, 1)
+        expected = []
+        for i in range(3):
+            expected.append(torchaudio.transforms.LFCC()(waveform[i]))
+        expected = torch.stack(expected)
 
         # Batch then transform
-        computed = torchaudio.transforms.LFCC()(waveform.repeat(3, 1, 1))
+        computed = torchaudio.transforms.LFCC()(waveform)
         self.assertEqual(computed, expected, atol=1e-4, rtol=1e-5)
 
     @parameterized.expand([(True, ), (False, )])
@@ -153,70 +192,87 @@ class TestTransforms(common_utils.TorchaudioTestCase):
         rate = 2
         num_freq = 1025
         num_frames = 400
+        batch = 3
 
-        spec = torch.randn(num_freq, num_frames, dtype=torch.complex64)
-        pattern = [3, 1, 1, 1]
+        spec = torch.randn(batch, num_freq, num_frames, dtype=torch.complex64)
         if test_pseudo_complex:
             spec = torch.view_as_real(spec)
-            pattern += [1]
 
         # Single then transform then batch
-        expected = torchaudio.transforms.TimeStretch(
-            fixed_rate=rate,
-            n_freq=num_freq,
-            hop_length=512,
-        )(spec).repeat(*pattern)
+        expected = []
+        for i in range(3):
+            expected.append(torchaudio.transforms.TimeStretch(
+                fixed_rate=rate,
+                n_freq=num_freq,
+                hop_length=512,)(spec[i]))
+        expected = torch.stack(expected)
 
         # Batch then transform
         computed = torchaudio.transforms.TimeStretch(
             fixed_rate=rate,
             n_freq=num_freq,
             hop_length=512,
-        )(spec.repeat(*pattern))
+        )(spec)
 
         self.assertEqual(computed, expected, atol=1e-5, rtol=1e-5)
 
     def test_batch_Fade(self):
-        waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=2)
+        waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
+        waveform = waveform.reshape(3, 2, -1)
         fade_in_len = 3000
         fade_out_len = 3000
 
         # Single then transform then batch
-        expected = torchaudio.transforms.Fade(fade_in_len, fade_out_len)(waveform).repeat(3, 1, 1)
+        expected = []
+        for i in range(3):
+            expected.append(torchaudio.transforms.Fade(fade_in_len, fade_out_len)(waveform[i]))
+        expected = torch.stack(expected)
 
         # Batch then transform
-        computed = torchaudio.transforms.Fade(fade_in_len, fade_out_len)(waveform.repeat(3, 1, 1))
+        computed = torchaudio.transforms.Fade(fade_in_len, fade_out_len)(waveform)
         self.assertEqual(computed, expected)
 
     def test_batch_Vol(self):
-        waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=2)
+        waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
+        waveform = waveform.reshape(3, 2, -1)
 
         # Single then transform then batch
-        expected = torchaudio.transforms.Vol(gain=1.1)(waveform).repeat(3, 1, 1)
+        expected = []
+        for i in range(3):
+            expected.append(torchaudio.transforms.Vol(gain=1.1)(waveform[i]))
+        expected = torch.stack(expected)
 
         # Batch then transform
-        computed = torchaudio.transforms.Vol(gain=1.1)(waveform.repeat(3, 1, 1))
+        computed = torchaudio.transforms.Vol(gain=1.1)(waveform)
         self.assertEqual(computed, expected)
 
     def test_batch_spectral_centroid(self):
         sample_rate = 44100
-        waveform = common_utils.get_whitenoise(sample_rate=sample_rate)
+        waveform = common_utils.get_whitenoise(sample_rate=sample_rate, n_channels=6)
+        waveform = waveform.reshape(3, 2, -1)
 
         # Single then transform then batch
-        expected = torchaudio.transforms.SpectralCentroid(sample_rate)(waveform).repeat(3, 1, 1)
+        expected = []
+        for i in range(3):
+            expected.append(torchaudio.transforms.SpectralCentroid(sample_rate)(waveform[i]))
+        expected = torch.stack(expected)
 
         # Batch then transform
-        computed = torchaudio.transforms.SpectralCentroid(sample_rate)(waveform.repeat(3, 1, 1))
+        computed = torchaudio.transforms.SpectralCentroid(sample_rate)(waveform)
         self.assertEqual(computed, expected)
 
     def test_batch_pitch_shift(self):
         sample_rate = 8000
         n_steps = -2
-        waveform = common_utils.get_whitenoise(sample_rate=sample_rate, duration=0.05)
+        waveform = common_utils.get_whitenoise(sample_rate=sample_rate, duration=0.05, n_channels=6)
+        waveform = waveform.reshape(3, 2, -1)
 
         # Single then transform then batch
-        expected = torchaudio.transforms.PitchShift(sample_rate, n_steps, n_fft=400)(waveform).repeat(3, 1, 1)
+        expected = []
+        for i in range(3):
+            expected.append(torchaudio.transforms.PitchShift(sample_rate, n_steps, n_fft=400)(waveform[i]))
+        expected = torch.stack(expected)
 
         # Batch then transform
-        computed = torchaudio.transforms.PitchShift(sample_rate, n_steps, n_fft=400)(waveform.repeat(3, 1, 1))
+        computed = torchaudio.transforms.PitchShift(sample_rate, n_steps, n_fft=400)(waveform)
         self.assertEqual(computed, expected)

--- a/test/torchaudio_unittest/transforms/batch_consistency_test.py
+++ b/test/torchaudio_unittest/transforms/batch_consistency_test.py
@@ -69,9 +69,7 @@ class TestTransforms(common_utils.TorchaudioTestCase):
         waveform = waveform.reshape(3, 2, -1)
 
         # Single then transform then batch
-        expected = []
-        for i in range(3):
-            expected.append(T.MuLawEncoding()(waveform[i]))
+        expected = [T.MuLawEncoding()(waveform[i]) for i in range(3)]
         expected = torch.stack(expected)
 
         # Batch then transform
@@ -81,9 +79,7 @@ class TestTransforms(common_utils.TorchaudioTestCase):
         self.assertEqual(computed, expected)
 
         # Single then transform then batch
-        expected_decoded = []
-        for i in range(3):
-            expected_decoded.append(T.MuLawDecoding()(expected[i]))
+        expected_decoded = [T.MuLawDecoding()(expected[i]) for i in range(3)]
         expected_decoded = torch.stack(expected_decoded)
 
         # Batch then transform

--- a/test/torchaudio_unittest/transforms/batch_consistency_test.py
+++ b/test/torchaudio_unittest/transforms/batch_consistency_test.py
@@ -1,7 +1,7 @@
 """Test numerical consistency among single input and batched input."""
 import torch
-import torchaudio
 from parameterized import parameterized
+from torchaudio import transforms as T
 
 from torchaudio_unittest import common_utils
 
@@ -9,84 +9,60 @@ from torchaudio_unittest import common_utils
 class TestTransforms(common_utils.TorchaudioTestCase):
     backend = 'default'
 
+    def assert_batch_consistency(
+            self, transform, batch, *args, atol=1e-8, rtol=1e-5, seed=42,
+            **kwargs):
+        n = batch.size(0)
+
+        # Compute items separately, then batch the result
+        torch.random.manual_seed(seed)
+        items_input = batch.clone()
+        items_result = torch.stack([
+            transform(items_input[i], *args, **kwargs) for i in range(n)
+        ])
+
+        # Batch the input and run
+        torch.random.manual_seed(seed)
+        batch_input = batch.clone()
+        batch_result = transform(batch_input, *args, **kwargs)
+
+        self.assertEqual(items_input, batch_input, rtol=rtol, atol=atol)
+        self.assertEqual(items_result, batch_result, rtol=rtol, atol=atol)
+
     """Test suite for classes defined in `transforms` module"""
     def test_batch_AmplitudeToDB(self):
         spec = torch.rand((3, 2, 6, 201))
+        transform = T.AmplitudeToDB()
 
-        # Single then transform then batch
-        expected = []
-        for i in range(3):
-            expected.append(torchaudio.transforms.AmplitudeToDB()(spec[i]))
-        expected = torch.stack(expected)
-
-        # Batch then transform
-        computed = torchaudio.transforms.AmplitudeToDB()(spec)
-
-        self.assertEqual(computed, expected)
+        self.assert_batch_consistency(transform, spec)
 
     def test_batch_Resample(self):
         waveform = torch.randn(3, 2, 2786)
+        transform = T.Resample()
 
-        # Single then transform then batch
-        expected = []
-        for i in range(3):
-            expected.append(torchaudio.transforms.Resample()(waveform[i]))
-        expected = torch.stack(expected)
-
-        # Batch then transform
-        computed = torchaudio.transforms.Resample()(waveform)
-
-        self.assertEqual(computed, expected)
+        self.assert_batch_consistency(transform, waveform)
 
     def test_batch_MelScale(self):
         specgram = torch.randn(3, 2, 201, 256)
+        transform = T.MelScale()
 
-        # Single then transform then batch
-        expected = []
-        for i in range(3):
-            expected.append(torchaudio.transforms.MelScale()(specgram[i]))
-        expected = torch.stack(expected)
-
-        # Batch then transform
-        computed = torchaudio.transforms.MelScale()(specgram)
-
-        # shape = (3, 2, 128, 256)
-        self.assertEqual(computed, expected)
+        self.assert_batch_consistency(transform, specgram)
 
     def test_batch_InverseMelScale(self):
         n_mels = 32
         n_stft = 5
         mel_spec = torch.randn(3, 2, n_mels, 32) ** 2
-
-        # Single then transform then batch
-        expected = []
-        for i in range(3):
-            expected.append(torchaudio.transforms.InverseMelScale(n_stft, n_mels)(mel_spec[i]))
-        expected = torch.stack(expected)
-
-        # Batch then transform
-        computed = torchaudio.transforms.InverseMelScale(n_stft, n_mels)(mel_spec)
-
-        # shape = (3, 2, n_mels, 32)
+        transform = T.InverseMelScale(n_stft, n_mels)
 
         # Because InverseMelScale runs SGD on randomly initialized values so they do not yield
         # exactly same result. For this reason, tolerance is very relaxed here.
-        self.assertEqual(computed, expected, atol=1.0, rtol=1e-5)
+        self.assert_batch_consistency(transform, mel_spec, atol=1.0, rtol=1e-5)
 
     def test_batch_compute_deltas(self):
         specgram = torch.randn(3, 2, 31, 2786)
+        transform = T.ComputeDeltas()
 
-        # Single then transform then batch
-        expected = []
-        for i in range(3):
-            expected.append(torchaudio.transforms.ComputeDeltas()(specgram[i]))
-        expected = torch.stack(expected)
-
-        # Batch then transform
-        computed = torchaudio.transforms.ComputeDeltas()(specgram)
-
-        # shape = (3, 2, 201, 1394)
-        self.assertEqual(computed, expected)
+        self.assert_batch_consistency(transform, specgram)
 
     def test_batch_mulaw(self):
         waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
@@ -95,11 +71,11 @@ class TestTransforms(common_utils.TorchaudioTestCase):
         # Single then transform then batch
         expected = []
         for i in range(3):
-            expected.append(torchaudio.transforms.MuLawEncoding()(waveform[i]))
+            expected.append(T.MuLawEncoding()(waveform[i]))
         expected = torch.stack(expected)
 
         # Batch then transform
-        computed = torchaudio.transforms.MuLawEncoding()(waveform)
+        computed = T.MuLawEncoding()(waveform)
 
         # shape = (3, 2, 201, 1394)
         self.assertEqual(computed, expected)
@@ -107,11 +83,11 @@ class TestTransforms(common_utils.TorchaudioTestCase):
         # Single then transform then batch
         expected_decoded = []
         for i in range(3):
-            expected_decoded.append(torchaudio.transforms.MuLawDecoding()(expected[i]))
+            expected_decoded.append(T.MuLawDecoding()(expected[i]))
         expected_decoded = torch.stack(expected_decoded)
 
         # Batch then transform
-        computed_decoded = torchaudio.transforms.MuLawDecoding()(computed)
+        computed_decoded = T.MuLawDecoding()(computed)
 
         # shape = (3, 2, 201, 1394)
         self.assertEqual(computed_decoded, expected_decoded)
@@ -119,73 +95,38 @@ class TestTransforms(common_utils.TorchaudioTestCase):
     def test_batch_spectrogram(self):
         waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
         waveform = waveform.reshape(3, 2, -1)
+        transform = T.Spectrogram()
 
-        # Single then transform then batch
-        expected = []
-        for i in range(3):
-            expected.append(torchaudio.transforms.Spectrogram()(waveform[i]))
-        expected = torch.stack(expected)
-
-        # Batch then transform
-        computed = torchaudio.transforms.Spectrogram()(waveform)
-        self.assertEqual(computed, expected)
+        self.assert_batch_consistency(transform, waveform)
 
     def test_batch_inverse_spectrogram(self):
         waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
         waveform = waveform.reshape(3, 2, -1)
-        transform = torchaudio.transforms.Spectrogram(power=None)(waveform)
+        specgram = T.Spectrogram(power=None)(waveform)
+        transform = T.InverseSpectrogram()
 
-        # Single then transform then batch
-        expected = []
-        for i in range(3):
-            expected.append(torchaudio.transforms.InverseSpectrogram()(transform[i]))
-        expected = torch.stack(expected)
-
-        # Batch then transform
-        computed = torchaudio.transforms.InverseSpectrogram()(transform)
-        self.assertEqual(computed, expected)
+        self.assert_batch_consistency(transform, specgram)
 
     def test_batch_melspectrogram(self):
         waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
         waveform = waveform.reshape(3, 2, -1)
+        transform = T.MelSpectrogram()
 
-        # Single then transform then batch
-        expected = []
-        for i in range(3):
-            expected.append(torchaudio.transforms.MelSpectrogram()(waveform[i]))
-        expected = torch.stack(expected)
-
-        # Batch then transform
-        computed = torchaudio.transforms.MelSpectrogram()(waveform)
-        self.assertEqual(computed, expected)
+        self.assert_batch_consistency(transform, waveform)
 
     def test_batch_mfcc(self):
         waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
         waveform = waveform.reshape(3, 2, -1)
+        transform = T.MFCC()
 
-        # Single then transform then batch
-        expected = []
-        for i in range(3):
-            expected.append(torchaudio.transforms.MFCC()(waveform[i]))
-        expected = torch.stack(expected)
-
-        # Batch then transform
-        computed = torchaudio.transforms.MFCC()(waveform)
-        self.assertEqual(computed, expected, atol=1e-4, rtol=1e-5)
+        self.assert_batch_consistency(transform, waveform, atol=1e-4, rtol=1e-5)
 
     def test_batch_lfcc(self):
         waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
         waveform = waveform.reshape(3, 2, -1)
+        transform = T.LFCC()
 
-        # Single then transform then batch
-        expected = []
-        for i in range(3):
-            expected.append(torchaudio.transforms.LFCC()(waveform[i]))
-        expected = torch.stack(expected)
-
-        # Batch then transform
-        computed = torchaudio.transforms.LFCC()(waveform)
-        self.assertEqual(computed, expected, atol=1e-4, rtol=1e-5)
+        self.assert_batch_consistency(transform, waveform, atol=1e-4, rtol=1e-5)
 
     @parameterized.expand([(True, ), (False, )])
     def test_batch_TimeStretch(self, test_pseudo_complex):
@@ -198,81 +139,43 @@ class TestTransforms(common_utils.TorchaudioTestCase):
         if test_pseudo_complex:
             spec = torch.view_as_real(spec)
 
-        # Single then transform then batch
-        expected = []
-        for i in range(3):
-            expected.append(torchaudio.transforms.TimeStretch(
-                fixed_rate=rate,
-                n_freq=num_freq,
-                hop_length=512,)(spec[i]))
-        expected = torch.stack(expected)
-
-        # Batch then transform
-        computed = torchaudio.transforms.TimeStretch(
+        transform = T.TimeStretch(
             fixed_rate=rate,
             n_freq=num_freq,
-            hop_length=512,
-        )(spec)
+            hop_length=512
+        )
 
-        self.assertEqual(computed, expected, atol=1e-5, rtol=1e-5)
+        self.assert_batch_consistency(transform, spec, atol=1e-5, rtol=1e-5)
 
     def test_batch_Fade(self):
         waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
         waveform = waveform.reshape(3, 2, -1)
         fade_in_len = 3000
         fade_out_len = 3000
+        transform = T.Fade(fade_in_len, fade_out_len)
 
-        # Single then transform then batch
-        expected = []
-        for i in range(3):
-            expected.append(torchaudio.transforms.Fade(fade_in_len, fade_out_len)(waveform[i]))
-        expected = torch.stack(expected)
-
-        # Batch then transform
-        computed = torchaudio.transforms.Fade(fade_in_len, fade_out_len)(waveform)
-        self.assertEqual(computed, expected)
+        self.assert_batch_consistency(transform, waveform)
 
     def test_batch_Vol(self):
         waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
         waveform = waveform.reshape(3, 2, -1)
+        transform = T.Vol(gain=1.1)
 
-        # Single then transform then batch
-        expected = []
-        for i in range(3):
-            expected.append(torchaudio.transforms.Vol(gain=1.1)(waveform[i]))
-        expected = torch.stack(expected)
-
-        # Batch then transform
-        computed = torchaudio.transforms.Vol(gain=1.1)(waveform)
-        self.assertEqual(computed, expected)
+        self.assert_batch_consistency(transform, waveform)
 
     def test_batch_spectral_centroid(self):
         sample_rate = 44100
         waveform = common_utils.get_whitenoise(sample_rate=sample_rate, n_channels=6)
         waveform = waveform.reshape(3, 2, -1)
+        transform = T.SpectralCentroid(sample_rate)
 
-        # Single then transform then batch
-        expected = []
-        for i in range(3):
-            expected.append(torchaudio.transforms.SpectralCentroid(sample_rate)(waveform[i]))
-        expected = torch.stack(expected)
-
-        # Batch then transform
-        computed = torchaudio.transforms.SpectralCentroid(sample_rate)(waveform)
-        self.assertEqual(computed, expected)
+        self.assert_batch_consistency(transform, waveform)
 
     def test_batch_pitch_shift(self):
         sample_rate = 8000
         n_steps = -2
         waveform = common_utils.get_whitenoise(sample_rate=sample_rate, duration=0.05, n_channels=6)
         waveform = waveform.reshape(3, 2, -1)
+        transform = T.PitchShift(sample_rate, n_steps, n_fft=400)
 
-        # Single then transform then batch
-        expected = []
-        for i in range(3):
-            expected.append(torchaudio.transforms.PitchShift(sample_rate, n_steps, n_fft=400)(waveform[i]))
-        expected = torch.stack(expected)
-
-        # Batch then transform
-        computed = torchaudio.transforms.PitchShift(sample_rate, n_steps, n_fft=400)(waveform)
-        self.assertEqual(computed, expected)
+        self.assert_batch_consistency(transform, waveform)

--- a/test/torchaudio_unittest/transforms/batch_consistency_test.py
+++ b/test/torchaudio_unittest/transforms/batch_consistency_test.py
@@ -7,6 +7,7 @@ from torchaudio_unittest import common_utils
 
 
 class TestTransforms(common_utils.TorchaudioTestCase):
+    """Test suite for classes defined in `transforms` module"""
     backend = 'default'
 
     def assert_batch_consistency(
@@ -29,7 +30,6 @@ class TestTransforms(common_utils.TorchaudioTestCase):
         self.assertEqual(items_input, batch_input, rtol=rtol, atol=atol)
         self.assertEqual(items_result, batch_result, rtol=rtol, atol=atol)
 
-    """Test suite for classes defined in `transforms` module"""
     def test_batch_AmplitudeToDB(self):
         spec = torch.rand((3, 2, 6, 201))
         transform = T.AmplitudeToDB()
@@ -101,9 +101,9 @@ class TestTransforms(common_utils.TorchaudioTestCase):
 
     def test_batch_inverse_spectrogram(self):
         waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
-        waveform = waveform.reshape(3, 2, -1)
-        specgram = T.Spectrogram(power=None)(waveform)
-        transform = T.InverseSpectrogram()
+        specgram = common_utils.get_spectrogram(waveform, n_fft=400)
+        specgram = specgram.reshape(3, 2, specgram.shape[-2], specgram.shape[-1])
+        transform = T.InverseSpectrogram(n_fft=400)
 
         self.assert_batch_consistency(transform, specgram)
 


### PR DESCRIPTION
The current batch consistency tests don't consider the inter-batch operation. If the transform contains inter-batch operation then the test should be failed. In the current implementation the inputs are repeated, hence the inter-batch operation may not be reflected.