### PR TITLE
exlucluding sphinx-gallery examples

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,6 @@ line-length = 120
 target-version = ["py37"]
 
 [tool.ufmt]
+excludes = [
+    "examples/tutorials",
+]


### PR DESCRIPTION
In order to align with the internal configuration and also torchvision we decided to  sphinx-gallery examples from the lint checks .

cc @NicolasHug @mthrok 