### PR TITLE
[DOC] Update prototype pipeline documentation

### DIFF
--- a/docs/source/prototype.pipelines.rst
+++ b/docs/source/prototype.pipelines.rst
@@ -16,20 +16,25 @@ RNNTBundle
 .. autoclass:: RNNTBundle
   :members: sample_rate, n_fft, n_mels, hop_length, segment_length, right_context_length
 
-  .. automethod:: get_decoder
+  .. automethod:: get_decoder() -> torchaudio.prototype.models.RNNTBeamSearch
 
-  .. automethod:: get_feature_extractor
+  .. automethod:: get_feature_extractor() -> RNNTBundle.FeatureExtractor
 
-  .. automethod:: get_streaming_feature_extractor
+  .. automethod:: get_streaming_feature_extractor() -> RNNTBundle.FeatureExtractor
 
-  .. automethod:: get_token_processor
+  .. automethod:: get_token_processor() -> RNNTBundle.TokenProcessor
 
-  .. autoclass:: torchaudio.prototype.pipelines::RNNTBundle.FeatureExtractor
-    :special-members: __call__
+RNNTBundle - FeatureExtractor
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  .. autoclass:: torchaudio.prototype.pipelines::RNNTBundle.TokenProcessor
-    :special-members: __call__
+.. autoclass:: torchaudio.prototype.pipelines::RNNTBundle.FeatureExtractor
+  :special-members: __call__
 
+RNNTBundle - TokenProcessor
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: torchaudio.prototype.pipelines::RNNTBundle.TokenProcessor
+  :special-members: __call__
 
 EMFORMER_RNNT_BASE_LIBRISPEECH
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- Unindent RNNTBundle components so that they show up on the right side bar
- Overwrite the sigunature of RNNTBundle methods so that back links are available

---

## Before

<img width="1440" alt="Screen Shot 2022-01-06 at 1 36 16 PM" src="https://user-images.githubusercontent.com/855818/148433552-9ba3051d-38b1-4825-9a8f-9173b23650ea.png">

## After

<img width="1436" alt="Screen Shot 2022-01-06 at 1 35 39 PM" src="https://user-images.githubusercontent.com/855818/148433525-733d138d-9a8b-43d6-bdf5-444b52d6a7a9.png">
