### PR TITLE
Add minimal ffmpeg build to linux wheel job envs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,10 @@ jobs:
       - checkout
       - attach_workspace:
           at: third_party
-      - run: packaging/build_wheel.sh
+      - run:
+          command: |
+            ./tools/bootstrap_ffmpeg.sh
+            packaging/build_wheel.sh
       - store_artifacts:
           path: dist
       - persist_to_workspace:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -160,7 +160,10 @@ jobs:
       - checkout
       - attach_workspace:
           at: third_party
-      - run: packaging/build_wheel.sh
+      - run:
+          command: |
+            ./tools/bootstrap_ffmpeg.sh
+            packaging/build_wheel.sh
       - store_artifacts:
           path: dist
       - persist_to_workspace:

--- a/tools/bootstrap_ffmpeg.sh
+++ b/tools/bootstrap_ffmpeg.sh
@@ -13,8 +13,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-this_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-
 cd "${build_dir}"
 
 wget --quiet -O ffmpeg.tar.gz https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n4.1.8.tar.gz

--- a/tools/bootstrap_ffmpeg.sh
+++ b/tools/bootstrap_ffmpeg.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Helper script to install MINIMUM ffmpeg in centos:7.
+# The goal of this script is to allow bootstrapping the ffmpeg-feature build
+# for Linux/wheel build process which happens in centos-based Docker.
+# It is not intended to build the useful feature subset of ffmpegs
+
+set -eux
+
+build_dir=$(mktemp -d -t ffmpeg-build-XXXXXXXXXX)
+cleanup() {
+    echo rm -rf "${build_dir}"
+}
+trap cleanup EXIT
+
+this_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+cd "${build_dir}"
+
+wget --quiet -O ffmpeg.tar.gz https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n4.1.8.tar.gz
+tar -xf ffmpeg.tar.gz --strip-components 1
+./configure \
+    --disable-all \
+    --disable-static \
+    --enable-shared \
+    --enable-pic \
+    --disable-debug \
+    --disable-doc \
+    --disable-autodetect \
+    --disable-x86asm \
+    --enable-avcodec \
+    --enable-avdevice \
+    --enable-avfilter \
+    --enable-avformat \
+    --enable-avutil
+
+make -j install


### PR DESCRIPTION
This change adds a minimal ffmpeg installation step to the build wheel job so that later, we can use the resulting ffmpeg libraries for building torchaudio's ffmpeg-features.

The linux wheel build jobs run in CentOS 8 based environment, which does not provide an easy way to install ffmpeg without conda.

After https://github.com/pytorch/audio/pull/2124 is merged, then we can enable the ffmpeg-feature build in Linux wheel.