### PR TITLE
Update decoder pretrained lm docs

### DIFF
--- a/docs/source/prototype.ctc_decoder.rst
+++ b/docs/source/prototype.ctc_decoder.rst
@@ -33,7 +33,7 @@ Utility Function
 ----------------
 
 download_pretrained_files
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: download_pretrained_files
 

--- a/docs/source/prototype.ctc_decoder.rst
+++ b/docs/source/prototype.ctc_decoder.rst
@@ -25,9 +25,17 @@ Factory Function
 ----------------
 
 lexicon_decoder
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 .. autoclass:: lexicon_decoder
+
+Utility Function
+----------------
+
+download_pretrained_files
+~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: download_pretrained_files
 
 References
 ----------

--- a/torchaudio/prototype/ctc_decoder/ctc_decoder.py
+++ b/torchaudio/prototype/ctc_decoder/ctc_decoder.py
@@ -277,15 +277,17 @@ def download_pretrained_files(model: str) -> _PretrainedFiles:
     Retrieves pretrained data files used for CTC decoder.
 
     Args:
-        model (str): pretrained language model to download
+        model (str): pretrained language model to download.
             Options: ["librispeech-3-gram", "librispeech-4-gram", "librispeech"]
 
     Returns:
-        Object with the following attributes:
-            lm: path corresponding to downloaded language model, or None if model is not
-                associated with an lm
-            lexicon: path corresponding to downloaded lexicon file
-            tokens: path corresponding to downloaded tokens file
+        Object with the following attributes
+            lm:
+                path corresponding to downloaded language model, or `None` if the model is not associated with an lm
+            lexicon:
+                path corresponding to downloaded lexicon file
+            tokens:
+                path corresponding to downloaded tokens file
     """
 
     files = _get_filenames(model)


### PR DESCRIPTION
`build_docs` test is failing on CI with `ImportError: cannot import name 'environmentfilter' from 'jinja2'`, but with local build:

<img width="902" alt="Screen Shot 2022-03-25 at 4 02 53 PM" src="https://user-images.githubusercontent.com/16568633/160157472-c91ff9b2-a2be-4c5d-959e-53b9f45425c6.png">

