### PR TITLE
v1.2.11 deleted; https://www.zlib.net/

### DIFF
--- a/third_party/zlib/CMakeLists.txt
+++ b/third_party/zlib/CMakeLists.txt
@@ -22,8 +22,8 @@ set(
 ExternalProject_Add(zlib-
   PREFIX ${CMAKE_CURRENT_BINARY_DIR}
   DOWNLOAD_DIR ${ARCHIVE_DIR}
-  URL https://zlib.net/zlib-1.2.11.tar.gz
-  URL_HASH SHA256=c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+  URL https://zlib.net/zlib-1.2.12.tar.gz
+  URL_HASH SHA256=91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
   BUILD_BYPRODUCTS ${ZLIB_LIBRARIES}
   CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env ${envs} ${CMAKE_CURRENT_BINARY_DIR}/src/zlib-/configure --static
   BUILD_COMMAND ${CMAKE_COMMAND} -E env ${envs} make VERBOSE=1


### PR DESCRIPTION
Due to the bug fixes, any installations of 1.2.11 should be replaced with 1.2.12.