### PR TITLE
Add a switch to build ffmpeg binding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ endif()
 
 # Options
 option(BUILD_SOX "Build libsox statically" ON)
+option(BUILD_FFMPEG "Enable ffmpeg-based features" OFF)
 option(BUILD_KALDI "Build kaldi statically" ON)
 option(BUILD_RNNT "Enable RNN transducer" ON)
 option(BUILD_CTC_DECODER "Build Flashlight CTC decoder" ON)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -14,6 +14,26 @@ if (BUILD_SOX)
 endif()
 
 ################################################################################
+# ffmpeg
+################################################################################
+if (BUILD_FFMPEG)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(LIBAV REQUIRED IMPORTED_TARGET
+    # requires ffmpeg>=4.1
+    libavdevice>=58
+    libavfilter>=7
+    libavformat>=58
+    libavcodec>=58
+    libswresample>=3
+    libswscale>=3
+    libavutil>=56
+    )
+  add_library(ffmpeg INTERFACE)
+  target_include_directories(ffmpeg INTERFACE ${LIBAV_INCLUDE_DIRS})
+  target_link_libraries(ffmpeg INTERFACE ${LIBAV_LINK_LIBRARIES})
+endif()
+
+################################################################################
 # kaldi
 ################################################################################
 if (BUILD_KALDI)

--- a/tools/setup_helpers/extension.py
+++ b/tools/setup_helpers/extension.py
@@ -36,6 +36,7 @@ _BUILD_SOX = False if platform.system() == "Windows" else _get_build("BUILD_SOX"
 _BUILD_KALDI = False if platform.system() == "Windows" else _get_build("BUILD_KALDI", True)
 _BUILD_RNNT = _get_build("BUILD_RNNT", True)
 _BUILD_CTC_DECODER = False if platform.system() == "Windows" else _get_build("BUILD_CTC_DECODER", True)
+_BUILD_FFMPEG = _get_build("BUILD_FFMPEG", False)
 _USE_ROCM = _get_build("USE_ROCM", torch.cuda.is_available() and torch.version.hip is not None)
 _USE_CUDA = _get_build("USE_CUDA", torch.cuda.is_available() and torch.version.hip is None)
 _USE_OPENMP = _get_build("USE_OPENMP", True) and "ATen parallel backend: OpenMP" in torch.__config__.parallel_info()
@@ -54,6 +55,8 @@ def get_ext_modules():
                 Extension(name="torchaudio._torchaudio_decoder", sources=[]),
             ]
         )
+    if _BUILD_FFMPEG:
+        modules.append(Extension(name='torchaudio.lib.libtorchaudio_ffmpeg', sources=[]))
     return modules
 
 
@@ -92,6 +95,7 @@ class CMakeBuild(build_ext):
             "-DCMAKE_VERBOSE_MAKEFILE=ON",
             f"-DPython_INCLUDE_DIR={distutils.sysconfig.get_python_inc()}",
             f"-DBUILD_SOX:BOOL={'ON' if _BUILD_SOX else 'OFF'}",
+            f"-DBUILD_FFMPEG:BOOL={'ON' if _BUILD_FFMPEG else 'OFF'}",
             f"-DBUILD_KALDI:BOOL={'ON' if _BUILD_KALDI else 'OFF'}",
             f"-DBUILD_RNNT:BOOL={'ON' if _BUILD_RNNT else 'OFF'}",
             f"-DBUILD_CTC_DECODER:BOOL={'ON' if _BUILD_CTC_DECODER else 'OFF'}",

--- a/tools/setup_helpers/extension.py
+++ b/tools/setup_helpers/extension.py
@@ -56,7 +56,7 @@ def get_ext_modules():
             ]
         )
     if _BUILD_FFMPEG:
-        modules.append(Extension(name='torchaudio.lib.libtorchaudio_ffmpeg', sources=[]))
+        modules.append(Extension(name="torchaudio.lib.libtorchaudio_ffmpeg", sources=[]))
     return modules
 
 

--- a/torchaudio/csrc/CMakeLists.txt
+++ b/torchaudio/csrc/CMakeLists.txt
@@ -167,6 +167,30 @@ else()
 endif()
 
 ################################################################################
+# libtorchaudio_ffmpeg
+################################################################################
+if(BUILD_FFMPEG)
+  set(
+    LIBTORCHAUDIO_FFMPEG_SOURCES
+    ffmpeg/prototype.cpp
+    ffmpeg/decoder.cpp
+    ffmpeg/ffmpeg.cpp
+    ffmpeg/filter_graph.cpp
+    ffmpeg/buffer.cpp
+    ffmpeg/sink.cpp
+    ffmpeg/stream_processor.cpp
+    ffmpeg/streamer.cpp
+    )
+define_library(
+  libtorchaudio_ffmpeg
+  "${LIBTORCHAUDIO_FFMPEG_SOURCES}"
+  "${LIBTORCHAUDIO_INCLUDE_DIRS}"
+  "libtorchaudio;ffmpeg"
+  "${LIBTORCHAUDIO_COMPILE_DEFINITIONS}"
+  )
+endif()
+
+################################################################################
 # _torchaudio.so
 ################################################################################
 if (BUILD_TORCHAUDIO_PYTHON_EXTENSION)


### PR DESCRIPTION
This PR adds `BUILD_FFMPEG` switch to torchaudio build process so that features related to ffmpeg are built.
The flag is false by default, so no CI jobs or development flow are affected.

This is because handling the dependencies around ffmpeg is a bit tricky.
Currently, the CMake file uses `pkg-config` to find an ffmpeg installation in the system.
This works fine for both conda-based installation and system-managed installation (like `apt`).

In subsequent PRs, I will find a solution that works for local development and binary distributions.