### PR TITLE
[Cherry-picked 0.10] Doc touch up

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -143,110 +143,146 @@ Pre-trained Models
 WAV2VEC2_BASE
 ^^^^^^^^^^^^^
 
-.. autodata:: WAV2VEC2_BASE
-   :no-value:
+.. container:: py attribute
+
+   .. autodata:: WAV2VEC2_BASE
+      :no-value:
 
 WAV2VEC2_ASR_BASE_10M
 ^^^^^^^^^^^^^^^^^^^^^
 
-.. autodata:: WAV2VEC2_ASR_BASE_10M
-   :no-value:
+.. container:: py attribute
+
+   .. autodata:: torchaudio.models.WAV2VEC2_ASR_BASE_10M
+      :no-value:
 
 WAV2VEC2_ASR_BASE_100H
 ^^^^^^^^^^^^^^^^^^^^^^
       
-.. autodata:: WAV2VEC2_ASR_BASE_100H
-   :no-value:
+.. container:: py attribute
+
+   .. autodata:: WAV2VEC2_ASR_BASE_100H
+      :no-value:
 
 WAV2VEC2_ASR_BASE_960H
 ^^^^^^^^^^^^^^^^^^^^^^
 
-.. autodata:: WAV2VEC2_ASR_BASE_960H
-   :no-value:
+.. container:: py attribute
+
+   .. autodata:: WAV2VEC2_ASR_BASE_960H
+      :no-value:
 
 WAV2VEC2_LARGE
 ^^^^^^^^^^^^^^
 
-.. autodata:: WAV2VEC2_LARGE
-   :no-value:
+.. container:: py attribute
+
+   .. autodata:: WAV2VEC2_LARGE
+      :no-value:
 
 WAV2VEC2_ASR_LARGE_10M
 ^^^^^^^^^^^^^^^^^^^^^^
 
-.. autodata:: WAV2VEC2_ASR_LARGE_10M
-   :no-value:
+.. container:: py attribute
+
+   .. autodata:: WAV2VEC2_ASR_LARGE_10M
+      :no-value:
 
 WAV2VEC2_ASR_LARGE_100H
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-.. autodata:: WAV2VEC2_ASR_LARGE_100H
-   :no-value:
+.. container:: py attribute
+
+   .. autodata:: WAV2VEC2_ASR_LARGE_100H
+      :no-value:
 
 WAV2VEC2_ASR_LARGE_960H
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-.. autodata:: WAV2VEC2_ASR_LARGE_960H
-   :no-value:
+.. container:: py attribute
+
+   .. autodata:: WAV2VEC2_ASR_LARGE_960H
+      :no-value:
 
 WAV2VEC2_LARGE_LV60K
 ^^^^^^^^^^^^^^^^^^^^
 
-.. autodata:: WAV2VEC2_LARGE_LV60K
-   :no-value:
+.. container:: py attribute
+
+   .. autodata:: WAV2VEC2_LARGE_LV60K
+      :no-value:
 
 WAV2VEC2_ASR_LARGE_LV60K_10M
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. autodata:: WAV2VEC2_ASR_LARGE_LV60K_10M
-   :no-value:
+.. container:: py attribute
+
+   .. autodata:: WAV2VEC2_ASR_LARGE_LV60K_10M
+      :no-value:
 
 WAV2VEC2_ASR_LARGE_LV60K_100H
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. autodata:: WAV2VEC2_ASR_LARGE_LV60K_100H
-   :no-value:
+.. container:: py attribute
+
+   .. autodata:: WAV2VEC2_ASR_LARGE_LV60K_100H
+      :no-value:
 
 WAV2VEC2_ASR_LARGE_LV60K_960H
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. autodata:: WAV2VEC2_ASR_LARGE_LV60K_960H
-   :no-value:
+.. container:: py attribute
+
+   .. autodata:: WAV2VEC2_ASR_LARGE_LV60K_960H
+      :no-value:
 
 WAV2VEC2_XLSR53
 ^^^^^^^^^^^^^^^
 
-.. autodata:: WAV2VEC2_XLSR53
-   :no-value:
+.. container:: py attribute
+
+   .. autodata:: WAV2VEC2_XLSR53
+      :no-value:
 
 HUBERT_BASE
 ^^^^^^^^^^^
 
-.. autodata:: HUBERT_BASE
-   :no-value:
+.. container:: py attribute
+
+   .. autodata:: HUBERT_BASE
+      :no-value:
 
 HUBERT_LARGE
 ^^^^^^^^^^^^
 
-.. autodata:: HUBERT_LARGE
-   :no-value:
+.. container:: py attribute
+
+   .. autodata:: HUBERT_LARGE
+      :no-value:
 
 HUBERT_XLARGE
 ^^^^^^^^^^^^^
 
-.. autodata:: HUBERT_XLARGE
-   :no-value:
+.. container:: py attribute
+
+   .. autodata:: HUBERT_XLARGE
+      :no-value:
 
 HUBERT_ASR_LARGE
 ^^^^^^^^^^^^^^^^
 
-.. autodata:: HUBERT_ASR_LARGE
-   :no-value:
+.. container:: py attribute
+
+   .. autodata:: HUBERT_ASR_LARGE
+      :no-value:
 
 HUBERT_ASR_XLARGE
 ^^^^^^^^^^^^^^^^^
 
-.. autodata:: HUBERT_ASR_XLARGE
-   :no-value:
+.. container:: py attribute
+
+   .. autodata:: HUBERT_ASR_XLARGE
+      :no-value:
 
 Utility Functions
 -----------------


### PR DESCRIPTION
After #1827, this commit adds the list of available pre-trained on the right side bar.
I liked the section presented in the before, but I think listing is more important and I do not know a way to have both.

**Before**
<img width="1026" alt="Screen Shot 2021-10-06 at 10 42 11 AM" src="https://user-images.githubusercontent.com/855818/136226498-0d9ffe0b-3786-419c-8270-f1a5664957f0.png">

**After**
<img width="1043" alt="Screen Shot 2021-10-06 at 10 41 11 AM" src="https://user-images.githubusercontent.com/855818/136226538-c713bce7-c067-440a-ad8c-161226224987.png">
