### PR TITLE
Update PR labeling workflow

### DIFF
--- a/.github/process_commit.py
+++ b/.github/process_commit.py
@@ -66,8 +66,9 @@ if __name__ == "__main__":
     commit_hash = sys.argv[1]
 
     merger, pr_number = get_pr_merger_and_number(commit_hash)
-    labels = get_labels(pr_number)
-    is_properly_labeled = bool(PRIMARY_LABELS.intersection(labels) and SECONDARY_LABELS.intersection(labels))
+    if pr_number:
+        labels = get_labels(pr_number)
+        is_properly_labeled = bool(PRIMARY_LABELS.intersection(labels) and SECONDARY_LABELS.intersection(labels))
 
-    if not is_properly_labeled:
-        print(f"@{merger}")
+        if not is_properly_labeled:
+            print(f"@{merger}")

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,9 +1,9 @@
 name: pr-labels
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types:
+      - closed
 
 jobs:
   is-properly-labeled:


### PR DESCRIPTION
update the labeling reminder to be triggered when PRs are closed rather than merged, because of the transition of merging through fbcode