### PR TITLE
Improve MVDR stability

### DIFF
--- a/test/torchaudio_unittest/transforms/autograd_test_impl.py
+++ b/test/torchaudio_unittest/transforms/autograd_test_impl.py
@@ -278,8 +278,7 @@ class AutogradTestMixin(TestBaseMixin):
         "ref_channel",
         # stv_power test time too long, comment for now
         # "stv_power",
-        # stv_evd will fail since the eigenvalues are not distinct
-        # "stv_evd",
+        "stv_evd",
     ])
     def test_mvdr(self, solution):
         transform = T.MVDR(solution=solution)

--- a/test/torchaudio_unittest/transforms/autograd_test_impl.py
+++ b/test/torchaudio_unittest/transforms/autograd_test_impl.py
@@ -278,7 +278,7 @@ class AutogradTestMixin(TestBaseMixin):
         "ref_channel",
         # stv_power and stv_evd test time too long, comment for now
         # "stv_power",
-        "stv_evd",
+        # "stv_evd",
     ])
     def test_mvdr(self, solution):
         transform = T.MVDR(solution=solution)

--- a/test/torchaudio_unittest/transforms/autograd_test_impl.py
+++ b/test/torchaudio_unittest/transforms/autograd_test_impl.py
@@ -276,7 +276,7 @@ class AutogradTestMixin(TestBaseMixin):
 
     @parameterized.expand([
         "ref_channel",
-        # stv_power test time too long, comment for now
+        # stv_power and stv_evd test time too long, comment for now
         # "stv_power",
         "stv_evd",
     ])

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -1829,7 +1829,7 @@ class MVDR(torch.nn.Module):
             denominator = torch.einsum("...d,...d->...", [stv.conj().squeeze(-1), numerator])
             # normalzie the numerator
             scale = stv.squeeze(-1)[..., self.ref_channel, None].conj()
-            beamform_vector = numerator * scale / (denominator.real.unsqueeze(-1) + eps)
+            beamform_vector = numerator / (denominator.real.unsqueeze(-1) + eps) * scale
 
         return beamform_vector
 


### PR DESCRIPTION
Division first, multiplication second. This helps avoid the value overflow issue. It also helps the ``stv_evd`` solution pass the gradient check.