### PR TITLE
Add HuBERT-feature support in preprocessing of HuBERT training

### DIFF
--- a/examples/hubert/utils/feature_utils.py
+++ b/examples/hubert/utils/feature_utils.py
@@ -141,7 +141,11 @@ def dump_features(
             Options: [``torch.device('cpu')``, torch.device('cuda')``].
         feature_type (str, optional): The type of the desired feature. Options: [``mfcc``, ``hubert``].
             (Default: ``mfcc``)
-        sample_rate (int, optional): The sample rate of the audio. (Default: 16000)
+        layer_index (int, optional): The index of transformer layers in ``torchaudio.models.HuBERTPretrainModel``
+            for extracting features. Only active when ``feature_type`` is set to ``hubert``. (Default: ``6``)
+        checkpoint_path(Path or None, optional): The checkpoint path of ``torchaudio.models.HuBERTPretrainModel``.
+            Only active when ``feature_type`` is set to ``hubert``. (Default: ``None``)
+        sample_rate (int, optional): The sample rate of the audio. (Default: ``16000``)
 
     Returns:
         None

--- a/examples/hubert/utils/feature_utils.py
+++ b/examples/hubert/utils/feature_utils.py
@@ -6,6 +6,7 @@
 import logging
 from pathlib import Path
 from typing import (
+    Optional,
     Tuple,
     Union,
 )
@@ -13,6 +14,7 @@ from typing import (
 import torch
 import torchaudio
 from torch import Tensor
+from torch.nn import Module
 
 from .common_utils import _get_feat_lens_paths
 
@@ -31,26 +33,24 @@ def get_shard_range(num_lines: int, num_rank: int, rank: int) -> Tuple[int, int]
         int: The start index for the current rank.
         int: The end index for the current rank.
     """
-    assert 0 <= rank < num_rank, f"invalid rank/num_rank {rank}/{num_rank}"
+    assert 1 <= rank <= num_rank, f"invalid rank/num_rank {rank}/{num_rank}"
     assert num_lines > 0, f"Found {num_lines} files, make sure you specify the correct root directory"
-    start = round(num_lines / num_rank * rank)
-    end = round(num_lines / num_rank * (rank + 1))
+    start = round(num_lines / num_rank * (rank - 1))
+    end = round(num_lines / num_rank * rank)
     _LG.info(f"rank {rank} of {num_rank}, process {end-start} " f"({start}-{end}) out of {num_lines}")
     return start, end
 
 
-def extract_feature(
+def extract_feature_mfcc(
     path: str,
     device: torch.device,
-    feature_type: str,
     sample_rate: int,
 ) -> Tensor:
-    r"""Extract features for KMeans clustering and pseudo label prediction.
+    r"""Extract MFCC features for KMeans clustering and pseudo label prediction.
     Args:
         path (str): The file path of the audio.
         device (torch.device): The location to allocate for PyTorch Tensors.
             Options: [``torch.device('cpu')``, torch.device('cuda')``].
-        feature_type (str): The type of the desired feature. Options: [``mfcc``, ``hubert``].
         sample_rate (int): The sample rate of the audio.
 
     Returns:
@@ -58,23 +58,63 @@ def extract_feature(
     """
     waveform, sr = torchaudio.load(path)
     assert sr == sample_rate
+    feature_extractor = torchaudio.transforms.MFCC(
+        sample_rate=sample_rate, n_mfcc=13, melkwargs={"n_fft": 400, "hop_length": 160, "center": False}
+    ).to(device)
     waveform = waveform[0].to(device)
-    if feature_type == "mfcc":
-        feature_extractor = torchaudio.transforms.MFCC(
-            sample_rate=sample_rate, n_mfcc=13, melkwargs={"n_fft": 400, "hop_length": 160, "center": False}
-        ).to(device)
-        mfccs = feature_extractor(waveform)  # (freq, time)
-        # mfccs = torchaudio.compliance.kaldi.mfcc(
-        #     waveform=waveform,
-        #     sample_frequency=sample_rate,
-        #     use_energy=False,
-        # )  # (time, freq)
-        # mfccs = mfccs.transpose(0, 1)  # (freq, time)
-        deltas = torchaudio.functional.compute_deltas(mfccs)
-        ddeltas = torchaudio.functional.compute_deltas(deltas)
-        concat = torch.cat([mfccs, deltas, ddeltas], dim=0)
-        concat = concat.transpose(0, 1)  # (time, freq)
-        return concat
+    mfccs = feature_extractor(waveform)  # (freq, time)
+    # mfccs = torchaudio.compliance.kaldi.mfcc(
+    #     waveform=waveform,
+    #     sample_frequency=sample_rate,
+    #     use_energy=False,
+    # )  # (time, freq)
+    # mfccs = mfccs.transpose(0, 1)  # (freq, time)
+    deltas = torchaudio.functional.compute_deltas(mfccs)
+    ddeltas = torchaudio.functional.compute_deltas(deltas)
+    concat = torch.cat([mfccs, deltas, ddeltas], dim=0)
+    feat = concat.transpose(0, 1)  # (time, freq)
+    return feat
+
+
+def extract_feature_hubert(
+    path: str,
+    device: torch.device,
+    sample_rate: int,
+    model: Module,
+    layer_index: int,
+) -> Tensor:
+    r"""Extract HuBERT features for KMeans clustering and pseudo label prediction.
+    Args:
+        path (str): The file path of the audio.
+        device (torch.device): The location to allocate for PyTorch Tensors.
+            Options: [``torch.device('cpu')``, torch.device('cuda')``].
+        sample_rate (int): The sample rate of the audio.
+        layer_index (int): The layer index in HuBERT model for feature extraction. (``1`` means the first layer output)
+
+    Returns:
+        Tensor: The desired feature tensor of the given audio file.
+    """
+    waveform, sr = torchaudio.load(path)
+    assert sr == sample_rate
+    waveform = waveform.to(device)
+    with torch.inference_mode():
+        feat = model.wav2vec2.extract_features(waveform, num_layers=layer_index)[0][-1][0]  # (time, feat_dim)
+    return feat
+
+
+def _load_state(model: Module, checkpoint_path: Path) -> Module:
+    """Load weights from HuBERTPretrainModel checkpoint into hubert_pretrain_base model.
+    Args:
+        model (Module): The hubert_pretrain_base model.
+        checkpoint_path (Path): The model checkpoint.
+
+    Returns:
+        (Module): The pretrained model.
+    """
+    state_dict = torch.load(checkpoint_path)
+    state_dict = {k.replace("model.", ""): v for k, v in state_dict["state_dict"].items()}
+    model.load_state_dict(state_dict)
+    return model
 
 
 def dump_features(
@@ -85,6 +125,8 @@ def dump_features(
     num_rank: int,
     device: torch.device,
     feature_type: str = "mfcc",
+    layer_index: int = 6,
+    checkpoint_path: Optional[Path] = None,
     sample_rate: int = 16_000,
 ) -> None:
     r"""Dump the feature tensors given a ``.tsv`` file list. The feature and lengths tensors
@@ -111,6 +153,14 @@ def dump_features(
     out_dir = Path(out_dir)
 
     feat_path, len_path = _get_feat_lens_paths(out_dir, split, rank, num_rank)
+
+    if feature_type == "hubert":
+        from torchaudio.models import hubert_pretrain_base
+
+        model = hubert_pretrain_base()
+        model = _load_state(model, checkpoint_path)
+        model.to(device)
+
     with open(tsv_file, "r") as f:
         root = f.readline().rstrip()
         lines = [line.rstrip() for line in f]
@@ -120,7 +170,10 @@ def dump_features(
             path, nsample = line.split("\t")
             path = f"{root}/{path}"
             nsample = int(nsample)
-            feature = extract_feature(path, device, feature_type, sample_rate)
+            if feature_type == "mfcc":
+                feature = extract_feature_mfcc(path, device, sample_rate)
+            else:
+                feature = extract_feature_hubert(path, device, sample_rate, model, layer_index)
             features.append(feature.cpu())
             lens.append(feature.shape[0])
     features = torch.cat(features)

--- a/examples/hubert/utils/feature_utils.py
+++ b/examples/hubert/utils/feature_utils.py
@@ -89,7 +89,10 @@ def extract_feature_hubert(
         device (torch.device): The location to allocate for PyTorch Tensors.
             Options: [``torch.device('cpu')``, torch.device('cuda')``].
         sample_rate (int): The sample rate of the audio.
-        layer_index (int): The layer index in HuBERT model for feature extraction. (``1`` means the first layer output)
+        model (Module): The loaded ``HuBERTPretrainModel`` model.
+        layer_index (int): The index of transformer layers in
+            ``torchaudio.models.HuBERTPretrainModel`` for extracting features.
+            (``1`` means the first layer output).
 
     Returns:
         Tensor: The desired feature tensor of the given audio file.
@@ -125,7 +128,7 @@ def dump_features(
     num_rank: int,
     device: torch.device,
     feature_type: str = "mfcc",
-    layer_index: int = 6,
+    layer_index: Optional[int] = None,
     checkpoint_path: Optional[Path] = None,
     sample_rate: int = 16_000,
 ) -> None:
@@ -141,8 +144,10 @@ def dump_features(
             Options: [``torch.device('cpu')``, torch.device('cuda')``].
         feature_type (str, optional): The type of the desired feature. Options: [``mfcc``, ``hubert``].
             (Default: ``mfcc``)
-        layer_index (int, optional): The index of transformer layers in ``torchaudio.models.HuBERTPretrainModel``
-            for extracting features. Only active when ``feature_type`` is set to ``hubert``. (Default: ``6``)
+        layer_index (int or None, optional): The index of transformer layers in
+            ``torchaudio.models.HuBERTPretrainModel`` for extracting features.
+            (``1`` means the first layer output). Only active when ``feature_type``
+            is set to ``hubert``. (Default: ``None``)
         checkpoint_path(Path or None, optional): The checkpoint path of ``torchaudio.models.HuBERTPretrainModel``.
             Only active when ``feature_type`` is set to ``hubert``. (Default: ``None``)
         sample_rate (int, optional): The sample rate of the audio. (Default: ``16000``)
@@ -151,7 +156,9 @@ def dump_features(
         None
     """
     if feature_type not in ["mfcc", "hubert"]:
-        raise ValueError("Unexpected feature type.")
+        raise ValueError(f"Expected feature type to be 'mfcc' or 'hubert'. Found {feature_type}.")
+    if feature_type == "hubert" and layer_index is None:
+        assert ValueError("Please set the layer_index for HuBERT feature.")
     features = []
     lens = []
     out_dir = Path(out_dir)

--- a/examples/hubert/utils/kmeans.py
+++ b/examples/hubert/utils/kmeans.py
@@ -37,7 +37,7 @@ def load_feature(
     """
     feats = []
     lens = []
-    for rank in range(num_rank):
+    for rank in range(1, num_rank + 1):
         feat_path, len_path = _get_feat_lens_paths(feat_dir, split, rank, num_rank)
         feat = torch.load(feat_path)
         length = torch.load(len_path)


### PR DESCRIPTION
The HuBERT base model requires two iterations of training.
- In the first iteration, the MFCC features of the waveforms are applied to K-Means clustering to generate the labels. The labels are then used for masked-prediction training of the HuBERT base model.
- In the second iteration, instead of MFCC feature, the outputs of the intermediate layer in the first iteration's HuBERT model are used for K-Means clustering. Then the new labels are used for training a HuBERT base model from scratch.

This PR adds support for extracting HuBERT features for K-Means model training and prediction. Users can select which layer's output to generate labels.