### PR TITLE
[release 0.10] Remove alpha from version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def _run_cmd(cmd, default):
 
 
 # Creating the version file
-version = '0.10.0a0'
+version = '0.10.0'
 sha = _run_cmd(['git', 'rev-parse', 'HEAD'], default='Unknown')
 
 if os.getenv('BUILD_VERSION'):


### PR DESCRIPTION
Fix the version number if `setup.py`, so that if users checkout the release tag and build `torchaudio` manually, the version is correct.

This does not affect the binary release, as the version number is set by an environment variable.