### PR TITLE
Add mvdr_weights_souden to torchaudio.functional

### DIFF
--- a/docs/source/functional.rst
+++ b/docs/source/functional.rst
@@ -246,6 +246,11 @@ psd
 
 .. autofunction:: psd
 
+mvdr_weights_souden
+-------------------
+
+.. autofunction:: mvdr_weights_souden
+
 :hidden:`Loss`
 ~~~~~~~~~~~~~~
 

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -251,3 +251,13 @@
   year={2017},
   publisher={IEEE}
 }
+@article{capon1969high,
+  title={High-resolution frequency-wavenumber spectrum analysis},
+  author={Capon, Jack},
+  journal={Proceedings of the IEEE},
+  volume={57},
+  number={8},
+  pages={1408--1418},
+  year={1969},
+  publisher={IEEE}
+}

--- a/test/torchaudio_unittest/common_utils/beamform_utils.py
+++ b/test/torchaudio_unittest/common_utils/beamform_utils.py
@@ -12,3 +12,20 @@ def psd_numpy(specgram, mask=None, normalize=True, eps=1e-10):
         psd = psd * mask_normmalized[..., None, None]
     psd = psd.sum(axis=-3)
     return psd
+
+
+def mvdr_weights_souden_numpy(psd_s, psd_n, reference_channel, diag_eps=1e-7, eps=1e-8):
+    channel = psd_s.shape[-1]
+    eye = np.eye(channel)
+    trace = np.matrix.trace(psd_n, axis1=1, axis2=2)
+    epsilon = trace.real[..., None, None] * diag_eps + eps
+    diag = epsilon * eye[..., :, :]
+    psd_n = psd_n + diag
+    numerator = np.linalg.solve(psd_n, psd_s)  # psd_n.inv() @ psd_s
+    numerator_trace = np.matrix.trace(numerator, axis1=1, axis2=2)
+    ws = numerator / (numerator_trace[..., None, None] + eps)
+    if isinstance(reference_channel, int):
+        beamform_weights = ws[..., :, reference_channel]
+    else:
+        beamform_weights = np.einsum("...c,...c->...", ws, reference_channel[..., None, None, :])
+    return beamform_weights

--- a/test/torchaudio_unittest/functional/autograd_impl.py
+++ b/test/torchaudio_unittest/functional/autograd_impl.py
@@ -265,6 +265,24 @@ class Autograd(TestBaseMixin):
             mask = None
         self.assert_grad(F.psd, (specgram, mask))
 
+    def test_mvdr_weights_souden(self):
+        torch.random.manual_seed(2434)
+        channel = 4
+        n_fft_bin = 5
+        psd_speech = torch.rand(n_fft_bin, channel, channel, dtype=torch.cfloat)
+        psd_noise = torch.rand(n_fft_bin, channel, channel, dtype=torch.cfloat)
+        self.assert_grad(F.mvdr_weights_souden, (psd_speech, psd_noise, 0))
+
+    def test_mvdr_weights_souden_with_tensor(self):
+        torch.random.manual_seed(2434)
+        channel = 4
+        n_fft_bin = 5
+        psd_speech = torch.rand(n_fft_bin, channel, channel, dtype=torch.cfloat)
+        psd_noise = torch.rand(n_fft_bin, channel, channel, dtype=torch.cfloat)
+        reference_channel = torch.zeros(channel)
+        reference_channel[0].fill_(1)
+        self.assert_grad(F.mvdr_weights_souden, (psd_speech, psd_noise, reference_channel))
+
 
 class AutogradFloat32(TestBaseMixin):
     def assert_grad(

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -317,3 +317,27 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         specgram = specgram.view(batch_size, channel, n_fft_bin, specgram.size(-1))
         mask = torch.rand(batch_size, n_fft_bin, specgram.size(-1))
         self.assert_batch_consistency(F.psd, (specgram, mask))
+
+    def test_mvdr_weights_souden(self):
+        torch.random.manual_seed(2434)
+        batch_size = 2
+        channel = 4
+        n_fft_bin = 10
+        psd_speech = torch.rand(batch_size, n_fft_bin, channel, channel, dtype=torch.cfloat)
+        psd_noise = torch.rand(batch_size, n_fft_bin, channel, channel, dtype=torch.cfloat)
+        kwargs = {
+            "reference_channel": 0,
+        }
+        func = partial(F.mvdr_weights_souden, **kwargs)
+        self.assert_batch_consistency(func, (psd_noise, psd_speech))
+
+    def test_mvdr_weights_souden_with_tensor(self):
+        torch.random.manual_seed(2434)
+        batch_size = 2
+        channel = 4
+        n_fft_bin = 10
+        psd_speech = torch.rand(batch_size, n_fft_bin, channel, channel, dtype=torch.cfloat)
+        psd_noise = torch.rand(batch_size, n_fft_bin, channel, channel, dtype=torch.cfloat)
+        reference_channel = torch.zeros(batch_size, channel)
+        reference_channel[..., 0].fill_(1)
+        self.assert_batch_consistency(F.mvdr_weights_souden, (psd_noise, psd_speech, reference_channel))

--- a/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
@@ -638,6 +638,32 @@ class Functional(TempDirMixin, TestBaseMixin):
         mask = torch.rand(batch_size, n_fft_bin, frame, device=self.device)
         self._assert_consistency_complex(F.psd, (specgram, mask, normalize, eps))
 
+    def test_mvdr_weights_souden(self):
+        channel = 4
+        n_fft_bin = 10
+        diagonal_loading = True
+        diag_eps = 1e-7
+        eps = 1e-8
+        psd_speech = torch.rand(n_fft_bin, channel, channel, dtype=torch.cfloat)
+        psd_noise = torch.rand(n_fft_bin, channel, channel, dtype=torch.cfloat)
+        self._assert_consistency_complex(
+            F.mvdr_weights_souden, (psd_speech, psd_noise, 0, diagonal_loading, diag_eps, eps)
+        )
+
+    def test_mvdr_weights_souden_with_tensor(self):
+        channel = 4
+        n_fft_bin = 10
+        diagonal_loading = True
+        diag_eps = 1e-7
+        eps = 1e-8
+        psd_speech = torch.rand(n_fft_bin, channel, channel, dtype=torch.cfloat)
+        psd_noise = torch.rand(n_fft_bin, channel, channel, dtype=torch.cfloat)
+        reference_channel = torch.zeros(channel)
+        reference_channel[..., 0].fill_(1)
+        self._assert_consistency_complex(
+            F.mvdr_weights_souden, (psd_speech, psd_noise, reference_channel, diagonal_loading, diag_eps, eps)
+        )
+
 
 class FunctionalFloat32Only(TestBaseMixin):
     def test_rnnt_loss(self):

--- a/torchaudio/functional/__init__.py
+++ b/torchaudio/functional/__init__.py
@@ -47,6 +47,7 @@ from .functional import (
     pitch_shift,
     rnnt_loss,
     psd,
+    mvdr_weights_souden,
 )
 
 __all__ = [
@@ -96,4 +97,5 @@ __all__ = [
     "pitch_shift",
     "rnnt_loss",
     "psd",
+    "mvdr_weights_souden",
 ]


### PR DESCRIPTION
This PR adds ``mvdr_weights_souden`` method to ``torchaudio.functional``.
It computes the MVDR weight matrix based on the solution proposed by [``Souden et, al.``](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.725.673&rep=rep1&type=pdf).
The input arguments are the complex-valued power spectral density (PSD) matrix of the target speech, PSD matrix of noise, int or one-hot Tensor to indicate the reference channel, respectively.