### PR TITLE
Revise Griffin-Lim transform test to reduce execution time

### DIFF
--- a/test/torchaudio_unittest/transforms/autograd_test_impl.py
+++ b/test/torchaudio_unittest/transforms/autograd_test_impl.py
@@ -101,11 +101,12 @@ class AutogradTestMixin(TestBaseMixin):
         [False, True],
     )
     def test_griffinlim(self, momentum, rand_init):
-        n_fft = 400
+        n_fft = 80
         power = 1
-        n_iter = 3
+        n_iter = 2
+
         spec = get_spectrogram(
-            get_whitenoise(sample_rate=8000, duration=0.05, n_channels=2),
+            get_whitenoise(sample_rate=8000, duration=0.01, n_channels=2),
             n_fft=n_fft, power=power)
         transform = _DeterministicWrapper(
             T.GriffinLim(n_fft=n_fft, n_iter=n_iter, momentum=momentum, rand_init=rand_init, power=power))


### PR DESCRIPTION
Our Griffin-Lim autograd tests take a long time to run. This PR adjusts some parameters to shorten the run time.

For one of the four tests:
Before:
```
test/torchaudio_unittest/transforms/autograd_cpu_test.py . [100%]

======================== 1 passed in 517.35s (0:08:37) =========================
```

After:
```
test/torchaudio_unittest/transforms/autograd_cpu_test.py . [100%]

======================== 1 passed in 104.59s (0:01:44) =========================
```