### PR TITLE
Add `is_ffmpeg_available` in test

### DIFF
--- a/test/torchaudio_unittest/common_utils/__init__.py
+++ b/test/torchaudio_unittest/common_utils/__init__.py
@@ -7,6 +7,7 @@ from .case_utils import (
     TestBaseMixin,
     PytorchTestCase,
     TorchaudioTestCase,
+    is_ffmpeg_available,
     skipIfNoCtcDecoder,
     skipIfNoCuda,
     skipIfNoExec,
@@ -15,6 +16,7 @@ from .case_utils import (
     skipIfNoSox,
     skipIfRocm,
     skipIfNoQengine,
+    skipIfNoFFmpeg,
 )
 from .data_utils import (
     get_asset_path,
@@ -31,7 +33,6 @@ from .wav_utils import (
     save_wav,
 )
 
-
 __all__ = [
     "get_asset_path",
     "get_whitenoise",
@@ -43,6 +44,7 @@ __all__ = [
     "TestBaseMixin",
     "PytorchTestCase",
     "TorchaudioTestCase",
+    "is_ffmpeg_available",
     "skipIfNoCtcDecoder",
     "skipIfNoCuda",
     "skipIfNoExec",
@@ -52,6 +54,7 @@ __all__ = [
     "skipIfNoSoxBackend",
     "skipIfRocm",
     "skipIfNoQengine",
+    "skipIfNoFFmpeg",
     "get_wav_data",
     "normalize_wav",
     "load_wav",

--- a/test/torchaudio_unittest/common_utils/case_utils.py
+++ b/test/torchaudio_unittest/common_utils/case_utils.py
@@ -7,6 +7,7 @@ import time
 import unittest
 
 import torch
+import torchaudio
 from torch.testing._internal.common_utils import TestCase as PytorchTestCase
 from torchaudio._internal.module_utils import is_module_available, is_sox_available, is_kaldi_available
 
@@ -93,6 +94,13 @@ class TestBaseMixin:
 
 class TorchaudioTestCase(TestBaseMixin, PytorchTestCase):
     pass
+
+
+def is_ffmpeg_available():
+    try:
+        return torchaudio._extension._load_lib("libtorchaudio_ffmpeg")
+    except Exception:
+        return False
 
 
 def _eval_env(var, default):
@@ -198,4 +206,9 @@ skipIfNoQengine = _skipIf(
     "fbgemm" not in torch.backends.quantized.supported_engines,
     reason="`fbgemm` is not available.",
     key="NO_QUANTIZATION",
+)
+skipIfNoFFmpeg = _skipIf(
+    not is_ffmpeg_available(),
+    reason="ffmpeg features are not available.",
+    key="NO_FFMPEG",
 )

--- a/torchaudio/_extension.py
+++ b/torchaudio/_extension.py
@@ -37,9 +37,13 @@ def _load_lib(lib: str) -> bool:
 
     Raises:
         Exception:
-            Any exception thrown when loading the library.
+            If the library file is found, but there is an issue loading the library file,
+            (when underlying `ctype.DLL` throws an exception), this function will pass
+            the exception as-is, instead of catching it and returning bool.
             The expected case is `OSError` thrown by `ctype.DLL` when a dynamic dependency
             is not found.
+            This behavior was chosen because the expected failure case is not recoverable.
+            If a dependency is missing, then users have to install it.
     """
     path = _get_lib_path(lib)
     if not path.exists():

--- a/torchaudio/_extension.py
+++ b/torchaudio/_extension.py
@@ -18,8 +18,8 @@ def _load_lib(lib: str) -> bool:
     """Load extension module
 
     Note:
-        In case `torchaudio` is deployed with `pex` format, the library file does not
-        exist as a stand alone file.
+        In case `torchaudio` is deployed with `pex` format, the library file
+        is not in a standard location.
         In this case, we expect that `libtorchaudio` is available somewhere
         in the search path of dynamic loading mechanism, so that importing
         `_torchaudio` will have library loader find and load `libtorchaudio`.
@@ -28,13 +28,18 @@ def _load_lib(lib: str) -> bool:
 
     Returns:
         bool:
-            False if the library file is not found.
             True if the library file is found AND the library loaded without failure.
+            False if the library file is not found (like in the case where torchaudio
+            is deployed with pex format, thus the shared library file is
+            in a non-standard location.).
+            If the library file is found but there is an issue loading the library,
+            (such as missing dependency) then this function raises the exception as-is.
 
     Raises:
         Exception:
-            Exception thrown by the underlying `ctypes.CDLL`.
-            Expected case is `OSError` when a dynamic dependency is not found.
+            Any exception thrown when loading the library.
+            The expected case is `OSError` thrown by `ctype.DLL` when a dynamic dependency
+            is not found.
     """
     path = _get_lib_path(lib)
     if not path.exists():


### PR DESCRIPTION
Part of #2164.
To make the tests introduced in #2164 skippable if ffmpeg features are not available,
this commit adds `is_ffmpeg_available`.

The availability of the features depend on two factors;
1. If it was enabled at build.
2. If the ffmpeg libraries are found at runtime.

A simple way (for OSS workflow) to detect these is simply checking if
`libtorchaudio_ffmpeg` presents and can be loaded without a failure.

To facilitate this, this commit changes the
`torchaudio._extension._load_lib` to return boolean result.