### PR TITLE
Make Streamer fail if an invalid option is provided

### DIFF
--- a/test/torchaudio_unittest/common_utils/parameterized_utils.py
+++ b/test/torchaudio_unittest/common_utils/parameterized_utils.py
@@ -19,11 +19,11 @@ def _name_func(func, _, params):
         else:
             strs.append(str(arg))
     # sanitize the test name
-    name = "_".join(strs).replace(".", "_")
-    return f"{func.__name__}_{name}"
+    name = "_".join(strs)
+    return parameterized.to_safe_name(f"{func.__name__}_{name}")
 
 
-def nested_params(*params_set):
+def nested_params(*params_set, name_func=_name_func):
     """Generate the cartesian product of the given list of parameters.
 
     Args:

--- a/test/torchaudio_unittest/prototype/io_test.py
+++ b/test/torchaudio_unittest/prototype/io_test.py
@@ -35,6 +35,24 @@ class StreamerInterfaceTest(TempDirMixin, TorchaudioTestCase):
         with self.assertRaises(RuntimeError):
             Streamer("foobar")
 
+    @nested_params(
+        [
+            ("foo",),
+            (
+                "foo",
+                "bar",
+            ),
+        ],
+        [{}, {"sample_rate": "16000"}],
+    )
+    def test_streamer_invalide_option(self, invalid_keys, options):
+        """When invalid options are given, Streamer raises an exception with these keys"""
+        options.update({k: k for k in invalid_keys})
+        src = get_video_asset()
+        with self.assertRaises(RuntimeError) as ctx:
+            Streamer(src, option=options)
+        assert all(f'"{k}"' in str(ctx.exception) for k in invalid_keys)
+
     def test_src_info(self):
         """`get_src_stream_info` properly fetches information"""
         s = Streamer(get_video_asset())


### PR DESCRIPTION
`torchaudio.prototype.io.Streamer` class takes context dependant options
as `option` argument in the form of mappings of strings.

Currently there is no check if the provided options were valid for
the given input.

This commit adds the check and raise an error if an invalid erro is given.

This is analogous to `ffmpeg` command error handling.

```
$ ffmpeg -foo
...
Unrecognized option 'foo'.
```