### PR TITLE
Standardize the location of third-party source code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,8 +145,8 @@ jobs:
 
       - run:
           command: |
-              mkdir -p third_party/sox/archives/
-              wget --no-clobber --directory-prefix=third_party/sox/archives/ $(awk '/URL /{print $2}' third_party/sox/CMakeLists.txt)
+              mkdir -p third_party/archives/
+              wget --no-clobber --directory-prefix=third_party/archives/ $(awk '/URL /{print $2}' third_party/*/CMakeLists.txt)
       - save_cache:
 
           key: tp-nix-v2-{{ checksum ".cachekey" }}

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -145,8 +145,8 @@ jobs:
           {% endraw %}
       - run:
           command: |
-              mkdir -p third_party/sox/archives/
-              wget --no-clobber --directory-prefix=third_party/sox/archives/ $(awk '/URL /{print $2}' third_party/sox/CMakeLists.txt)
+              mkdir -p third_party/archives/
+              wget --no-clobber --directory-prefix=third_party/archives/ $(awk '/URL /{print $2}' third_party/*/CMakeLists.txt)
       - save_cache:
           {% raw %}
           key: tp-nix-v2-{{ checksum ".cachekey" }}

--- a/.gitignore
+++ b/.gitignore
@@ -128,4 +128,3 @@ examples/tutorials/_assets
 # third parties
 third_party/install/
 third_party/archives/
-third_party/sox/archives/

--- a/setup.py
+++ b/setup.py
@@ -103,19 +103,9 @@ def _parse_url(path):
                 yield url
 
 
-def _parse_sox_sources():
-    sox_dir = ROOT_DIR / 'third_party' / 'sox'
-    cmake_file = sox_dir / 'CMakeLists.txt'
-    archive_dir = sox_dir / 'archives'
-    archive_dir.mkdir(exist_ok=True)
-    for url in _parse_url(cmake_file):
-        path = archive_dir / os.path.basename(url)
-        yield path, url
-
-
-def _parse_kenlm_sources():
+def _parse_sources():
     third_party_dir = ROOT_DIR / 'third_party'
-    libs = ['zlib', 'bzip2', 'lzma', 'boost']
+    libs = ['zlib', 'bzip2', 'lzma', 'boost', 'sox']
     archive_dir = third_party_dir / 'archives'
     archive_dir.mkdir(exist_ok=True)
     for lib in libs:
@@ -136,8 +126,7 @@ def _fetch_third_party_libraries():
     if not (ROOT_DIR / 'third_party' / 'kaldi' / 'submodule' / 'CMakeLists.txt').exists():
         _init_submodule()
     if os.name != 'nt':
-        _fetch_archives(_parse_sox_sources())
-        _fetch_archives(_parse_kenlm_sources())
+        _fetch_archives(_parse_sources())
 
 
 def _main():

--- a/third_party/sox/CMakeLists.txt
+++ b/third_party/sox/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(ExternalProject)
 
 set(INSTALL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../install)
-set(ARCHIVE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/archives)
+set(ARCHIVE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../archives)
 set(COMMON_ARGS --quiet --disable-shared --enable-static --prefix=${INSTALL_DIR} --with-pic --disable-dependency-tracking --disable-debug --disable-examples --disable-doc)
 
 # To pass custom environment variables to ExternalProject_Add command,


### PR DESCRIPTION
Previously sox-related third-party source code was archived at
`third_party/sox/archives`.
Recently KenLM-related third-party source code was added and
they are archived at `third_party/archives`.

This PR changes the sox archive location to `third_party/archives`,
so that all the archvies are cached at the same location.