### PR TITLE
Register RNN-T pipeline global stats constants as buffers

### DIFF
--- a/torchaudio/prototype/pipelines/rnnt_pipeline.py
+++ b/torchaudio/prototype/pipelines/rnnt_pipeline.py
@@ -52,8 +52,8 @@ class _GlobalStatsNormalization(torch.nn.Module):
         with open(global_stats_path) as f:
             blob = json.loads(f.read())
 
-        self.mean = torch.tensor(blob["mean"])
-        self.invstddev = torch.tensor(blob["invstddev"])
+        self.register_buffer("mean", torch.tensor(blob["mean"]))
+        self.register_buffer("invstddev", torch.tensor(blob["invstddev"]))
 
     def forward(self, input):
         return (input - self.mean) * self.invstddev


### PR DESCRIPTION
Currently, `mean` and `invstddev` exist as vanilla object attributes in the global stats normalization module that uses them. This, however, would preclude them from being moved to the same device that the module is moved to. To resolve this, this PR registers them as buffers.