### PR TITLE
Update to xavier_uniform and avoid legacy data.uniform_ initialization

### DIFF
--- a/torchaudio/models/tacotron2.py
+++ b/torchaudio/models/tacotron2.py
@@ -986,7 +986,7 @@ class Tacotron2(nn.Module):
         self.embedding = nn.Embedding(n_symbol, symbol_embedding_dim)
         std = sqrt(2.0 / (n_symbol + symbol_embedding_dim))
         val = sqrt(3.0) * std
-        self.embedding.weight.data.uniform_(-val, val)
+        torch.nn.init.xavier_uniform_(embedding.weight)
         self.encoder = _Encoder(
             encoder_embedding_dim, encoder_n_convolution, encoder_kernel_size
         )

--- a/torchaudio/models/tacotron2.py
+++ b/torchaudio/models/tacotron2.py
@@ -26,7 +26,6 @@
 # *****************************************************************************
 
 import warnings
-from math import sqrt
 from typing import Tuple, List, Optional, Union
 
 import torch

--- a/torchaudio/models/tacotron2.py
+++ b/torchaudio/models/tacotron2.py
@@ -984,8 +984,6 @@ class Tacotron2(nn.Module):
         self.n_mels = n_mels
         self.n_frames_per_step = n_frames_per_step
         self.embedding = nn.Embedding(n_symbol, symbol_embedding_dim)
-        std = sqrt(2.0 / (n_symbol + symbol_embedding_dim))
-        val = sqrt(3.0) * std
         torch.nn.init.xavier_uniform_(self.embedding.weight)
         self.encoder = _Encoder(
             encoder_embedding_dim, encoder_n_convolution, encoder_kernel_size

--- a/torchaudio/models/tacotron2.py
+++ b/torchaudio/models/tacotron2.py
@@ -986,7 +986,7 @@ class Tacotron2(nn.Module):
         self.embedding = nn.Embedding(n_symbol, symbol_embedding_dim)
         std = sqrt(2.0 / (n_symbol + symbol_embedding_dim))
         val = sqrt(3.0) * std
-        torch.nn.init.xavier_uniform_(embedding.weight)
+        torch.nn.init.xavier_uniform_(self.embedding.weight)
         self.encoder = _Encoder(
             encoder_embedding_dim, encoder_n_convolution, encoder_kernel_size
         )

--- a/torchaudio/models/wavernn.py
+++ b/torchaudio/models/wavernn.py
@@ -174,7 +174,7 @@ class UpsampleNetwork(nn.Module):
                              kernel_size=(1, scale * 2 + 1),
                              padding=(0, scale),
                              bias=False)
-            conv.weight.data.fill_(1. / (scale * 2 + 1))
+            torch.nn.init.constant_(conv.weight, 1. / (scale * 2 + 1))
             up_layers.append(stretch)
             up_layers.append(conv)
         self.upsample_layers = nn.Sequential(*up_layers)

--- a/torchaudio/models/wavernn.py
+++ b/torchaudio/models/wavernn.py
@@ -174,7 +174,7 @@ class UpsampleNetwork(nn.Module):
                              kernel_size=(1, scale * 2 + 1),
                              padding=(0, scale),
                              bias=False)
-            torch.nn.init.constant_(conv.weight, 1. / (scale * 2 + 1))
+            conv.weight.data.fill_(1. / (scale * 2 + 1))
             up_layers.append(stretch)
             up_layers.append(conv)
         self.upsample_layers = nn.Sequential(*up_layers)


### PR DESCRIPTION
Fixes #1820

@mthrok 
I have also noticed that we use `.fill_` and was wondering if we could replace with [this](https://pytorch.org/docs/stable/generated/torch.Tensor.fill_.html).  
https://github.com/pytorch/audio/blob/main/torchaudio/models/wavernn.py#L177 

and when I tried doing that this is the error
```
----> 1 conv.weight.fill_(1)

RuntimeError: a leaf Variable that requires grad is being used in an in-place operation.
```