### PR TITLE
Fix indentation and grouping

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -111,6 +111,12 @@ import_fairseq_model
 WaveRNN
 ~~~~~~~
 
+Model
+-----
+
+WaveRNN
+^^^^^^^
+
 .. autoclass:: WaveRNN
 
   .. automethod:: forward
@@ -121,7 +127,7 @@ Factory Functions
 -----------------
 
 wavernn
--------
+^^^^^^^
 
 .. autofunction:: wavernn
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -28,6 +28,12 @@ DeepSpeech
 Tacotron2
 ~~~~~~~~~
 
+Model
+-----
+
+Tacotoron2
+^^^^^^^^^^
+
 .. autoclass:: Tacotron2
 
   .. automethod:: forward
@@ -38,7 +44,7 @@ Factory Functions
 -----------------
 
 tacotron2
----------
+^^^^^^^^^
 
 .. autofunction:: tacotron2
 
@@ -55,8 +61,11 @@ Wav2Letter
 Wav2Vec2.0
 ~~~~~~~~~~
 
+Model
+-----
+
 Wav2Vec2Model
--------------
+^^^^^^^^^^^^^
 
 .. autoclass:: Wav2Vec2Model
 
@@ -68,17 +77,17 @@ Factory Functions
 -----------------
 
 wav2vec2_base
--------------
+^^^^^^^^^^^^^
 
 .. autofunction:: wav2vec2_base
 
 wav2vec2_large
---------------
+^^^^^^^^^^^^^^
 
 .. autofunction:: wav2vec2_large
 
 wav2vec2_large_lv60k
---------------------
+^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: wav2vec2_large_lv60k
 
@@ -88,12 +97,12 @@ Utility Functions
 -----------------
 
 import_huggingface_model
-------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^
 		   
 .. autofunction:: import_huggingface_model
 
 import_fairseq_model
---------------------
+^^^^^^^^^^^^^^^^^^^^
 		   
 .. autofunction:: import_fairseq_model
 


### PR DESCRIPTION
Cleans up categories in models.

Before

<img width="252" alt="Screen Shot 2021-09-17 at 15 52 59" src="https://user-images.githubusercontent.com/855818/133846044-b1d85192-17b6-447c-a518-a1ea5d2c480d.png">

After

<img width="261" alt="Screen Shot 2021-09-17 at 15 52 36" src="https://user-images.githubusercontent.com/855818/133846057-ab71bf8a-b0fe-41ad-a6aa-714f90744233.png">

