### PR TITLE
[BC-Breaking] Split pretraining and finetuning factory functions

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -76,15 +76,33 @@ Wav2Vec2Model
 Factory Functions
 -----------------
 
+wav2vec2_base
+^^^^^^^^^^^^^
+
 .. autofunction:: wav2vec2_base
+
+wav2vec2_large
+^^^^^^^^^^^^^^
 
 .. autofunction:: wav2vec2_large
 
+wav2vec2_large_lv60k
+^^^^^^^^^^^^^^^^^^^^
+
 .. autofunction:: wav2vec2_large_lv60k
+
+wav2vec2_asr_base
+^^^^^^^^^^^^^^^^^
 
 .. autofunction:: wav2vec2_asr_base
 
+wav2vec2_asr_large
+^^^^^^^^^^^^^^^^^^
+
 .. autofunction:: wav2vec2_asr_large
+
+wav2vec2_asr_large_lv60k
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: wav2vec2_asr_large_lv60k
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -76,20 +76,17 @@ Wav2Vec2Model
 Factory Functions
 -----------------
 
-wav2vec2_base
-^^^^^^^^^^^^^
-
 .. autofunction:: wav2vec2_base
-
-wav2vec2_large
-^^^^^^^^^^^^^^
 
 .. autofunction:: wav2vec2_large
 
-wav2vec2_large_lv60k
-^^^^^^^^^^^^^^^^^^^^
-
 .. autofunction:: wav2vec2_large_lv60k
+
+.. autofunction:: wav2vec2_asr_base
+
+.. autofunction:: wav2vec2_asr_large
+
+.. autofunction:: wav2vec2_asr_large_lv60k
 
 .. currentmodule:: torchaudio.models.wav2vec2.utils
 

--- a/test/torchaudio_unittest/models/wav2vec2/huggingface_intergration_test.py
+++ b/test/torchaudio_unittest/models/wav2vec2/huggingface_intergration_test.py
@@ -2,6 +2,9 @@ import json
 
 import torch
 from torchaudio.models.wav2vec2 import (
+    wav2vec2_asr_base,
+    wav2vec2_asr_large,
+    wav2vec2_asr_large_lv60k,
     wav2vec2_base,
     wav2vec2_large,
     wav2vec2_large_lv60k,
@@ -47,11 +50,11 @@ PRETRAIN_CONFIGS = parameterized.expand([
     (HF_BASE_10K_VOXPOPULI, wav2vec2_base),
 ], name_func=_name_func)
 FINETUNE_CONFIGS = parameterized.expand([
-    (HF_BASE_960H, wav2vec2_base),
-    (HF_LARGE_960H, wav2vec2_large),
-    (HF_LARGE_LV60_960H, wav2vec2_large_lv60k),
-    (HF_LARGE_LV60_SELF_960H, wav2vec2_large_lv60k),
-    (HF_LARGE_XLSR_DE, wav2vec2_large_lv60k),
+    (HF_BASE_960H, wav2vec2_asr_base),
+    (HF_LARGE_960H, wav2vec2_asr_large),
+    (HF_LARGE_LV60_960H, wav2vec2_asr_large_lv60k),
+    (HF_LARGE_LV60_SELF_960H, wav2vec2_asr_large_lv60k),
+    (HF_LARGE_XLSR_DE, wav2vec2_asr_large_lv60k),
 ], name_func=_name_func)
 
 
@@ -81,7 +84,7 @@ class TestHFIntegration(TorchaudioTestCase):
             return Wav2Vec2ForCTC(Wav2Vec2Config(**config))
         raise ValueError(f'Unexpected arch: {config["architectures"]}')
 
-    def _test_import_pretrain(self, original, imported, config, ):
+    def _test_import_pretrain(self, original, imported, config):
         torch.manual_seed(0)
         # FeatureExtractor
         x = torch.randn(3, 1024)
@@ -115,7 +118,7 @@ class TestHFIntegration(TorchaudioTestCase):
         self.assertEqual(ref, hyp)
 
     def _test_import_finetune(self, original, imported, config):
-        # Readout
+        # Aux
         x = torch.randn(3, 10, config["hidden_size"])
         ref = original.lm_head(x)
         hyp = imported.aux(x)
@@ -193,11 +196,12 @@ class TestHFIntegration(TorchaudioTestCase):
         ref = imported.encoder.transformer(x)
         hyp = reloaded.encoder.transformer(x)
         self.assertEqual(ref, hyp)
-        # Readout
-        x = torch.randn(3, 10, config["hidden_size"])
-        ref = imported.aux(x)
-        hyp = reloaded.aux(x)
-        self.assertEqual(ref, hyp)
+        # Aux
+        if imported.aux is not None:
+            x = torch.randn(3, 10, config["hidden_size"])
+            ref = imported.aux(x)
+            hyp = reloaded.aux(x)
+            self.assertEqual(ref, hyp)
         # The whole model
         x = torch.randn(3, 1024)
         ref, _ = imported(x)
@@ -208,7 +212,7 @@ class TestHFIntegration(TorchaudioTestCase):
     def test_recreate_pretrain(self, config, factory_func):
         """Imported models can be recreated via a factory function without Hugging Face transformers."""
         imported = import_huggingface_model(self._get_model(config)).eval()
-        reloaded = factory_func(num_out=imported.aux.out_features)
+        reloaded = factory_func()
         reloaded.load_state_dict(imported.state_dict())
         reloaded.eval()
         self._test_recreate(imported, reloaded, config)

--- a/test/torchaudio_unittest/models/wav2vec2/model_test.py
+++ b/test/torchaudio_unittest/models/wav2vec2/model_test.py
@@ -37,8 +37,7 @@ finetune_factory_funcs = parameterized.expand([
 
 
 class TestWav2Vec2Model(TorchaudioTestCase):
-    def _smoke_test(self, device, dtype):
-        model = wav2vec2_asr_base(num_out=32)
+    def _smoke_test(self, model, device, dtype):
         model = model.to(device=device, dtype=dtype)
         model = model.eval()
 
@@ -54,12 +53,18 @@ class TestWav2Vec2Model(TorchaudioTestCase):
 
     @parameterized.expand([(torch.float32, ), (torch.float64, )])
     def test_cpu_smoke_test(self, dtype):
-        self._smoke_test(torch.device('cpu'), dtype)
+        model = wav2vec2_base()
+        self._smoke_test(model, torch.device('cpu'), dtype)
+        model = wav2vec2_asr_base(num_out=32)
+        self._smoke_test(model, torch.device('cpu'), dtype)
 
     @parameterized.expand([(torch.float32, ), (torch.float64, )])
     @skipIfNoCuda
     def test_cuda_smoke_test(self, dtype):
-        self._smoke_test(torch.device('cuda'), dtype)
+        model = wav2vec2_base()
+        self._smoke_test(model, torch.device('cuda'), dtype)
+        model = wav2vec2_asr_base(num_out=32)
+        self._smoke_test(model, torch.device('cuda'), dtype)
 
     def _feature_extractor_test(self, model):
         batch_size, num_frames = 3, 1024

--- a/test/torchaudio_unittest/models/wav2vec2/model_test.py
+++ b/test/torchaudio_unittest/models/wav2vec2/model_test.py
@@ -125,13 +125,13 @@ class TestWav2Vec2Model(TorchaudioTestCase):
 
     @pretrain_factory_funcs
     def test_pretrain_batch_consistency(self, factory_func):
-        """Results from sigle process and batched process should be reasonably close
+        """Results from single process and batched process should be reasonably close
         """
         self._test_batch_consistency(factory_func())
 
     @pretrain_factory_funcs
     def test_finetune_batch_consistency(self, factory_func):
-        """Results from sigle process and batched process should be reasonably close
+        """Results from single process and batched process should be reasonably close
         """
         self._test_batch_consistency(factory_func())
 

--- a/torchaudio/models/__init__.py
+++ b/torchaudio/models/__init__.py
@@ -5,6 +5,9 @@ from .deepspeech import DeepSpeech
 from .tacotron2 import Tacotron2, tacotron2
 from .wav2vec2 import (
     Wav2Vec2Model,
+    wav2vec2_asr_base,
+    wav2vec2_asr_large,
+    wav2vec2_asr_large_lv60k,
     wav2vec2_base,
     wav2vec2_large,
     wav2vec2_large_lv60k,
@@ -18,6 +21,9 @@ __all__ = [
     'ConvTasNet',
     'DeepSpeech',
     'Wav2Vec2Model',
+    'wav2vec2_asr_base',
+    'wav2vec2_asr_large',
+    'wav2vec2_asr_large_lv60k',
     'wav2vec2_base',
     'wav2vec2_large',
     'wav2vec2_large_lv60k',

--- a/torchaudio/models/wav2vec2/__init__.py
+++ b/torchaudio/models/wav2vec2/__init__.py
@@ -1,5 +1,8 @@
 from .model import (
     Wav2Vec2Model,
+    wav2vec2_asr_base,
+    wav2vec2_asr_large,
+    wav2vec2_asr_large_lv60k,
     wav2vec2_base,
     wav2vec2_large,
     wav2vec2_large_lv60k,
@@ -8,6 +11,9 @@ from . import utils
 
 __all__ = [
     'Wav2Vec2Model',
+    'wav2vec2_asr_base',
+    'wav2vec2_asr_large',
+    'wav2vec2_asr_large_lv60k',
     'wav2vec2_base',
     'wav2vec2_large',
     'wav2vec2_large_lv60k',

--- a/torchaudio/models/wav2vec2/components.py
+++ b/torchaudio/models/wav2vec2/components.py
@@ -617,8 +617,6 @@ def _get_encoder(
             Probability to drop each encoder layer during training.
             This option corresponds to "layerdrop" from fairseq.
             Expected values are 0.1 for both Base and Large arch.
-        num_out (int):
-            The dimension of the output. The number of labels.
 
     See Also:
         * "encoder_embed_dim"

--- a/torchaudio/models/wav2vec2/model.py
+++ b/torchaudio/models/wav2vec2/model.py
@@ -116,7 +116,7 @@ def _get_model(
         encoder_dropout: float,
         encoder_layer_norm_first: bool,
         encoder_layer_drop: float,
-        aux_num_out: Optional[int] = None,
+        aux_num_out: Optional[int],
 ) -> Wav2Vec2Model:
     if extractor_conv_layer_config is None:
         extractor_conv_layer_config = [(512, 10, 5)] + [(512, 3, 2)] * 4 + [(512, 2, 2)] * 2

--- a/torchaudio/models/wav2vec2/utils/import_fairseq.py
+++ b/torchaudio/models/wav2vec2/utils/import_fairseq.py
@@ -189,6 +189,6 @@ def _import_finetuned(original: Module) -> Wav2Vec2Model:
 
 def _import_pretrained(original: Module) -> Wav2Vec2Model:
     config = _parse_config(original)
-    model = _get_model(**config)
+    model = _get_model(**config, aux_num_out=None)
     model.load_state_dict(_convert_state_dict(original.state_dict()), strict=False)
     return model

--- a/torchaudio/models/wav2vec2/utils/import_fairseq.py
+++ b/torchaudio/models/wav2vec2/utils/import_fairseq.py
@@ -3,14 +3,13 @@
 For this module to work, you need `fairseq`.
 """
 import re
-from typing import Optional
 
 from torch.nn import Module
 
 from ..model import Wav2Vec2Model, _get_model
 
 
-def _parse_config(w2v_model, num_out):
+def _parse_config(w2v_model):
     encoder = w2v_model.encoder
     conv_layers = w2v_model.feature_extractor.conv_layers
 
@@ -46,7 +45,6 @@ def _parse_config(w2v_model, num_out):
         'encoder_dropout': encoder.layers[0].dropout3.p,
         'encoder_layer_norm_first': encoder.layer_norm_first,
         'encoder_layer_drop': encoder.layerdrop,
-        'aux_num_out': num_out,
     }
     return config
 
@@ -108,7 +106,8 @@ def _map_key(key):
     if match:
         return f"encoder.transformer.layers.{match.group(1)}.final_layer_norm.{match.group(2)}"
     match = re.match(r"proj\.(weight|bias)", key)
-    # Encoder - Readout layer
+    # Auxiliary Module
+    # Only relevant when loading fine-tuned models
     if match:
         return f"aux.{match.group(1)}"
     raise ValueError(f'Unexpected key: {key_}')
@@ -123,9 +122,7 @@ def _convert_state_dict(state_dict):
     return converted
 
 
-def import_fairseq_model(
-        original: Module,
-        num_out: Optional[int] = None) -> Wav2Vec2Model:
+def import_fairseq_model(original: Module) -> Wav2Vec2Model:
     """Build Wav2Vec2Model from pretrained parameters published by `fairseq`_.
 
     Args:
@@ -133,9 +130,6 @@ def import_fairseq_model(
             An instance of fairseq's Wav2Vec2.0 model class.
             Either ``fairseq.models.wav2vec.wav2vec2_asr.Wav2VecEncoder`` or
             ``fairseq.models.wav2vec.wav2vec2.Wav2Vec2Model``.
-        num_out (int or None, optional):
-            The number of output labels. Required only when the original model is
-            an instance of ``fairseq.models.wav2vec.wav2vec2.Wav2Vec2Model``.
 
     Returns:
         Wav2Vec2Model: Imported model.
@@ -147,7 +141,7 @@ def import_fairseq_model(
         >>> model_file = 'wav2vec_small.pt'
         >>> model, _, _ = fairseq.checkpoint_utils.load_model_ensemble_and_task([model_file])
         >>> original = model[0]
-        >>> imported = import_fairseq_model(original, num_out=28)
+        >>> imported = import_fairseq_model(original)
         >>>
         >>> # Perform feature extraction
         >>> waveform, _ = torchaudio.load('audio.wav')
@@ -179,12 +173,7 @@ def import_fairseq_model(
     """
     class_ = original.__class__.__name__
     if class_ == 'Wav2Vec2Model':
-        if num_out is None:
-            raise ValueError(
-                'When importing a pretrained model without readout layer, '
-                '`num_out` argument must be given.'
-            )
-        return _import_pretrained(original, num_out)
+        return _import_pretrained(original)
     if class_ == 'Wav2VecEncoder':
         return _import_finetuned(original)
     raise ValueError(
@@ -192,14 +181,14 @@ def import_fairseq_model(
 
 
 def _import_finetuned(original: Module) -> Wav2Vec2Model:
-    config = _parse_config(original.w2v_model, original.proj.out_features)
-    model = _get_model(**config)
+    config = _parse_config(original.w2v_model)
+    model = _get_model(**config, aux_num_out=original.proj.out_features)
     model.load_state_dict(_convert_state_dict(original.state_dict()))
     return model
 
 
-def _import_pretrained(original: Module, num_out: int) -> Wav2Vec2Model:
-    config = _parse_config(original, num_out)
+def _import_pretrained(original: Module) -> Wav2Vec2Model:
+    config = _parse_config(original)
     model = _get_model(**config)
     model.load_state_dict(_convert_state_dict(original.state_dict()), strict=False)
     return model

--- a/torchaudio/models/wav2vec2/utils/import_huggingface.py
+++ b/torchaudio/models/wav2vec2/utils/import_huggingface.py
@@ -32,14 +32,15 @@ def _get_config(cfg):
 
 def _build(config, original):
     if original.__class__.__name__ == 'Wav2Vec2ForCTC':
-        config['aux_num_out'] = original.config.vocab_size
+        aux_num_out = original.config.vocab_size
         wav2vec2 = original.wav2vec2
     else:
         _LG.warning(
             'The model is not an instance of Wav2Vec2ForCTC. '
             '"lm_head" module is not imported.')
+        aux_num_out = None
         wav2vec2 = original
-    imported = _get_model(**config)
+    imported = _get_model(**config, aux_num_out=aux_num_out)
     imported.feature_extractor.load_state_dict(wav2vec2.feature_extractor.state_dict())
     imported.encoder.feature_projection.load_state_dict(wav2vec2.feature_projection.state_dict())
     imported.encoder.transformer.load_state_dict(wav2vec2.encoder.state_dict())

--- a/torchaudio/models/wav2vec2/utils/import_huggingface.py
+++ b/torchaudio/models/wav2vec2/utils/import_huggingface.py
@@ -26,17 +26,19 @@ def _get_config(cfg):
         'encoder_dropout': cfg.hidden_dropout,
         'encoder_layer_norm_first': cfg.do_stable_layer_norm,
         'encoder_layer_drop': cfg.layerdrop,
-        'aux_num_out': cfg.vocab_size,
     }
     return config
 
 
 def _build(config, original):
     if original.__class__.__name__ == 'Wav2Vec2ForCTC':
+        config['aux_num_out'] = original.config.vocab_size
         wav2vec2 = original.wav2vec2
     else:
+        _LG.warning(
+            'The model is not an instance of Wav2Vec2ForCTC. '
+            '"lm_head" module is not imported.')
         wav2vec2 = original
-
     imported = _get_model(**config)
     imported.feature_extractor.load_state_dict(wav2vec2.feature_extractor.state_dict())
     imported.encoder.feature_projection.load_state_dict(wav2vec2.feature_projection.state_dict())
@@ -67,8 +69,6 @@ def import_huggingface_model(original: Module) -> Wav2Vec2Model:
     .. _Transformers: https://huggingface.co/transformers/
     """
     _LG.info('Importing model.')
-    if original.__class__.__name__ != 'Wav2Vec2ForCTC':
-        _LG.warning('The model is not an instance of Wav2Vec2ForCTC')
     _LG.info('Loading model configuration.')
     config = _get_config(original.config)
     _LG.debug('  - config: %s', config)


### PR DESCRIPTION
Previously, factory functions of wav2vec2 only generated the architecture
for the fine-tuning architecture used in wav2ve2 paper for ASR task.
That is, pre-training architecture + Linear module, and it did not
provide a straightforward way to generate architectures for pre-training.

The goal of the original implementation was to allow the inference of
wav2vec2 in non-Python environment via TorchScript. Now we would like to
expand it to pre-training/fine-tuning and HuBERT model as well.

Therefore, we need to have factory functions for both pre-training and
fine-tuning. This commit introduces new factory functions and separate
functions for pre-training and fine-tuning.

1. New functions for ASR fine-tuning.

We introdcue `wav2vec2_asr_XXX` functions which generates the architecture
used for the fine-tuning task in wav2vec2 paper. *1

2. Re-purpse the old functions

The existing functions, `wav2vec2_XXX`, now generates the architecture with
pre-trainig module only. (no Linear module)

Note
*1 This architecture is just one way to define architecture for fine-tuning
and it is not universal definition. The new `wav2vec2_asr_XXX` functions are
designed to provide these specific fine-tuning configuration and they are not
meant to support generic architecture for downstream task.