### PR TITLE
Add mvdr_weights_rtf to torchaudio.functional

### DIFF
--- a/docs/source/functional.rst
+++ b/docs/source/functional.rst
@@ -251,6 +251,11 @@ mvdr_weights_souden
 
 .. autofunction:: mvdr_weights_souden
 
+mvdr_weights_rtf
+----------------
+
+.. autofunction:: mvdr_weights_rtf
+
 :hidden:`Loss`
 ~~~~~~~~~~~~~~
 

--- a/test/torchaudio_unittest/functional/autograd_impl.py
+++ b/test/torchaudio_unittest/functional/autograd_impl.py
@@ -283,6 +283,26 @@ class Autograd(TestBaseMixin):
         reference_channel[0].fill_(1)
         self.assert_grad(F.mvdr_weights_souden, (psd_speech, psd_noise, reference_channel))
 
+    def test_mvdr_weights_rtf(self):
+        torch.random.manual_seed(2434)
+        batch_size = 2
+        channel = 4
+        n_fft_bin = 10
+        rtf = torch.rand(batch_size, n_fft_bin, channel, dtype=self.complex_dtype)
+        psd_noise = torch.rand(batch_size, n_fft_bin, channel, channel, dtype=self.complex_dtype)
+        self.assert_grad(F.mvdr_weights_rtf, (rtf, psd_noise, 0))
+
+    def test_mvdr_weights_rtf_with_tensor(self):
+        torch.random.manual_seed(2434)
+        batch_size = 2
+        channel = 4
+        n_fft_bin = 10
+        rtf = torch.rand(batch_size, n_fft_bin, channel, dtype=self.complex_dtype)
+        psd_noise = torch.rand(batch_size, n_fft_bin, channel, channel, dtype=self.complex_dtype)
+        reference_channel = torch.zeros(batch_size, channel)
+        reference_channel[..., 0].fill_(1)
+        self.assert_grad(F.mvdr_weights_rtf, (rtf, psd_noise, reference_channel))
+
 
 class AutogradFloat32(TestBaseMixin):
     def assert_grad(

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -341,3 +341,27 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         reference_channel = torch.zeros(batch_size, channel)
         reference_channel[..., 0].fill_(1)
         self.assert_batch_consistency(F.mvdr_weights_souden, (psd_noise, psd_speech, reference_channel))
+
+    def test_mvdr_weights_rtf(self):
+        torch.random.manual_seed(2434)
+        batch_size = 2
+        channel = 4
+        n_fft_bin = 129
+        rtf = torch.rand(batch_size, n_fft_bin, channel, dtype=torch.cfloat)
+        psd_noise = torch.rand(batch_size, n_fft_bin, channel, channel, dtype=torch.cfloat)
+        kwargs = {
+            "reference_channel": 0,
+        }
+        func = partial(F.mvdr_weights_rtf, **kwargs)
+        self.assert_batch_consistency(func, (rtf, psd_noise))
+
+    def test_mvdr_weights_rtf_with_tensor(self):
+        torch.random.manual_seed(2434)
+        batch_size = 2
+        channel = 4
+        n_fft_bin = 129
+        rtf = torch.rand(batch_size, n_fft_bin, channel, dtype=torch.cfloat)
+        psd_noise = torch.rand(batch_size, n_fft_bin, channel, channel, dtype=torch.cfloat)
+        reference_channel = torch.zeros(batch_size, channel)
+        reference_channel[..., 0].fill_(1)
+        self.assert_batch_consistency(F.mvdr_weights_rtf, (rtf, psd_noise, reference_channel))

--- a/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
@@ -664,6 +664,33 @@ class Functional(TempDirMixin, TestBaseMixin):
             F.mvdr_weights_souden, (psd_speech, psd_noise, reference_channel, diagonal_loading, diag_eps, eps)
         )
 
+    def test_mvdr_weights_rtf(self):
+        channel = 4
+        n_fft_bin = 10
+        diagonal_loading = True
+        diag_eps = 1e-7
+        eps = 1e-8
+        rtf = torch.rand(n_fft_bin, channel, dtype=self.complex_dtype)
+        psd_noise = torch.rand(n_fft_bin, channel, channel, dtype=self.complex_dtype)
+        reference_channel = 0
+        self._assert_consistency_complex(
+            F.mvdr_weights_rtf, (rtf, psd_noise, reference_channel, diagonal_loading, diag_eps, eps)
+        )
+
+    def test_mvdr_weights_rtf_with_tensor(self):
+        channel = 4
+        n_fft_bin = 10
+        diagonal_loading = True
+        diag_eps = 1e-7
+        eps = 1e-8
+        rtf = torch.rand(n_fft_bin, channel, dtype=self.complex_dtype)
+        psd_noise = torch.rand(n_fft_bin, channel, channel, dtype=self.complex_dtype)
+        reference_channel = torch.zeros(channel)
+        reference_channel[..., 0].fill_(1)
+        self._assert_consistency_complex(
+            F.mvdr_weights_rtf, (rtf, psd_noise, reference_channel, diagonal_loading, diag_eps, eps)
+        )
+
 
 class FunctionalFloat32Only(TestBaseMixin):
     def test_rnnt_loss(self):

--- a/torchaudio/functional/__init__.py
+++ b/torchaudio/functional/__init__.py
@@ -48,6 +48,7 @@ from .functional import (
     rnnt_loss,
     psd,
     mvdr_weights_souden,
+    mvdr_weights_rtf,
 )
 
 __all__ = [
@@ -98,4 +99,5 @@ __all__ = [
     "rnnt_loss",
     "psd",
     "mvdr_weights_souden",
+    "mvdr_weights_rtf",
 ]


### PR DESCRIPTION
This PR adds ``mvdr_weights_rtf`` method to ``torchaudio.functional``.
It computes the MVDR weight matrix based on the solution that applies relative transfer function (RTF). See [the paper](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.725.673&rep=rep1&type=pdf) for the reference.
The input arguments are the complex-valued RTF Tensor of the target speech, power spectral density (PSD) matrix of noise, int or one-hot Tensor to indicate the reference channel, respectively.