### PR TITLE
Fix Wav2Vec2ASRBundle document page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,8 @@ include:
     - _static
     - _modules
     - _sources
+    - _tts
+    - _wav2vec2
 exclude:
     - node_modules
     - README.md


### PR DESCRIPTION
To address https://github.com/pytorch/audio/issues/1996