### PR TITLE
Relax mvdr dtype constraint

### DIFF
--- a/test/torchaudio_unittest/transforms/batch_consistency_test.py
+++ b/test/torchaudio_unittest/transforms/batch_consistency_test.py
@@ -203,7 +203,6 @@ class TestTransforms(common_utils.TorchaudioTestCase):
     ])
     def test_MVDR(self, multi_mask):
         waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
-        waveform = waveform.to(torch.double)
         specgram = common_utils.get_spectrogram(waveform, n_fft=400)
         specgram = specgram.reshape(3, 2, specgram.shape[-2], specgram.shape[-1])
         if multi_mask:

--- a/test/torchaudio_unittest/transforms/torchscript_consistency_cpu_test.py
+++ b/test/torchaudio_unittest/transforms/torchscript_consistency_cpu_test.py
@@ -1,7 +1,7 @@
 import torch
 
 from torchaudio_unittest.common_utils import PytorchTestCase
-from .torchscript_consistency_impl import Transforms, TransformsFloat32Only, TransformsFloat64Only
+from .torchscript_consistency_impl import Transforms, TransformsFloat32Only
 
 
 class TestTransformsFloat32(Transforms, TransformsFloat32Only, PytorchTestCase):
@@ -9,6 +9,6 @@ class TestTransformsFloat32(Transforms, TransformsFloat32Only, PytorchTestCase):
     device = torch.device('cpu')
 
 
-class TestTransformsFloat64(Transforms, TransformsFloat64Only, PytorchTestCase):
+class TestTransformsFloat64(Transforms, PytorchTestCase):
     dtype = torch.float64
     device = torch.device('cpu')

--- a/test/torchaudio_unittest/transforms/torchscript_consistency_cuda_test.py
+++ b/test/torchaudio_unittest/transforms/torchscript_consistency_cuda_test.py
@@ -1,7 +1,7 @@
 import torch
 
 from torchaudio_unittest.common_utils import skipIfNoCuda, PytorchTestCase
-from .torchscript_consistency_impl import Transforms, TransformsFloat32Only, TransformsFloat64Only
+from .torchscript_consistency_impl import Transforms, TransformsFloat32Only
 
 
 @skipIfNoCuda
@@ -11,6 +11,6 @@ class TestTransformsFloat32(Transforms, TransformsFloat32Only, PytorchTestCase):
 
 
 @skipIfNoCuda
-class TestTransformsFloat64(Transforms, TransformsFloat64Only, PytorchTestCase):
+class TestTransformsFloat64(Transforms, PytorchTestCase):
     dtype = torch.float64
     device = torch.device('cuda')

--- a/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
@@ -157,6 +157,25 @@ class Transforms(TestBaseMixin):
         mask = torch.rand(spectrogram.shape[-2:], device=self.device)
         self._assert_consistency_complex(T.PSD(), spectrogram, mask)
 
+    @parameterized.expand([
+        ["ref_channel", True],
+        ["stv_evd", True],
+        ["stv_power", True],
+        ["ref_channel", False],
+        ["stv_evd", False],
+        ["stv_power", False],
+    ])
+    def test_MVDR(self, solution, online):
+        tensor = common_utils.get_whitenoise(sample_rate=8000, n_channels=4)
+        spectrogram = common_utils.get_spectrogram(tensor, n_fft=400, hop_length=100)
+        spectrogram = spectrogram.to(device=self.device, dtype=torch.cfloat)
+        mask_s = torch.rand(spectrogram.shape[-2:], device=self.device)
+        mask_n = torch.rand(spectrogram.shape[-2:], device=self.device)
+        self._assert_consistency_complex(
+            T.MVDR(solution=solution, online=online),
+            spectrogram, mask_s, mask_n
+        )
+
 
 class TransformsFloat32Only(TestBaseMixin):
     def test_rnnt_loss(self):
@@ -172,24 +191,3 @@ class TransformsFloat32Only(TestBaseMixin):
         target_lengths = torch.tensor([2], device=tensor.device, dtype=torch.int32)
 
         self._assert_consistency(T.RNNTLoss(), logits, targets, logit_lengths, target_lengths)
-
-
-class TransformsFloat64Only(TestBaseMixin):
-    @parameterized.expand([
-        ["ref_channel", True],
-        ["stv_evd", True],
-        ["stv_power", True],
-        ["ref_channel", False],
-        ["stv_evd", False],
-        ["stv_power", False],
-    ])
-    def test_MVDR(self, solution, online):
-        tensor = common_utils.get_whitenoise(sample_rate=8000, n_channels=4)
-        spectrogram = common_utils.get_spectrogram(tensor, n_fft=400, hop_length=100)
-        spectrogram = spectrogram.to(device=self.device, dtype=torch.cdouble)
-        mask_s = torch.rand(spectrogram.shape[-2:], device=self.device)
-        mask_n = torch.rand(spectrogram.shape[-2:], device=self.device)
-        self._assert_consistency_complex(
-            T.MVDR(solution=solution, online=online),
-            spectrogram, mask_s, mask_n
-        )

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -1953,7 +1953,7 @@ class MVDR(torch.nn.Module):
                 f"The type of ``specgram`` tensor must be ``torch.cfloat`` or ``torch.cdouble``.\
                     Found: {specgram.dtype}"
             )
-        if specgram.dype == torch.cfloat:
+        if specgram.dtype == torch.cfloat:
             specgram = specgram.cdouble()  # Convert specgram to ``torch.cdouble``.
 
         if mask_n is None:
@@ -1979,7 +1979,7 @@ class MVDR(torch.nn.Module):
         u = torch.zeros(
             specgram.size()[:-2],
             device=specgram.device,
-            dtype=torch.cdouble,
+            dtype=torch.cdouble
         )  # (..., channel)
         u[..., self.ref_channel].fill_(1)
 


### PR DESCRIPTION
To make MVDR work in the neural network distributed training. Address https://github.com/pytorch/audio/issues/1991