### PR TITLE
update windows gpu image from previous to stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ executors:
   windows-gpu:
     machine:
       resource_class: windows.gpu.nvidia.medium
-      image: windows-server-2019-nvidia:previous
+      image: windows-server-2019-nvidia:stable
       shell: bash.exe
 
 commands:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -16,7 +16,7 @@ executors:
   windows-gpu:
     machine:
       resource_class: windows.gpu.nvidia.medium
-      image: windows-server-2019-nvidia:previous
+      image: windows-server-2019-nvidia:stable
       shell: bash.exe
 
 commands:


### PR DESCRIPTION
It's the culprit that torch.cuda.is_available() always return False.
https://app.circleci.com/pipelines/github/pytorch/audio/7395/workflows/a1a046b3-d808-468b-be9c-30db30244d44/jobs/339150
![image](https://user-images.githubusercontent.com/16190118/134489454-97cf85b3-848f-4cc6-8219-8fada7ca081a.png)

It's the first PR to enable unit tests with cuda on windows


@malfet @mthrok 
It's verified in
https://app.circleci.com/pipelines/github/pytorch/audio/7396/workflows/058b3c2c-8421-40c2-915c-a8441deac091/jobs/339245