### PR TITLE
make sure inputs live on CPU for ctc decoder

### DIFF
--- a/torchaudio/prototype/ctc_decoder/ctc_decoder.py
+++ b/torchaudio/prototype/ctc_decoder/ctc_decoder.py
@@ -135,10 +135,10 @@ class LexiconDecoder:
             List[List[Hypothesis]]:
                 List of sorted best hypotheses for each audio sequence in the batch.
         """
- 
+
         if emissions.dtype != torch.float32:
             raise ValueError('emissions must be float32.')
-  
+
         if emissions.is_cuda:
             raise RuntimeError('emissions must live on CPU.')
 

--- a/torchaudio/prototype/ctc_decoder/ctc_decoder.py
+++ b/torchaudio/prototype/ctc_decoder/ctc_decoder.py
@@ -127,23 +127,27 @@ class LexiconDecoder:
 
         Args:
             emissions (torch.FloatTensor): tensor of shape `(batch, frame, num_tokens)` storing sequences of
-                probability distribution over labels; output of acoustic model. It must lives on CPU.
+                probability distribution over labels; output of acoustic model. It must live on CPU.
             lengths (Tensor or None, optional): tensor of shape `(batch, )` storing the valid length of
-                in time axis of the output Tensor in each batch. It must lives on CPU.
+                in time axis of the output Tensor in each batch. It must live on CPU.
 
         Returns:
             List[List[Hypothesis]]:
                 List of sorted best hypotheses for each audio sequence in the batch.
         """
-        assert emissions.dtype == torch.float32
+        
+        if emissions.dtype != torch.float32:
+            raise ValueError('emissions must be float32.')
+        
+        if emissions.is_cuda:
+            raise Exception('emissions must live on CPU.')
 
-
+        if lengths is not None and lengths.is_cuda:
+            raise Exception('lengths must live on CPU.')
+        
         B, T, N = emissions.size()
         if lengths is None:
             lengths = torch.full((B,), T)
-
-        assert not emissions.is_cuda
-        assert not lengths.is_cuda
         
         float_bytes = 4
         hypos = []

--- a/torchaudio/prototype/ctc_decoder/ctc_decoder.py
+++ b/torchaudio/prototype/ctc_decoder/ctc_decoder.py
@@ -127,15 +127,18 @@ class LexiconDecoder:
 
         Args:
             emissions (torch.FloatTensor): tensor of shape `(batch, frame, num_tokens)` storing sequences of
-                probability distribution over labels; output of acoustic model
+                probability distribution over labels; output of acoustic model. It must lives on CPU.
             lengths (Tensor or None, optional): tensor of shape `(batch, )` storing the valid length of
-                in time axis of the output Tensor in each batch
+                in time axis of the output Tensor in each batch. It must lives on CPU.
 
         Returns:
             List[List[Hypothesis]]:
                 List of sorted best hypotheses for each audio sequence in the batch.
         """
         assert emissions.dtype == torch.float32
+
+	asser not emissions.is_cuda
+	asser not lengths.is_cuda
 
         B, T, N = emissions.size()
         if lengths is None:

--- a/torchaudio/prototype/ctc_decoder/ctc_decoder.py
+++ b/torchaudio/prototype/ctc_decoder/ctc_decoder.py
@@ -135,16 +135,16 @@ class LexiconDecoder:
             List[List[Hypothesis]]:
                 List of sorted best hypotheses for each audio sequence in the batch.
         """
-        
+ 
         if emissions.dtype != torch.float32:
             raise ValueError('emissions must be float32.')
-        
+  
         if emissions.is_cuda:
             raise RuntimeError('emissions must live on CPU.')
 
         if lengths is not None and lengths.is_cuda:
             raise RuntimeError('lengths must live on CPU.')
-        
+
         B, T, N = emissions.size()
         if lengths is None:
             lengths = torch.full((B,), T)

--- a/torchaudio/prototype/ctc_decoder/ctc_decoder.py
+++ b/torchaudio/prototype/ctc_decoder/ctc_decoder.py
@@ -140,10 +140,10 @@ class LexiconDecoder:
             raise ValueError("emissions must be float32.")
 
         if emissions.is_cuda:
-            raise RuntimeError("emissions must live on CPU.")
+            raise RuntimeError("emissions must be a CPU tensor.")
 
         if lengths is not None and lengths.is_cuda:
-            raise RuntimeError("lengths must live on CPU.")
+            raise RuntimeError("lengths must be a CPU tensor.")
 
         B, T, N = emissions.size()
         if lengths is None:

--- a/torchaudio/prototype/ctc_decoder/ctc_decoder.py
+++ b/torchaudio/prototype/ctc_decoder/ctc_decoder.py
@@ -148,6 +148,7 @@ class LexiconDecoder:
         B, T, N = emissions.size()
         if lengths is None:
             lengths = torch.full((B,), T)
+
         float_bytes = 4
         hypos = []
         for b in range(B):

--- a/torchaudio/prototype/ctc_decoder/ctc_decoder.py
+++ b/torchaudio/prototype/ctc_decoder/ctc_decoder.py
@@ -137,13 +137,14 @@ class LexiconDecoder:
         """
         assert emissions.dtype == torch.float32
 
-	asser not emissions.is_cuda
-	asser not lengths.is_cuda
 
         B, T, N = emissions.size()
         if lengths is None:
             lengths = torch.full((B,), T)
 
+        assert not emissions.is_cuda
+        assert not lengths.is_cuda
+        
         float_bytes = 4
         hypos = []
         for b in range(B):

--- a/torchaudio/prototype/ctc_decoder/ctc_decoder.py
+++ b/torchaudio/prototype/ctc_decoder/ctc_decoder.py
@@ -126,10 +126,10 @@ class LexiconDecoder:
             List[List[torchaudio.prototype.ctc_decoder.Hypothesis]]
 
         Args:
-            emissions (torch.FloatTensor): tensor of shape `(batch, frame, num_tokens)` storing sequences of
-                probability distribution over labels; output of acoustic model. It must live on CPU.
-            lengths (Tensor or None, optional): tensor of shape `(batch, )` storing the valid length of
-                in time axis of the output Tensor in each batch. It must live on CPU.
+            emissions (torch.FloatTensor): CPU tensor of shape `(batch, frame, num_tokens)` storing sequences of
+                probability distribution over labels; output of acoustic model.
+            lengths (Tensor or None, optional): CPU tensor of shape `(batch, )` storing the valid length of
+                in time axis of the output Tensor in each batch.
 
         Returns:
             List[List[Hypothesis]]:
@@ -140,15 +140,14 @@ class LexiconDecoder:
             raise ValueError('emissions must be float32.')
         
         if emissions.is_cuda:
-            raise Exception('emissions must live on CPU.')
+            raise RuntimeError('emissions must live on CPU.')
 
         if lengths is not None and lengths.is_cuda:
-            raise Exception('lengths must live on CPU.')
+            raise RuntimeError('lengths must live on CPU.')
         
         B, T, N = emissions.size()
         if lengths is None:
             lengths = torch.full((B,), T)
-        
         float_bytes = 4
         hypos = []
         for b in range(B):

--- a/torchaudio/prototype/ctc_decoder/ctc_decoder.py
+++ b/torchaudio/prototype/ctc_decoder/ctc_decoder.py
@@ -137,13 +137,13 @@ class LexiconDecoder:
         """
 
         if emissions.dtype != torch.float32:
-            raise ValueError('emissions must be float32.')
+            raise ValueError("emissions must be float32.")
 
         if emissions.is_cuda:
-            raise RuntimeError('emissions must live on CPU.')
+            raise RuntimeError("emissions must live on CPU.")
 
         if lengths is not None and lengths.is_cuda:
-            raise RuntimeError('lengths must live on CPU.')
+            raise RuntimeError("lengths must live on CPU.")
 
         B, T, N = emissions.size()
         if lengths is None:


### PR DESCRIPTION
Addressing the issue https://github.com/pytorch/audio/issues/2274: 
Raise Runtime errors when the input tensors to the CTC decoder are GPU tensors since the CTC decoder only runs on CPU. Also update the data type check to use "raise" rather than "assert". 

---
Pull Request resolved: https://github.com/pytorch/audio/pull/2289
GitHub Author: xiaohui-zhang <xiaohuizhang@fb.com>