### PR TITLE
Consolidate network utils

### DIFF
--- a/test/integration_tests/conftest.py
+++ b/test/integration_tests/conftest.py
@@ -1,5 +1,5 @@
 import torch
-import requests
+from torchaudio._internal import download_url_to_file
 import pytest
 
 
@@ -51,10 +51,7 @@ def sample_speech(tmp_path, lang):
     if not path.exists():
         url = f'https://download.pytorch.org/torchaudio/test-assets/{filename}'
         print(f'downloading from {url}')
-        with open(path, 'wb') as file:
-            with requests.get(url) as resp:
-                resp.raise_for_status()
-                file.write(resp.content)
+        download_url_to_file(url, path, progress=False)
     return path
 
 

--- a/torchaudio/_internal/__init__.py
+++ b/torchaudio/_internal/__init__.py
@@ -1,0 +1,7 @@
+from torch.hub import load_state_dict_from_url, download_url_to_file
+
+
+__all__ = [
+    "load_state_dict_from_url",
+    "download_url_to_file",
+]

--- a/torchaudio/pipelines/_tts/impl.py
+++ b/torchaudio/pipelines/_tts/impl.py
@@ -4,8 +4,8 @@ from typing import Union, Optional, Dict, Any, Tuple, List
 
 import torch
 from torch import Tensor
-from torch.hub import load_state_dict_from_url
 
+from torchaudio._internal import load_state_dict_from_url
 from torchaudio.models import Tacotron2, WaveRNN
 from torchaudio.functional import mu_law_decoding
 from torchaudio.transforms import InverseMelScale, GriffinLim

--- a/torchaudio/pipelines/_tts/utils.py
+++ b/torchaudio/pipelines/_tts/utils.py
@@ -3,7 +3,10 @@ import logging
 
 import torch
 
-from torchaudio._internal import module_utils as _mod_utils
+from torchaudio._internal import (
+    download_url_to_file,
+    module_utils as _mod_utils,
+)
 
 
 def _get_chars():
@@ -174,7 +177,7 @@ def _load_phonemizer(file, dl_kwargs):
         path = os.path.join(directory, file)
         if not os.path.exists(path):
             dl_kwargs = {} if dl_kwargs is None else dl_kwargs
-            torch.hub.download_url_to_file(url, path, **dl_kwargs)
+            download_url_to_file(url, path, **dl_kwargs)
         return Phonemizer.from_checkpoint(path)
     finally:
         logger.setLevel(orig_level)

--- a/torchaudio/pipelines/_wav2vec2/impl.py
+++ b/torchaudio/pipelines/_wav2vec2/impl.py
@@ -2,8 +2,8 @@ from dataclasses import dataclass
 from typing import Dict, Tuple, Any
 
 import torch
-from torch.hub import load_state_dict_from_url
 
+from torchaudio._internal import load_state_dict_from_url
 from torchaudio.models import wav2vec2_model, Wav2Vec2Model
 from . import utils
 


### PR DESCRIPTION
This commit changes all the `torch.hub` network utility functions to
be imported from `torchaudio._internal`, so that later we can replace
the function within fbcode.

Supersedes #1959
See also [D32078361](https://phabricator.intern.facebook.com/D32078361)