### PR TITLE
Temporarily skip threadpool test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -474,7 +474,7 @@ jobs:
           command: docker run -t --gpus all -e UPLOAD_CHANNEL -e CONDA_CHANNEL_FLAGS -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/install.sh
       - run:
           name: Run tests
-          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "TORCHAUDIO_TEST_FORCE_CUDA=1" "${image_name}" -e "CI=${CI}" .circleci/unittest/linux/scripts/run_test.sh
+          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "TORCHAUDIO_TEST_FORCE_CUDA=1" -e "CI=${CI}" "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -474,7 +474,7 @@ jobs:
           command: docker run -t --gpus all -e UPLOAD_CHANNEL -e CONDA_CHANNEL_FLAGS -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/install.sh
       - run:
           name: Run tests
-          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "TORCHAUDIO_TEST_FORCE_CUDA=1" "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
+          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "TORCHAUDIO_TEST_FORCE_CUDA=1" "${image_name}" -e "CI=${CI}" .circleci/unittest/linux/scripts/run_test.sh
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -474,7 +474,7 @@ jobs:
           command: docker run -t --gpus all -e UPLOAD_CHANNEL -e CONDA_CHANNEL_FLAGS -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/install.sh
       - run:
           name: Run tests
-          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "TORCHAUDIO_TEST_FORCE_CUDA=1" "${image_name}" -e "CI=${CI}" .circleci/unittest/linux/scripts/run_test.sh
+          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "TORCHAUDIO_TEST_FORCE_CUDA=1" -e "CI=${CI}" "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -474,7 +474,7 @@ jobs:
           command: docker run -t --gpus all -e UPLOAD_CHANNEL -e CONDA_CHANNEL_FLAGS -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/install.sh
       - run:
           name: Run tests
-          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "TORCHAUDIO_TEST_FORCE_CUDA=1" "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
+          command: docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "TORCHAUDIO_TEST_FORCE_CUDA=1" "${image_name}" -e "CI=${CI}" .circleci/unittest/linux/scripts/run_test.sh
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/test/torchaudio_unittest/sox_effect/dataset_test.py
+++ b/test/torchaudio_unittest/sox_effect/dataset_test.py
@@ -148,7 +148,7 @@ class TestProcessPoolExecutor(TempDirMixin, PytorchTestCase):
             save_wav(path, data, sample_rate)
             self.flist.append(path)
 
-    @skipIf("CI" in os.environ, "This test now hangs in CI")
+    @skipIf(os.environ.get("CI") == 'true', "This test now hangs in CI")
     def test_executor(self):
         """Test that apply_effects_tensor with speed + rate does not crush
 

--- a/test/torchaudio_unittest/sox_effect/dataset_test.py
+++ b/test/torchaudio_unittest/sox_effect/dataset_test.py
@@ -1,6 +1,7 @@
+import os
 import sys
 import platform
-from unittest import skipIf, expectedFailure
+from unittest import skipIf
 from typing import List, Tuple
 from concurrent.futures import ProcessPoolExecutor
 
@@ -147,7 +148,7 @@ class TestProcessPoolExecutor(TempDirMixin, PytorchTestCase):
             save_wav(path, data, sample_rate)
             self.flist.append(path)
 
-    @expectedFailure
+    @skipIf("CI" in os.environ, "This test now hangs in CI")
     def test_executor(self):
         """Test that apply_effects_tensor with speed + rate does not crush
 

--- a/test/torchaudio_unittest/sox_effect/dataset_test.py
+++ b/test/torchaudio_unittest/sox_effect/dataset_test.py
@@ -1,6 +1,6 @@
 import sys
 import platform
-from unittest import skipIf
+from unittest import skipIf, expectedFailure
 from typing import List, Tuple
 from concurrent.futures import ProcessPoolExecutor
 
@@ -147,6 +147,7 @@ class TestProcessPoolExecutor(TempDirMixin, PytorchTestCase):
             save_wav(path, data, sample_rate)
             self.flist.append(path)
 
+    @expectedFailure
     def test_executor(self):
         """Test that apply_effects_tensor with speed + rate does not crush
 


### PR DESCRIPTION
The sox_effects test in `concurrent.future.ThreadPoolExecutor` started failing since couple of days. While investigate this, skipping the test.