### PR TITLE
[CI] Pin flake8 version

### DIFF
--- a/.circleci/unittest/linux/scripts/run_style_checks.sh
+++ b/.circleci/unittest/linux/scripts/run_style_checks.sh
@@ -11,7 +11,7 @@ eval "$("${conda_dir}/bin/conda" shell.bash hook)"
 conda activate "${env_dir}"
 
 # 1. Install tools
-conda install flake8
+conda install -y flake8==3.9.2
 printf "Installed flake8: "
 flake8 --version
 


### PR DESCRIPTION
This fixes:
```
Installed flake8: + flake8 --version
Traceback (most recent call last):
  File "/root/project/env/bin/flake8", line 6, in <module>
    from flake8.main.cli import main
  File "/root/project/env/lib/python3.7/site-packages/flake8/main/cli.py", line 6, in <module>
    from flake8.main import application
  File "/root/project/env/lib/python3.7/site-packages/flake8/main/application.py", line 24, in <module>
    from flake8.plugins import manager as plugin_manager
  File "/root/project/env/lib/python3.7/site-packages/flake8/plugins/manager.py", line 11, in <module>
    from flake8._compat import importlib_metadata
  File "/root/project/env/lib/python3.7/site-packages/flake8/_compat.py", line 7, in <module>
    import importlib_metadata
ModuleNotFoundError: No module named 'importlib_metata'
```
