### PR TITLE
Tweak test name by appending factory function name

### DIFF
--- a/test/torchaudio_unittest/models/wav2vec2/model_test.py
+++ b/test/torchaudio_unittest/models/wav2vec2/model_test.py
@@ -15,8 +15,8 @@ from torchaudio_unittest.common_utils import (
 from parameterized import parameterized
 
 
-def _name_func(testcase_func, _, param):
-    return f"{testcase_func.__name__}_{param[0][0].__name__}"
+def _name_func(testcase_func, i, param):
+    return f"{testcase_func.__name__}_{i}_{param[0][0].__name__}"
 
 
 factory_funcs = parameterized.expand([


### PR DESCRIPTION
Spin-off from my working branch;

Apply tweak around the test names so that it's easier to see which tests are failing.

before: `test_import_finetuned_model_2`
after:  `test_import_finetuned_model_2_wav2vec2_large_lv60k`