### PR TITLE
Raise error for resampling int waveform

### DIFF
--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -1399,6 +1399,9 @@ def _apply_sinc_resample_kernel(
     kernel: Tensor,
     width: int,
 ):
+    if not waveform.is_floating_point():
+        raise TypeError(f"Expected floating point type for waveform tensor, but received {waveform.dtype}.")
+
     orig_freq = int(orig_freq) // gcd
     new_freq = int(new_freq) // gcd
 


### PR DESCRIPTION
Resolves #2294

Raise an error if the waveform to be resampled is not of floating point type. The `conv1d` operation used in resampling and `nn.Module` used for the transforms don't support integer type.