### PR TITLE
Surpress stderr from subprocess in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ ROOT_DIR = Path(__file__).parent.resolve()
 
 def _run_cmd(cmd):
     try:
-        return subprocess.check_output(cmd, cwd=ROOT_DIR).decode("ascii").strip()
+        return subprocess.check_output(cmd, cwd=ROOT_DIR, stderr=subprocess.DEVNULL).decode("ascii").strip()
     except Exception:
         return None
 


### PR DESCRIPTION
This commits supress the stderr output when shell commands are
executed `setup.py`.

`setup.py` performs multiple git commands to gather metadata.
When `git tag` command tries to find a tag, (which fails unless on release)
it produces `fatal: No names found, cannot describe anything.`

This is confusing especially when it is executed from higher level,
like `pip install git+https://...`.