### PR TITLE
[Cherry-picked 0.10] Use int in pitch shift resample

### DIFF
--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -1690,7 +1690,7 @@ def pitch_shift(
 
     Args:
         waveform (Tensor): The input waveform of shape `(..., time)`.
-        sample_rate (float): Sample rate of `waveform`.
+        sample_rate (int): Sample rate of `waveform`.
         n_steps (int): The (fractional) steps to shift `waveform`.
         bins_per_octave (int, optional): The number of steps per octave (Default: ``12``).
         n_fft (int, optional): Size of FFT, creates ``n_fft // 2 + 1`` bins (Default: ``512``).
@@ -1736,7 +1736,7 @@ def pitch_shift(
                                    win_length=win_length,
                                    window=window,
                                    length=len_stretch)
-    waveform_shift = resample(waveform_stretch, sample_rate / rate, float(sample_rate))
+    waveform_shift = resample(waveform_stretch, sample_rate // rate, float(sample_rate))
     shift_len = waveform_shift.size()[-1]
     if shift_len > ori_len:
         waveform_shift = waveform_shift[..., :ori_len]


### PR DESCRIPTION
torchaudio resample will throw an error for non-integer sampling rates starting release 0.10 (see #1857), since the internal computation casts the sampling rate to an integer anyways. this PR moves the int cast to outside of the resample function used in pitch shift to avoid this error, but produces no functional changes to the method