### PR TITLE
Add an option to use GroupNorm instead of BatchNorm in Conformer model

### DIFF
--- a/torchaudio/models/conformer.py
+++ b/torchaudio/models/conformer.py
@@ -31,6 +31,7 @@ class _ConvolutionModule(torch.nn.Module):
         num_channels: int,
         depthwise_kernel_size: int,
         bias: bool = False,
+        use_group_norm: bool = False,
         dropout: float = 0.0,
     ) -> None:
         super().__init__()
@@ -55,7 +56,7 @@ class _ConvolutionModule(torch.nn.Module):
                 groups=num_channels,
                 bias=bias,
             ),
-            torch.nn.BatchNorm1d(num_channels),
+            torch.nn.GroupNorm(num_groups=1, num_channels=num_channels) if use_group_norm else torch.nn.BatchNorm1d(num_channels),
             torch.nn.SiLU(),
             torch.nn.Conv1d(
                 num_channels,
@@ -131,6 +132,7 @@ class ConformerLayer(torch.nn.Module):
         num_attention_heads: int,
         depthwise_conv_kernel_size: int,
         dropout: float = 0.0,
+        use_group_norm: bool = False,
     ) -> None:
         super().__init__()
 
@@ -145,6 +147,7 @@ class ConformerLayer(torch.nn.Module):
             num_channels=input_dim,
             depthwise_kernel_size=depthwise_conv_kernel_size,
             bias=True,
+            use_group_norm=use_group_norm,
             dropout=dropout,
         )
 


### PR DESCRIPTION
gpurun pytest test/torchaudio_unittest/models/conformer
git add ============================= test session starts ==============================
platform linux -- Python 3.7.0, pytest-7.1.1, pluggy-1.0.0
rootdir: /data/home/xiaohuizhang/audio_dev2
collected 4 items

test/torchaudio_unittest/models/conformer/conformer_cpu_test.py ..       [ 50%]
test/torchaudio_unittest/models/conformer/conformer_gpu_test.py ..       [100%]

============================== 4 passed in 10.36s ==============================