### PR TITLE
Skip hubert_asr_xlargeTS test on Windows

### DIFF
--- a/test/torchaudio_unittest/models/wav2vec2/model_test.py
+++ b/test/torchaudio_unittest/models/wav2vec2/model_test.py
@@ -1,3 +1,5 @@
+import os
+
 import torch
 import torch.nn.functional as F
 
@@ -192,6 +194,10 @@ class TestWav2Vec2Model(TorchaudioTestCase):
     @finetune_factory_funcs
     def test_finetune_torchscript(self, factory_func):
         """Wav2Vec2Model should be scriptable"""
+        if factory_func.__name__ == 'hubert_asr_xlarge' and os.name == 'nt':
+            self.skipTest(
+                'hubert_asr_xlarge is known to fail on Windows CI. '
+                'See https://github.com/pytorch/pytorch/issues/65776')
         self._test_torchscript(factory_func(num_out=32))
 
     def _test_quantize_smoke_test(self, model):


### PR DESCRIPTION
Skipping the failing `test_finetune_torchscript_4_hubert_asr_xlarge` on Windows. 

Failure log https://app.circleci.com/pipelines/github/pytorch/audio/7480/workflows/8f04fd1e-6add-4be6-975d-98701dd81fbd/jobs/347505

The issue is reported here https://github.com/pytorch/pytorch/issues/65776