### PR TITLE
Notify merger of incorrectly labeled PRs

### DIFF
--- a/.github/process_commit.py
+++ b/.github/process_commit.py
@@ -1,0 +1,73 @@
+"""
+This script finds the merger responsible for labeling a PR by a commit SHA. It is used by the workflow in
+'.github/workflows/pr-labels.yml'. If there exists no PR associated with the commit or the PR is properly labeled,
+this script is a no-op.
+Note: we ping the merger only, not the reviewers, as the reviewers can sometimes be external to torchaudio
+with no labeling responsibility, so we don't want to bother them.
+"""
+
+import sys
+from typing import Any, Optional, Set, Tuple
+
+import requests
+
+# For a PR to be properly labeled it should have one primary label and one secondary label
+# For a PR with primary label "other", it does not require an additional secondary label
+PRIMARY_LABELS = {
+    "BC-breaking",
+    "deprecation",
+    "bug",
+    "new feature",
+    "improvement",
+    "example",
+    "prototype",
+    "other",
+}
+
+SECONDARY_LABELS = {
+    "module: I/O",
+    "module: ops",
+    "module: models",
+    "module: pipelines",
+    "module: datasets",
+    "module: docs"
+    "module: tests"
+    "build",
+    "style",
+    "perf",
+    "other",
+}
+
+
+def query_torchaudio(cmd: str, *, accept) -> Any:
+    response = requests.get(f"https://api.github.com/repos/pytorch/audio/{cmd}", headers=dict(Accept=accept))
+    return response.json()
+
+
+def get_pr_number(commit_hash: str) -> Optional[int]:
+    # See https://docs.github.com/en/rest/reference/repos#list-pull-requests-associated-with-a-commit
+    data = query_torchaudio(f"commits/{commit_hash}/pulls", accept="application/vnd.github.groot-preview+json")
+    if not data:
+        return None
+    return data[0]["number"]
+
+
+def get_pr_merger_and_labels(pr_number: int) -> Tuple[str, Set[str]]:
+    # See https://docs.github.com/en/rest/reference/pulls#get-a-pull-request
+    data = query_torchaudio(f"pulls/{pr_number}", accept="application/vnd.github.v3+json")
+    merger = data["merged_by"]["login"]
+    labels = {label["name"] for label in data["labels"]}
+    return merger, labels
+
+
+if __name__ == "__main__":
+    commit_hash = sys.argv[1]
+    pr_number = get_pr_number(commit_hash)
+    if not pr_number:
+        sys.exit(0)
+
+    merger, labels = get_pr_merger_and_labels(pr_number)
+    is_properly_labeled = bool(PRIMARY_LABELS.intersection(labels) and SECONDARY_LABELS.intersection(labels))
+
+    if not is_properly_labeled:
+        print(f"@{merger}")

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,34 @@
+name: pr-labels
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  is-properly-labeled:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up python
+        uses: actions/setup-python@v2
+
+      - name: Install requests
+        run: pip install requests
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Process commit and find merger responsible for labeling
+        id: commit
+        run: echo "::set-output name=merger::$(python .github/process_commit.py ${{ github.sha }})"
+
+      - name: Ping merger responsible for labeling if necessary
+        if: ${{ steps.commit.outputs.merger != '' }}
+        uses: mshick/add-pr-comment@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          message: |
+            Hey ${{ steps.commit.outputs.merger }}!
+            You merged this PR, but no labels were added. The list of valid labels is available at https://github.com/pytorch/audio/blob/main/.github/process_commit.py


### PR DESCRIPTION
To make compilation of release notes easier for future releases, we will start using GitHub labels to label PRs with their associated primary (main) and secondary (subsection) labels. This PR is based on scripts from [torchvision](https://github.com/pytorch/vision) ([here](https://github.com/pytorch/vision/blob/main/.github/process_commit.py), [here](https://github.com/pytorch/vision/blob/main/.github/workflows/pr-labels.yml)), and will notify the merger if a PR is merged without the proper labels via PR comment.

followups:
- merge this PR w/o proper labels as a test
- update torchaudio labels to reflect the finalized primary/secondary labels