### PR TITLE
Update ffmpeg discovery logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ option(USE_CUDA "Enable CUDA support" OFF)
 option(USE_ROCM "Enable ROCM support" OFF)
 option(USE_OPENMP "Enable OpenMP support" OFF)
 
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # check that USE_CUDA and USE_ROCM are not set at the same time
 if(USE_CUDA AND USE_ROCM)

--- a/cmake/FindFFMPEG.cmake
+++ b/cmake/FindFFMPEG.cmake
@@ -76,6 +76,7 @@ function (_ffmpeg_find component headername)
       "lib${component}/${headername}"
     PATHS
       "${FFMPEG_ROOT}/include"
+      "$ENV{CONDA_PREFIX}/include"
       ~/Library/Frameworks
       /Library/Frameworks
       /usr/local/include
@@ -101,6 +102,7 @@ function (_ffmpeg_find component headername)
       "${component}"
     PATHS
       "${FFMPEG_ROOT}/lib"
+      "$ENV{CONDA_PREFIX}/lib"
       ~/Library/Frameworks
       /Library/Frameworks
       /usr/local/lib

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -17,30 +17,11 @@ endif()
 # ffmpeg
 ################################################################################
 if (BUILD_FFMPEG)
-  if(WIN32)
-    message(FATAL_ERROR "FFmpeg integration is not supported on Windows.")
-    # TODO
-    # Since pkg-config is not well-supported on Windows (for example, ffmpeg
-    # installed from conda-forge does not include `.pc` medata file),
-    # to support windows, we need to fill interface manually.
-    #
-    # Something like this might work
-    # https://github.com/microsoft/vcpkg/issues/1379#issuecomment-312483740
-  endif()
-  find_package(PkgConfig REQUIRED)
-  pkg_check_modules(LIBAV REQUIRED IMPORTED_TARGET
-    # requires ffmpeg>=4.1
-    libavdevice>=58
-    libavfilter>=7
-    libavformat>=58
-    libavcodec>=58
-    libswresample>=3
-    libswscale>=3
-    libavutil>=56
-    )
+  set(FFMPEG_FIND_COMPONENTS avdevice avfilter avformat avcodec avutil)
+  include(FindFFMPEG)
   add_library(ffmpeg INTERFACE)
-  target_include_directories(ffmpeg INTERFACE ${LIBAV_INCLUDE_DIRS})
-  target_link_libraries(ffmpeg INTERFACE ${LIBAV_LINK_LIBRARIES})
+  target_include_directories(ffmpeg INTERFACE ${FFMPEG_INCLUDE_DIRS})
+  target_link_libraries(ffmpeg INTERFACE ${FFMPEG_LIBRARIES})
 endif()
 
 ################################################################################


### PR DESCRIPTION
Update ffmpeg discovery logic

Previously the build process used pkg-config to locate
an installation of ffmpeg, which does not work well Windows/CentOS.

This commit update the discovery process to use the custom
FindFFMPEG.cmake adopted from Kitware/VTK repository with addition of
conda environment.

 The custom discovery logic can support Windows and CentOS.