### PR TITLE
Add EMFORMER_RNNT_BASE_MUSTC into pipeline demo script

### DIFF
--- a/examples/asr/emformer_rnnt/pipeline_demo.py
+++ b/examples/asr/emformer_rnnt/pipeline_demo.py
@@ -13,11 +13,11 @@ from typing import Callable
 
 import torch
 import torchaudio
-from common import MODEL_TYPE_LIBRISPEECH, MODEL_TYPE_TEDLIUM3
+from common import MODEL_TYPE_LIBRISPEECH, MODEL_TYPE_MUSTC, MODEL_TYPE_TEDLIUM3
+from mustc.dataset import MUSTC
 from torchaudio.pipelines import EMFORMER_RNNT_BASE_LIBRISPEECH
 from torchaudio.pipelines import RNNTBundle
-from torchaudio.prototype.pipelines import EMFORMER_RNNT_BASE_TEDLIUM3
-
+from torchaudio.prototype.pipelines import EMFORMER_RNNT_BASE_MUSTC, EMFORMER_RNNT_BASE_TEDLIUM3
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +32,10 @@ _CONFIGS = {
     MODEL_TYPE_LIBRISPEECH: Config(
         partial(torchaudio.datasets.LIBRISPEECH, url="test-clean"),
         EMFORMER_RNNT_BASE_LIBRISPEECH,
+    ),
+    MODEL_TYPE_MUSTC: Config(
+        partial(MUSTC, subset="tst-COMMON"),
+        EMFORMER_RNNT_BASE_MUSTC,
     ),
     MODEL_TYPE_TEDLIUM3: Config(
         partial(torchaudio.datasets.TEDLIUM, release="release3", subset="test"),


### PR DESCRIPTION
This PR adds ``EMFORMER_RNNT_BASE_MUSTC`` support in `pipeline_demo.py`. The bundle is trained on MuST-C release 2.0 dataset. The model  preserves the casing and punctuations in the transcript.

Here is a screen recording of how it works in streaming and non-streaming modes. The test set is `tst-COMMON` subset of MuST-C release 2.0.

https://user-images.githubusercontent.com/8653221/154356521-fe84bdc1-fb0c-41bd-8729-9edbb3224a07.mov


