### PR TITLE
[Cherry-picked 0.10] [BC-Breaking] Ensure integer input frequencies for resample

### DIFF
--- a/test/torchaudio_unittest/functional/functional_impl.py
+++ b/test/torchaudio_unittest/functional/functional_impl.py
@@ -27,10 +27,10 @@ class Functional(TestBaseMixin):
         new_sample_rate = sample_rate
 
         if up_scale_factor is not None:
-            new_sample_rate *= up_scale_factor
+            new_sample_rate = int(new_sample_rate * up_scale_factor)
 
         if down_scale_factor is not None:
-            new_sample_rate //= down_scale_factor
+            new_sample_rate = int(new_sample_rate / down_scale_factor)
 
         duration = 5  # seconds
         original_timestamps = torch.arange(0, duration, 1.0 / sample_rate)

--- a/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
@@ -659,7 +659,7 @@ class Functional(TempDirMixin, TestBaseMixin):
 
     def test_resample_sinc(self):
         def func(tensor):
-            sr1, sr2 = 16000., 8000.
+            sr1, sr2 = 16000, 8000
             return F.resample(tensor, sr1, sr2, resampling_method="sinc_interpolation")
 
         tensor = common_utils.get_whitenoise(sample_rate=16000)
@@ -667,11 +667,11 @@ class Functional(TempDirMixin, TestBaseMixin):
 
     def test_resample_kaiser(self):
         def func(tensor):
-            sr1, sr2 = 16000., 8000.
+            sr1, sr2 = 16000, 8000
             return F.resample(tensor, sr1, sr2, resampling_method="kaiser_window")
 
         def func_beta(tensor):
-            sr1, sr2 = 16000., 8000.
+            sr1, sr2 = 16000, 8000
             beta = 6.
             return F.resample(tensor, sr1, sr2, resampling_method="kaiser_window", beta=beta)
 

--- a/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
@@ -84,7 +84,7 @@ class Transforms(TestBaseMixin):
     def test_Resample(self):
         sr1, sr2 = 16000, 8000
         tensor = common_utils.get_whitenoise(sample_rate=sr1)
-        self._assert_consistency(T.Resample(float(sr1), float(sr2)), tensor)
+        self._assert_consistency(T.Resample(sr1, sr2), tensor)
 
     def test_ComplexNorm(self):
         tensor = torch.rand((1, 2, 201, 2))

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -1471,8 +1471,8 @@ def compute_kaldi_pitch(
 
 
 def _get_sinc_resample_kernel(
-        orig_freq: float,
-        new_freq: float,
+        orig_freq: int,
+        new_freq: int,
         gcd: int,
         lowpass_filter_width: int,
         rolloff: float,
@@ -1559,8 +1559,8 @@ def _get_sinc_resample_kernel(
 
 def _apply_sinc_resample_kernel(
         waveform: Tensor,
-        orig_freq: float,
-        new_freq: float,
+        orig_freq: int,
+        new_freq: int,
         gcd: int,
         kernel: Tensor,
         width: int,
@@ -1586,8 +1586,8 @@ def _apply_sinc_resample_kernel(
 
 def resample(
         waveform: Tensor,
-        orig_freq: float,
-        new_freq: float,
+        orig_freq: int,
+        new_freq: int,
         lowpass_filter_width: int = 6,
         rolloff: float = 0.99,
         resampling_method: str = "sinc_interpolation",
@@ -1603,8 +1603,8 @@ def resample(
 
     Args:
         waveform (Tensor): The input signal of dimension `(..., time)`
-        orig_freq (float): The original frequency of the signal
-        new_freq (float): The desired frequency
+        orig_freq (int): The original frequency of the signal
+        new_freq (int): The desired frequency
         lowpass_filter_width (int, optional): Controls the sharpness of the filter, more == sharper
             but less efficient. (Default: ``6``)
         rolloff (float, optional): The roll-off frequency of the filter, as a fraction of the Nyquist.
@@ -1733,7 +1733,7 @@ def pitch_shift(
                                    win_length=win_length,
                                    window=window,
                                    length=len_stretch)
-    waveform_shift = resample(waveform_stretch, sample_rate // rate, float(sample_rate))
+    waveform_shift = resample(waveform_stretch, int(sample_rate / rate), sample_rate)
     shift_len = waveform_shift.size()[-1]
     if shift_len > ori_len:
         waveform_shift = waveform_shift[..., :ori_len]

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -815,8 +815,8 @@ class Resample(torch.nn.Module):
         Alternatively, you could rewrite a transform that caches a higher precision kernel.
 
     Args:
-        orig_freq (float, optional): The original frequency of the signal. (Default: ``16000``)
-        new_freq (float, optional): The desired frequency. (Default: ``16000``)
+        orig_freq (int, optional): The original frequency of the signal. (Default: ``16000``)
+        new_freq (int, optional): The desired frequency. (Default: ``16000``)
         resampling_method (str, optional): The resampling method to use.
             Options: [``sinc_interpolation``, ``kaiser_window``] (Default: ``'sinc_interpolation'``)
         lowpass_filter_width (int, optional): Controls the sharpness of the filter, more == sharper
@@ -840,8 +840,8 @@ class Resample(torch.nn.Module):
 
     def __init__(
             self,
-            orig_freq: float = 16000,
-            new_freq: float = 16000,
+            orig_freq: int = 16000,
+            new_freq: int = 16000,
             resampling_method: str = 'sinc_interpolation',
             lowpass_filter_width: int = 6,
             rolloff: float = 0.99,


### PR DESCRIPTION
To ensure resampling quality, the `resample` method will only accept integer sampling rates starting from release 0.10.

See https://github.com/pytorch/audio/issues/1487 for more details