### PR TITLE
[Cherry-picked 0.10] Fix Phonemizer download

### DIFF
--- a/torchaudio/pipelines/_tts/utils.py
+++ b/torchaudio/pipelines/_tts/utils.py
@@ -169,7 +169,9 @@ def _load_phonemizer(file, dl_kwargs):
     logger.setLevel(logging.INFO)
     try:
         url = f'https://public-asai-dl-models.s3.eu-central-1.amazonaws.com/DeepPhonemizer/{file}'
-        path = os.path.join(torch.hub.get_dir(), 'checkpoints', file)
+        directory = os.path.join(torch.hub.get_dir(), 'checkpoints')
+        os.makedirs(directory, exist_ok=True)
+        path = os.path.join(directory, file)
         if not os.path.exists(path):
             dl_kwargs = {} if dl_kwargs is None else dl_kwargs
             torch.hub.download_url_to_file(url, path, **dl_kwargs)


### PR DESCRIPTION
If `torch.hub` is never used, the cache directory "~/.cach/torch/hub/checkpoints/" does not exist,
and the attempt to download DeepPhonemizer checkpoint there would fail.

This commit fixes it by calling `os.makedirs(directory, exit_ok=True)`.