### PR TITLE
[Release 0.11] Remove complex32 dtype in griffinlim

### DIFF
--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -201,8 +201,6 @@ def _get_complex_dtype(real_dtype: torch.dtype):
         return torch.cdouble
     if real_dtype == torch.float:
         return torch.cfloat
-    if real_dtype == torch.half:
-        return torch.complex32
     raise ValueError(f"Unexpected dtype {real_dtype}")
 
 


### PR DESCRIPTION
`torch.complex32` is disabled in PyTorch release 1.11. The PR removed the `complex32` data type support in `torchaudio.functional.griffinlim` in torchaudio's 0.11 release.