### PR TITLE
Fix header include

### DIFF
--- a/torchaudio/csrc/ffmpeg/ffmpeg.cpp
+++ b/torchaudio/csrc/ffmpeg/ffmpeg.cpp
@@ -1,4 +1,5 @@
 #include <torchaudio/csrc/ffmpeg/ffmpeg.h>
+#include <stdexcept>
 
 namespace torchaudio {
 namespace ffmpeg {

--- a/torchaudio/csrc/ffmpeg/prototype.cpp
+++ b/torchaudio/csrc/ffmpeg/prototype.cpp
@@ -1,5 +1,6 @@
 #include <torch/script.h>
 #include <torchaudio/csrc/ffmpeg/streamer.h>
+#include <stdexcept>
 
 namespace torchaudio {
 namespace ffmpeg {

--- a/torchaudio/csrc/ffmpeg/sink.cpp
+++ b/torchaudio/csrc/ffmpeg/sink.cpp
@@ -1,4 +1,5 @@
 #include <torchaudio/csrc/ffmpeg/sink.h>
+#include <stdexcept>
 
 namespace torchaudio {
 namespace ffmpeg {

--- a/torchaudio/csrc/ffmpeg/stream_processor.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_processor.cpp
@@ -1,5 +1,5 @@
 #include <torchaudio/csrc/ffmpeg/stream_processor.h>
-#include "libavutil/frame.h"
+#include <stdexcept>
 
 namespace torchaudio {
 namespace ffmpeg {


### PR DESCRIPTION
MSVS is strict on header and would not allow `std::runtime_error`
without `<stdexcept>`.

Also this commit removes the stray `"libavutil/frame.h"`,
inserted by IDE, which I missed.

Ref #2124 