### PR TITLE
Update script for getting PR merger and labels

### DIFF
--- a/.github/process_commit.py
+++ b/.github/process_commit.py
@@ -1,9 +1,8 @@
 """
-This script finds the merger responsible for labeling a PR by a commit SHA. It is used by the workflow in
-'.github/workflows/pr-labels.yml'. If there exists no PR associated with the commit or the PR is properly labeled,
-this script is a no-op.
-Note: we ping the merger only, not the reviewers, as the reviewers can sometimes be external to torchaudio
-with no labeling responsibility, so we don't want to bother them.
+This script finds the person responsible for labeling a PR by a commit SHA. It is used by the workflow in
+'.github/workflows/pr-labels.yml'.
+Note: we only ping the person who pulls the pr, not the reviewers, as the reviewers can sometimes be external
+to torchaudio with no labeling responsibility, so we don't want to bother them.
 """
 
 import sys
@@ -44,29 +43,30 @@ def query_torchaudio(cmd: str, *, accept) -> Any:
     return response.json()
 
 
-def get_pr_number(commit_hash: str) -> Optional[int]:
-    # See https://docs.github.com/en/rest/reference/repos#list-pull-requests-associated-with-a-commit
-    data = query_torchaudio(f"commits/{commit_hash}/pulls", accept="application/vnd.github.groot-preview+json")
-    if not data:
-        return None
-    return data[0]["number"]
+def get_pr_merger_and_number(commit_hash: str) -> Optional[str]:
+    data = query_torchaudio(f"commits/{commit_hash}", accept="application/vnd.github.v3+json")
+    commit_message = data['commit']['message']
+
+    pulled_by = commit_message.split('Pulled By: ')
+    pulled_by = pulled_by[1].split('\n')[0] if len(pulled_by) > 1 else None
+
+    pr_number = commit_message.split('Pull Request resolved: https://github.com/pytorch/audio/pull/')
+    pr_number = pr_number[1].split('\n')[0] if len(pr_number) > 1 else None
+
+    return pulled_by, pr_number
 
 
-def get_pr_merger_and_labels(pr_number: int) -> Tuple[str, Set[str]]:
-    # See https://docs.github.com/en/rest/reference/pulls#get-a-pull-request
+def get_labels(pr_number: int) -> Set[str]:
     data = query_torchaudio(f"pulls/{pr_number}", accept="application/vnd.github.v3+json")
-    merger = data["merged_by"]["login"]
     labels = {label["name"] for label in data["labels"]}
-    return merger, labels
+    return labels
 
 
 if __name__ == "__main__":
     commit_hash = sys.argv[1]
-    pr_number = get_pr_number(commit_hash)
-    if not pr_number:
-        sys.exit(0)
 
-    merger, labels = get_pr_merger_and_labels(pr_number)
+    merger, pr_number = get_pr_merger_and_number(commit_hash)
+    labels = get_labels(pr_number)
     is_properly_labeled = bool(PRIMARY_LABELS.intersection(labels) and SECONDARY_LABELS.intersection(labels))
 
     if not is_properly_labeled:


### PR DESCRIPTION
The previous way of detecting the merger and labels given a commit hash no longer works with ShipIt, as PRs are closed and not merged and are not associated with a commit hash. To work around this, update the script to get the merger (pulled by: ) and PR number from the commit hash message, and then collect labels from the corresponding PR.