### PR TITLE
[BC-Breaking] Drop pseudo complex support from spectrogram

### DIFF
--- a/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
@@ -47,7 +47,7 @@ class Functional(TempDirMixin, TestBaseMixin):
 
         self.assertEqual(ts_output, output)
 
-    def test_spectrogram_complex(self):
+    def test_spectrogram(self):
         def func(tensor):
             n_fft = 400
             ws = 400
@@ -61,21 +61,7 @@ class Functional(TempDirMixin, TestBaseMixin):
         tensor = common_utils.get_whitenoise()
         self._assert_consistency(func, tensor)
 
-    def test_spectrogram_real(self):
-        def func(tensor):
-            n_fft = 400
-            ws = 400
-            hop = 200
-            pad = 0
-            window = torch.hann_window(ws, device=tensor.device, dtype=tensor.dtype)
-            power = 2.
-            normalize = False
-            return F.spectrogram(tensor, pad, window, n_fft, hop, ws, power, normalize, return_complex=False)
-
-        tensor = common_utils.get_whitenoise()
-        self._assert_consistency(func, tensor)
-
-    def test_inverse_spectrogram_complex(self):
+    def test_inverse_spectrogram(self):
         def func(tensor):
             length = 400
             n_fft = 400
@@ -89,22 +75,6 @@ class Functional(TempDirMixin, TestBaseMixin):
         waveform = common_utils.get_whitenoise(sample_rate=8000, duration=0.05)
         tensor = common_utils.get_spectrogram(waveform, n_fft=400, hop_length=200)
         self._assert_consistency_complex(func, tensor)
-
-    def test_inverse_spectrogram_real(self):
-        def func(tensor):
-            length = 400
-            n_fft = 400
-            hop = 200
-            ws = 400
-            pad = 0
-            window = torch.hann_window(ws, device=tensor.device, dtype=tensor.dtype)
-            normalize = False
-            return F.inverse_spectrogram(tensor, length, pad, window, n_fft, hop, ws, normalize)
-
-        waveform = common_utils.get_whitenoise(sample_rate=8000, duration=0.05)
-        tensor = common_utils.get_spectrogram(waveform, n_fft=400, hop_length=200)
-        tensor = torch.view_as_real(tensor)
-        self._assert_consistency(func, tensor)
 
     @skipIfRocm
     def test_griffinlim(self):

--- a/test/torchaudio_unittest/transforms/autograd_test_impl.py
+++ b/test/torchaudio_unittest/transforms/autograd_test_impl.py
@@ -77,15 +77,11 @@ class AutogradTestMixin(TestBaseMixin):
         waveform = get_whitenoise(sample_rate=8000, duration=0.05, n_channels=2)
         self.assert_grad(transform, [waveform], nondet_tol=1e-10)
 
-    @parameterized.expand([(False, ), (True, )])
-    def test_inverse_spectrogram(self, return_complex):
+    def test_inverse_spectrogram(self):
         # create a realistic input:
         waveform = get_whitenoise(sample_rate=8000, duration=0.05, n_channels=2)
         length = waveform.shape[-1]
         spectrogram = get_spectrogram(waveform, n_fft=400)
-        if not return_complex:
-            spectrogram = torch.view_as_real(spectrogram)
-
         # test
         inv_transform = T.InverseSpectrogram(n_fft=400)
         self.assert_grad(inv_transform, [spectrogram, length])

--- a/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
@@ -50,12 +50,6 @@ class Transforms(TestBaseMixin):
         spectrogram = common_utils.get_spectrogram(tensor, n_fft=400, hop_length=100)
         self._assert_consistency_complex(T.InverseSpectrogram(n_fft=400, hop_length=100), spectrogram)
 
-    def test_InverseSpectrogram_pseudocomplex(self):
-        tensor = common_utils.get_whitenoise(sample_rate=8000)
-        spectrogram = common_utils.get_spectrogram(tensor, n_fft=400, hop_length=100)
-        spectrogram = torch.view_as_real(spectrogram)
-        self._assert_consistency(T.InverseSpectrogram(n_fft=400, hop_length=100), spectrogram)
-
     @skipIfRocm
     def test_GriffinLim(self):
         tensor = torch.rand((1, 201, 6))

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -87,7 +87,7 @@ def spectrogram(
     if return_complex is not None:
         warnings.warn(
             "`return_complex` argument is now deprecated and is not effective."
-            "`torchaudio.functional.spectrogram(power=None)` always return tensor with "
+            "`torchaudio.functional.spectrogram(power=None)` always returns a tensor with "
             "complex dtype. Please remove the argument in the function call."
         )
 

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -105,7 +105,7 @@ class Spectrogram(torch.nn.Module):
         if return_complex is not None:
             warnings.warn(
                 "`return_complex` argument is now deprecated and is not effective."
-                "`torchaudio.transforms.Spectrogram(power=None)` always return tensor with "
+                "`torchaudio.transforms.Spectrogram(power=None)` always returns a tensor with "
                 "complex dtype. Please remove the argument in the function call."
             )
 

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -65,13 +65,7 @@ class Spectrogram(torch.nn.Module):
         onesided (bool, optional): controls whether to return half of results to
             avoid redundancy (Default: ``True``)
         return_complex (bool, optional):
-            Indicates whether the resulting complex-valued Tensor should be represented with
-            native complex dtype, such as `torch.cfloat` and `torch.cdouble`, or real dtype
-            mimicking complex value with an extra dimension for real and imaginary parts.
-            (See also ``torch.view_as_real``.)
-            This argument is only effective when ``power=None``. It is ignored for
-            cases where ``power`` is a number as in those cases, the returned tensor is
-            power spectrogram, which is a real-valued tensor.
+            Deprecated and not used.
 
     Example
         >>> waveform, sample_rate = torchaudio.load('test.wav', normalize=True)
@@ -93,7 +87,7 @@ class Spectrogram(torch.nn.Module):
                  center: bool = True,
                  pad_mode: str = "reflect",
                  onesided: bool = True,
-                 return_complex: bool = True) -> None:
+                 return_complex: Optional[bool] = None) -> None:
         super(Spectrogram, self).__init__()
         self.n_fft = n_fft
         # number of FFT bins. the returned STFT result will have n_fft // 2 + 1
@@ -108,7 +102,12 @@ class Spectrogram(torch.nn.Module):
         self.center = center
         self.pad_mode = pad_mode
         self.onesided = onesided
-        self.return_complex = return_complex
+        if return_complex is not None:
+            warnings.warn(
+                "`return_complex` argument is now deprecated and is not effective."
+                "`torchaudio.transforms.Spectrogram(power=None)` always return tensor with "
+                "complex dtype. Please remove the argument in the function call."
+            )
 
     def forward(self, waveform: Tensor) -> Tensor:
         r"""
@@ -132,7 +131,6 @@ class Spectrogram(torch.nn.Module):
             self.center,
             self.pad_mode,
             self.onesided,
-            self.return_complex,
         )
 
 


### PR DESCRIPTION
Following the plan #1337, this PR drops the support for pseudo complex type from `F.spectrogram` and `T.Spectrogram`. It also deprecates the use of `return_complex` argument.