### PR TITLE
Build ffmpeg-features on macOS wheel binary dist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,6 +204,8 @@ jobs:
             sh conda.sh -b
             source $HOME/miniconda3/bin/activate
             packaging/build_wheel.sh
+          environment:
+            BUILD_FFMPEG=1
       - store_artifacts:
           path: dist
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
             source $HOME/miniconda3/bin/activate
             packaging/build_wheel.sh
           environment:
-            BUILD_FFMPEG=1
+            BUILD_FFMPEG: true
       - store_artifacts:
           path: dist
       - persist_to_workspace:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -204,6 +204,8 @@ jobs:
             sh conda.sh -b
             source $HOME/miniconda3/bin/activate
             packaging/build_wheel.sh
+          environment:
+            BUILD_FFMPEG=1
       - store_artifacts:
           path: dist
       - persist_to_workspace:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -205,7 +205,7 @@ jobs:
             source $HOME/miniconda3/bin/activate
             packaging/build_wheel.sh
           environment:
-            BUILD_FFMPEG=1
+            BUILD_FFMPEG: true
       - store_artifacts:
           path: dist
       - persist_to_workspace:

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -183,7 +183,7 @@ setup_wheel_python() {
     conda create -yn "env$PYTHON_VERSION" python="$PYTHON_VERSION"
     conda activate "env$PYTHON_VERSION"
     if [[ "$(uname)" == Darwin ]]; then
-        conda install --quiet -y pkg-config
+        conda install --quiet -y pkg-config "ffmpeg>=4.1"
     fi
   else
     case "$PYTHON_VERSION" in


### PR DESCRIPTION
This commit enable ffmpeg-feature build on wheel-based binary distribution on macOS.

For macOS, since the underlying Python env is Conda, it installs `ffmpeg` from conda.


Depends on #1873 