### PR TITLE
Add rtf_power method to torchaudio.functional

### DIFF
--- a/docs/source/functional.rst
+++ b/docs/source/functional.rst
@@ -261,6 +261,11 @@ rtf_evd
 
 .. autofunction:: rtf_evd
 
+rtf_power
+---------
+
+.. autofunction:: rtf_power
+
 :hidden:`Loss`
 ~~~~~~~~~~~~~~
 

--- a/test/torchaudio_unittest/common_utils/beamform_utils.py
+++ b/test/torchaudio_unittest/common_utils/beamform_utils.py
@@ -53,3 +53,20 @@ def rtf_evd_numpy(psd):
     _, v = np.linalg.eigh(psd)
     rtf = v[..., -1]
     return rtf
+
+
+def rtf_power_numpy(psd_s, psd_n, reference_channel, n_iter):
+    phi = np.linalg.solve(psd_n, psd_s)
+    if isinstance(reference_channel, int):
+        rtf = phi[..., reference_channel]
+    else:
+        rtf = phi @ reference_channel
+    rtf = np.expand_dims(rtf, -1)
+    if n_iter >= 2:
+        for _ in range(n_iter - 2):
+            rtf = phi @ rtf
+        rtf = psd_s @ rtf
+    else:
+        rtf = psd_n @ rtf
+    rtf = rtf.squeeze(-1)
+    return rtf

--- a/test/torchaudio_unittest/functional/autograd_impl.py
+++ b/test/torchaudio_unittest/functional/autograd_impl.py
@@ -303,6 +303,36 @@ class Autograd(TestBaseMixin):
         reference_channel[..., 0].fill_(1)
         self.assert_grad(F.mvdr_weights_rtf, (rtf, psd_noise, reference_channel))
 
+    @parameterized.expand(
+        [
+            (1,),
+            (3,),
+        ]
+    )
+    def test_rtf_power(self, n_iter):
+        torch.random.manual_seed(2434)
+        channel = 4
+        n_fft_bin = 5
+        psd_speech = torch.rand(n_fft_bin, channel, channel, dtype=torch.cfloat)
+        psd_noise = torch.rand(n_fft_bin, channel, channel, dtype=torch.cfloat)
+        self.assert_grad(F.rtf_power, (psd_speech, psd_noise, 0, n_iter))
+
+    @parameterized.expand(
+        [
+            (1,),
+            (3,),
+        ]
+    )
+    def test_rtf_power_with_tensor(self, n_iter):
+        torch.random.manual_seed(2434)
+        channel = 4
+        n_fft_bin = 5
+        psd_speech = torch.rand(n_fft_bin, channel, channel, dtype=torch.cfloat)
+        psd_noise = torch.rand(n_fft_bin, channel, channel, dtype=torch.cfloat)
+        reference_channel = torch.zeros(channel)
+        reference_channel[0].fill_(1)
+        self.assert_grad(F.rtf_power, (psd_speech, psd_noise, reference_channel, n_iter))
+
 
 class AutogradFloat32(TestBaseMixin):
     def assert_grad(

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -374,3 +374,44 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         spectrum = torch.rand(batch_size, n_fft_bin, channel, dtype=torch.cfloat)
         psd = torch.einsum("...c,...d->...cd", spectrum, spectrum.conj())
         self.assert_batch_consistency(F.rtf_evd, (psd,))
+
+    @parameterized.expand(
+        [
+            (1,),
+            (3,),
+        ]
+    )
+    def test_rtf_power(self, n_iter):
+        torch.random.manual_seed(2434)
+        channel = 4
+        batch_size = 2
+        n_fft_bin = 10
+        psd_speech = torch.rand(batch_size, n_fft_bin, channel, channel, dtype=torch.cfloat)
+        psd_noise = torch.rand(batch_size, n_fft_bin, channel, channel, dtype=torch.cfloat)
+        kwargs = {
+            "reference_channel": 0,
+            "n_iter": n_iter,
+        }
+        func = partial(F.rtf_power, **kwargs)
+        self.assert_batch_consistency(func, (psd_speech, psd_noise))
+
+    @parameterized.expand(
+        [
+            (1,),
+            (3,),
+        ]
+    )
+    def test_rtf_power_with_tensor(self, n_iter):
+        torch.random.manual_seed(2434)
+        channel = 4
+        batch_size = 2
+        n_fft_bin = 10
+        psd_speech = torch.rand(batch_size, n_fft_bin, channel, channel, dtype=torch.cfloat)
+        psd_noise = torch.rand(batch_size, n_fft_bin, channel, channel, dtype=torch.cfloat)
+        reference_channel = torch.zeros(batch_size, channel)
+        reference_channel[..., 0].fill_(1)
+        kwargs = {
+            "n_iter": n_iter,
+        }
+        func = partial(F.rtf_power, **kwargs)
+        self.assert_batch_consistency(func, (psd_speech, psd_noise, reference_channel))

--- a/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
@@ -698,6 +698,35 @@ class Functional(TempDirMixin, TestBaseMixin):
         tensor = torch.rand(batch_size, n_fft_bin, channel, channel, dtype=self.complex_dtype)
         self._assert_consistency_complex(F.rtf_evd, (tensor,))
 
+    @parameterized.expand(
+        [
+            (1,),
+            (3,),
+        ]
+    )
+    def test_rtf_power(self, n_iter):
+        channel = 4
+        n_fft_bin = 10
+        psd_speech = torch.rand(n_fft_bin, channel, channel, dtype=self.complex_dtype)
+        psd_noise = torch.rand(n_fft_bin, channel, channel, dtype=self.complex_dtype)
+        reference_channel = 0
+        self._assert_consistency_complex(F.rtf_power, (psd_speech, psd_noise, reference_channel, n_iter))
+
+    @parameterized.expand(
+        [
+            (1,),
+            (3,),
+        ]
+    )
+    def test_rtf_power_with_tensor(self, n_iter):
+        channel = 4
+        n_fft_bin = 10
+        psd_speech = torch.rand(n_fft_bin, channel, channel, dtype=self.complex_dtype)
+        psd_noise = torch.rand(n_fft_bin, channel, channel, dtype=self.complex_dtype)
+        reference_channel = torch.zeros(channel)
+        reference_channel[..., 0].fill_(1)
+        self._assert_consistency_complex(F.rtf_power, (psd_speech, psd_noise, reference_channel, n_iter))
+
 
 class FunctionalFloat32Only(TestBaseMixin):
     def test_rnnt_loss(self):

--- a/torchaudio/functional/__init__.py
+++ b/torchaudio/functional/__init__.py
@@ -50,6 +50,7 @@ from .functional import (
     mvdr_weights_souden,
     mvdr_weights_rtf,
     rtf_evd,
+    rtf_power,
 )
 
 __all__ = [
@@ -102,4 +103,5 @@ __all__ = [
     "mvdr_weights_souden",
     "mvdr_weights_rtf",
     "rtf_evd",
+    "rtf_power",
 ]


### PR DESCRIPTION
This PR adds ``rtf_power`` method to ``torchaudio.functional``.
The method computes the relative transfer function (RTF) or the steering vector by [the power iteration method](https://onlinelibrary.wiley.com/doi/abs/10.1002/zamm.19290090206). 
[This paper](https://arxiv.org/pdf/2011.15003.pdf) describes the power iteration method in English.
The input arguments are the complex-valued power spectral density (PSD) matrix of the target speech, PSD matrix of noise, int or one-hot Tensor to indicate the reference channel, number of iterations, respectively.