### PR TITLE
ci: Limit scope of unittest to one python version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1323,56 +1323,14 @@ workflows:
           cuda_version: cpu
           name: unittest_windows_cpu_py3.7
           python_version: '3.7'
-      - unittest_windows_cpu:
-          cuda_version: cpu
-          name: unittest_windows_cpu_py3.8
-          python_version: '3.8'
-      - unittest_windows_cpu:
-          cuda_version: cpu
-          name: unittest_windows_cpu_py3.9
-          python_version: '3.9'
-      - unittest_windows_cpu:
-          cuda_version: cpu
-          name: unittest_windows_cpu_py3.10
-          python_version: '3.10'
       - unittest_windows_gpu:
           cuda_version: cu113
           name: unittest_windows_gpu_py3.7
           python_version: '3.7'
-      - unittest_windows_gpu:
-          cuda_version: cu113
-          name: unittest_windows_gpu_py3.8
-          python_version: '3.8'
-      - unittest_windows_gpu:
-          cuda_version: cu113
-          name: unittest_windows_gpu_py3.9
-          python_version: '3.9'
-      - unittest_windows_gpu:
-          cuda_version: cu113
-          name: unittest_windows_gpu_py3.10
-          python_version: '3.10'
       - unittest_macos_cpu:
           cuda_version: cpu
           name: unittest_macos_cpu_py3.7
           python_version: '3.7'
-          requires:
-          - download_third_parties_nix
-      - unittest_macos_cpu:
-          cuda_version: cpu
-          name: unittest_macos_cpu_py3.8
-          python_version: '3.8'
-          requires:
-          - download_third_parties_nix
-      - unittest_macos_cpu:
-          cuda_version: cpu
-          name: unittest_macos_cpu_py3.9
-          python_version: '3.9'
-          requires:
-          - download_third_parties_nix
-      - unittest_macos_cpu:
-          cuda_version: cpu
-          name: unittest_macos_cpu_py3.10
-          python_version: '3.10'
           requires:
           - download_third_parties_nix
   nightly:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -210,6 +210,13 @@ def indent(indentation, data_list):
     return ("\n" + " " * indentation).join(yaml.dump(data_list).splitlines())
 
 
+def unittest_python_versions(os):
+    return {
+        "windows": PYTHON_VERSIONS[:1],
+        "macos": PYTHON_VERSIONS[:1],
+        "linux": PYTHON_VERSIONS,
+    }.get(os)
+
 def unittest_workflows(indentation=6):
     jobs = []
     jobs += build_download_job(None)
@@ -218,7 +225,7 @@ def unittest_workflows(indentation=6):
             if os_type == "macos" and device_type == "gpu":
                 continue
 
-            for i, python_version in enumerate(PYTHON_VERSIONS):
+            for i, python_version in enumerate(unittest_python_versions(os_type)):
                 job = {
                     "name": f"unittest_{os_type}_{device_type}_py{python_version}",
                     "python_version": python_version,

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -217,6 +217,7 @@ def unittest_python_versions(os):
         "linux": PYTHON_VERSIONS,
     }.get(os)
 
+
 def unittest_workflows(indentation=6):
     jobs = []
     jobs += build_download_job(None)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #2256

Limits scope of unittesting to one python version for both macOS and
Windows. These types of workflows are particularly expensive and take a
long time so running them on every PR / every push is a bit wasteful
considering the value in signal between different python versions is
probably negligible.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D34459626](https://our.internmc.facebook.com/intern/diff/D34459626)