### PR TITLE
Fetch third party sources automatically

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -48,7 +48,6 @@ printf "Installing PyTorch with %s\n" "${cudatoolkit}"
 
 # 2. Install torchaudio
 printf "* Installing torchaudio\n"
-git submodule update --init --recursive
 python setup.py install
 
 # 3. Install Test tools

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -42,7 +42,6 @@ fi
 
 # 2. Install torchaudio
 printf "* Installing torchaudio\n"
-git submodule update --init --recursive
 "$root_dir/packaging/vc_env_helper.bat" python setup.py install
 
 # 3. Install Test tools

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,9 +20,6 @@ jobs:
         with:
           languages: python, cpp
 
-      - name: Update submodules
-        run: git submodule update --init --recursive
-
       - name: Install Torch
         run: |
               python -m pip install cmake ninja

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -26,7 +26,6 @@ jobs:
         python -m pip install --quiet --upgrade pip
         python -m pip install --quiet --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
         python -m pip install --quiet pytest requests cmake ninja deep-phonemizer
-        git submodule update --init --recursive
         python setup.py install
     - name: Run integration test
       run: |


### PR DESCRIPTION
This PR changes the build process so that the third party code are fetched automatically when `setup.py` is invoked.

This is to allow
1. `build_sdist` to contain the third party library codes, so that source code distribution created at the time release tag is created is complete.
2. It makes it possible to do `pip install https://github.com/pytorch/audio.git`.
    Example: https://colab.research.google.com/drive/1hK-WfiIKDTgccOmbdPwMd-b9LTA8Yg0n?usp=sharing
   ```
   !pip install 'cmake>=3.18' ninja
   !pip install --verbose git+https://github.com/mthrok/audio.git@auto-source
   ```

~Note:~
~I am changing all the CI test job to use `pip install ...` in place of `python setup.py ...`, following the movement around PEP 517 (interesting read https://bernat.tech/posts/pep-517-518/), but I leave the packaging script as-is.~

See also https://github.com/pytorch/text/pull/1154