### PR TITLE
Disable matplotlib warning in tutorial rendering

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,10 +22,14 @@
 # sys.path.insert(0, os.path.abspath('.'))
 import os
 import re
+import warnings
 
 import pytorch_sphinx_theme
 
 # -- General configuration ------------------------------------------------
+
+warnings.filterwarnings("ignore", module="matplotlib\..*")
+
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #


### PR DESCRIPTION
*Before:*

https://pytorch.org/audio/main/tutorials/audio_data_augmentation_tutorial.html#effects-applied

<img width="831" alt="Screen Shot 2021-12-28 at 11 25 08 AM" src="https://user-images.githubusercontent.com/855818/147586457-55d566bf-f016-4327-a07e-5de68f80e984.png">

*After:*

https://484994-90321822-gh.circle-artifacts.com/0/docs/tutorials/audio_data_augmentation_tutorial.html#effects-applied

<img width="830" alt="Screen Shot 2021-12-28 at 11 25 57 AM" src="https://user-images.githubusercontent.com/855818/147586531-90333201-b9e3-450f-a2d7-6fb987b7e9d9.png">
