### PR TITLE
Fix third party archive fetch job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,11 +152,11 @@ jobs:
           key: tp-nix-v2-{{ checksum ".cachekey" }}
 
           paths:
-            - third_party/sox/archives
+            - third_party/archives
       - persist_to_workspace:
           root: third_party
           paths:
-            - sox/archives
+            - archives
 
   binary_linux_wheel:
     <<: *binary_common

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -152,11 +152,11 @@ jobs:
           key: tp-nix-v2-{{ checksum ".cachekey" }}
           {% endraw %}
           paths:
-            - third_party/sox/archives
+            - third_party/archives
       - persist_to_workspace:
           root: third_party
           paths:
-            - sox/archives
+            - archives
 
   binary_linux_wheel:
     <<: *binary_common


### PR DESCRIPTION
Follow-up of #2086 

The CI job to download the third party code and cache daily has not been properly updated.