### PR TITLE
Tweak doc build

### DIFF
--- a/.circleci/build_docs/build_docs.sh
+++ b/.circleci/build_docs/build_docs.sh
@@ -9,5 +9,7 @@ setup_wheel_python
 
 pushd docs
 pip install -r requirements.txt
-make html
+yum install -y -q libsndfile-devel
+pip install -r requirements-tutorials.txt
+BUILD_GALLERY=1 make html
 popd

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,30 @@ cd docs
 make html
 ```
 
-The built docs should now be available in `docs/build/html`
+The built docs should now be available in `docs/build/html`.
+
+By default, the documentation only builds API reference.
+If you are working to add a new example/tutorial with sphinx-gallery then
+install the additional packages and set `BUILD_GALLERY` environment variable.
+
+```bash
+pip install -r requirements-tutorials.txt
+BUILD_GALLERY=1 make html
+```
+
+This will build all the tutorials with ending `_tutorial.py`.
+This can be time consuming. You can further filter which tutorial to build by using
+`GALLERY_PATTERN` environment variable.
+
+```
+BUILD_GALLERY=1 GALLERY_PATTERN=forced_alignment_tutorial.py make html
+```
+
+Omitting `BUILD_GALLERY` while providing `GALLERY_PATTERN` assumes `BUILD_GALLERY=1`.
+
+```
+GALLERY_PATTERN=forced_alignment_tutorial.py make html
+```
 
 ## Conventions
 

--- a/docs/requirements-tutorials.txt
+++ b/docs/requirements-tutorials.txt
@@ -1,0 +1,6 @@
+IPython
+deep-phonemizer
+boto3
+pandas
+librosa
+numpy<=1.20

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,5 +5,3 @@ sphinxcontrib.bibtex
 matplotlib
 pyparsing<3,>=2.0.2
 sphinx_gallery
-IPython
-deep-phonemizer

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -89,7 +89,7 @@ def _get_pattern():
     if not _get_var('BUILD_GALLERY', default=False if pattern is None else True):
         if pattern is not None:
             print(
-                ' --- WARNING: "GALLERY_PATTERN" is provided, but "BUILD_GALLERY" valus is falsy. '
+                ' --- WARNING: "GALLERY_PATTERN" is provided, but "BUILD_GALLERY" value is falsy. '
                 'Sphinx galleries are not built. To build galleries, set `BUILD_GALLERY=1`.'
             )
         return {


### PR DESCRIPTION
With the introduction of TTS tutorial (#1973), it takes more than couple of minutes
to build documentation. This commit makes the doc build process defaults to
not build tutorials.

https://422851-90321822-gh.circle-artifacts.com/0/docs/auto_examples/wav2vec2/index.html

To build tutorials one can use environment variable `BUILD_GALLERY=1`,
and set `GALLERY_PATTERN=...` to filter the tutorials to build.

This `GALLERY_PATTERN` is same approach as in `tutorials` repo.

https://github.com/pytorch/tutorials/blob/cbf2238df0e78d84c15bd94288966d2f4b2e83ae/conf.py#L75-L83

Also this commit dynamically parse the subdirectory of `examples/gallery` so that when a new category of examples are added, it will automatically parsed.