### PR TITLE
[Cherry-picked 0.10] Default to eval mode

### DIFF
--- a/torchaudio/models/wav2vec2/pretrained.py
+++ b/torchaudio/models/wav2vec2/pretrained.py
@@ -72,6 +72,7 @@ class Wav2Vec2PretrainedModelBundle:
         dl_kwargs = {} if dl_kwargs is None else dl_kwargs
         state_dict = load_state_dict_from_url(url, **dl_kwargs)
         model.load_state_dict(state_dict)
+        model.eval()
         return model
 
     def get_labels(


### PR DESCRIPTION
Since the expected usages of these pre-trained models are inference or downstream training (while freezing the upstream), making the model default to eval mode.