### PR TITLE
Run integration tests on CI

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,33 @@
+name: Integration Test
+
+on:
+  pull_request:
+    branches: [ main ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ 3.8 ]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install packages
+      run: |
+        python -m pip install --quiet --upgrade pip
+        python -m pip install --quiet --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+        python -m pip install --quiet pytest requests cmake ninja deep-phonemizer
+        git submodule update --init --recursive
+        python setup.py install
+    - name: Run integration test
+      run: |
+        cd test && pytest integration_tests -v --use-tmp-hub-dir

--- a/test/integration_tests/conftest.py
+++ b/test/integration_tests/conftest.py
@@ -55,3 +55,25 @@ def sample_speech(tmp_path, lang):
                 resp.raise_for_status()
                 file.write(resp.content)
     return path
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--use-tmp-hub-dir",
+        action="store_true",
+        help=(
+            "When provided, tests will use temporary directory as Torch Hub directory. "
+            "Downloaded models will be deleted after each test."
+        )
+    )
+
+
+@pytest.fixture(autouse=True)
+def temp_hub_dir(tmpdir, pytestconfig):
+    if not pytestconfig.getoption('use_tmp_hub_dir'):
+        yield
+    else:
+        org_dir = torch.hub.get_dir()
+        torch.hub.set_dir(tmpdir)
+        yield
+        torch.hub.set_dir(org_dir)


### PR DESCRIPTION
This PR adds integration test CI jobs.
It also adds custom `--use-tmp-hub-dir` option so that pre-trained weights (some of them are larger than 1GB) are deleted after each test. This should avoid the failure where CI runs out of the disk space.

Since we expect the integration job to download huge files, the test is only ran with Python 3.8.
