### PR TITLE
Add ffmpeg integration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 120
 ignore = E203,E305,E402,E721,E741,F405,W503,W504,F999
-exclude = build,docs/source,_ext,third_party,examples/tutorials
+exclude = build,docs/source,_ext,third_party,examples/tutorials,docs/src

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -90,6 +90,7 @@ Advanced Usages
    tutorials/tacotron2_pipeline_tutorial
    tutorials/mvdr_tutorial
    tutorials/asr_inference_with_ctc_decoder_tutorial
+   tutorials/online_asr_tutorial
 
 Citing torchaudio
 -----------------

--- a/docs/source/prototype.io.rst
+++ b/docs/source/prototype.io.rst
@@ -32,3 +32,16 @@ Streamer
 
 .. autoclass:: Streamer
   :members:
+
+Non-Streaming API
+-----------------
+
+info
+~~~~
+
+.. autofunction:: info
+
+load
+~~~~
+
+.. autofunction:: load

--- a/test/torchaudio_unittest/prototype/io_test.py
+++ b/test/torchaudio_unittest/prototype/io_test.py
@@ -14,6 +14,7 @@ from torchaudio_unittest.common_utils import (
 )
 
 if is_ffmpeg_available():
+    import torchaudio.prototype.io
     from torchaudio.prototype.io import (
         Streamer,
         SourceStream,
@@ -24,6 +25,29 @@ if is_ffmpeg_available():
 
 def get_video_asset(file="nasa_13013.mp4"):
     return get_asset_path(file)
+
+
+class LoadTest(TempDirMixin, TorchaudioTestCase):
+    @nested_params(
+        ["int16", "uint8", "int32"],  # "float", "double", "int64"]
+        [1, 2, 4, 8],
+    )
+    def test_load_wav(self, dtype, num_channels):
+        expected = get_wav_data(
+            dtype,
+            num_channels=num_channels,
+            normalize=False,
+            num_frames=15,
+            channels_first=True,
+        )
+        sample_rate = 8000
+        path = self.get_temp_path("test.wav")
+        save_wav(path, expected, sample_rate)
+
+        output, sr = torchaudio.prototype.io.load(path)
+
+        assert sample_rate == sr
+        self.assertEqual(output.T, expected)
 
 
 @skipIfNoFFmpeg

--- a/torchaudio/prototype/io/__init__.py
+++ b/torchaudio/prototype/io/__init__.py
@@ -4,6 +4,10 @@ import torchaudio
 torchaudio._extension._load_lib("libtorchaudio_ffmpeg")
 torch.ops.torchaudio.ffmpeg_init()
 
+from .io import (
+    info,
+    load,
+)
 from .streamer import (
     Streamer,
     SourceStream,
@@ -13,6 +17,8 @@ from .streamer import (
 )
 
 __all__ = [
+    "info",
+    "load",
     "Streamer",
     "SourceStream",
     "SourceAudioStream",

--- a/torchaudio/prototype/io/io.py
+++ b/torchaudio/prototype/io/io.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import torch
+import torchaudio
+
+from .streamer import Streamer, _parse_si
+
+
+def info(src: str) -> List[torchaudio.prototype.io.SourceStream]:
+    """Get the stream information of the source
+
+    Args:
+        src (str): Source URI.
+
+    Returns:
+        list of SourceStream: Stream information.
+    """
+    s = Streamer(src)
+    return [
+        _parse_si(torch.ops.torchaudio.ffmpeg_streamer_get_src_stream_info(s._s, i)) for i in range(s.num_src_streams)
+    ]
+
+
+def load(src: str) -> Tuple[torch.Tensor, int]:
+    """Load audio from source
+
+    Args:
+        src (str): Source URI.
+
+    Returns:
+        `(Tensor, int)`:
+            Audio Tensor and its sampling rate.
+    """
+    return torch.ops.torchaudio.ffmpeg_load(src)


### PR DESCRIPTION
This PR adds prototype streaming API based on ffmpeg.
Currently, the Python surface is minimum implementation.
It needs refinement.

- [x] Handles audio
   - [x] Can change the sampling rate on the fly
   - [x] Can change the sample format on the fly.
       - [x] (Implemented and tested) `uint8`, `int16`, `int32`, and `float32`
       - [ ] (Implemented but not tested) `int64` and `float64`.
   - [ ] ~Can change the resampling algorithm~ Covered via custom filter
- [x] Handles video
   - [x] Can change the image resolution on the fly.
       - [ ] ~Can change the rescaling algorithm.~ Covered via custom filter
   - [x] Can change the frame rate on the fly.
       - [ ] ~Can change the algorithm for changing the frame rate.~ Covered via custom filter
- [x] Handles multiple input streams.
- [x] Handles multiple output streams.
   - [x] Can duplicate input streams for different output configurations.
- [x] avdevice integration
- [x] Seek mechanism

- [x] Figure out the way to build / package.
  - [x] Split the binary `libtorchaudio` and `libtorchaudio_ffmpeg`.
  - [x] If binding dynamically, figure out the best way to detect installed ffmpeg across platforms. (`pkg-config` seems straightforward.)
- [ ] Add API similar to existing `torchaudio.load` function for simple use cases.
  - [x] Add the function definition
  - [ ] Add the parameters
