### PR TITLE
Allow token list as CTC decoder input

### DIFF
--- a/torchaudio/csrc/decoder/bindings/pybind.cpp
+++ b/torchaudio/csrc/decoder/bindings/pybind.cpp
@@ -225,6 +225,7 @@ PYBIND11_MODULE(_torchaudio_decoder, m) {
 
   py::class_<Dictionary>(m, "_Dictionary")
       .def(py::init<>())
+      .def(py::init<const std::vector<std::string>&>(), "tkns"_a)
       .def(py::init<const std::string&>(), "filename"_a)
       .def("entry_size", &Dictionary::entrySize)
       .def("index_size", &Dictionary::indexSize)

--- a/torchaudio/csrc/decoder/src/dictionary/Dictionary.cpp
+++ b/torchaudio/csrc/decoder/src/dictionary/Dictionary.cpp
@@ -26,6 +26,15 @@ Dictionary::Dictionary(const std::string& filename) {
   createFromStream(stream);
 }
 
+Dictionary::Dictionary(const std::vector<std::string>& tkns) {
+  for (const auto& tkn : tkns) {
+    addEntry(tkn);
+  }
+  if (!isContiguous()) {
+    throw std::runtime_error("Invalid dictionary format - not contiguous");
+  }
+}
+
 void Dictionary::createFromStream(std::istream& stream) {
   if (!stream) {
     throw std::runtime_error("Unable to open dictionary input stream.");

--- a/torchaudio/csrc/decoder/src/dictionary/Dictionary.h
+++ b/torchaudio/csrc/decoder/src/dictionary/Dictionary.h
@@ -26,6 +26,8 @@ class Dictionary {
 
   explicit Dictionary(const std::string& filename);
 
+  explicit Dictionary(const std::vector<std::string>& tkns);
+
   size_t entrySize() const;
 
   size_t indexSize() const;

--- a/torchaudio/prototype/ctc_decoder/ctc_decoder.py
+++ b/torchaudio/prototype/ctc_decoder/ctc_decoder.py
@@ -1,7 +1,7 @@
 import itertools as it
 from collections import namedtuple
 from typing import Dict
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import torch
 from torchaudio._torchaudio_decoder import (
@@ -157,7 +157,7 @@ class KenLMLexiconDecoder:
 
 def kenlm_lexicon_decoder(
     lexicon: str,
-    tokens: str,
+    tokens: Union[str, List[str]],
     kenlm: str,
     nbest: int = 1,
     beam_size: int = 50,
@@ -177,7 +177,7 @@ def kenlm_lexicon_decoder(
 
     Args:
         lexicon (str): lexicon file containing the possible words
-        tokens (str): file containing valid tokens
+        tokens (str or List[str]): file or list containing valid tokens
         kenlm (str): file containing languge model
         nbest (int, optional): number of best decodings to return (Default: 1)
         beam_size (int, optional): max number of hypos to hold after each decode step (Default: 50)


### PR DESCRIPTION
Additionally accept list of tokens as CTC decoder input. This makes it possible to directly pass in something like `bundles.get_labels()` into the decoder factory function instead of requiring a separate tokens file.