### PR TITLE
Fix Kaldi submodule integration

### DIFF
--- a/third_party/kaldi/CMakeLists.txt
+++ b/third_party/kaldi/CMakeLists.txt
@@ -13,7 +13,7 @@ execute_process(
 # Update the version string
 execute_process(
   WORKING_DIRECTORY ${KALDI_REPO}/src/base
-  COMMAND sh get_version.sh
+  COMMAND bash get_version.sh
   )
 endif()
 


### PR DESCRIPTION
When building Kaldi submodule, it requires to run `get_version.sh`, so that version header is available. 
It was pointed that the script should run with `bash`, instead of `sh`.

Fixes #2268