### PR TITLE
Drop support for python3.6 as per task T109096383. Item 2 on issue 2051.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -671,47 +671,6 @@ workflows:
           name: download_third_parties_nix
       - binary_linux_wheel:
           cuda_version: cpu
-          name: binary_linux_wheel_py3.6_cpu
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-      - binary_linux_wheel:
-          cuda_version: cu102
-          name: binary_linux_wheel_py3.6_cu102
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-          wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_linux_wheel:
-          cuda_version: cu111
-          name: binary_linux_wheel_py3.6_cu111
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-          wheel_docker_image: pytorch/manylinux-cuda111
-      - binary_linux_wheel:
-          cuda_version: cu113
-          name: binary_linux_wheel_py3.6_cu113
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-          wheel_docker_image: pytorch/manylinux-cuda113
-      - binary_linux_wheel:
-          cuda_version: cu115
-          name: binary_linux_wheel_py3.6_cu115
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-          wheel_docker_image: pytorch/manylinux-cuda115
-      - binary_linux_wheel:
-          cuda_version: rocm4.1
-          name: binary_linux_wheel_py3.6_rocm4.1
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-          wheel_docker_image: pytorch/manylinux-rocm:4.1
-      - binary_linux_wheel:
-          cuda_version: cpu
           name: binary_linux_wheel_py3.7_cpu
           python_version: '3.7'
           requires:
@@ -841,12 +800,6 @@ workflows:
           wheel_docker_image: pytorch/manylinux-rocm:4.1
       - binary_macos_wheel:
           cuda_version: cpu
-          name: binary_macos_wheel_py3.6_cpu
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-      - binary_macos_wheel:
-          cuda_version: cpu
           name: binary_macos_wheel_py3.7_cpu
           python_version: '3.7'
           requires:
@@ -863,20 +816,6 @@ workflows:
           python_version: '3.9'
           requires:
           - download_third_parties_nix
-      - binary_windows_wheel:
-          cuda_version: cpu
-          name: binary_windows_wheel_py3.6_cpu
-          python_version: '3.6'
-      - binary_windows_wheel:
-          cuda_version: cu113
-          name: binary_windows_wheel_py3.6_cu113
-          python_version: '3.6'
-          wheel_docker_image: pytorch/manylinux-cuda113
-      - binary_windows_wheel:
-          cuda_version: cu115
-          name: binary_windows_wheel_py3.6_cu115
-          python_version: '3.6'
-          wheel_docker_image: pytorch/manylinux-cuda115
       - binary_windows_wheel:
           cuda_version: cpu
           name: binary_windows_wheel_py3.7_cpu
@@ -919,41 +858,6 @@ workflows:
           name: binary_windows_wheel_py3.9_cu115
           python_version: '3.9'
           wheel_docker_image: pytorch/manylinux-cuda115
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cpu
-          cuda_version: cpu
-          name: binary_linux_conda_py3.6_cpu
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda102
-          cuda_version: cu102
-          name: binary_linux_conda_py3.6_cu102
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda111
-          cuda_version: cu111
-          name: binary_linux_conda_py3.6_cu111
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cuda_version: cu113
-          name: binary_linux_conda_py3.6_cu113
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda115
-          cuda_version: cu115
-          name: binary_linux_conda_py3.6_cu115
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cuda_version: cpu
@@ -1062,13 +966,6 @@ workflows:
       - binary_macos_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cuda_version: cpu
-          name: binary_macos_conda_py3.6_cpu
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-      - binary_macos_conda:
-          conda_docker_image: pytorch/conda-builder:cpu
-          cuda_version: cpu
           name: binary_macos_conda_py3.7_cpu
           python_version: '3.7'
           requires:
@@ -1087,21 +984,6 @@ workflows:
           python_version: '3.9'
           requires:
           - download_third_parties_nix
-      - binary_windows_conda:
-          conda_docker_image: pytorch/conda-builder:cpu
-          cuda_version: cpu
-          name: binary_windows_conda_py3.6_cpu
-          python_version: '3.6'
-      - binary_windows_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cuda_version: cu113
-          name: binary_windows_conda_py3.6_cu113
-          python_version: '3.6'
-      - binary_windows_conda:
-          conda_docker_image: pytorch/conda-builder:cuda115
-          cuda_version: cu115
-          name: binary_windows_conda_py3.6_cu115
-          python_version: '3.6'
       - binary_windows_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cuda_version: cpu
@@ -1181,20 +1063,14 @@ workflows:
           name: download_third_parties_nix
       - unittest_linux_cpu:
           cuda_version: cpu
-          name: unittest_linux_cpu_py3.6
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-      - stylecheck:
-          cuda_version: cpu
-          name: stylecheck_py3.6
-          python_version: '3.6'
-      - unittest_linux_cpu:
-          cuda_version: cpu
           name: unittest_linux_cpu_py3.7
           python_version: '3.7'
           requires:
           - download_third_parties_nix
+      - stylecheck:
+          cuda_version: cpu
+          name: stylecheck_py3.7
+          python_version: '3.7'
       - unittest_linux_cpu:
           cuda_version: cpu
           name: unittest_linux_cpu_py3.8
@@ -1205,12 +1081,6 @@ workflows:
           cuda_version: cpu
           name: unittest_linux_cpu_py3.9
           python_version: '3.9'
-          requires:
-          - download_third_parties_nix
-      - unittest_linux_gpu:
-          cuda_version: cu113
-          name: unittest_linux_gpu_py3.6
-          python_version: '3.6'
           requires:
           - download_third_parties_nix
       - unittest_linux_gpu:
@@ -1233,10 +1103,6 @@ workflows:
           - download_third_parties_nix
       - unittest_windows_cpu:
           cuda_version: cpu
-          name: unittest_windows_cpu_py3.6
-          python_version: '3.6'
-      - unittest_windows_cpu:
-          cuda_version: cpu
           name: unittest_windows_cpu_py3.7
           python_version: '3.7'
       - unittest_windows_cpu:
@@ -1249,10 +1115,6 @@ workflows:
           python_version: '3.9'
       - unittest_windows_gpu:
           cuda_version: cu113
-          name: unittest_windows_gpu_py3.6
-          python_version: '3.6'
-      - unittest_windows_gpu:
-          cuda_version: cu113
           name: unittest_windows_gpu_py3.7
           python_version: '3.7'
       - unittest_windows_gpu:
@@ -1263,12 +1125,6 @@ workflows:
           cuda_version: cu113
           name: unittest_windows_gpu_py3.9
           python_version: '3.9'
-      - unittest_macos_cpu:
-          cuda_version: cpu
-          name: unittest_macos_cpu_py3.6
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
       - unittest_macos_cpu:
           cuda_version: cpu
           name: unittest_macos_cpu_py3.7
@@ -1301,227 +1157,6 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: download_third_parties_nix
-      - binary_linux_wheel:
-          cuda_version: cpu
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_cpu
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_cpu_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.6_cpu
-          subfolder: cpu/
-      - smoke_test_linux_pip:
-          cuda_version: cpu
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_cpu_smoke_test_pip
-          python_version: '3.6'
-          requires:
-          - nightly_binary_linux_wheel_py3.6_cpu_upload
-      - binary_linux_wheel:
-          cuda_version: cu102
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_cu102
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-          wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_cu102_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.6_cu102
-          subfolder: cu102/
-      - smoke_test_linux_pip:
-          cuda_version: cu102
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_cu102_smoke_test_pip
-          python_version: '3.6'
-          requires:
-          - nightly_binary_linux_wheel_py3.6_cu102_upload
-      - binary_linux_wheel:
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_cu111
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-          wheel_docker_image: pytorch/manylinux-cuda111
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_cu111_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.6_cu111
-          subfolder: cu111/
-      - smoke_test_linux_pip:
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_cu111_smoke_test_pip
-          python_version: '3.6'
-          requires:
-          - nightly_binary_linux_wheel_py3.6_cu111_upload
-      - binary_linux_wheel:
-          cuda_version: cu113
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_cu113
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-          wheel_docker_image: pytorch/manylinux-cuda113
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_cu113_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.6_cu113
-          subfolder: cu113/
-      - smoke_test_linux_pip:
-          cuda_version: cu113
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_cu113_smoke_test_pip
-          python_version: '3.6'
-          requires:
-          - nightly_binary_linux_wheel_py3.6_cu113_upload
-      - binary_linux_wheel:
-          cuda_version: cu115
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_cu115
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-          wheel_docker_image: pytorch/manylinux-cuda115
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_cu115_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.6_cu115
-          subfolder: cu115/
-      - smoke_test_linux_pip:
-          cuda_version: cu115
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_cu115_smoke_test_pip
-          python_version: '3.6'
-          requires:
-          - nightly_binary_linux_wheel_py3.6_cu115_upload
-      - binary_linux_wheel:
-          cuda_version: rocm4.1
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_rocm4.1
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-          wheel_docker_image: pytorch/manylinux-rocm:4.1
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_rocm4.1_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.6_rocm4.1
-          subfolder: rocm4.1/
-      - smoke_test_linux_pip:
-          cuda_version: rocm4.1
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.6_rocm4.1_smoke_test_pip
-          python_version: '3.6'
-          requires:
-          - nightly_binary_linux_wheel_py3.6_rocm4.1_upload
       - binary_linux_wheel:
           cuda_version: cpu
           filters:
@@ -2193,30 +1828,6 @@ workflows:
               - nightly
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_wheel_py3.6_cpu
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_wheel_py3.6_cpu_upload
-          requires:
-          - nightly_binary_macos_wheel_py3.6_cpu
-          subfolder: ''
-      - binary_macos_wheel:
-          cuda_version: cpu
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: nightly_binary_macos_wheel_py3.7_cpu
           python_version: '3.7'
           requires:
@@ -2281,110 +1892,6 @@ workflows:
           requires:
           - nightly_binary_macos_wheel_py3.9_cpu
           subfolder: ''
-      - binary_windows_wheel:
-          cuda_version: cpu
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_wheel_py3.6_cpu
-          python_version: '3.6'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_wheel_py3.6_cpu_upload
-          requires:
-          - nightly_binary_windows_wheel_py3.6_cpu
-          subfolder: cpu/
-      - smoke_test_windows_pip:
-          cuda_version: cpu
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_wheel_py3.6_cpu_smoke_test_pip
-          python_version: '3.6'
-          requires:
-          - nightly_binary_windows_wheel_py3.6_cpu_upload
-      - binary_windows_wheel:
-          cuda_version: cu113
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_wheel_py3.6_cu113
-          python_version: '3.6'
-          wheel_docker_image: pytorch/manylinux-cuda113
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_wheel_py3.6_cu113_upload
-          requires:
-          - nightly_binary_windows_wheel_py3.6_cu113
-          subfolder: cu113/
-      - smoke_test_windows_pip:
-          cuda_version: cu113
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_wheel_py3.6_cu113_smoke_test_pip
-          python_version: '3.6'
-          requires:
-          - nightly_binary_windows_wheel_py3.6_cu113_upload
-      - binary_windows_wheel:
-          cuda_version: cu115
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_wheel_py3.6_cu115
-          python_version: '3.6'
-          wheel_docker_image: pytorch/manylinux-cuda115
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_wheel_py3.6_cu115_upload
-          requires:
-          - nightly_binary_windows_wheel_py3.6_cu115
-          subfolder: cu115/
-      - smoke_test_windows_pip:
-          cuda_version: cu115
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_wheel_py3.6_cu115_smoke_test_pip
-          python_version: '3.6'
-          requires:
-          - nightly_binary_windows_wheel_py3.6_cu115_upload
       - binary_windows_wheel:
           cuda_version: cpu
           filters:
@@ -2697,186 +2204,6 @@ workflows:
           python_version: '3.9'
           requires:
           - nightly_binary_windows_wheel_py3.9_cu115_upload
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cpu
-          cuda_version: cpu
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_cpu
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_cpu_upload
-          requires:
-          - nightly_binary_linux_conda_py3.6_cpu
-      - smoke_test_linux_conda:
-          cuda_version: cpu
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_cpu_smoke_test_conda
-          python_version: '3.6'
-          requires:
-          - nightly_binary_linux_conda_py3.6_cpu_upload
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda102
-          cuda_version: cu102
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_cu102
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_cu102_upload
-          requires:
-          - nightly_binary_linux_conda_py3.6_cu102
-      - smoke_test_linux_conda_gpu:
-          cuda_version: cu102
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_cu102_smoke_test_conda
-          python_version: '3.6'
-          requires:
-          - nightly_binary_linux_conda_py3.6_cu102_upload
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda111
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_cu111
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_cu111_upload
-          requires:
-          - nightly_binary_linux_conda_py3.6_cu111
-      - smoke_test_linux_conda_gpu:
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_cu111_smoke_test_conda
-          python_version: '3.6'
-          requires:
-          - nightly_binary_linux_conda_py3.6_cu111_upload
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cuda_version: cu113
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_cu113
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_cu113_upload
-          requires:
-          - nightly_binary_linux_conda_py3.6_cu113
-      - smoke_test_linux_conda_gpu:
-          cuda_version: cu113
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_cu113_smoke_test_conda
-          python_version: '3.6'
-          requires:
-          - nightly_binary_linux_conda_py3.6_cu113_upload
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda115
-          cuda_version: cu115
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_cu115
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_cu115_upload
-          requires:
-          - nightly_binary_linux_conda_py3.6_cu115
-      - smoke_test_linux_conda_gpu:
-          cuda_version: cu115
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.6_cu115_smoke_test_conda
-          python_version: '3.6'
-          requires:
-          - nightly_binary_linux_conda_py3.6_cu115_upload
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cuda_version: cpu
@@ -3426,30 +2753,6 @@ workflows:
               - nightly
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_conda_py3.6_cpu
-          python_version: '3.6'
-          requires:
-          - download_third_parties_nix
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_conda_py3.6_cpu_upload
-          requires:
-          - nightly_binary_macos_conda_py3.6_cpu
-      - binary_macos_conda:
-          conda_docker_image: pytorch/conda-builder:cpu
-          cuda_version: cpu
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: nightly_binary_macos_conda_py3.7_cpu
           python_version: '3.7'
           requires:
@@ -3513,108 +2816,6 @@ workflows:
           name: nightly_binary_macos_conda_py3.9_cpu_upload
           requires:
           - nightly_binary_macos_conda_py3.9_cpu
-      - binary_windows_conda:
-          conda_docker_image: pytorch/conda-builder:cpu
-          cuda_version: cpu
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_conda_py3.6_cpu
-          python_version: '3.6'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_conda_py3.6_cpu_upload
-          requires:
-          - nightly_binary_windows_conda_py3.6_cpu
-      - smoke_test_windows_conda:
-          cuda_version: cpu
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_conda_py3.6_cpu_smoke_test_conda
-          python_version: '3.6'
-          requires:
-          - nightly_binary_windows_conda_py3.6_cpu_upload
-      - binary_windows_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cuda_version: cu113
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_conda_py3.6_cu113
-          python_version: '3.6'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_conda_py3.6_cu113_upload
-          requires:
-          - nightly_binary_windows_conda_py3.6_cu113
-      - smoke_test_windows_conda:
-          cuda_version: cu113
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_conda_py3.6_cu113_smoke_test_conda
-          python_version: '3.6'
-          requires:
-          - nightly_binary_windows_conda_py3.6_cu113_upload
-      - binary_windows_conda:
-          conda_docker_image: pytorch/conda-builder:cuda115
-          cuda_version: cu115
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_conda_py3.6_cu115
-          python_version: '3.6'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_conda_py3.6_cu115_upload
-          requires:
-          - nightly_binary_windows_conda_py3.6_cu115
-      - smoke_test_windows_conda:
-          cuda_version: cu115
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_windows_conda_py3.6_cu115_smoke_test_conda
-          python_version: '3.6'
-          requires:
-          - nightly_binary_windows_conda_py3.6_cu115_upload
       - binary_windows_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cuda_version: cpu

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -21,7 +21,7 @@ import yaml
 from jinja2 import select_autoescape
 
 
-PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9"]
+PYTHON_VERSIONS = ["3.7", "3.8", "3.9"]
 CU_VERSIONS_DICT = {
     "linux": ["cpu", "cu102", "cu111", "cu113", "cu115", "rocm4.1"],
     "windows": ["cpu", "cu113", "cu115"],


### PR DESCRIPTION
As per item 2 on [issue 2051](https://github.com/pytorch/audio/issues/2051), dropping support for python 3.6.
Removed 3.6 from test matrix and ran `.circleci/regenerate.py `.