### PR TITLE
Pin jinja2 version for build_docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+Jinja2<3.1.0
 sphinx==3.5.4
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git@b4d0005#egg=pytorch_sphinx_theme
 sphinxcontrib.katex


### PR DESCRIPTION
`build_docs` CircleCI currently failing with `ImportError: cannot import name 'environmentfilter' from 'jinja2'`. Pin Jinja2<3.1 to resolve this issue, see https://github.com/sphinx-doc/sphinx/issues/10291#issuecomment-1078046986