### PR TITLE
Add pretrained Emformer RNN-T streaming ASR inference pipeline

### DIFF
--- a/docs/source/prototype.rst
+++ b/docs/source/prototype.rst
@@ -87,6 +87,12 @@ RNNTBundle
 
   .. automethod:: get_token_processor
 
+  .. autoclass:: torchaudio.prototype::RNNTBundle.FeatureExtractor
+    :special-members: __call__
+
+  .. autoclass:: torchaudio.prototype::RNNTBundle.TokenProcessor
+    :special-members: __call__
+
 
 EMFORMER_RNNT_BASE_LIBRISPEECH
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/prototype.rst
+++ b/docs/source/prototype.rst
@@ -73,6 +73,28 @@ Hypothesis
 .. autoclass:: Hypothesis
 
 
+RNNTBundle
+~~~~~~~~~~
+
+.. autoclass:: RNNTBundle
+  :members: sample_rate, n_fft, n_mels, hop_length, segment_length, right_context_length
+
+  .. automethod:: get_decoder
+
+  .. automethod:: get_feature_extractor
+
+  .. automethod:: get_streaming_feature_extractor
+
+  .. automethod:: get_token_processor
+
+
+EMFORMER_RNNT_BASE_LIBRISPEECH
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autodata:: EMFORMER_RNNT_BASE_LIBRISPEECH
+  :no-value:
+
+
 KenLMLexiconDecoder
 ~~~~~~~~~~~~~~~~~~~
 
@@ -91,18 +113,6 @@ kenlm_lexicon_decoder
 .. currentmodule:: torchaudio.prototype.ctc_decoder
 
 .. autoclass:: kenlm_lexicon_decoder
-
-
-RNNTBundle
-~~~~~~~~~~
-
-.. autoclass:: RNNTBundle
-
-
-EMFORMER_RNNT_BASE_LIBRISPEECH
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autofunction:: EMFORMER_RNNT_BASE_LIBRISPEECH
 
 
 References

--- a/docs/source/prototype.rst
+++ b/docs/source/prototype.rst
@@ -93,6 +93,18 @@ kenlm_lexicon_decoder
 .. autoclass:: kenlm_lexicon_decoder
 
 
+RNNTBundle
+~~~~~~~~~~
+
+.. autoclass:: RNNTBundle
+
+
+EMFORMER_RNNT_BASE_LIBRISPEECH
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: EMFORMER_RNNT_BASE_LIBRISPEECH
+
+
 References
 ~~~~~~~~~~
 

--- a/examples/asr/librispeech_emformer_rnnt/pipeline_demo.py
+++ b/examples/asr/librispeech_emformer_rnnt/pipeline_demo.py
@@ -1,0 +1,50 @@
+from argparse import ArgumentParser
+import pathlib
+import torch
+import torchaudio
+from torchaudio.prototype.rnnt_pipeline import EMFORMER_RNNT_BASE_LIBRISPEECH
+
+
+SAMPLES_PER_CHUNK = 640
+
+
+def cli_main():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--librispeech_path", type=pathlib.Path, help="Path to LibriSpeech datasets.",
+    )
+    args = parser.parse_args()
+
+    dataset = torchaudio.datasets.LIBRISPEECH(args.librispeech_path, url="test-clean")
+    decoder = EMFORMER_RNNT_BASE_LIBRISPEECH.get_decoder()
+    token_processor = EMFORMER_RNNT_BASE_LIBRISPEECH.get_token_processor()
+    feature_extractor = EMFORMER_RNNT_BASE_LIBRISPEECH.get_feature_extractor()
+    streaming_feature_extractor = EMFORMER_RNNT_BASE_LIBRISPEECH.get_streaming_feature_extractor()
+
+    for idx in range(10):
+        sample = dataset[idx]
+
+        with torch.no_grad():
+            waveform = sample[0].squeeze()
+
+            # Streaming decode.
+            state, hypothesis = None, None
+            for idx in range(0, len(waveform), 4 * SAMPLES_PER_CHUNK):
+                segment = waveform[idx: idx + 5 * SAMPLES_PER_CHUNK]
+                segment = torch.nn.functional.pad(segment, (0, 5 * SAMPLES_PER_CHUNK - len(segment)))
+                features, length = streaming_feature_extractor(segment)
+                hypos, state = decoder.infer(features, length, 10, state=state, hypothesis=hypothesis)
+                hypothesis = hypos[0]
+                transcript = token_processor(hypothesis.tokens)
+                if transcript:
+                    print(transcript, end=" ", flush=True)
+            print()
+
+            # Non-streaming decode.
+            features, length = feature_extractor(waveform)
+            hypos = decoder(features, length, 10)
+            print(token_processor(hypos[0].tokens))
+
+
+if __name__ == "__main__":
+    cli_main()

--- a/examples/asr/librispeech_emformer_rnnt/pipeline_demo.py
+++ b/examples/asr/librispeech_emformer_rnnt/pipeline_demo.py
@@ -18,10 +18,10 @@ def cli_main():
     feature_extractor = EMFORMER_RNNT_BASE_LIBRISPEECH.get_feature_extractor()
     streaming_feature_extractor = EMFORMER_RNNT_BASE_LIBRISPEECH.get_streaming_feature_extractor()
 
-    samples_per_frame = EMFORMER_RNNT_BASE_LIBRISPEECH.samples_per_frame
-    num_samples_segment = EMFORMER_RNNT_BASE_LIBRISPEECH.segment_length * samples_per_frame
+    hop_length = EMFORMER_RNNT_BASE_LIBRISPEECH.hop_length
+    num_samples_segment = EMFORMER_RNNT_BASE_LIBRISPEECH.segment_length * hop_length
     num_samples_segment_right_context = (
-        num_samples_segment + EMFORMER_RNNT_BASE_LIBRISPEECH.right_context_length * samples_per_frame
+        num_samples_segment + EMFORMER_RNNT_BASE_LIBRISPEECH.right_context_length * hop_length
     )
 
     for idx in range(10):

--- a/torchaudio/prototype/__init__.py
+++ b/torchaudio/prototype/__init__.py
@@ -2,6 +2,7 @@ from .conformer import Conformer
 from .emformer import Emformer
 from .rnnt import RNNT, emformer_rnnt_base, emformer_rnnt_model
 from .rnnt_decoder import Hypothesis, RNNTBeamSearch
+from .rnnt_pipeline import EMFORMER_RNNT_BASE_LIBRISPEECH, RNNTBundle
 
 
 __all__ = [
@@ -12,4 +13,6 @@ __all__ = [
     "RNNTBeamSearch",
     "emformer_rnnt_base",
     "emformer_rnnt_model",
+    "EMFORMER_RNNT_BASE_LIBRISPEECH",
+    "RNNTBundle",
 ]

--- a/torchaudio/prototype/rnnt_pipeline.py
+++ b/torchaudio/prototype/rnnt_pipeline.py
@@ -157,7 +157,9 @@ class _SentencePieceTokenProcessor(_TokenProcessor):
 
 @dataclass
 class RNNTBundle:
-    """Dataclass that bundles components for performing automatic speech recognition (ASR, speech-to-text)
+    """torchaudio.prototype.rnnt_pipeline.RNNTBundle()
+
+    Dataclass that bundles components for performing automatic speech recognition (ASR, speech-to-text)
     inference with an RNN-T model.
 
     More specifically, the class provides methods that produce the featurization pipeline,

--- a/torchaudio/prototype/rnnt_pipeline.py
+++ b/torchaudio/prototype/rnnt_pipeline.py
@@ -1,0 +1,149 @@
+from typing import Callable, List, Tuple
+from dataclasses import dataclass
+import json
+import math
+import os
+import sys
+import torch
+
+import sentencepiece as spm
+import torchaudio
+from torchaudio._internal import download_url_to_file, load_state_dict_from_url
+from torchaudio.prototype import RNNT, RNNTBeamSearch, emformer_rnnt_base
+
+
+__all__ = []
+
+
+_BASE_MODELS_URL = "https://download.pytorch.org/torchaudio/models"
+_BASE_PIPELINES_URL = "https://download.pytorch.org/torchaudio/pipeline-assets"
+
+
+def _download_asset(asset_path: str):
+    dst_path = f"{os.getcwd()}/_assets/{asset_path}"
+    if not os.path.exists(dst_path):
+        os.makedirs(f"{os.getcwd()}/_assets", exist_ok=True)
+        download_url_to_file(f"{_BASE_PIPELINES_URL}/{asset_path}", dst_path)
+    else:
+        sys.stderr.write(f"{asset_path} found at {dst_path}; skipping download.\n")
+        sys.stderr.flush()
+    return dst_path
+
+
+_decibel = 2 * 20 * math.log10(torch.iinfo(torch.int16).max)
+_gain = pow(10, 0.05 * _decibel)
+
+
+def _piecewise_linear_log(x):
+    x[x > math.e] = torch.log(x[x > math.e])
+    x[x <= math.e] = x[x <= math.e] / math.e
+    return x
+
+
+class _FunctionalModule(torch.nn.Module):
+    def __init__(self, functional):
+        super().__init__()
+        self.functional = functional
+
+    def forward(self, input):
+        return self.functional(input)
+
+
+class _GlobalStatsNormalization(torch.nn.Module):
+    def __init__(self, global_stats_path):
+        super().__init__()
+
+        with open(global_stats_path) as f:
+            blob = json.loads(f.read())
+
+        self.mean = torch.tensor(blob["mean"])
+        self.invstddev = torch.tensor(blob["invstddev"])
+
+    def forward(self, input):
+        return (input - self.mean) * self.invstddev
+
+
+class FeatureExtractor(torch.nn.Module):
+    def __init__(self, pipeline: torch.nn.Module) -> None:
+        super().__init__()
+        self.pipeline = pipeline
+
+    def forward(self, input: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        features = self.pipeline(input)
+        lengths = torch.tensor([features.shape[0]])
+        return features, lengths
+
+
+class SentencePieceTokenProcessor:
+    def __init__(self, sp_model_path: str) -> None:
+        self.sp_model = spm.SentencePieceProcessor(model_file=sp_model_path)
+        self.post_process_remove_list = {
+            self.sp_model.unk_id(),
+            self.sp_model.eos_id(),
+            self.sp_model.pad_id(),
+        }
+
+    def __call__(self, tokens: List[str]) -> str:
+        filtered_hypo_tokens = [
+            token_index for token_index in tokens[1:] if token_index not in self.post_process_remove_list
+        ]
+        return self.sp_model.decode(filtered_hypo_tokens)
+
+
+@dataclass
+class RNNTBundle:
+    _rnnt_path: str
+    _rnnt_factory_func: Callable[[], RNNT]
+    _global_stats_path: str
+    _sp_model_path: str
+    _right_padding: int
+    _blank: int
+
+    def _get_model(self) -> RNNT:
+        model = self._rnnt_factory_func()
+        url = f"{_BASE_MODELS_URL}/{self._rnnt_path}"
+        state_dict = load_state_dict_from_url(url)
+        model.load_state_dict(state_dict)
+        model.eval()
+        return model
+
+    def get_decoder(self) -> RNNTBeamSearch:
+        model = self._get_model()
+        return RNNTBeamSearch(model, self._blank)
+
+    def get_feature_extractor(self) -> FeatureExtractor:
+        local_path = _download_asset(self._global_stats_path)
+        return FeatureExtractor(
+            torch.nn.Sequential(
+                torchaudio.transforms.MelSpectrogram(sample_rate=16000, n_fft=400, n_mels=80, hop_length=160),
+                _FunctionalModule(lambda x: x.transpose(1, 0)),
+                _FunctionalModule(lambda x: _piecewise_linear_log(x * _gain)),
+                _GlobalStatsNormalization(local_path),
+                _FunctionalModule(lambda x: torch.nn.functional.pad(x, (0, 0, 0, self._right_padding))),
+            )
+        )
+
+    def get_streaming_feature_extractor(self) -> FeatureExtractor:
+        local_path = _download_asset(self._global_stats_path)
+        return FeatureExtractor(
+            torch.nn.Sequential(
+                torchaudio.transforms.MelSpectrogram(sample_rate=16000, n_fft=400, n_mels=80, hop_length=160),
+                _FunctionalModule(lambda x: x.transpose(1, 0)),
+                _FunctionalModule(lambda x: _piecewise_linear_log(x * _gain)),
+                _GlobalStatsNormalization(local_path),
+            )
+        )
+
+    def get_token_processor(self) -> SentencePieceTokenProcessor:
+        local_path = _download_asset(self._sp_model_path)
+        return SentencePieceTokenProcessor(local_path)
+
+
+EMFORMER_RNNT_BASE_LIBRISPEECH = RNNTBundle(
+    _rnnt_path="emformer_rnnt_base_librispeech.pt",
+    _rnnt_factory_func=emformer_rnnt_base,
+    _global_stats_path="global_stats_rnnt_librispeech.json",
+    _sp_model_path="spm_bpe_4096_librispeech.model",
+    _right_padding=4,
+    _blank=4096,
+)


### PR DESCRIPTION
Adds pretrained Emformer RNN-T inference pipeline that's capable of performing streaming and non-streaming ASR.

Includes demo script that uses pipeline to alternately perform streaming and non-streaming ASR on LibriSpeech test samples (video below).


https://user-images.githubusercontent.com/8345689/147590753-d5126557-d575-4551-8dfe-5977276cb4ad.mov


