### PR TITLE
[release/0.10] Cherry pick #2004 and #2024 to release/0.10

### DIFF
--- a/test/torchaudio_unittest/transforms/autograd_test_impl.py
+++ b/test/torchaudio_unittest/transforms/autograd_test_impl.py
@@ -285,9 +285,8 @@ class AutogradTestMixin(TestBaseMixin):
 
     @parameterized.expand([
         "ref_channel",
-        # stv_power test time too long, comment for now
+        # stv_power and stv_evd test time too long, comment for now
         # "stv_power",
-        # stv_evd will fail since the eigenvalues are not distinct
         # "stv_evd",
     ])
     def test_mvdr(self, solution):

--- a/test/torchaudio_unittest/transforms/batch_consistency_test.py
+++ b/test/torchaudio_unittest/transforms/batch_consistency_test.py
@@ -207,7 +207,6 @@ class TestTransforms(common_utils.TorchaudioTestCase):
     ])
     def test_MVDR(self, multi_mask):
         waveform = common_utils.get_whitenoise(sample_rate=8000, duration=1, n_channels=6)
-        waveform = waveform.to(torch.double)
         specgram = common_utils.get_spectrogram(waveform, n_fft=400)
         specgram = specgram.reshape(3, 2, specgram.shape[-2], specgram.shape[-1])
         if multi_mask:

--- a/test/torchaudio_unittest/transforms/torchscript_consistency_cpu_test.py
+++ b/test/torchaudio_unittest/transforms/torchscript_consistency_cpu_test.py
@@ -1,7 +1,7 @@
 import torch
 
 from torchaudio_unittest.common_utils import PytorchTestCase
-from .torchscript_consistency_impl import Transforms, TransformsFloat32Only, TransformsFloat64Only
+from .torchscript_consistency_impl import Transforms, TransformsFloat32Only
 
 
 class TestTransformsFloat32(Transforms, TransformsFloat32Only, PytorchTestCase):
@@ -9,6 +9,6 @@ class TestTransformsFloat32(Transforms, TransformsFloat32Only, PytorchTestCase):
     device = torch.device('cpu')
 
 
-class TestTransformsFloat64(Transforms, TransformsFloat64Only, PytorchTestCase):
+class TestTransformsFloat64(Transforms, PytorchTestCase):
     dtype = torch.float64
     device = torch.device('cpu')

--- a/test/torchaudio_unittest/transforms/torchscript_consistency_cuda_test.py
+++ b/test/torchaudio_unittest/transforms/torchscript_consistency_cuda_test.py
@@ -1,7 +1,7 @@
 import torch
 
 from torchaudio_unittest.common_utils import skipIfNoCuda, PytorchTestCase
-from .torchscript_consistency_impl import Transforms, TransformsFloat32Only, TransformsFloat64Only
+from .torchscript_consistency_impl import Transforms, TransformsFloat32Only
 
 
 @skipIfNoCuda
@@ -11,6 +11,6 @@ class TestTransformsFloat32(Transforms, TransformsFloat32Only, PytorchTestCase):
 
 
 @skipIfNoCuda
-class TestTransformsFloat64(Transforms, TransformsFloat64Only, PytorchTestCase):
+class TestTransformsFloat64(Transforms, PytorchTestCase):
     dtype = torch.float64
     device = torch.device('cuda')

--- a/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
@@ -164,6 +164,24 @@ class Transforms(TestBaseMixin):
         mask = torch.rand(spectrogram.shape[-2:], device=self.device)
         self._assert_consistency_complex(T.PSD(), spectrogram, False, mask)
 
+    @parameterized.expand([
+        ["ref_channel", True],
+        ["stv_evd", True],
+        ["stv_power", True],
+        ["ref_channel", False],
+        ["stv_evd", False],
+        ["stv_power", False],
+    ])
+    def test_MVDR(self, solution, online):
+        tensor = common_utils.get_whitenoise(sample_rate=8000, n_channels=4)
+        spectrogram = common_utils.get_spectrogram(tensor, n_fft=400, hop_length=100)
+        mask_s = torch.rand(spectrogram.shape[-2:], device=self.device)
+        mask_n = torch.rand(spectrogram.shape[-2:], device=self.device)
+        self._assert_consistency_complex(
+            T.MVDR(solution=solution, online=online),
+            spectrogram, False, mask_s, mask_n
+        )
+
 
 class TransformsFloat32Only(TestBaseMixin):
     def test_rnnt_loss(self):
@@ -179,24 +197,3 @@ class TransformsFloat32Only(TestBaseMixin):
         target_lengths = torch.tensor([2], device=tensor.device, dtype=torch.int32)
 
         self._assert_consistency(T.RNNTLoss(), logits, targets, logit_lengths, target_lengths)
-
-
-class TransformsFloat64Only(TestBaseMixin):
-    @parameterized.expand([
-        ["ref_channel", True],
-        ["stv_evd", True],
-        ["stv_power", True],
-        ["ref_channel", False],
-        ["stv_evd", False],
-        ["stv_power", False],
-    ])
-    def test_MVDR(self, solution, online):
-        tensor = common_utils.get_whitenoise(sample_rate=8000, n_channels=4)
-        spectrogram = common_utils.get_spectrogram(tensor, n_fft=400, hop_length=100)
-        spectrogram = spectrogram.to(device=self.device, dtype=torch.cdouble)
-        mask_s = torch.rand(spectrogram.shape[-2:], device=self.device)
-        mask_n = torch.rand(spectrogram.shape[-2:], device=self.device)
-        self._assert_consistency_complex(
-            T.MVDR(solution=solution, online=online),
-            spectrogram, False, mask_s, mask_n
-        )

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -1870,7 +1870,7 @@ class MVDR(torch.nn.Module):
             denominator = torch.einsum("...d,...d->...", [stv.conj().squeeze(-1), numerator])
             # normalzie the numerator
             scale = stv.squeeze(-1)[..., self.ref_channel, None].conj()
-            beamform_vector = numerator * scale / (denominator.real.unsqueeze(-1) + eps)
+            beamform_vector = numerator / (denominator.real.unsqueeze(-1) + eps) * scale
 
         return beamform_vector
 

--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -1706,9 +1706,9 @@ class MVDR(torch.nn.Module):
             (Default: ``False``)
 
     Note:
-        The MVDR Module requires the input STFT to be double precision (``torch.complex128`` or ``torch.cdouble``),
-        to improve the numerical stability. You can downgrade the precision to ``torch.float`` after generating the
-        enhanced waveform for ASR joint training.
+        To improve the numerical stability, the input spectrogram will be converted to double precision
+        (``torch.complex128`` or ``torch.cdouble``) dtype for internal computation. The output spectrogram
+        is converted to the dtype of the input spectrogram to be compatible with other modules.
 
     Note:
         If you use ``stv_evd`` solution, the gradient of the same input may not be identical if the
@@ -1985,14 +1985,18 @@ class MVDR(torch.nn.Module):
             torch.Tensor: The single-channel STFT of the enhanced speech.
                 Tensor of dimension `(..., freq, time)`
         """
+        dtype = specgram.dtype
         if specgram.ndim < 3:
             raise ValueError(
                 f"Expected at least 3D tensor (..., channel, freq, time). Found: {specgram.shape}"
             )
-        if specgram.dtype != torch.cdouble:
+        if not specgram.is_complex():
             raise ValueError(
-                f"The type of ``specgram`` tensor must be ``torch.cdouble``. Found: {specgram.dtype}"
+                f"The type of ``specgram`` tensor must be ``torch.cfloat`` or ``torch.cdouble``.\
+                    Found: {specgram.dtype}"
             )
+        if specgram.dtype == torch.cfloat:
+            specgram = specgram.cdouble()  # Convert specgram to ``torch.cdouble``.
 
         if mask_n is None:
             warnings.warn(
@@ -2047,4 +2051,5 @@ class MVDR(torch.nn.Module):
         # unpack batch
         specgram_enhanced = specgram_enhanced.reshape(shape[:-3] + shape[-2:])
 
+        specgram_enhanced.to(dtype)
         return specgram_enhanced


### PR DESCRIPTION
#2004 
#2024
This allows user to use ``cfloat`` dtype for MVDR module in 0.10 release.