### PR TITLE
Add custom CSS to make signatures appear in multi-line

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -1,0 +1,11 @@
+/* https://github.com/sphinx-doc/sphinx/issues/1514#issuecomment-742703082 */
+/* Newlines (\a) and spaces (\20) before each parameter */
+dt > em.sig-param:before {
+    content: "\a\20\20\20\20";
+    white-space: pre;
+}
+/* Newline after the last parameter (so the closing bracket is on a new line) */
+dt > em.sig-param:last-of-type::after {
+    content: "\a";
+    white-space: pre;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -199,10 +199,7 @@ html_logo = "_static/img/pytorch-logo-dark.svg"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
-html_css_files = [
-    "https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css",
-    "css/custom.css"
-]
+html_css_files = ["https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css", "css/custom.css"]
 
 # -- Options for HTMLHelp output ------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -199,7 +199,10 @@ html_logo = "_static/img/pytorch-logo-dark.svg"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
-html_css_files = ["https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css"]
+html_css_files = [
+    "https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css",
+    "css/custom.css"
+]
 
 # -- Options for HTMLHelp output ------------------------------------------
 


### PR DESCRIPTION


* Before

https://pytorch.org/audio/main/models.html

<img width="852" alt="Screen Shot 2022-01-04 at 11 00 12 AM" src="https://user-images.githubusercontent.com/855818/148087255-3b94e63b-9870-4c7e-95c6-17acc1e65fef.png">


*After

https://503135-90321822-gh.circle-artifacts.com/0/docs/models.html

<img width="842" alt="Screen Shot 2022-01-04 at 10 59 40 AM" src="https://user-images.githubusercontent.com/855818/148087148-b951c7b0-d9cf-4014-8a50-b88c749f12ba.png">
