### PR TITLE
Add device arg to Resample class

### DIFF
--- a/torchaudio/transforms.py
+++ b/torchaudio/transforms.py
@@ -895,6 +895,7 @@ class Resample(torch.nn.Module):
         rolloff: float = 0.99,
         beta: Optional[float] = None,
         *,
+        device=torch.device("cpu"),
         dtype: Optional[torch.dtype] = None,
     ) -> None:
         super().__init__()
@@ -916,6 +917,7 @@ class Resample(torch.nn.Module):
                 self.rolloff,
                 self.resampling_method,
                 beta,
+                device=device,
                 dtype=dtype,
             )
             self.register_buffer("kernel", kernel)


### PR DESCRIPTION
This PR adds the ability to specify the device on which resampling would compute in Resample class. 