### PR TITLE
Add unit tests for PyTorch Lightning modules of emformer_rnnt recipes

### DIFF
--- a/test/torchaudio_unittest/example/emformer_rnnt/test_librispeech_lightning.py
+++ b/test/torchaudio_unittest/example/emformer_rnnt/test_librispeech_lightning.py
@@ -51,6 +51,7 @@ def get_lightning_module():
 class TestLibriSpeechRNNTModule(TorchaudioTestCase):
     @classmethod
     def setUpClass(cls) -> None:
+        super().setUpClass()
         torch.random.manual_seed(31)
 
     def test_training_step(self):

--- a/test/torchaudio_unittest/example/emformer_rnnt/test_librispeech_lightning.py
+++ b/test/torchaudio_unittest/example/emformer_rnnt/test_librispeech_lightning.py
@@ -3,6 +3,7 @@ from functools import partial
 from unittest.mock import patch
 
 import torch
+from parameterized import parameterized
 from torchaudio._internal.module_utils import is_module_available
 from torchaudio_unittest.common_utils import TorchaudioTestCase, skipIfNoModule
 
@@ -54,26 +55,30 @@ class TestLibriSpeechRNNTModule(TorchaudioTestCase):
         super().setUpClass()
         torch.random.manual_seed(31)
 
-    def test_training_step(self):
+    @parameterized.expand(
+        [
+            ("train",),
+            ("dev",),
+            ("test",),
+            ("forward",),
+        ]
+    )
+    def test_step(self, subset):
         with get_lightning_module() as lightning_module:
-            train_dataloader = lightning_module.train_dataloader()
-            batch = next(iter(train_dataloader))
-            lightning_module.training_step(batch, 0)
-
-    def test_validation_step(self):
-        with get_lightning_module() as lightning_module:
-            val_dataloader = lightning_module.val_dataloader()
-            batch = next(iter(val_dataloader))
-            lightning_module.validation_step(batch, 0)
-
-    def test_test_step(self):
-        with get_lightning_module() as lightning_module:
-            test_dataloader = lightning_module.test_dataloader()
-            batch = next(iter(test_dataloader))
-            lightning_module.test_step(batch, 0)
-
-    def test_forward(self):
-        with get_lightning_module() as lightning_module:
-            val_dataloader = lightning_module.val_dataloader()
-            batch = next(iter(val_dataloader))
-            lightning_module(batch)
+            if subset == "train":
+                dataloader = lightning_module.train_dataloader()
+                step = lightning_module.training_step
+            elif subset == "dev":
+                dataloader = lightning_module.val_dataloader()
+                step = lightning_module.validation_step
+            elif subset == "test":
+                dataloader = lightning_module.test_dataloader()
+                step = lightning_module.test_step
+            else:
+                dataloader = lightning_module.val_dataloader()
+                step = lightning_module
+            batch = next(iter(dataloader))
+            if subset == "forward":
+                step(batch)
+            else:
+                step(batch, 0)

--- a/test/torchaudio_unittest/example/emformer_rnnt/test_librispeech_lightning.py
+++ b/test/torchaudio_unittest/example/emformer_rnnt/test_librispeech_lightning.py
@@ -7,7 +7,7 @@ from parameterized import parameterized
 from torchaudio._internal.module_utils import is_module_available
 from torchaudio_unittest.common_utils import TorchaudioTestCase, skipIfNoModule
 
-from .utils import MockSentencePieceProcessor, MockCustomDataset
+from .utils import MockSentencePieceProcessor, MockCustomDataset, MockDataloader
 
 if is_module_available("pytorch_lightning", "sentencepiece"):
     from asr.emformer_rnnt.librispeech.lightning import LibriSpeechRNNTModule
@@ -39,6 +39,8 @@ def get_lightning_module():
         "torchaudio.datasets.LIBRISPEECH", new=MockLIBRISPEECH
     ), patch(
         "asr.emformer_rnnt.librispeech.lightning.CustomDataset", new=MockCustomDataset
+    ), patch(
+        "torch.utils.data.DataLoader", new=MockDataloader
     ):
         yield LibriSpeechRNNTModule(
             librispeech_path="librispeech_path",
@@ -57,28 +59,24 @@ class TestLibriSpeechRNNTModule(TorchaudioTestCase):
 
     @parameterized.expand(
         [
-            ("train",),
-            ("dev",),
-            ("test",),
-            ("forward",),
+            ("training_step", "train_dataloader"),
+            ("validation_step", "val_dataloader"),
+            ("test_step", "test_dataloader"),
         ]
     )
-    def test_step(self, subset):
+    def test_step(self, step_fname, dataloader_fname):
         with get_lightning_module() as lightning_module:
-            if subset == "train":
-                dataloader = lightning_module.train_dataloader()
-                step = lightning_module.training_step
-            elif subset == "dev":
-                dataloader = lightning_module.val_dataloader()
-                step = lightning_module.validation_step
-            elif subset == "test":
-                dataloader = lightning_module.test_dataloader()
-                step = lightning_module.test_step
-            else:
-                dataloader = lightning_module.val_dataloader()
-                step = lightning_module
+            dataloader = getattr(lightning_module, dataloader_fname)()
             batch = next(iter(dataloader))
-            if subset == "forward":
-                step(batch)
-            else:
-                step(batch, 0)
+            getattr(lightning_module, step_fname)(batch, 0)
+
+    @parameterized.expand(
+        [
+            ("val_dataloader",),
+        ]
+    )
+    def test_forward(self, dataloader_fname):
+        with get_lightning_module() as lightning_module:
+            dataloader = getattr(lightning_module, dataloader_fname)()
+            batch = next(iter(dataloader))
+            lightning_module(batch)

--- a/test/torchaudio_unittest/example/emformer_rnnt/test_mustc_lightning.py
+++ b/test/torchaudio_unittest/example/emformer_rnnt/test_mustc_lightning.py
@@ -45,6 +45,7 @@ def get_lightning_module():
 class TestMuSTCRNNTModule(TorchaudioTestCase):
     @classmethod
     def setUpClass(cls) -> None:
+        super().setUpClass()
         torch.random.manual_seed(31)
 
     def test_training_step(self):

--- a/test/torchaudio_unittest/example/emformer_rnnt/test_tedlium3_lightning.py
+++ b/test/torchaudio_unittest/example/emformer_rnnt/test_tedlium3_lightning.py
@@ -49,6 +49,7 @@ def get_lightning_module():
 class TestTEDLIUM3RNNTModule(TorchaudioTestCase):
     @classmethod
     def setUpClass(cls) -> None:
+        super().setUpClass()
         torch.random.manual_seed(31)
 
     def test_training_step(self):

--- a/test/torchaudio_unittest/example/emformer_rnnt/test_tedlium3_lightning.py
+++ b/test/torchaudio_unittest/example/emformer_rnnt/test_tedlium3_lightning.py
@@ -3,6 +3,7 @@ from functools import partial
 from unittest.mock import patch
 
 import torch
+from parameterized import parameterized
 from torchaudio._internal.module_utils import is_module_available
 from torchaudio_unittest.common_utils import TorchaudioTestCase, skipIfNoModule
 
@@ -52,26 +53,30 @@ class TestTEDLIUM3RNNTModule(TorchaudioTestCase):
         super().setUpClass()
         torch.random.manual_seed(31)
 
-    def test_training_step(self):
+    @parameterized.expand(
+        [
+            ("train",),
+            ("dev",),
+            ("test",),
+            ("forward",),
+        ]
+    )
+    def test_step(self, subset):
         with get_lightning_module() as lightning_module:
-            train_dataloader = lightning_module.train_dataloader()
-            batch = next(iter(train_dataloader))
-            lightning_module.training_step(batch, 0)
-
-    def test_validation_step(self):
-        with get_lightning_module() as lightning_module:
-            val_dataloader = lightning_module.val_dataloader()
-            batch = next(iter(val_dataloader))
-            lightning_module.validation_step(batch, 0)
-
-    def test_test_step(self):
-        with get_lightning_module() as lightning_module:
-            test_dataloader = lightning_module.test_dataloader()
-            batch = next(iter(test_dataloader))
-            lightning_module.test_step(batch, 0)
-
-    def test_forward(self):
-        with get_lightning_module() as lightning_module:
-            val_dataloader = lightning_module.val_dataloader()
-            batch = next(iter(val_dataloader))
-            lightning_module(batch)
+            if subset == "train":
+                dataloader = lightning_module.train_dataloader()
+                step = lightning_module.training_step
+            elif subset == "dev":
+                dataloader = lightning_module.val_dataloader()
+                step = lightning_module.validation_step
+            elif subset == "test":
+                dataloader = lightning_module.test_dataloader()
+                step = lightning_module.test_step
+            else:
+                dataloader = lightning_module.val_dataloader()
+                step = lightning_module
+            batch = next(iter(dataloader))
+            if subset == "forward":
+                step(batch)
+            else:
+                step(batch, 0)

--- a/test/torchaudio_unittest/example/emformer_rnnt/test_tedlium3_lightning.py
+++ b/test/torchaudio_unittest/example/emformer_rnnt/test_tedlium3_lightning.py
@@ -9,10 +9,10 @@ from torchaudio_unittest.common_utils import TorchaudioTestCase, skipIfNoModule
 from .utils import MockSentencePieceProcessor, MockCustomDataset
 
 if is_module_available("pytorch_lightning", "sentencepiece"):
-    from asr.emformer_rnnt.librispeech.lightning import LibriSpeechRNNTModule
+    from asr.emformer_rnnt.tedlium3.lightning import TEDLIUM3RNNTModule
 
 
-class MockLIBRISPEECH:
+class MockTEDLIUM:
     def __init__(self, *args, **kwargs):
         pass
 
@@ -32,15 +32,13 @@ class MockLIBRISPEECH:
 
 @contextmanager
 def get_lightning_module():
-    with patch(
-        "sentencepiece.SentencePieceProcessor", new=partial(MockSentencePieceProcessor, num_symbols=4096)
-    ), patch("asr.emformer_rnnt.librispeech.lightning.GlobalStatsNormalization", new=torch.nn.Identity), patch(
-        "torchaudio.datasets.LIBRISPEECH", new=MockLIBRISPEECH
-    ), patch(
-        "asr.emformer_rnnt.librispeech.lightning.CustomDataset", new=MockCustomDataset
+    with patch("sentencepiece.SentencePieceProcessor", new=partial(MockSentencePieceProcessor, num_symbols=500)), patch(
+        "asr.emformer_rnnt.tedlium3.lightning.GlobalStatsNormalization", new=torch.nn.Identity
+    ), patch("torchaudio.datasets.TEDLIUM", new=MockTEDLIUM), patch(
+        "asr.emformer_rnnt.tedlium3.lightning.CustomDataset", new=MockCustomDataset
     ):
-        yield LibriSpeechRNNTModule(
-            librispeech_path="librispeech_path",
+        yield TEDLIUM3RNNTModule(
+            tedlium_path="tedlium_path",
             sp_model_path="sp_model_path",
             global_stats_path="global_stats_path",
         )
@@ -48,7 +46,7 @@ def get_lightning_module():
 
 @skipIfNoModule("pytorch_lightning")
 @skipIfNoModule("sentencepiece")
-class TestLibriSpeechRNNTModule(TorchaudioTestCase):
+class TestTEDLIUM3RNNTModule(TorchaudioTestCase):
     @classmethod
     def setUpClass(cls) -> None:
         torch.random.manual_seed(31)

--- a/test/torchaudio_unittest/example/emformer_rnnt/utils.py
+++ b/test/torchaudio_unittest/example/emformer_rnnt/utils.py
@@ -1,0 +1,32 @@
+class MockSentencePieceProcessor:
+    def __init__(self, num_symbols, *args, **kwargs):
+        self.num_symbols = num_symbols
+
+    def get_piece_size(self):
+        return self.num_symbols
+
+    def encode(self, input):
+        return [1, 5, 2]
+
+    def decode(self, input):
+        return "hey"
+
+    def unk_id(self):
+        return 0
+
+    def eos_id(self):
+        return 1
+
+    def pad_id(self):
+        return 2
+
+
+class MockCustomDataset:
+    def __init__(self, base_dataset, *args, **kwargs):
+        self.base_dataset = base_dataset
+
+    def __getitem__(self, n: int):
+        return [self.base_dataset[n]]
+
+    def __len__(self):
+        return len(self.base_dataset)

--- a/test/torchaudio_unittest/example/emformer_rnnt/utils.py
+++ b/test/torchaudio_unittest/example/emformer_rnnt/utils.py
@@ -30,3 +30,19 @@ class MockCustomDataset:
 
     def __len__(self):
         return len(self.base_dataset)
+
+
+class MockDataloader:
+    def __init__(self, base_dataset, batch_size, collate_fn, *args, **kwargs):
+        self.base_dataset = base_dataset
+        self.batch_size = batch_size
+        self.collate_fn = collate_fn
+
+    def __iter__(self):
+        for sample in iter(self.base_dataset):
+            if self.batch_size == 1:
+                sample = [sample]
+            yield self.collate_fn(sample)
+
+    def __len__(self):
+        return len(self.base_dataset)

--- a/torchaudio/pipelines/rnnt_pipeline.py
+++ b/torchaudio/pipelines/rnnt_pipeline.py
@@ -388,7 +388,7 @@ EMFORMER_RNNT_BASE_LIBRISPEECH.__doc__ = """Pre-trained Emformer-RNNT-based ASR 
 
     The underlying model is constructed by :py:func:`torchaudio.models.emformer_rnnt_base`
     and utilizes weights trained on LibriSpeech using training script ``train.py``
-    `here <https://github.com/pytorch/audio/tree/main/examples/asr/librispeech_emformer_rnnt>`__ with default arguments.
+    `here <https://github.com/pytorch/audio/tree/main/examples/asr/emformer_rnnt>`__ with default arguments.
 
     Please refer to :py:class:`RNNTBundle` for usage instructions.
     """

--- a/torchaudio/prototype/pipelines/rnnt_pipeline.py
+++ b/torchaudio/prototype/pipelines/rnnt_pipeline.py
@@ -22,7 +22,7 @@ EMFORMER_RNNT_BASE_TEDLIUM3.__doc__ = """Pre-trained Emformer-RNNT-based ASR pip
 
     The underlying model is constructed by :py:func:`torchaudio.models.emformer_rnnt_base`
     and utilizes weights trained on TED-LIUM Release 3 dataset using training script ``train.py``
-    `here <https://github.com/pytorch/audio/tree/main/examples/asr/tedlium3_emformer_rnnt>`__ with ``num_symbols=501``.
+    `here <https://github.com/pytorch/audio/tree/main/examples/asr/emformer_rnnt>`__ with ``num_symbols=501``.
 
     Please refer to :py:class:`torchaudio.pipelines.RNNTBundle` for usage instructions.
     """


### PR DESCRIPTION
- Refactor the current `LibriSpeechRNNTModule`'s unit test.
- Add unit tests for `TEDLIUM3RNNTModule` and `MuSTCRNNTModule`
- Replace the lambda with partial in `TEDLIUM3RNNTModule` to pass the lightning unit test.