### PR TITLE
Add subset support for TEDLIUM release3 dataset

### DIFF
--- a/torchaudio/datasets/tedlium.py
+++ b/torchaudio/datasets/tedlium.py
@@ -52,17 +52,17 @@ class TEDLIUM(Dataset):
             Allowed values are ``"release1"``, ``"release2"`` or ``"release3"``.
             (default: ``"release1"``).
         subset (str, optional): The subset of dataset to use. Valid options are ``"train"``, ``"dev"``,
-            and ``"test"`` for releases 1&2, ``None`` for release3. Defaults to ``"train"`` or ``None``.
+            and ``"test"``. Defaults to ``"train"``.
         download (bool, optional):
             Whether to download the dataset if it is not found at root path. (default: ``False``).
-        audio_ext (str, optional): extension for audio file (default: ``"audio_ext"``)
+        audio_ext (str, optional): extension for audio file (default: ``".sph"``)
     """
 
     def __init__(
         self,
         root: Union[str, Path],
         release: str = "release1",
-        subset: str = None,
+        subset: str = "train",
         download: bool = False,
         audio_ext: str = ".sph",
     ) -> None:
@@ -96,10 +96,11 @@ class TEDLIUM(Dataset):
 
         basename = basename.split(".")[0]
 
-        if release == "release3" and subset == "train":
-            self._path = os.path.join(root, folder_in_archive, _RELEASE_CONFIGS[release]["data_path"])
-        elif release == "release3" and subset in ["dev", "test"]:
-            self._path = os.path.join(root, folder_in_archive, "legacy", subset)
+        if release == "release3":
+            if subset == "train":
+                self._path = os.path.join(root, folder_in_archive, _RELEASE_CONFIGS[release]["data_path"])
+            else:
+                self._path = os.path.join(root, folder_in_archive, "legacy", subset)
         else:
             self._path = os.path.join(root, folder_in_archive, _RELEASE_CONFIGS[release]["data_path"], subset)
 

--- a/torchaudio/datasets/tedlium.py
+++ b/torchaudio/datasets/tedlium.py
@@ -35,8 +35,8 @@ _RELEASE_CONFIGS = {
         "url": "http://www.openslr.org/resources/51/TEDLIUM_release-3.tgz",
         "checksum": "ad1e454d14d1ad550bc2564c462d87c7a7ec83d4dc2b9210f22ab4973b9eccdb",
         "data_path": "data/",
-        "subset": None,
-        "supported_subsets": [None],
+        "subset": "train",
+        "supported_subsets": ["train", "test", "dev"],
         "dict": "TEDLIUM.152k.dic",
     },
 }
@@ -96,9 +96,12 @@ class TEDLIUM(Dataset):
 
         basename = basename.split(".")[0]
 
-        self._path = os.path.join(root, folder_in_archive, _RELEASE_CONFIGS[release]["data_path"])
-        if subset in ["train", "dev", "test"]:
-            self._path = os.path.join(self._path, subset)
+        if release == "release3" and subset == "train":
+            self._path = os.path.join(root, folder_in_archive, _RELEASE_CONFIGS[release]["data_path"])
+        elif release == "release3" and subset in ["dev", "test"]:
+            self._path = os.path.join(root, folder_in_archive, "legacy", subset)
+        else:
+            self._path = os.path.join(root, folder_in_archive, _RELEASE_CONFIGS[release]["data_path"], subset)
 
         if download:
             if not os.path.isdir(self._path):


### PR DESCRIPTION
According to [the dataset discription](https://paperswithcode.com/dataset/ted-lium-3), the ``dev`` and ``test`` subsets of TEDLIUM v3 dataset are the same as v2. (under ``TEDLIUM_release-3/legacy`` directory). The ``train`` subset is under ``TEDLIUM_release-3/data`` directory. This PR adds subset support for it.

This also aligns with [TensorFlow's tedlium/release3](https://www.tensorflow.org/datasets/catalog/tedlium#tedliumrelease3) dataset.