### PR TITLE
Add an option to use Tanh instead of ReLU in RNNT joiner

### DIFF
--- a/torchaudio/models/rnnt.py
+++ b/torchaudio/models/rnnt.py
@@ -377,20 +377,20 @@ class _Joiner(torch.nn.Module):
     Args:
         input_dim (int): source and target input dimension.
         output_dim (int): output dimension.
-        joiner_activation (str, optional): activation function to use in the joiner
+        activation (str, optional): activation function to use in the joiner
             Must be one of ("relu", "tanh"). (Default: "relu")
 
     """
 
-    def __init__(self, input_dim: int, output_dim: int, joiner_activation: str = "relu") -> None:
+    def __init__(self, input_dim: int, output_dim: int, activation: str = "relu") -> None:
         super().__init__()
         self.linear = torch.nn.Linear(input_dim, output_dim, bias=True)
-        if joiner_activation == "relu":
+        if activation == "relu":
             self.activation = torch.nn.ReLU()
-        elif joiner_activation == "tanh":
+        elif activation == "tanh":
             self.activation = torch.nn.Tanh()
         else:
-            raise ValueError(f"Unsupported activation {joiner_activation}")
+            raise ValueError(f"Unsupported activation {activation}")
 
     def forward(
         self,

--- a/torchaudio/models/rnnt.py
+++ b/torchaudio/models/rnnt.py
@@ -377,12 +377,17 @@ class _Joiner(torch.nn.Module):
     Args:
         input_dim (int): source and target input dimension.
         output_dim (int): output dimension.
+        use_tanh (bool, optional): if ``True``, uses Tanh rather ReLU activation. (Default: ``False``)
+
     """
 
-    def __init__(self, input_dim: int, output_dim: int) -> None:
+    def __init__(self, input_dim: int, output_dim: int, use_tanh: bool = False) -> None:
         super().__init__()
         self.linear = torch.nn.Linear(input_dim, output_dim, bias=True)
-        self.relu = torch.nn.ReLU()
+        if use_tanh:
+            self.activation = torch.nn.Tanh()
+        else:
+            self.activation = torch.nn.ReLU()
 
     def forward(
         self,
@@ -419,8 +424,8 @@ class _Joiner(torch.nn.Module):
                     number of valid elements along dim 2 for i-th batch element in joint network output.
         """
         joint_encodings = source_encodings.unsqueeze(2).contiguous() + target_encodings.unsqueeze(1).contiguous()
-        relu_out = self.relu(joint_encodings)
-        output = self.linear(relu_out)
+        activation_out = self.activation(joint_encodings)
+        output = self.linear(activation_out)
         return output, source_lengths, target_lengths
 
 

--- a/torchaudio/models/rnnt.py
+++ b/torchaudio/models/rnnt.py
@@ -385,12 +385,12 @@ class _Joiner(torch.nn.Module):
     def __init__(self, input_dim: int, output_dim: int, joiner_activation: str = "relu") -> None:
         super().__init__()
         self.linear = torch.nn.Linear(input_dim, output_dim, bias=True)
-        if joiner_activation == "relu": 
+        if joiner_activation == "relu":
             self.activation = torch.nn.ReLU()
-        elif joiner_activation == "tanh": 
+        elif joiner_activation == "tanh":
             self.activation = torch.nn.Tanh()
-        else: 
-            raise ValueError(f"Unsupported activation {joiner_activation}") 
+        else:
+            raise ValueError(f"Unsupported activation {joiner_activation}")
 
     def forward(
         self,

--- a/torchaudio/models/rnnt.py
+++ b/torchaudio/models/rnnt.py
@@ -377,17 +377,20 @@ class _Joiner(torch.nn.Module):
     Args:
         input_dim (int): source and target input dimension.
         output_dim (int): output dimension.
-        use_tanh (bool, optional): if ``True``, uses Tanh rather ReLU activation. (Default: ``False``)
+        joiner_activation (str, optional): activation function to use in the joiner
+            Must be one of ("relu", "tanh"). (Default: "relu")
 
     """
 
-    def __init__(self, input_dim: int, output_dim: int, use_tanh: bool = False) -> None:
+    def __init__(self, input_dim: int, output_dim: int, joiner_activation: str = "relu") -> None:
         super().__init__()
         self.linear = torch.nn.Linear(input_dim, output_dim, bias=True)
-        if use_tanh:
-            self.activation = torch.nn.Tanh()
-        else:
+        if joiner_activation == "relu": 
             self.activation = torch.nn.ReLU()
+        elif joiner_activation == "tanh": 
+            self.activation = torch.nn.Tanh()
+        else: 
+            raise ValueError(f"Unsupported activation {joiner_activation}") 
 
     def forward(
         self,


### PR DESCRIPTION
Add an option to use Tanh instead of ReLU in RNNT joiner, which enables better training performance sometimes.

---
Pull Request resolved: https://github.com/pytorch/audio/pull/2319
GitHub Author: xiaohui-zhang <xiaohuizhang@fb.com>
