### PR TITLE
Improve ffmpeg library discovery

### DIFF
--- a/cmake/FindFFMPEG.cmake
+++ b/cmake/FindFFMPEG.cmake
@@ -53,7 +53,6 @@ The following components are supported:
   * `avdevice`
   * `avfilter`
   * `avformat`
-  * `avresample`
   * `avutil`
   * `swresample`
   * `swscale`
@@ -75,7 +74,15 @@ function (_ffmpeg_find component headername)
     NAMES
       "lib${component}/${headername}"
     PATHS
-      "${FFMPEG_ROOT}/include"
+      "$ENV{FFMPEG_ROOT}/include"
+    PATH_SUFFIXES
+      ffmpeg
+    DOC "FFMPEG's ${component} include directory"
+    NO_DEFAULT_PATH)
+  find_path("FFMPEG_${component}_INCLUDE_DIR"
+    NAMES
+      "lib${component}/${headername}"
+    PATHS
       "$ENV{CONDA_PREFIX}/include"
       ~/Library/Frameworks
       /Library/Frameworks
@@ -101,7 +108,13 @@ function (_ffmpeg_find component headername)
     NAMES
       "${component}"
     PATHS
-      "${FFMPEG_ROOT}/lib"
+      "$ENV{FFMPEG_ROOT}/lib"
+    DOC "FFMPEG's ${component} library"
+    NO_DEFAULT_PATH)
+  find_library("FFMPEG_${component}_LIBRARY"
+    NAMES
+      "${component}"
+    PATHS
       "$ENV{CONDA_PREFIX}/lib"
       ~/Library/Frameworks
       /Library/Frameworks
@@ -114,7 +127,7 @@ function (_ffmpeg_find component headername)
       /opt/csw/lib
       /opt/lib
       /usr/freeware/lib64
-      "${FFMPEG_ROOT}/bin"
+      "$ENV{FFMPEG_ROOT}/bin"
     DOC "FFMPEG's ${component} library")
   mark_as_advanced("FFMPEG_${component}_LIBRARY")
 
@@ -176,8 +189,6 @@ function (_ffmpeg_find component headername)
 endfunction ()
 
 _ffmpeg_find(avutil     avutil.h)
-_ffmpeg_find(avresample avresample.h
-  avutil)
 _ffmpeg_find(swresample swresample.h
   avutil)
 _ffmpeg_find(swscale    swscale.h

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -14,17 +14,6 @@ if (BUILD_SOX)
 endif()
 
 ################################################################################
-# ffmpeg
-################################################################################
-if (BUILD_FFMPEG)
-  set(FFMPEG_FIND_COMPONENTS avdevice avfilter avformat avcodec avutil)
-  include(FindFFMPEG)
-  add_library(ffmpeg INTERFACE)
-  target_include_directories(ffmpeg INTERFACE ${FFMPEG_INCLUDE_DIRS})
-  target_link_libraries(ffmpeg INTERFACE ${FFMPEG_LIBRARIES})
-endif()
-
-################################################################################
 # kaldi
 ################################################################################
 if (BUILD_KALDI)

--- a/torchaudio/csrc/CMakeLists.txt
+++ b/torchaudio/csrc/CMakeLists.txt
@@ -178,12 +178,13 @@ if(BUILD_FFMPEG)
     ffmpeg/stream_processor.cpp
     ffmpeg/streamer.cpp
     )
-define_library(
-  libtorchaudio_ffmpeg
-  "${LIBTORCHAUDIO_FFMPEG_SOURCES}"
-  "${LIBTORCHAUDIO_INCLUDE_DIRS}"
-  "torch;ffmpeg"
-  "${LIBTORCHAUDIO_COMPILE_DEFINITIONS}"
+  find_package(FFMPEG 4.1 REQUIRED COMPONENTS avdevice avfilter avformat avcodec avutil)
+  define_library(
+    libtorchaudio_ffmpeg
+    "${LIBTORCHAUDIO_FFMPEG_SOURCES}"
+    "${LIBTORCHAUDIO_INCLUDE_DIRS};${FFMPEG_INCLUDE_DIRS}"
+    "torch;${FFMPEG_LIBRARIES}"
+    "${LIBTORCHAUDIO_COMPILE_DEFINITIONS}"
   )
 endif()
 


### PR DESCRIPTION
This commit fixes the issue with ffmpeg discovery at build time.
The original implementation had issues like.

1. Wrong usage of FindFFMPEG, which caused mixture of ffmpeg libraries from system directory and user directory.
2. The optional `FFMPEG_ROOT` variable was not set within cmake.

The issue 1 is problematic when a user does not have a permission to
modify the environment. For example, an old version of ffmpeg, which is
installed in a directory managed by the system (such as `/usr/local/lib`),
then there is no way to specify a path in which user installs a supported version
of ffmpeg.

This commit changes the behavior by first searching the library
in `FFMPEG_ROOT` environment variables, then
resorting to the original behavior of searching the custom paths with
system default path.

Also this commirt removes support for `libavresample`, which is deprecated in
ffmpeg 4 and removed in ffmpeg 5.