### PR TITLE
Relax dtype for MVDR

### DIFF
--- a/test/torchaudio_unittest/transforms/batch_consistency_test.py
+++ b/test/torchaudio_unittest/transforms/batch_consistency_test.py
@@ -203,7 +203,6 @@ class TestTransforms(common_utils.TorchaudioTestCase):
     ])
     def test_MVDR(self, multi_mask):
         waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
-        waveform = waveform.to(torch.double)
         specgram = common_utils.get_spectrogram(waveform, n_fft=400)
         specgram = specgram.reshape(3, 2, specgram.shape[-2], specgram.shape[-1])
         if multi_mask:

--- a/test/torchaudio_unittest/transforms/torchscript_consistency_cpu_test.py
+++ b/test/torchaudio_unittest/transforms/torchscript_consistency_cpu_test.py
@@ -1,7 +1,7 @@
 import torch
 
 from torchaudio_unittest.common_utils import PytorchTestCase
-from .torchscript_consistency_impl import Transforms, TransformsFloat32Only, TransformsFloat64Only
+from .torchscript_consistency_impl import Transforms, TransformsFloat32Only
 
 
 class TestTransformsFloat32(Transforms, TransformsFloat32Only, PytorchTestCase):
@@ -9,6 +9,6 @@ class TestTransformsFloat32(Transforms, TransformsFloat32Only, PytorchTestCase):
     device = torch.device('cpu')
 
 
-class TestTransformsFloat64(Transforms, TransformsFloat64Only, PytorchTestCase):
+class TestTransformsFloat64(Transforms, PytorchTestCase):
     dtype = torch.float64
     device = torch.device('cpu')

--- a/test/torchaudio_unittest/transforms/torchscript_consistency_cuda_test.py
+++ b/test/torchaudio_unittest/transforms/torchscript_consistency_cuda_test.py
@@ -1,7 +1,7 @@
 import torch
 
 from torchaudio_unittest.common_utils import skipIfNoCuda, PytorchTestCase
-from .torchscript_consistency_impl import Transforms, TransformsFloat32Only, TransformsFloat64Only
+from .torchscript_consistency_impl import Transforms, TransformsFloat32Only
 
 
 @skipIfNoCuda
@@ -11,6 +11,6 @@ class TestTransformsFloat32(Transforms, TransformsFloat32Only, PytorchTestCase):
 
 
 @skipIfNoCuda
-class TestTransformsFloat64(Transforms, TransformsFloat64Only, PytorchTestCase):
+class TestTransformsFloat64(Transforms, PytorchTestCase):
     dtype = torch.float64
     device = torch.device('cuda')


### PR DESCRIPTION
Allow users to use `torch.cfloat` dtype input for MVDR module. It internally convert the spectrogram into `torch.cdouble` and output the tensor with the original dtype of the spectrogram.