### PR TITLE
Add decoder class

### DIFF
--- a/torchaudio/csrc/ffmpeg/decoder.cpp
+++ b/torchaudio/csrc/ffmpeg/decoder.cpp
@@ -1,0 +1,20 @@
+#include <torchaudio/csrc/ffmpeg/decoder.h>
+
+namespace torchaudio {
+namespace ffmpeg {
+
+////////////////////////////////////////////////////////////////////////////////
+// Decoder
+////////////////////////////////////////////////////////////////////////////////
+Decoder::Decoder(AVCodecParameters* pParam) : pCodecContext(pParam) {}
+
+int Decoder::process_packet(AVPacket* pPacket) {
+  return avcodec_send_packet(pCodecContext, pPacket);
+}
+
+int Decoder::get_frame(AVFrame* pFrame) {
+  return avcodec_receive_frame(pCodecContext, pFrame);
+}
+
+} // namespace ffmpeg
+} // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/decoder.h
+++ b/torchaudio/csrc/ffmpeg/decoder.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <torchaudio/csrc/ffmpeg/ffmpeg.h>
+
+namespace torchaudio {
+namespace ffmpeg {
+
+class Decoder {
+  AVCodecContextPtr pCodecContext;
+
+ public:
+  // Default constructable
+  Decoder(AVCodecParameters* pParam);
+  // Custom destructor to clean up the resources
+  ~Decoder() = default;
+  // Non-copyable
+  Decoder(const Decoder&) = delete;
+  Decoder& operator=(const Decoder&) = delete;
+  // Movable
+  Decoder(Decoder&&) = default;
+  Decoder& operator=(Decoder&&) = default;
+
+  // Process incoming packet
+  int process_packet(AVPacket* pPacket);
+  // Fetch a decoded frame
+  int get_frame(AVFrame* pFrame);
+};
+
+} // namespace ffmpeg
+} // namespace torchaudio


### PR DESCRIPTION
Part of #1986. Splitting the PR for easier review.

Add `Decoder` class that manages `AVCodecContext` resource and process input `AVPacket`.
For the overall architecture, see https://github.com/mthrok/audio/blob/ffmpeg/torchaudio/csrc/ffmpeg/README.md.

Note: Without a change to build process, the code added here won't be compiled. The build process will be updated later.
Needs to be imported after #2041.