### PR TITLE
Add EMFORMER_RNNT_BASE_MUSTC bundle

### DIFF
--- a/docs/source/prototype.pipelines.rst
+++ b/docs/source/prototype.pipelines.rst
@@ -9,6 +9,14 @@ The pipelines subpackage contains APIs to models with pretrained weights and rel
 RNN-T Streaming/Non-Streaming ASR
 ---------------------------------
 
+EMFORMER_RNNT_BASE_MUSTC
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. container:: py attribute
+
+   .. autodata:: EMFORMER_RNNT_BASE_MUSTC
+      :no-value:
+
 EMFORMER_RNNT_BASE_TEDLIUM3
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/examples/asr/emformer_rnnt/README.md
+++ b/examples/asr/emformer_rnnt/README.md
@@ -30,7 +30,7 @@ srun --cpus-per-task=12 --gpus-per-node=8 -N 4 --ntasks-per-node=8 python train.
 
 Sample SLURM command for evaluation:
 ```
-srun python eval.py --model_type librispeech --checkpoint_path ./experiments/checkpoints/epoch=119-step=208079.ckpt --dataset-path ./datasets/librispeech  --sp-model-path ./spm_bpe_4096.model --use-cuda
+srun python eval.py --model-type librispeech --checkpoint-path ./experiments/checkpoints/epoch=119-step=208079.ckpt --dataset-path ./datasets/librispeech  --sp-model-path ./spm_bpe_4096.model --use-cuda
 ```
 
 The script used for training the SentencePiece model that's referenced by the training command above can be found at [`librispeech/train_spm.py`](./librispeech/train_spm.py); a pretrained SentencePiece model can be downloaded [here](https://download.pytorch.org/torchaudio/pipeline-assets/spm_bpe_4096_librispeech.model).

--- a/examples/asr/emformer_rnnt/eval.py
+++ b/examples/asr/emformer_rnnt/eval.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python
 import logging
 import pathlib
-from argparse import ArgumentParser
+from argparse import ArgumentParser, RawTextHelpFormatter
 
 import torch
 import torchaudio
@@ -10,7 +11,7 @@ from mustc.lightning import MuSTCRNNTModule
 from tedlium3.lightning import TEDLIUM3RNNTModule
 
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def compute_word_level_distance(seq1, seq2):
@@ -78,7 +79,7 @@ def get_lightning_module(args):
 
 
 def parse_args():
-    parser = ArgumentParser()
+    parser = ArgumentParser(description=__doc__, formatter_class=RawTextHelpFormatter)
     parser.add_argument(
         "--model-type", type=str, choices=[MODEL_TYPE_LIBRISPEECH, MODEL_TYPE_TEDLIUM3, MODEL_TYPE_MUSTC], required=True
     )

--- a/examples/asr/emformer_rnnt/eval.py
+++ b/examples/asr/emformer_rnnt/eval.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import logging
 import pathlib
 from argparse import ArgumentParser, RawTextHelpFormatter

--- a/examples/asr/emformer_rnnt/global_stats.py
+++ b/examples/asr/emformer_rnnt/global_stats.py
@@ -1,7 +1,8 @@
+#!/usr/bin/env python
 """Generate feature statistics for training set.
 
 Example:
-python global_stats.py --model_type librispeech --dataset_path /home/librispeech
+python global_stats.py --model-type librispeech --dataset-path /home/librispeech
 """
 
 import json

--- a/examples/asr/emformer_rnnt/global_stats.py
+++ b/examples/asr/emformer_rnnt/global_stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Generate feature statistics for training set.
 
 Example:

--- a/examples/asr/emformer_rnnt/librispeech/train_spm.py
+++ b/examples/asr/emformer_rnnt/librispeech/train_spm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Trains a SentencePiece model on transcripts across LibriSpeech train-clean-100, train-clean-360, and train-other-500.
 
 Example:

--- a/examples/asr/emformer_rnnt/librispeech/train_spm.py
+++ b/examples/asr/emformer_rnnt/librispeech/train_spm.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """Trains a SentencePiece model on transcripts across LibriSpeech train-clean-100, train-clean-360, and train-other-500.
 
 Example:

--- a/examples/asr/emformer_rnnt/mustc/train_spm.py
+++ b/examples/asr/emformer_rnnt/mustc/train_spm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Train the SentencePiece model by using the transcripts of MuST-C release v2.0 training set.
 Example:
 python train_spm.py --mustc-path /home/datasets/

--- a/examples/asr/emformer_rnnt/mustc/train_spm.py
+++ b/examples/asr/emformer_rnnt/mustc/train_spm.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """Train the SentencePiece model by using the transcripts of MuST-C release v2.0 training set.
 Example:
 python train_spm.py --mustc-path /home/datasets/

--- a/examples/asr/emformer_rnnt/pipeline_demo.py
+++ b/examples/asr/emformer_rnnt/pipeline_demo.py
@@ -1,38 +1,39 @@
+#!/usr/bin/env python
+"""Train the SentencePiece model by using the transcripts of MuST-C release v2.0 training set.
+Example:
+python pipeline_demo.py --model-type librispeech --dataset-path ./datasets/librispeech
+"""
 import logging
 import pathlib
-from argparse import ArgumentParser
+from argparse import ArgumentParser, RawTextHelpFormatter
+from functools import partial
 
 import torch
 import torchaudio
-from common import MODEL_TYPE_LIBRISPEECH, MODEL_TYPE_TEDLIUM3
+from common import MODEL_TYPE_LIBRISPEECH, MODEL_TYPE_MUSTC, MODEL_TYPE_TEDLIUM3
+from mustc.dataset import MUSTC
 from torchaudio.pipelines import EMFORMER_RNNT_BASE_LIBRISPEECH
-from torchaudio.prototype.pipelines import EMFORMER_RNNT_BASE_TEDLIUM3
+from torchaudio.prototype.pipelines import EMFORMER_RNNT_BASE_MUSTC, EMFORMER_RNNT_BASE_TEDLIUM3
+
+logger = logging.getLogger(__name__)
 
 
-logger = logging.getLogger()
+BUNBLES = {
+    MODEL_TYPE_LIBRISPEECH: EMFORMER_RNNT_BASE_LIBRISPEECH,
+    MODEL_TYPE_MUSTC: EMFORMER_RNNT_BASE_MUSTC,
+    MODEL_TYPE_TEDLIUM3: EMFORMER_RNNT_BASE_TEDLIUM3,
+}
 
-
-def get_dataset(model_type, dataset_path):
-    if model_type == MODEL_TYPE_LIBRISPEECH:
-        return torchaudio.datasets.LIBRISPEECH(dataset_path, url="test-clean")
-    elif model_type == MODEL_TYPE_TEDLIUM3:
-        return torchaudio.datasets.TEDLIUM(dataset_path, release="release3", subset="test")
-    else:
-        raise ValueError(f"Encountered unsupported model type {model_type}.")
-
-
-def get_pipeline_bundle(model_type):
-    if model_type == MODEL_TYPE_LIBRISPEECH:
-        return EMFORMER_RNNT_BASE_LIBRISPEECH
-    elif model_type == MODEL_TYPE_TEDLIUM3:
-        return EMFORMER_RNNT_BASE_TEDLIUM3
-    else:
-        raise ValueError(f"Encountered unsupported model type {model_type}.")
+DATASETS = {
+    MODEL_TYPE_LIBRISPEECH: partial(torchaudio.datasets.LIBRISPEECH, url="test-clean"),
+    MODEL_TYPE_MUSTC: partial(MUSTC, subset="tst-HE"),
+    MODEL_TYPE_TEDLIUM3: partial(torchaudio.datasets.TEDLIUM, release="release3", subset="test"),
+}
 
 
 def run_eval_streaming(args):
-    dataset = get_dataset(args.model_type, args.dataset_path)
-    bundle = get_pipeline_bundle(args.model_type)
+    dataset = DATASETS[args.model_type](args.dataset_path)
+    bundle = BUNBLES[args.model_type]
     decoder = bundle.get_decoder()
     token_processor = bundle.get_token_processor()
     feature_extractor = bundle.get_feature_extractor()
@@ -66,10 +67,12 @@ def run_eval_streaming(args):
 
 
 def parse_args():
-    parser = ArgumentParser()
-    parser.add_argument("--model_type", type=str, choices=[MODEL_TYPE_LIBRISPEECH, MODEL_TYPE_TEDLIUM3], required=True)
+    parser = ArgumentParser(description=__doc__, formatter_class=RawTextHelpFormatter)
     parser.add_argument(
-        "--dataset_path",
+        "--model-type", type=str, choices=[MODEL_TYPE_LIBRISPEECH, MODEL_TYPE_MUSTC, MODEL_TYPE_TEDLIUM3], required=True
+    )
+    parser.add_argument(
+        "--dataset-path",
         type=pathlib.Path,
         help="Path to dataset.",
         required=True,

--- a/examples/asr/emformer_rnnt/tedlium3/eval_pipeline.py
+++ b/examples/asr/emformer_rnnt/tedlium3/eval_pipeline.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import logging
 import pathlib
 from argparse import ArgumentParser, RawTextHelpFormatter

--- a/examples/asr/emformer_rnnt/tedlium3/eval_pipeline.py
+++ b/examples/asr/emformer_rnnt/tedlium3/eval_pipeline.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import logging
 import pathlib
 from argparse import ArgumentParser, RawTextHelpFormatter

--- a/examples/asr/emformer_rnnt/tedlium3/lightning.py
+++ b/examples/asr/emformer_rnnt/tedlium3/lightning.py
@@ -197,8 +197,8 @@ class TEDLIUM3RNNTModule(LightningModule):
     def validation_step(self, batch, batch_idx):
         return self._step(batch, batch_idx, "val")
 
-    def test_step(self, batch, batch_idx):
-        return self._step(batch, batch_idx, "test")
+    def test_step(self, batch_tuple, batch_idx):
+        return self._step(batch_tuple[0], batch_idx, "test")
 
     def train_dataloader(self):
         dataset = CustomDataset(torchaudio.datasets.TEDLIUM(self.tedlium_path, release="release3", subset="train"), 100)

--- a/examples/asr/emformer_rnnt/tedlium3/train_spm.py
+++ b/examples/asr/emformer_rnnt/tedlium3/train_spm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Train the SentencePiece model by using the transcripts of TED-LIUM release 3 training set.
 Example:
 python train_spm.py --tedlium-path /home/datasets/

--- a/examples/asr/emformer_rnnt/tedlium3/train_spm.py
+++ b/examples/asr/emformer_rnnt/tedlium3/train_spm.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """Train the SentencePiece model by using the transcripts of TED-LIUM release 3 training set.
 Example:
 python train_spm.py --tedlium-path /home/datasets/

--- a/examples/asr/emformer_rnnt/train.py
+++ b/examples/asr/emformer_rnnt/train.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import logging
 import pathlib
 from argparse import ArgumentParser

--- a/examples/asr/emformer_rnnt/train.py
+++ b/examples/asr/emformer_rnnt/train.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import logging
 import pathlib
 from argparse import ArgumentParser

--- a/test/torchaudio_unittest/example/emformer_rnnt/test_librispeech_lightning.py
+++ b/test/torchaudio_unittest/example/emformer_rnnt/test_librispeech_lightning.py
@@ -1,35 +1,15 @@
 from contextlib import contextmanager
+from functools import partial
 from unittest.mock import patch
 
 import torch
 from torchaudio._internal.module_utils import is_module_available
 from torchaudio_unittest.common_utils import TorchaudioTestCase, skipIfNoModule
 
+from .test_utils import MockSentencePieceProcessor, MockCustomDataset
+
 if is_module_available("pytorch_lightning", "sentencepiece"):
     from asr.emformer_rnnt.librispeech.lightning import LibriSpeechRNNTModule
-
-
-class MockSentencePieceProcessor:
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def get_piece_size(self):
-        return 4096
-
-    def encode(self, input):
-        return [1, 5, 2]
-
-    def decode(self, input):
-        return "hey"
-
-    def unk_id(self):
-        return 0
-
-    def eos_id(self):
-        return 1
-
-    def pad_id(self):
-        return 2
 
 
 class MockLIBRISPEECH:
@@ -50,22 +30,13 @@ class MockLIBRISPEECH:
         return 10
 
 
-class MockCustomDataset:
-    def __init__(self, base_dataset, *args, **kwargs):
-        self.base_dataset = base_dataset
-
-    def __getitem__(self, n: int):
-        return [self.base_dataset[n]]
-
-    def __len__(self):
-        return len(self.base_dataset)
-
-
 @contextmanager
 def get_lightning_module():
-    with patch("sentencepiece.SentencePieceProcessor", new=MockSentencePieceProcessor), patch(
-        "asr.emformer_rnnt.librispeech.lightning.GlobalStatsNormalization", new=torch.nn.Identity
-    ), patch("torchaudio.datasets.LIBRISPEECH", new=MockLIBRISPEECH), patch(
+    with patch(
+        "sentencepiece.SentencePieceProcessor", new=partial(MockSentencePieceProcessor, num_symbols=4096)
+    ), patch("asr.emformer_rnnt.librispeech.lightning.GlobalStatsNormalization", new=torch.nn.Identity), patch(
+        "torchaudio.datasets.LIBRISPEECH", new=MockLIBRISPEECH
+    ), patch(
         "asr.emformer_rnnt.librispeech.lightning.CustomDataset", new=MockCustomDataset
     ):
         yield LibriSpeechRNNTModule(

--- a/test/torchaudio_unittest/example/emformer_rnnt/test_mustc_lightning.py
+++ b/test/torchaudio_unittest/example/emformer_rnnt/test_mustc_lightning.py
@@ -1,35 +1,15 @@
 from contextlib import contextmanager
+from functools import partial
 from unittest.mock import patch
 
 import torch
 from torchaudio._internal.module_utils import is_module_available
 from torchaudio_unittest.common_utils import TorchaudioTestCase, skipIfNoModule
 
+from .test_utils import MockSentencePieceProcessor, MockCustomDataset
+
 if is_module_available("pytorch_lightning", "sentencepiece"):
     from asr.emformer_rnnt.mustc.lightning import MuSTCRNNTModule
-
-
-class MockSentencePieceProcessor:
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def get_piece_size(self):
-        return 500
-
-    def encode(self, input):
-        return [1, 5, 2]
-
-    def decode(self, input):
-        return "hey"
-
-    def unk_id(self):
-        return 0
-
-    def eos_id(self):
-        return 1
-
-    def pad_id(self):
-        return 2
 
 
 class MockMUSTC:
@@ -46,20 +26,9 @@ class MockMUSTC:
         return 10
 
 
-class MockCustomDataset:
-    def __init__(self, base_dataset, *args, **kwargs):
-        self.base_dataset = base_dataset
-
-    def __getitem__(self, n: int):
-        return [self.base_dataset[n]]
-
-    def __len__(self):
-        return len(self.base_dataset)
-
-
 @contextmanager
 def get_lightning_module():
-    with patch("sentencepiece.SentencePieceProcessor", new=MockSentencePieceProcessor), patch(
+    with patch("sentencepiece.SentencePieceProcessor", new=partial(MockSentencePieceProcessor, num_symbols=500)), patch(
         "asr.emformer_rnnt.mustc.lightning.GlobalStatsNormalization", new=torch.nn.Identity
     ), patch("asr.emformer_rnnt.mustc.lightning.MUSTC", new=MockMUSTC), patch(
         "asr.emformer_rnnt.mustc.lightning.CustomDataset", new=MockCustomDataset

--- a/test/torchaudio_unittest/example/emformer_rnnt/test_mustc_lightning.py
+++ b/test/torchaudio_unittest/example/emformer_rnnt/test_mustc_lightning.py
@@ -1,0 +1,109 @@
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import torch
+from torchaudio._internal.module_utils import is_module_available
+from torchaudio_unittest.common_utils import TorchaudioTestCase, skipIfNoModule
+
+if is_module_available("pytorch_lightning", "sentencepiece"):
+    from asr.emformer_rnnt.mustc.lightning import MuSTCRNNTModule
+
+
+class MockSentencePieceProcessor:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def get_piece_size(self):
+        return 500
+
+    def encode(self, input):
+        return [1, 5, 2]
+
+    def decode(self, input):
+        return "hey"
+
+    def unk_id(self):
+        return 0
+
+    def eos_id(self):
+        return 1
+
+    def pad_id(self):
+        return 2
+
+
+class MockMUSTC:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __getitem__(self, n: int):
+        return (
+            torch.rand(1, 32640),
+            "sup",
+        )
+
+    def __len__(self):
+        return 10
+
+
+class MockCustomDataset:
+    def __init__(self, base_dataset, *args, **kwargs):
+        self.base_dataset = base_dataset
+
+    def __getitem__(self, n: int):
+        return [self.base_dataset[n]]
+
+    def __len__(self):
+        return len(self.base_dataset)
+
+
+@contextmanager
+def get_lightning_module():
+    with patch("sentencepiece.SentencePieceProcessor", new=MockSentencePieceProcessor), patch(
+        "asr.emformer_rnnt.mustc.lightning.GlobalStatsNormalization", new=torch.nn.Identity
+    ), patch("asr.emformer_rnnt.mustc.lightning.MUSTC", new=MockMUSTC), patch(
+        "asr.emformer_rnnt.mustc.lightning.CustomDataset", new=MockCustomDataset
+    ):
+        yield MuSTCRNNTModule(
+            mustc_path="mustc_path",
+            sp_model_path="sp_model_path",
+            global_stats_path="global_stats_path",
+        )
+
+
+@skipIfNoModule("pytorch_lightning")
+@skipIfNoModule("sentencepiece")
+class TestMuSTCRNNTModule(TorchaudioTestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        torch.random.manual_seed(31)
+
+    def test_training_step(self):
+        with get_lightning_module() as lightning_module:
+            train_dataloader = lightning_module.train_dataloader()
+            batch = next(iter(train_dataloader))
+            lightning_module.training_step(batch, 0)
+
+    def test_validation_step(self):
+        with get_lightning_module() as lightning_module:
+            val_dataloader = lightning_module.val_dataloader()
+            batch = next(iter(val_dataloader))
+            lightning_module.validation_step(batch, 0)
+
+    def test_test_common_step(self):
+        with get_lightning_module() as lightning_module:
+            test_dataloader = lightning_module.test_common_dataloader()
+            batch = next(iter(test_dataloader))
+            lightning_module.test_step(batch, 0)
+
+    def test_test_he_step(self):
+        with get_lightning_module() as lightning_module:
+            test_dataloader = lightning_module.test_he_dataloader()
+            batch = next(iter(test_dataloader))
+            lightning_module.test_step(batch, 0)
+
+    def test_forward(self):
+        with get_lightning_module() as lightning_module:
+            val_dataloader = lightning_module.val_dataloader()
+            batch = next(iter(val_dataloader))
+            lightning_module(batch)

--- a/test/torchaudio_unittest/example/emformer_rnnt/test_tedlium3_lightning.py
+++ b/test/torchaudio_unittest/example/emformer_rnnt/test_tedlium3_lightning.py
@@ -1,0 +1,107 @@
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import torch
+from torchaudio._internal.module_utils import is_module_available
+from torchaudio_unittest.common_utils import TorchaudioTestCase, skipIfNoModule
+
+if is_module_available("pytorch_lightning", "sentencepiece"):
+    from asr.emformer_rnnt.tedlium3.lightning import TEDLIUM3RNNTModule
+
+
+class MockSentencePieceProcessor:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def get_piece_size(self):
+        return 500
+
+    def encode(self, input):
+        return [1, 5, 2]
+
+    def decode(self, input):
+        return "hey"
+
+    def unk_id(self):
+        return 0
+
+    def eos_id(self):
+        return 1
+
+    def pad_id(self):
+        return 2
+
+
+class MockTEDLIUM:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __getitem__(self, n: int):
+        return (
+            torch.rand(1, 32640),
+            16000,
+            "sup",
+            2,
+            3,
+            4,
+        )
+
+    def __len__(self):
+        return 10
+
+
+class MockCustomDataset:
+    def __init__(self, base_dataset, *args, **kwargs):
+        self.base_dataset = base_dataset
+
+    def __getitem__(self, n: int):
+        return [self.base_dataset[n]]
+
+    def __len__(self):
+        return len(self.base_dataset)
+
+
+@contextmanager
+def get_lightning_module():
+    with patch("sentencepiece.SentencePieceProcessor", new=MockSentencePieceProcessor), patch(
+        "asr.emformer_rnnt.tedlium3.lightning.GlobalStatsNormalization", new=torch.nn.Identity
+    ), patch("torchaudio.datasets.TEDLIUM", new=MockTEDLIUM), patch(
+        "asr.emformer_rnnt.tedlium3.lightning.CustomDataset", new=MockCustomDataset
+    ):
+        yield TEDLIUM3RNNTModule(
+            tedlium_path="tedlium_path",
+            sp_model_path="sp_model_path",
+            global_stats_path="global_stats_path",
+        )
+
+
+@skipIfNoModule("pytorch_lightning")
+@skipIfNoModule("sentencepiece")
+class TestLibriSpeechRNNTModule(TorchaudioTestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        torch.random.manual_seed(31)
+
+    def test_training_step(self):
+        with get_lightning_module() as lightning_module:
+            train_dataloader = lightning_module.train_dataloader()
+            batch = next(iter(train_dataloader))
+            lightning_module.training_step(batch, 0)
+
+    def test_validation_step(self):
+        with get_lightning_module() as lightning_module:
+            val_dataloader = lightning_module.val_dataloader()
+            batch = next(iter(val_dataloader))
+            lightning_module.validation_step(batch, 0)
+
+    def test_test_step(self):
+        with get_lightning_module() as lightning_module:
+            test_dataloader = lightning_module.test_dataloader()
+            batch = next(iter(test_dataloader))
+            lightning_module.test_step(batch, 0)
+
+    def test_forward(self):
+        with get_lightning_module() as lightning_module:
+            val_dataloader = lightning_module.val_dataloader()
+            batch = next(iter(val_dataloader))
+            lightning_module(batch)

--- a/test/torchaudio_unittest/example/emformer_rnnt/test_utils.py
+++ b/test/torchaudio_unittest/example/emformer_rnnt/test_utils.py
@@ -1,0 +1,32 @@
+class MockSentencePieceProcessor:
+    def __init__(self, num_symbols, *args, **kwargs):
+        self.num_symbols = num_symbols
+
+    def get_piece_size(self):
+        return self.num_symbols
+
+    def encode(self, input):
+        return [1, 5, 2]
+
+    def decode(self, input):
+        return "hey"
+
+    def unk_id(self):
+        return 0
+
+    def eos_id(self):
+        return 1
+
+    def pad_id(self):
+        return 2
+
+
+class MockCustomDataset:
+    def __init__(self, base_dataset, *args, **kwargs):
+        self.base_dataset = base_dataset
+
+    def __getitem__(self, n: int):
+        return [self.base_dataset[n]]
+
+    def __len__(self):
+        return len(self.base_dataset)

--- a/torchaudio/pipelines/rnnt_pipeline.py
+++ b/torchaudio/pipelines/rnnt_pipeline.py
@@ -388,7 +388,7 @@ EMFORMER_RNNT_BASE_LIBRISPEECH.__doc__ = """Pre-trained Emformer-RNNT-based ASR 
 
     The underlying model is constructed by :py:func:`torchaudio.models.emformer_rnnt_base`
     and utilizes weights trained on LibriSpeech using training script ``train.py``
-    `here <https://github.com/pytorch/audio/tree/main/examples/asr/librispeech_emformer_rnnt>`__ with default arguments.
+    `here <https://github.com/pytorch/audio/tree/main/examples/asr/emformer_rnnt>`__ with default arguments.
 
     Please refer to :py:class:`RNNTBundle` for usage instructions.
     """

--- a/torchaudio/prototype/pipelines/__init__.py
+++ b/torchaudio/prototype/pipelines/__init__.py
@@ -1,6 +1,7 @@
-from .rnnt_pipeline import EMFORMER_RNNT_BASE_TEDLIUM3
+from .rnnt_pipeline import EMFORMER_RNNT_BASE_MUSTC, EMFORMER_RNNT_BASE_TEDLIUM3
 
 
 __all__ = [
+    "EMFORMER_RNNT_BASE_MUSTC",
     "EMFORMER_RNNT_BASE_TEDLIUM3",
 ]

--- a/torchaudio/prototype/pipelines/rnnt_pipeline.py
+++ b/torchaudio/prototype/pipelines/rnnt_pipeline.py
@@ -4,6 +4,30 @@ from torchaudio.models import emformer_rnnt_base
 from torchaudio.pipelines import RNNTBundle
 
 
+EMFORMER_RNNT_BASE_MUSTC = RNNTBundle(
+    _rnnt_path="emformer_rnnt_base_mustc.pt",
+    _rnnt_factory_func=partial(emformer_rnnt_base, num_symbols=501),
+    _global_stats_path="global_stats_rnnt_mustc.json",
+    _sp_model_path="spm_bpe_500_mustc.model",
+    _right_padding=4,
+    _blank=500,
+    _sample_rate=16000,
+    _n_fft=400,
+    _n_mels=80,
+    _hop_length=160,
+    _segment_length=16,
+    _right_context_length=4,
+)
+EMFORMER_RNNT_BASE_MUSTC.__doc__ = """Pre-trained Emformer-RNNT-based ASR pipeline capable of performing both streaming and non-streaming inference.
+
+    The underlying model is constructed by :py:func:`torchaudio.models.emformer_rnnt_base`
+    and utilizes weights trained on MuST-C release v2.0 dataset using training script ``train.py``
+    `here <https://github.com/pytorch/audio/tree/main/examples/asr/emformer_rnnt>`__ with ``num_symbols=501``.
+
+    Please refer to :py:class:`torchaudio.pipelines.RNNTBundle` for usage instructions.
+    """
+
+
 EMFORMER_RNNT_BASE_TEDLIUM3 = RNNTBundle(
     _rnnt_path="emformer_rnnt_base_tedlium3.pt",
     _rnnt_factory_func=partial(emformer_rnnt_base, num_symbols=501),
@@ -22,7 +46,7 @@ EMFORMER_RNNT_BASE_TEDLIUM3.__doc__ = """Pre-trained Emformer-RNNT-based ASR pip
 
     The underlying model is constructed by :py:func:`torchaudio.models.emformer_rnnt_base`
     and utilizes weights trained on TED-LIUM Release 3 dataset using training script ``train.py``
-    `here <https://github.com/pytorch/audio/tree/main/examples/asr/tedlium3_emformer_rnnt>`__ with ``num_symbols=501``.
+    `here <https://github.com/pytorch/audio/tree/main/examples/asr/emformer_rnnt>`__ with ``num_symbols=501``.
 
     Please refer to :py:class:`torchaudio.pipelines.RNNTBundle` for usage instructions.
     """


### PR DESCRIPTION
 - Add EMFORMER_RNNT_BASE_MUSTC bundle to `torchaudio.prototype.pipelines`
- Add unit tests for training recipes of TED-LIUM and MuST-C
- Refactor training and evaluation scripts