### PR TITLE
[doc] Fix return type of wav2vec2 model

### DIFF
--- a/torchaudio/models/wav2vec2/model.py
+++ b/torchaudio/models/wav2vec2/model.py
@@ -59,13 +59,13 @@ class Wav2Vec2Model(Module):
                 intermediate layers are returned.
 
         Returns:
-            List of Tensor:
-                Features from corresponding layers.
-                Shape: ``(batch, frames, feature dimention)``
-            Tensor, optional:
-                Indicates the valid length of each feature in the batch, computed
-                based on the given ``lengths`` argument.
-                Shape: ``(batch, )``.
+            List of Tensors and an optional Tensor:
+            List of Tensors
+                Features from requested layers.
+                Each Tensor is of shape: ``(batch, frames, feature dimention)``
+            Tensor or None
+                If ``lengths`` argument was provided, a Tensor of shape ``(batch, )``
+                is retuned. It indicates the valid length of each feature in the batch.
         """
         x, lengths = self.feature_extractor(waveforms, lengths)
         x = self.encoder.extract_features(x, lengths, num_layers)
@@ -85,13 +85,13 @@ class Wav2Vec2Model(Module):
                 Shape: ``(batch, )``.
 
         Returns:
-            Tensor:
+            Tensor and an optional Tensor:
+            Tensor
                 The sequences of probability distribution (in logit) over labels.
                 Shape: ``(batch, frames, num labels)``.
-            Tensor, optional:
-                Indicates the valid length of each feature in the batch, computed
-                based on the given ``lengths`` argument.
-                Shape: ``(batch, )``.
+            Tensor or None
+                If ``lengths`` argument was provided, a Tensor of shape ``(batch, )``
+                is retuned. It indicates the valid length of each feature in the batch.
         """
         x, lengths = self.feature_extractor(waveforms, lengths)
         x = self.encoder(x, lengths)


### PR DESCRIPTION
## Before

<img width="829" alt="Screen Shot 2021-09-24 at 17 48 55" src="https://user-images.githubusercontent.com/855818/134743228-db1add5e-90bc-4fa0-a4c6-de5ea28112fd.png">

## After

<img width="756" alt="Screen Shot 2021-09-24 at 17 49 10" src="https://user-images.githubusercontent.com/855818/134743250-64cbd373-ca8e-43a3-a7c9-1ccaa813bba4.png">
