### PR TITLE
set libtorchaudio suffix as pyd on Windows

### DIFF
--- a/torchaudio/_extension.py
+++ b/torchaudio/_extension.py
@@ -11,7 +11,7 @@ def _init_extension():
         warnings.warn('torchaudio C++ extension is not available.')
         return
 
-    suffix = 'dll' if os.name == 'nt' else 'so'
+    suffix = 'pyd' if os.name == 'nt' else 'so'
     path = Path(__file__).parent / 'lib' / f'libtorchaudio.{suffix}'
     # In case `torchaudio` is deployed with `pex` format, this file does not exist.
     # In this case, we expect that `libtorchaudio` is available somewhere

--- a/torchaudio/csrc/CMakeLists.txt
+++ b/torchaudio/csrc/CMakeLists.txt
@@ -90,6 +90,10 @@ if(USE_CUDA)
     )
 endif()
 
+if (MSVC)
+    set_target_properties(libtorchaudio PROPERTIES SUFFIX ".pyd")
+endif(MSVC)
+
 install(
   TARGETS libtorchaudio
   LIBRARY DESTINATION lib


### PR DESCRIPTION
It's a supplement of #1752, which fixes an error while build audio on Windows with CUDA
![image](https://user-images.githubusercontent.com/16190118/134615045-1047abd7-c079-4153-a87f-d1962c109b03.png)

The change has been verified in install torchaudio step of 
https://app.circleci.com/pipelines/github/pytorch/audio/7405/workflows/5ac1303e-ac19-4180-8327-75fd7f8cdcac/jobs/340152.

And I verified it locally as well