### PR TITLE
Fix lm used for ctc decoder example

### DIFF
--- a/examples/asr/librispeech_ctc_decoder/inference.py
+++ b/examples/asr/librispeech_ctc_decoder/inference.py
@@ -34,7 +34,7 @@ def run_inference(args):
     decoder = lexicon_decoder(
         lexicon=lexicon_file,
         tokens=tokens,
-        lm=None,
+        lm=kenlm_file,
         nbest=1,
         beam_size=1500,
         beam_size_token=None,


### PR DESCRIPTION
LM in example script was unintentionally changed to None when adding no LM support previously. this changes it back and is consistent with the WERs listed in the readme