### PR TITLE
Add melkwargs setting for MFCC in HuBERT pipeline

### DIFF
--- a/examples/hubert/utils/feature_utils.py
+++ b/examples/hubert/utils/feature_utils.py
@@ -68,7 +68,9 @@ def extract_feature(
     waveform = waveform[0].to(device)
     if feature_type == "mfcc":
         feature_extractor = torchaudio.transforms.MFCC(
-            sample_rate=sample_rate
+            sample_rate=sample_rate,
+            n_mfcc=13,
+            melkwargs={'n_fft': 400, 'hop_length': 160, 'center': False}
         ).to(device)
         mfccs = feature_extractor(waveform)  # (freq, time)
         # mfccs = torchaudio.compliance.kaldi.mfcc(


### PR DESCRIPTION
In ``torchaudio.compliance.kaldi.mfcc``, given an 1-second torch tensor of shape `(1, 16000)`, the shape of the MFCC feature is `(98, 13)`. 

To make ``torchaudio.transforms.MFCC`` consistent with the one above, add the melkwargs settings to match the output shape.