### PR TITLE
Fix pytorch_sphinx_theme version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==3.5.4
--e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
+-e git+https://github.com/pytorch/pytorch_sphinx_theme.git@b4d0005#egg=pytorch_sphinx_theme
 sphinxcontrib.katex
 sphinxcontrib.bibtex
 matplotlib


### PR DESCRIPTION
The hack introduced in #1969 could break if upstream theme changes its HTML or Javascript.
To prevent our documentation from randomly break, this commit fixes the commit of the them.