### PR TITLE
Update requirements.txt for doc build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==3.5.4
--e git+git://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
+-e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinxcontrib.katex
 sphinxcontrib.bibtex
 matplotlib

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ sphinx==3.5.4
 sphinxcontrib.katex
 sphinxcontrib.bibtex
 matplotlib
+pyparsing<3,>=2.0.2


### PR DESCRIPTION
Resolves;

```
$ make html
Running Sphinx v3.5.4
making output directory... done

Exception occurred:
  File "/opt/_internal/cpython-3.8.1/lib/python3.8/site-packages/pkg_resources/__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (pyparsing 3.0.4 (/opt/_internal/cpython-3.8.1/lib/python3.8/site-packages), Requirement.parse('pyparsing<3,>=2.0.2'), {'packaging'})
The full traceback has been saved in /tmp/sphinx-err-jaxom3j2.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
make: *** [html] Error
```

and

```
Obtaining pytorch_sphinx_theme from git+git://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme (from -r requirements.txt (line 2))
  Cloning git://github.com/pytorch/pytorch_sphinx_theme.git to ./src/pytorch-sphinx-theme
  Running command git clone -q git://github.com/pytorch/pytorch_sphinx_theme.git /root/project/docs/src/pytorch-sphinx-theme
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
ERROR: Command errored out with exit status 128: git clone -q git://github.com/pytorch/pytorch_sphinx_theme.git /root/project/docs/src/pytorch-sphinx-theme Check the logs for full command output.
```