### PR TITLE
Simplify setup_env.sh

### DIFF
--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -23,20 +23,8 @@ if [ ! -d "${conda_dir}" ]; then
     printf "* Installing conda\n"
     curl --silent -L -o miniconda.sh "http://repo.continuum.io/miniconda/Miniconda3-latest-${os}-x86_64.sh"
     bash ./miniconda.sh -b -f -p "${conda_dir}"
-    eval "$("${conda_dir}/bin/conda" shell.bash hook)"
-    printf "* Updating the base Python version to %s\n" "${PYTHON_VERSION}"
-
-    ADDITIONAL_CHANNELS=""
-    if [[ ${PYTHON_VERSION} == 3.10 ]]; then
-        ADDITIONAL_CHANNELS="-c conda-forge"
-    fi
-
-    # Need to disable shell check since this'll fail out if ADDITIONAL_CHANNELS is empty
-    # shellcheck disable=SC2086
-    conda install ${ADDITIONAL_CHANNELS} --quiet -y python="${PYTHON_VERSION}"
-else
-    eval "$("${conda_dir}/bin/conda" shell.bash hook)"
 fi
+eval "$("${conda_dir}/bin/conda" shell.bash hook)"
 
 
 # 2. Create test environment at ./env

--- a/.circleci/unittest/windows/scripts/setup_env.sh
+++ b/.circleci/unittest/windows/scripts/setup_env.sh
@@ -23,20 +23,8 @@ if [ ! -d "${conda_dir}" ]; then
     "$this_dir/install_conda.bat"
     unset tmp_conda
     unset miniconda_exe
-    eval "$("${conda_dir}/Scripts/conda.exe" 'shell.bash' 'hook')"
-    printf "* Updating the base Python version to %s\n" "${PYTHON_VERSION}"
-
-    ADDITIONAL_CHANNELS=""
-    if [[ ${PYTHON_VERSION} == 3.10 ]]; then
-        ADDITIONAL_CHANNELS="-c conda-forge"
-    fi
-
-    # Need to disable shell check since this'll fail out if ADDITIONAL_CHANNELS is empty
-    # shellcheck disable=SC2086
-    conda install ${ADDITIONAL_CHANNELS} --quiet -y python="$PYTHON_VERSION"
-else
-    eval "$("${conda_dir}/Scripts/conda.exe" 'shell.bash' 'hook')"
 fi
+eval "$("${conda_dir}/Scripts/conda.exe" 'shell.bash' 'hook')"
 
 # 2. Create test environment at ./env
 if [ ! -d "${env_dir}" ]; then


### PR DESCRIPTION
Make them more aligned with ones in
https://github.com/pytorch/vision/blob/main/.circleci/unittest/linux/scripts/setup_env.sh


This is preliminary step towards eradicating unneeded conda-forge dependencies, see https://github.com/pytorch/audio/pull/2260