### PR TITLE
ci: Remove CUDA 11.1 from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -743,13 +743,6 @@ workflows:
           - download_third_parties_nix
           wheel_docker_image: pytorch/manylinux-cuda102
       - binary_linux_wheel:
-          cuda_version: cu111
-          name: binary_linux_wheel_py3.7_cu111
-          python_version: '3.7'
-          requires:
-          - download_third_parties_nix
-          wheel_docker_image: pytorch/manylinux-cuda111
-      - binary_linux_wheel:
           cuda_version: cu113
           name: binary_linux_wheel_py3.7_cu113
           python_version: '3.7'
@@ -797,13 +790,6 @@ workflows:
           - download_third_parties_nix
           wheel_docker_image: pytorch/manylinux-cuda102
       - binary_linux_wheel:
-          cuda_version: cu111
-          name: binary_linux_wheel_py3.8_cu111
-          python_version: '3.8'
-          requires:
-          - download_third_parties_nix
-          wheel_docker_image: pytorch/manylinux-cuda111
-      - binary_linux_wheel:
           cuda_version: cu113
           name: binary_linux_wheel_py3.8_cu113
           python_version: '3.8'
@@ -845,13 +831,6 @@ workflows:
           - download_third_parties_nix
           wheel_docker_image: pytorch/manylinux-cuda102
       - binary_linux_wheel:
-          cuda_version: cu111
-          name: binary_linux_wheel_py3.9_cu111
-          python_version: '3.9'
-          requires:
-          - download_third_parties_nix
-          wheel_docker_image: pytorch/manylinux-cuda111
-      - binary_linux_wheel:
           cuda_version: cu113
           name: binary_linux_wheel_py3.9_cu113
           python_version: '3.9'
@@ -892,13 +871,6 @@ workflows:
           requires:
           - download_third_parties_nix
           wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_linux_wheel:
-          cuda_version: cu111
-          name: binary_linux_wheel_py3.10_cu111
-          python_version: '3.10'
-          requires:
-          - download_third_parties_nix
-          wheel_docker_image: pytorch/manylinux-cuda111
       - binary_linux_wheel:
           cuda_version: cu113
           name: binary_linux_wheel_py3.10_cu113
@@ -1022,13 +994,6 @@ workflows:
           requires:
           - download_third_parties_nix
       - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda111
-          cuda_version: cu111
-          name: binary_linux_conda_py3.7_cu111
-          python_version: '3.7'
-          requires:
-          - download_third_parties_nix
-      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda113
           cuda_version: cu113
           name: binary_linux_conda_py3.7_cu113
@@ -1053,13 +1018,6 @@ workflows:
           conda_docker_image: pytorch/conda-builder:cuda102
           cuda_version: cu102
           name: binary_linux_conda_py3.8_cu102
-          python_version: '3.8'
-          requires:
-          - download_third_parties_nix
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda111
-          cuda_version: cu111
-          name: binary_linux_conda_py3.8_cu111
           python_version: '3.8'
           requires:
           - download_third_parties_nix
@@ -1092,13 +1050,6 @@ workflows:
           requires:
           - download_third_parties_nix
       - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda111
-          cuda_version: cu111
-          name: binary_linux_conda_py3.9_cu111
-          python_version: '3.9'
-          requires:
-          - download_third_parties_nix
-      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda113
           cuda_version: cu113
           name: binary_linux_conda_py3.9_cu113
@@ -1123,13 +1074,6 @@ workflows:
           conda_docker_image: pytorch/conda-builder:cuda102
           cuda_version: cu102
           name: binary_linux_conda_py3.10_cu102
-          python_version: '3.10'
-          requires:
-          - download_third_parties_nix
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda111
-          cuda_version: cu111
-          name: binary_linux_conda_py3.10_cu111
           python_version: '3.10'
           requires:
           - download_third_parties_nix
@@ -1463,43 +1407,6 @@ workflows:
           requires:
           - nightly_binary_linux_wheel_py3.7_cu102_upload
       - binary_linux_wheel:
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.7_cu111
-          python_version: '3.7'
-          requires:
-          - download_third_parties_nix
-          wheel_docker_image: pytorch/manylinux-cuda111
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.7_cu111_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.7_cu111
-          subfolder: cu111/
-      - smoke_test_linux_pip:
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.7_cu111_smoke_test_pip
-          python_version: '3.7'
-          requires:
-          - nightly_binary_linux_wheel_py3.7_cu111_upload
-      - binary_linux_wheel:
           cuda_version: cu113
           filters:
             branches:
@@ -1720,43 +1627,6 @@ workflows:
           python_version: '3.8'
           requires:
           - nightly_binary_linux_wheel_py3.8_cu102_upload
-      - binary_linux_wheel:
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.8_cu111
-          python_version: '3.8'
-          requires:
-          - download_third_parties_nix
-          wheel_docker_image: pytorch/manylinux-cuda111
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.8_cu111_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.8_cu111
-          subfolder: cu111/
-      - smoke_test_linux_pip:
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.8_cu111_smoke_test_pip
-          python_version: '3.8'
-          requires:
-          - nightly_binary_linux_wheel_py3.8_cu111_upload
       - binary_linux_wheel:
           cuda_version: cu113
           filters:
@@ -1979,43 +1849,6 @@ workflows:
           requires:
           - nightly_binary_linux_wheel_py3.9_cu102_upload
       - binary_linux_wheel:
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.9_cu111
-          python_version: '3.9'
-          requires:
-          - download_third_parties_nix
-          wheel_docker_image: pytorch/manylinux-cuda111
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.9_cu111_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.9_cu111
-          subfolder: cu111/
-      - smoke_test_linux_pip:
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.9_cu111_smoke_test_pip
-          python_version: '3.9'
-          requires:
-          - nightly_binary_linux_wheel_py3.9_cu111_upload
-      - binary_linux_wheel:
           cuda_version: cu113
           filters:
             branches:
@@ -2236,43 +2069,6 @@ workflows:
           python_version: '3.10'
           requires:
           - nightly_binary_linux_wheel_py3.10_cu102_upload
-      - binary_linux_wheel:
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.10_cu111
-          python_version: '3.10'
-          requires:
-          - download_third_parties_nix
-          wheel_docker_image: pytorch/manylinux-cuda111
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.10_cu111_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.10_cu111
-          subfolder: cu111/
-      - smoke_test_linux_pip:
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.10_cu111_smoke_test_pip
-          python_version: '3.10'
-          requires:
-          - nightly_binary_linux_wheel_py3.10_cu111_upload
       - binary_linux_wheel:
           cuda_version: cu113
           filters:
@@ -3006,42 +2802,6 @@ workflows:
           requires:
           - nightly_binary_linux_conda_py3.7_cu102_upload
       - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda111
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.7_cu111
-          python_version: '3.7'
-          requires:
-          - download_third_parties_nix
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.7_cu111_upload
-          requires:
-          - nightly_binary_linux_conda_py3.7_cu111
-      - smoke_test_linux_conda_gpu:
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.7_cu111_smoke_test_conda
-          python_version: '3.7'
-          requires:
-          - nightly_binary_linux_conda_py3.7_cu111_upload
-      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda113
           cuda_version: cu113
           filters:
@@ -3185,42 +2945,6 @@ workflows:
           python_version: '3.8'
           requires:
           - nightly_binary_linux_conda_py3.8_cu102_upload
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda111
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.8_cu111
-          python_version: '3.8'
-          requires:
-          - download_third_parties_nix
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.8_cu111_upload
-          requires:
-          - nightly_binary_linux_conda_py3.8_cu111
-      - smoke_test_linux_conda_gpu:
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.8_cu111_smoke_test_conda
-          python_version: '3.8'
-          requires:
-          - nightly_binary_linux_conda_py3.8_cu111_upload
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda113
           cuda_version: cu113
@@ -3366,42 +3090,6 @@ workflows:
           requires:
           - nightly_binary_linux_conda_py3.9_cu102_upload
       - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda111
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.9_cu111
-          python_version: '3.9'
-          requires:
-          - download_third_parties_nix
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.9_cu111_upload
-          requires:
-          - nightly_binary_linux_conda_py3.9_cu111
-      - smoke_test_linux_conda_gpu:
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.9_cu111_smoke_test_conda
-          python_version: '3.9'
-          requires:
-          - nightly_binary_linux_conda_py3.9_cu111_upload
-      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda113
           cuda_version: cu113
           filters:
@@ -3545,42 +3233,6 @@ workflows:
           python_version: '3.10'
           requires:
           - nightly_binary_linux_conda_py3.10_cu102_upload
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda111
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.10_cu111
-          python_version: '3.10'
-          requires:
-          - download_third_parties_nix
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.10_cu111_upload
-          requires:
-          - nightly_binary_linux_conda_py3.10_cu111
-      - smoke_test_linux_conda_gpu:
-          cuda_version: cu111
-          filters:
-            branches:
-              only:
-              - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.10_cu111_smoke_test_conda
-          python_version: '3.10'
-          requires:
-          - nightly_binary_linux_conda_py3.10_cu111_upload
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda113
           cuda_version: cu113

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -23,7 +23,7 @@ from jinja2 import select_autoescape
 
 PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10"]
 CU_VERSIONS_DICT = {
-    "linux": ["cpu", "cu102", "cu111", "cu113", "cu115", "rocm4.3.1", "rocm4.5.2"],
+    "linux": ["cpu", "cu102", "cu113", "cu115", "rocm4.3.1", "rocm4.5.2"],
     "windows": ["cpu", "cu113", "cu115"],
     "macos": ["cpu"],
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #2259

We're deprecating support for CUDA 11.1 binaries since CUDA 11.3 should
be forwards compatible with CUDA 11.1 drivers

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D34458400](https://our.internmc.facebook.com/intern/diff/D34458400)