### PR TITLE
[CI] Install tools from conda instead of brew

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,13 +38,6 @@ commands:
               our_upload_channel=test
             fi
             echo "export UPLOAD_CHANNEL=${our_upload_channel}" >> ${BASH_ENV}
-  install_build_tools_macos:
-    description: "installs tools required to build torchaudio"
-    steps:
-      - run:
-          name: Install build tools
-          command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config wget
-          # Disable brew auto update which is very slow
   load_conda_channel_flags:
     description: "Determines whether we need extra conda channels"
     steps:
@@ -199,7 +192,6 @@ jobs:
       xcode: "12.0"
     steps:
       - checkout
-      - install_build_tools_macos
       - load_conda_channel_flags
       - attach_workspace:
           at: third_party
@@ -225,7 +217,6 @@ jobs:
       xcode: "12.0"
     steps:
       - checkout
-      - install_build_tools_macos
       - load_conda_channel_flags
       - attach_workspace:
           at: third_party
@@ -560,7 +551,6 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - install_build_tools_macos
       - load_conda_channel_flags
       - attach_workspace:
           at: third_party

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -38,13 +38,6 @@ commands:
               our_upload_channel=test
             fi
             echo "export UPLOAD_CHANNEL=${our_upload_channel}" >> ${BASH_ENV}
-  install_build_tools_macos:
-    description: "installs tools required to build torchaudio"
-    steps:
-      - run:
-          name: Install build tools
-          command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config wget
-          # Disable brew auto update which is very slow
   load_conda_channel_flags:
     description: "Determines whether we need extra conda channels"
     steps:
@@ -199,7 +192,6 @@ jobs:
       xcode: "12.0"
     steps:
       - checkout
-      - install_build_tools_macos
       - load_conda_channel_flags
       - attach_workspace:
           at: third_party
@@ -225,7 +217,6 @@ jobs:
       xcode: "12.0"
     steps:
       - checkout
-      - install_build_tools_macos
       - load_conda_channel_flags
       - attach_workspace:
           at: third_party
@@ -560,7 +551,6 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - install_build_tools_macos
       - load_conda_channel_flags
       - attach_workspace:
           at: third_party

--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -21,7 +21,7 @@ esac
 # 1. Install conda at ./conda
 if [ ! -d "${conda_dir}" ]; then
     printf "* Installing conda\n"
-    wget --quiet -O miniconda.sh "http://repo.continuum.io/miniconda/Miniconda3-latest-${os}-x86_64.sh"
+    curl --silent -L -o miniconda.sh "http://repo.continuum.io/miniconda/Miniconda3-latest-${os}-x86_64.sh"
     bash ./miniconda.sh -b -f -p "${conda_dir}"
     eval "$("${conda_dir}/bin/conda" shell.bash hook)"
     printf "* Updating the base Python version to %s\n" "${PYTHON_VERSION}"
@@ -40,4 +40,4 @@ conda activate "${env_dir}"
 
 # 3. Install minimal build tools
 pip --quiet install cmake ninja
-conda install --quiet -y -c conda-forge 'ffmpeg>4.1' pkg-config
+conda install --quiet -y 'ffmpeg>=4.1' pkg-config

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -182,6 +182,9 @@ setup_wheel_python() {
     conda env remove -n "env$PYTHON_VERSION" || true
     conda create -yn "env$PYTHON_VERSION" python="$PYTHON_VERSION"
     conda activate "env$PYTHON_VERSION"
+    if [[ "$(uname)" == Darwin ]]; then
+	conda install --quiet -y pkg-config
+    fi
   else
     case "$PYTHON_VERSION" in
       2.7)

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -183,7 +183,7 @@ setup_wheel_python() {
     conda create -yn "env$PYTHON_VERSION" python="$PYTHON_VERSION"
     conda activate "env$PYTHON_VERSION"
     if [[ "$(uname)" == Darwin ]]; then
-	conda install --quiet -y pkg-config
+        conda install --quiet -y pkg-config
     fi
   else
     case "$PYTHON_VERSION" in

--- a/packaging/torchaudio/meta.yaml
+++ b/packaging/torchaudio/meta.yaml
@@ -14,6 +14,7 @@ requirements:
   host:
     - python
     - setuptools
+    - pkg-config  # [not win]
     - cmake
     - ninja
     - defaults::numpy >=1.11

--- a/third_party/sox/CMakeLists.txt
+++ b/third_party/sox/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(PkgConfig REQUIRED)
+
 include(ExternalProject)
 
 set(INSTALL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../install)


### PR DESCRIPTION
Currently, macOS CI jobs install `pkg-config` and `wget` with `brew`.
This is problematic as brew takes a long time with auto-update, and disabling the auto-update is not an ideal solution.
Conda also distributes these packages, so switching to conda.

Example issues with brew installation.
https://app.circleci.com/pipelines/github/pytorch/audio/7825/workflows/53965bcf-6ddf-4e42-ad52-83fd1bbab717

This commit removes the use of `brew` by
1. Replacing the use of `wget` with `curl` (pre-installed in most distro)
2. Install `pkg-condig` from conda.
    Note: All the macOS jobs, including binary build jobs, uses conda. Using `pkg-config` from Conda makes it easy to discover the packages installed from conda. (like `ffmpeg` in #2122)
3. Add `pkg-config` to conda build-time dependency
4. Make sure that the availability of `pkg-config` is explicitly checked when `sox` is being configured. (otherwise, it will fail at somewhere in the middle of build process with somewhat unintuitve error message)