### PR TITLE
Update PR label notifier

### DIFF
--- a/.github/process_commit.py
+++ b/.github/process_commit.py
@@ -77,8 +77,8 @@ def _main():
     if not is_properly_labeled:
         print(f"""Hi @{merger}
 
-You merged this PR, but the category labels are missing.
-Please add a primary label ({_get_formatted(PRIMARY_LABELS)}) and a secondary label ({_get_formatted(SECONDARY_LABELS)}).
+You merged this PR, but one or more labels are missing.
+Please include a primary label ({_get_formatted(PRIMARY_LABELS)}) and a secondary label ({_get_formatted(SECONDARY_LABELS)}).
 """)  # noqa: E501
 
 

--- a/.github/process_commit.py
+++ b/.github/process_commit.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 This script finds the merger responsible for labeling a PR by a commit SHA. It is used by the workflow in
 '.github/workflows/pr-labels.yml'. If there exists no PR associated with the commit or the PR is properly labeled,
@@ -60,14 +61,26 @@ def get_pr_merger_and_labels(pr_number: int) -> Tuple[str, Set[str]]:
     return merger, labels
 
 
-if __name__ == "__main__":
+def _get_formatted(l):
+    return ', '.join(f'`{i}`' for i in l)
+
+
+def _main():
     commit_hash = sys.argv[1]
     pr_number = get_pr_number(commit_hash)
     if not pr_number:
-        sys.exit(0)
+        return
 
     merger, labels = get_pr_merger_and_labels(pr_number)
     is_properly_labeled = bool(PRIMARY_LABELS.intersection(labels) and SECONDARY_LABELS.intersection(labels))
 
     if not is_properly_labeled:
-        print(f"@{merger}")
+        print(f"""Hi @{merger}
+
+You merged this PR, but the category labels are missing.
+Please add a primary label ({_get_formatted(PRIMARY_LABELS)}) and a secondary label ({_get_formatted(SECONDARY_LABELS)}).
+""")  # noqa: E501
+
+
+if __name__ == "__main__":
+    _main()

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -21,15 +21,12 @@ jobs:
 
       - name: Process commit and find merger responsible for labeling
         id: commit
-        run: echo "::set-output name=merger::$(python .github/process_commit.py ${{ github.sha }})"
+        run: echo "::set-output name=message::$(python .github/process_commit.py ${{ github.sha }})"
 
       - name: Ping merger responsible for labeling if necessary
-        if: ${{ steps.commit.outputs.merger != '' }}
+        if: ${{ steps.commit.outputs.message != '' }}
         uses: mshick/add-pr-comment@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          message: |
-            Hey ${{ steps.commit.outputs.merger }}!
-            You merged this PR, but labels were not properly added. Please add a primary and secondary label
-            (See https://github.com/pytorch/audio/blob/main/.github/process_commit.py)
+          message: ${{ steps.commit.outputs.message }}


### PR DESCRIPTION
I found it hard to recall which labels are primary and which are secondary. This PR changes the bot to include that in the message.

```
% python .github/process_commit.py cbf267c357a7574d9382ffcace75089dc2798295
Hi @mthrok

You merged this PR, but the category labels are missing.
Please add a primary label (`bug fix`, `example`, `other`, `prototype`, `new feature`, `BC-breaking`, `deprecation`, `improvement`) and a secondary label (`module: ops`, `style`, `module: tests`, `other`, `build`, `module: docs`, `perf`, `module: models`, `module: datasets`, `module: pipelines`, `module: I/O`).
```

```
% python .github/process_commit.py 8c78273be11f05b8b77ba24f0764829b7b404b7b
```