### PR TITLE
[BC-Breaking] Update `extract_features` of Wav2Vec2Model

### DIFF
--- a/test/torchaudio_unittest/models/wav2vec2/fairseq_integration_test.py
+++ b/test/torchaudio_unittest/models/wav2vec2/fairseq_integration_test.py
@@ -86,9 +86,10 @@ class TestFairseqIntegration(TorchaudioTestCase):
         imported = import_fairseq_model(original, 28).eval()
 
         x = torch.randn(batch_size, num_frames)
-        ref = original.feature_extractor(x).transpose(1, 2)
         hyp, _ = imported.extract_features(x)
-        self.assertEqual(ref, hyp)
+        refs = original.extract_features(x, padding_mask=torch.zeros_like(x), layer=-1)
+        for i, (ref, _) in enumerate(refs['layer_results']):
+            self.assertEqual(hyp[i], ref.transpose(0, 1))
 
     @parameterized.expand(PRETRAINED_CONFIGS)
     def test_recreate_pretrained_model(self, config, factory_func):

--- a/test/torchaudio_unittest/models/wav2vec2/model_test.py
+++ b/test/torchaudio_unittest/models/wav2vec2/model_test.py
@@ -14,11 +14,16 @@ from torchaudio_unittest.common_utils import (
 )
 from parameterized import parameterized
 
+
+def _name_func(testcase_func, _, param):
+    return f"{testcase_func.__name__}_{param[0][0].__name__}"
+
+
 factory_funcs = parameterized.expand([
     (wav2vec2_base, ),
     (wav2vec2_large, ),
     (wav2vec2_large_lv60k, ),
-])
+], name_func=_name_func)
 
 
 class TestWav2Vec2Model(TorchaudioTestCase):
@@ -47,7 +52,7 @@ class TestWav2Vec2Model(TorchaudioTestCase):
         self._smoke_test(torch.device('cuda'), dtype)
 
     @factory_funcs
-    def test_feature_extractor_smoke_test(self, factory_func):
+    def test_feature_extractor_test(self, factory_func):
         """`extract_features` method does not fail"""
         batch_size, num_frames = 3, 1024
 

--- a/test/torchaudio_unittest/models/wav2vec2/model_test.py
+++ b/test/torchaudio_unittest/models/wav2vec2/model_test.py
@@ -58,9 +58,9 @@ class TestWav2Vec2Model(TorchaudioTestCase):
         waveforms = torch.randn(batch_size, num_frames)
         lengths = torch.randint(low=0, high=num_frames, size=[batch_size, ])
 
-        # Not providing indices returns all the intermediate features from
+        # Not providing num_layers returns all the intermediate features from
         # tranformer layers
-        all_features, lengths_ = model.extract_features(waveforms, lengths, indices=None)
+        all_features, lengths_ = model.extract_features(waveforms, lengths, num_layers=None)
         assert len(all_features) == num_layers
         for features in all_features:
             assert features.ndim == 3
@@ -68,16 +68,10 @@ class TestWav2Vec2Model(TorchaudioTestCase):
         assert lengths_.shape == torch.Size([batch_size])
 
         # Fetching individual layers
-        for i in range(num_layers):
-            features, lengths_ = model.extract_features(waveforms, lengths, indices=[i])
-            self.assertEqual(all_features[i], features[0])
-            assert lengths_.shape == torch.Size([batch_size])
-
-        # Fetching multiple layers
-        indices = [0, 2, 4]
-        features, lengths_ = model.extract_features(waveforms, lengths, indices=indices)
-        for i, j in enumerate(indices):
-            self.assertEqual(all_features[j], features[i])
+        for i in range(1, num_layers + 1):
+            features, lengths_ = model.extract_features(waveforms, lengths, num_layers=i)
+            for j in range(i):
+                self.assertEqual(all_features[j], features[j])
             assert lengths_.shape == torch.Size([batch_size])
 
     @factory_funcs

--- a/test/torchaudio_unittest/models/wav2vec2/model_test.py
+++ b/test/torchaudio_unittest/models/wav2vec2/model_test.py
@@ -68,10 +68,11 @@ class TestWav2Vec2Model(TorchaudioTestCase):
         assert lengths_.shape == torch.Size([batch_size])
 
         # Fetching individual layers
-        for i in range(1, num_layers + 1):
-            features, lengths_ = model.extract_features(waveforms, lengths, num_layers=i)
-            for j in range(i):
-                self.assertEqual(all_features[j], features[j])
+        for l in range(1, num_layers + 1):
+            features, lengths_ = model.extract_features(waveforms, lengths, num_layers=l)
+            assert len(features) == l
+            for i in range(l):
+                self.assertEqual(all_features[i], features[i])
             assert lengths_.shape == torch.Size([batch_size])
 
     @factory_funcs

--- a/test/torchaudio_unittest/models/wav2vec2/model_test.py
+++ b/test/torchaudio_unittest/models/wav2vec2/model_test.py
@@ -67,7 +67,7 @@ class TestWav2Vec2Model(TorchaudioTestCase):
             assert features.shape[0] == batch_size
         assert lengths_.shape == torch.Size([batch_size])
 
-        # Fetching individual layers
+        # Limiting the number of layers to `l`.
         for l in range(1, num_layers + 1):
             features, lengths_ = model.extract_features(waveforms, lengths, num_layers=l)
             assert len(features) == l

--- a/torchaudio/models/wav2vec2/components.py
+++ b/torchaudio/models/wav2vec2/components.py
@@ -408,17 +408,16 @@ class Transformer(Module):
             num_layers: Optional[int] = None,
     ) -> List[Tensor]:
         if num_layers is not None:
-            if num_layers <= 0 or num_layers > len(self.layers):
+            if not 0 < num_layers <= len(self.layers):
                 raise ValueError(f'`num_layers` must be between [1, {len(self.layers)}]')
 
         ret: List[Tensor] = []
         x = self._preprocess(x)
-        for i, layer in enumerate(self.layers):
+        for layer in self.layers:
             x = layer(x, attention_mask)
             ret.append(x)
-            if num_layers is not None:
-                if num_layers >= len(ret):
-                    return ret
+            if num_layers is not None and len(ret) >= num_layers:
+                return ret
         return ret
 
 

--- a/torchaudio/models/wav2vec2/model.py
+++ b/torchaudio/models/wav2vec2/model.py
@@ -35,20 +35,23 @@ class Wav2Vec2Model(Module):
             self,
             waveforms: Tensor,
             lengths: Optional[Tensor] = None,
-            indices: Optional[List[int]] = None,
+            num_layers: Optional[int] = None,
     ) -> Tuple[List[Tensor], Optional[Tensor]]:
         """Extract feature vectors from raw waveforms
 
         This returns the list of outputs from the intermediate layers of
-        transformer part in encoder.
+        transformer block in encoder.
 
         Args:
             waveforms (Tensor): Audio tensor of shape ``(batch, frames)``.
             lengths (Tensor or None, optional):
                 Indicates the valid length of each audio sample in the batch.
                 Shape: ``(batch, )``.
-            indices (list of int or None, optional):
-                Indicates the layers from which the output is retrieved.
+            num_layers (int or None, optional):
+                If given, limit the number of intermediate layers to go through.
+                Providing `1` will stop the computation after going through one
+                intermediate layers. If not given, the outputs from all the
+                intermediate layers are returned.
 
         Returns:
             List of Tensor:
@@ -60,7 +63,7 @@ class Wav2Vec2Model(Module):
                 Shape: ``(batch, )``.
         """
         x, lengths = self.feature_extractor(waveforms, lengths)
-        x = self.encoder.extract_feature(x, lengths, indices)
+        x = self.encoder.extract_features(x, lengths, num_layers)
         return x, lengths
 
     def forward(


### PR DESCRIPTION
Originally, `extract_features` method was returning the result from
passing the input waveform to convolutional feature extractor module.

The features commonly used in downstream tasks are outputs from intermediate
layers of transformer block in encoder.

This commit update the behavior of `extract_features` to allow selectively
retrieve such features.

The previous behavior can be achieved with
`Wav2Vec2Model.feature_extractor(waveform)`.