### PR TITLE
Add "+cpu" suffix to doc build job

### DIFF
--- a/.circleci/build_docs/install_wheels.sh
+++ b/.circleci/build_docs/install_wheels.sh
@@ -7,6 +7,8 @@ source ./packaging/pkg_helpers.bash
 export NO_CUDA_PACKAGE=1
 setup_env 0.8.0
 setup_wheel_python
+# Starting 0.10, `pip install pytorch` defaults to ROCm.
+export PYTORCH_VERSION_SUFFIX="+cpu"
 setup_pip_pytorch_version
 # pytorch is already installed
 pip install --no-deps ~/workspace/torchaudio*


### PR DESCRIPTION
While updating the documentation in release/0.10, a HIP error was raised.
https://app.circleci.com/pipelines/github/pytorch/audio/8577/workflows/02c6ff44-a042-4f9a-8fb8-573a231f60db/jobs/452639

This happens because `pip install torchaudio -f https://...` defaults to
ROCm version while `build_doc` is supposed to pick the CPU version.

Adding suffix `+cpu` should resolve the isssue.

It is validated on https://github.com/pytorch/audio/pull/2060 https://app.circleci.com/pipelines/github/pytorch/audio/8584/workflows/25ae26e5-273f-46f8-805d-ffc7b6b8eb58/jobs/453337
