### PR TITLE
Use postponed evaluation to remove signature override

### DIFF
--- a/torchaudio/models/wav2vec2/model.py
+++ b/torchaudio/models/wav2vec2/model.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 from typing import Optional, Tuple, List
 
 import torch
+import torchaudio
 from torch import Tensor
 from torch.nn import Module
 
@@ -122,7 +125,8 @@ class HuBERTPretrainModel(Module):
 
     Note:
         To build the model, please use one of the factory functions in
-            `[hubert_pretrain_base, hubert_pretrain_large, hubert_pretrain_xlarge]`.
+        :py:func:`hubert_pretrain_base`, :py:func:`hubert_pretrain_large`
+        and :py:func:`hubert_pretrain_xlarge`.
 
     Args:
         feature_extractor (torch.nn.Module):
@@ -222,11 +226,8 @@ def wav2vec2_model(
     encoder_layer_norm_first: bool,
     encoder_layer_drop: float,
     aux_num_out: Optional[int],
-) -> Wav2Vec2Model:
-    # Overriding the signature so that the return type is correct on Sphinx
-    """wav2vec2_model(extractor_mode: str, extractor_conv_layer_config: Optional[List[Tuple[int, int, int]]], extractor_conv_bias: bool, encoder_embed_dim: int, encoder_projection_dropout: float, encoder_pos_conv_kernel: int, encoder_pos_conv_groups: int, encoder_num_layers: int, encoder_num_heads: int, encoder_attention_dropout: float, encoder_ff_interm_features: int, encoder_ff_interm_dropout: float, encoder_dropout: float, encoder_layer_norm_first: bool, encoder_layer_drop: float, aux_num_out: Optional[int]) -> torchaudio.models.Wav2Vec2Model
-
-    Build a custom Wav2Vec2Model
+) -> torchaudio.models.Wav2Vec2Model:
+    """Build a custom Wav2Vec2Model
 
     Note:
         The "feature extractor" below corresponds to
@@ -381,11 +382,8 @@ def wav2vec2_base(
     encoder_dropout: float = 0.1,
     encoder_layer_drop: float = 0.1,
     aux_num_out: Optional[int] = None,
-) -> Wav2Vec2Model:
-    # Overriding the signature so that the return type is correct on Sphinx
-    """wav2vec2_base(encoder_projection_dropout: float = 0.1, encoder_attention_dropout: float = 0.1, encoder_ff_interm_dropout: float = 0.1, encoder_dropout: float = 0.1, encoder_layer_drop: float = 0.1, aux_num_out: Optional[int] = None) -> torchaudio.models.Wav2Vec2Model
-
-    Build Wav2Vec2Model with "base" architecture from *wav2vec 2.0* [:footcite:`baevski2020wav2vec`]
+) -> torchaudio.models.Wav2Vec2Model:
+    """Build Wav2Vec2Model with "base" architecture from *wav2vec 2.0* [:footcite:`baevski2020wav2vec`]
 
     Args:
         encoder_projection_dropout (float):
@@ -432,11 +430,8 @@ def wav2vec2_large(
     encoder_dropout: float = 0.1,
     encoder_layer_drop: float = 0.1,
     aux_num_out: Optional[int] = None,
-) -> Wav2Vec2Model:
-    # Overriding the signature so that the return type is correct on Sphinx
-    """wav2vec2_large(encoder_projection_dropout: float = 0.1, encoder_attention_dropout: float = 0.1, encoder_ff_interm_dropout: float = 0.1, encoder_dropout: float = 0.1, encoder_layer_drop: float = 0.1, aux_num_out: Optional[int] = None) -> torchaudio.models.Wav2Vec2Model
-
-    Build Wav2Vec2Model with "large" architecture from *wav2vec 2.0* [:footcite:`baevski2020wav2vec`]
+) -> torchaudio.models.Wav2Vec2Model:
+    """Build Wav2Vec2Model with "large" architecture from *wav2vec 2.0* [:footcite:`baevski2020wav2vec`]
 
     Args:
         encoder_projection_dropout (float):
@@ -483,11 +478,8 @@ def wav2vec2_large_lv60k(
     encoder_dropout: float = 0.0,
     encoder_layer_drop: float = 0.1,
     aux_num_out: Optional[int] = None,
-) -> Wav2Vec2Model:
-    # Overriding the signature so that the return type is correct on Sphinx
-    """wav2vec2_large_lv60k( encoder_projection_dropout: float = 0.1, encoder_attention_dropout: float = 0.0, encoder_ff_interm_dropout: float = 0.1, encoder_dropout: float = 0.0, encoder_layer_drop: float = 0.1, aux_num_out: Optional[int] = None) -> torchaudio.models.Wav2Vec2Model
-
-    Build Wav2Vec2Model with "large lv-60k" architecture from *wav2vec 2.0* [:footcite:`baevski2020wav2vec`]
+) -> torchaudio.models.Wav2Vec2Model:
+    """Build Wav2Vec2Model with "large lv-60k" architecture from *wav2vec 2.0* [:footcite:`baevski2020wav2vec`]
 
     Args:
         encoder_projection_dropout (float):
@@ -534,11 +526,8 @@ def hubert_base(
     encoder_dropout: float = 0.1,
     encoder_layer_drop: float = 0.05,
     aux_num_out: Optional[int] = None,
-) -> Wav2Vec2Model:
-    # Overriding the signature so that the return type is correct on Sphinx
-    """hubert_base(encoder_projection_dropout: float = 0.1, encoder_attention_dropout: float = 0.1, encoder_ff_interm_dropout: float = 0.0, encoder_dropout: float = 0.1, encoder_layer_drop: float = 0.05, aux_num_out: Optional[int] = None) -> torchaudio.models.Wav2Vec2Model
-
-    Build HuBERT model with "base" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
+) -> torchaudio.models.Wav2Vec2Model:
+    """Build HuBERT model with "base" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
 
     Args:
         encoder_projection_dropout (float):
@@ -585,11 +574,8 @@ def hubert_large(
     encoder_dropout: float = 0.0,
     encoder_layer_drop: float = 0.0,
     aux_num_out: Optional[int] = None,
-) -> Wav2Vec2Model:
-    # Overriding the signature so that the return type is correct on Sphinx
-    """hubert_large(encoder_projection_dropout: float = 0.0, encoder_attention_dropout: float = 0.0, encoder_ff_interm_dropout: float = 0.0, encoder_dropout: float = 0.0, encoder_layer_drop: float = 0.0, aux_num_out: Optional[int] = None) -> torchaudio.models.Wav2Vec2Model
-
-    Build HuBERT model with "large" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
+) -> torchaudio.models.Wav2Vec2Model:
+    """Build HuBERT model with "large" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
 
     Args:
         encoder_projection_dropout (float):
@@ -636,11 +622,8 @@ def hubert_xlarge(
     encoder_dropout: float = 0.0,
     encoder_layer_drop: float = 0.0,
     aux_num_out: Optional[int] = None,
-) -> Wav2Vec2Model:
-    # Overriding the signature so that the return type is correct on Sphinx
-    """hubert_xlarge(encoder_projection_dropout: float = 0.0, encoder_attention_dropout: float = 0.0, encoder_ff_interm_dropout: float = 0.0, encoder_dropout: float = 0.0, encoder_layer_drop: float = 0.0, aux_num_out: Optional[int] = None) -> torchaudio.models.Wav2Vec2Model
-
-    Build HuBERT model with "extra large" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
+) -> torchaudio.models.Wav2Vec2Model:
+    """Build HuBERT model with "extra large" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
 
     Args:
         encoder_projection_dropout (float):
@@ -712,11 +695,8 @@ def hubert_pretrain_model(
     skip_nomask: bool,
     num_classes: int,
     final_dim: int,
-) -> HuBERTPretrainModel:
-    # Overriding the signature so that the return type is correct on Sphinx
-    """hubert_pretrain_model(extractor_mode: str, extractor_conv_layer_config: Optional[List[Tuple[int, int, int]]], extractor_conv_bias: bool, encoder_embed_dim: int, encoder_projection_dropout: float, encoder_pos_conv_kernel: int, encoder_pos_conv_groups: int, encoder_num_layers: int, encoder_num_heads: int, encoder_attention_dropout: float, encoder_ff_interm_features: int, encoder_ff_interm_dropout: float, encoder_dropout: float, encoder_layer_norm_first: bool, encoder_layer_drop: float, mask_prob: float, mask_selection: str, mask_other: float, mask_length: int, no_mask_overlap: bool, mask_min_space: int, mask_channel_prob: float, mask_channel_selection: str, mask_channel_other: float, mask_channel_length: int, no_mask_channel_overlap: bool, mask_channel_min_space: int, skip_masked: bool, skip_nomask: bool, num_classes: int, final_dim: int) -> torchaudio.models.HuBERTPretrainModel
-
-    Build a custom HuBERTPretrainModel for training from scratch
+) -> torchaudio.models.HuBERTPretrainModel:
+    """Build a custom HuBERTPretrainModel for training from scratch
 
     Note:
         The "feature extractor" below corresponds to
@@ -968,11 +948,8 @@ def hubert_pretrain_base(
     encoder_dropout: float = 0.1,
     encoder_layer_drop: float = 0.05,
     num_classes: int = 100,
-) -> HuBERTPretrainModel:
-    # Overriding the signature so that the return type is correct on Sphinx
-    """hubert_pretrain_base(encoder_projection_dropout: float = 0.1, encoder_attention_dropout: float = 0.1, encoder_ff_interm_dropout: float = 0.0, encoder_dropout: float = 0.1, encoder_layer_drop: float = 0.05, num_classes: int = 100) -> torchaudio.models.HuBERTPretrainModel
-
-    Build HuBERTPretrainModel model with "base" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
+) -> torchaudio.models.HuBERTPretrainModel:
+    """Build HuBERTPretrainModel model with "base" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
 
     Args:
         encoder_projection_dropout (float):
@@ -1033,11 +1010,8 @@ def hubert_pretrain_large(
     encoder_ff_interm_dropout: float = 0.0,
     encoder_dropout: float = 0.0,
     encoder_layer_drop: float = 0.0,
-) -> HuBERTPretrainModel:
-    # Overriding the signature so that the return type is correct on Sphinx
-    """hubert_pretrain_large(encoder_projection_dropout: float = 0.0, encoder_attention_dropout: float = 0.0, encoder_ff_interm_dropout: float = 0.0, encoder_dropout: float = 0.0, encoder_layer_drop: float = 0.0) -> torchaudio.models.HuBERTPretrainModel
-
-    Build HuBERTPretrainModel model for pre-training with "large" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
+) -> torchaudio.models.HuBERTPretrainModel:
+    """Build HuBERTPretrainModel model for pre-training with "large" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
 
     Args:
         encoder_projection_dropout (float):
@@ -1096,11 +1070,8 @@ def hubert_pretrain_xlarge(
     encoder_ff_interm_dropout: float = 0.0,
     encoder_dropout: float = 0.0,
     encoder_layer_drop: float = 0.0,
-) -> HuBERTPretrainModel:
-    # Overriding the signature so that the return type is correct on Sphinx
-    """hubert_pretrain_xlarge(encoder_projection_dropout: float = 0.0, encoder_attention_dropout: float = 0.0, encoder_ff_interm_dropout: float = 0.0, encoder_dropout: float = 0.0, encoder_layer_drop: float = 0.0) -> torchaudio.models.HuBERTPretrainModel
-
-    Build HuBERTPretrainModel model for pre-training with "extra large" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
+) -> torchaudio.models.HuBERTPretrainModel:
+    """Build HuBERTPretrainModel model for pre-training with "extra large" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
 
     Args:
         encoder_projection_dropout (float):


### PR DESCRIPTION
Python 3.7 introduced postponed evaluation of annotation. https://docs.python.org/3/whatsnew/3.7.html

Enabling this allows the code to use the exported name in annotation.
As a result we can directly annotate functions with exported name, and this way, Sphinx displays the output class in exported name without manually overriding the signature.