### PR TITLE
Fix calculation of SNR value in tutorial

### DIFF
--- a/examples/tutorials/audio_data_augmentation_tutorial.py
+++ b/examples/tutorials/audio_data_augmentation_tutorial.py
@@ -350,7 +350,7 @@ noise_power = noise.norm(p=2)
 snr_dbs = [20, 10, 3]
 noisy_speeches = []
 for snr_db in snr_dbs:
-    snr = math.exp(snr_db / 10)
+    snr = 10 ** (snr_db / 20)
     scale = snr * noise_power / speech_power
     noisy_speeches.append((scale * speech + noise) / 2)
 


### PR DESCRIPTION
The calculation of the SNR in tha data augmentation examples seems to be wrong to me:

![image](https://user-images.githubusercontent.com/173624/159487032-c60470c6-ef8e-48a0-ad5e-a117fcb8d606.png)

If we start from the definition of the signal-to-noise ratio using the root mean square value we get:

```
SNR = 20 log10 ( rms(scale * speech) / rms(noise) )
```
this can be transformed to
```
scale = 10^(SNR/20) rms(noise) / rms(speech)
```
In the example not `rms` is used but `lambda x: x.norm(p=2)`, but as we have the same length of the speech and noise signal, we have
```
rms(noise) / rms(speech) = noise.norm(p=2) / speech.norm(p=2)
```
this would lead us to:
```
10^(SNR/20) = e^(SNR / 10)
```
which is not true.

Hence I changed `e^(SNR / 10)` to `10^(SNR/20)`.

For the proposed SNR values of 20 dB, 10 dB, 3 dB the value of `scale` would change from 7.39, 2.72, 1.35 to 10.0, 3.16, 1.41.
