### PR TITLE
Revert linting exemptions introduced in #2071

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
           command: pre-commit run --all-files || true
       - run:
           name: Required lint modifications
-          when: on_fail
+          when: always
           command: git --no-pager diff
 
   download_third_parties_nix:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -128,7 +128,7 @@ jobs:
           command: pre-commit run --all-files || true
       - run:
           name: Required lint modifications
-          when: on_fail
+          when: always
           command: git --no-pager diff
 
   download_third_parties_nix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,3 @@ line-length = 120
 target-version = ["py37"]
 
 [tool.ufmt]
-excludes = [
-    "examples/tutorials",
-]


### PR DESCRIPTION
After discussing with Moto Hira, we decided to revert linting exemptions
introduced previously in order to keep the entire audio project as formatted
as possible, to reduce the time we spend on formatting discussion.