### PR TITLE
Limit Windows GPU testing to CUDA-11.3 only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1098,25 +1098,25 @@ workflows:
           requires:
           - download_third_parties_nix
       - unittest_linux_gpu:
-          cuda_version: cu102
+          cuda_version: cu113
           name: unittest_linux_gpu_py3.6
           python_version: '3.6'
           requires:
           - download_third_parties_nix
       - unittest_linux_gpu:
-          cuda_version: cu102
+          cuda_version: cu113
           name: unittest_linux_gpu_py3.7
           python_version: '3.7'
           requires:
           - download_third_parties_nix
       - unittest_linux_gpu:
-          cuda_version: cu102
+          cuda_version: cu113
           name: unittest_linux_gpu_py3.8
           python_version: '3.8'
           requires:
           - download_third_parties_nix
       - unittest_linux_gpu:
-          cuda_version: cu102
+          cuda_version: cu113
           name: unittest_linux_gpu_py3.9
           python_version: '3.9'
           requires:
@@ -1138,19 +1138,19 @@ workflows:
           name: unittest_windows_cpu_py3.9
           python_version: '3.9'
       - unittest_windows_gpu:
-          cuda_version: cu102
+          cuda_version: cu113
           name: unittest_windows_gpu_py3.6
           python_version: '3.6'
       - unittest_windows_gpu:
-          cuda_version: cu102
+          cuda_version: cu113
           name: unittest_windows_gpu_py3.7
           python_version: '3.7'
       - unittest_windows_gpu:
-          cuda_version: cu102
+          cuda_version: cu113
           name: unittest_windows_gpu_py3.8
           python_version: '3.8'
       - unittest_windows_gpu:
-          cuda_version: cu102
+          cuda_version: cu113
           name: unittest_windows_gpu_py3.9
           python_version: '3.9'
       - unittest_macos_cpu:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -209,7 +209,7 @@ def unittest_workflows(indentation=6):
                 job = {
                     "name": f"unittest_{os_type}_{device_type}_py{python_version}",
                     "python_version": python_version,
-                    "cuda_version": 'cpu' if device_type=="cpu" else "cu102",
+                    "cuda_version": 'cpu' if device_type=="cpu" else "cu113",
                 }
 
                 if os_type != "windows":
@@ -222,7 +222,7 @@ def unittest_workflows(indentation=6):
                         "stylecheck": {
                             "name": f"stylecheck_py{python_version}",
                             "python_version": python_version,
-                            "cuda_version": 'cpu' if device_type=="cpu" else "cu102",
+                            "cuda_version": 'cpu' if device_type=="cpu" else "cu113",
                         }
                     })
     return indent(indentation, jobs)


### PR DESCRIPTION
Which is the only CUDA version that planned to be supported on Windows
for the upcoming release

Fixes https://github.com/pytorch/pytorch/issues/66047