### PR TITLE
Add devices/properties badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ instance/
 docs/_build/
 docs/src/
 docs/source/tutorials
+docs/source/gen_images
 docs/source/gen_modules
 
 # PyBuilder

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -9,7 +9,7 @@ dt > em.sig-param:last-of-type::after {
     content: "\a";
     white-space: pre;
 }
-/* For shileds */
+/* For shields */
 article.pytorch-article img.shield-badge {
     width: unset;
     margin-top: -18px;

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -9,3 +9,9 @@ dt > em.sig-param:last-of-type::after {
     content: "\a";
     white-space: pre;
 }
+/* For shileds */
+article.pytorch-article img.shield-badge {
+    width: unset;
+    margin-top: -18px;
+    margin-bottom: 9px;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,10 +17,10 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
 import os
+import sys
+
+sys.path.insert(0, os.path.abspath("."))
 import re
 import warnings
 from datetime import datetime
@@ -342,3 +342,13 @@ def inject_minigalleries(app, what, name, obj, options, lines):
 
 def setup(app):
     app.connect("autodoc-process-docstring", inject_minigalleries)
+
+
+from custom_directives import SupportedDevices, SupportedFeatures
+
+# Register custom directives
+
+from docutils.parsers import rst
+
+rst.directives.register_directive("devices", SupportedDevices)
+rst.directives.register_directive("features", SupportedFeatures)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -344,11 +344,11 @@ def setup(app):
     app.connect("autodoc-process-docstring", inject_minigalleries)
 
 
-from custom_directives import SupportedDevices, SupportedFeatures
+from custom_directives import SupportedDevices, SupportedProperties
 
 # Register custom directives
 
 from docutils.parsers import rst
 
 rst.directives.register_directive("devices", SupportedDevices)
-rst.directives.register_directive("features", SupportedFeatures)
+rst.directives.register_directive("properties", SupportedProperties)

--- a/docs/source/custom_directives.py
+++ b/docs/source/custom_directives.py
@@ -1,0 +1,116 @@
+import hashlib
+from pathlib import Path
+from typing import List
+from urllib.parse import quote, urlencode
+
+import requests
+from docutils import nodes
+from docutils.parsers.rst.directives.images import Image
+
+
+_THIS_DIR = Path(__file__).parent
+
+# Color palette from PyTorch Developer Day 2021 Presentation Template
+YELLOW = "F9DB78"
+GREEN = "70AD47"
+BLUE = "00B0F0"
+PINK = "FF71DA"
+ORANGE = "FF8300"
+TEAL = "00E5D1"
+GRAY = "7F7F7F"
+
+
+def _get_cache_path(key, ext):
+    filename = f"{hashlib.sha256(key).hexdigest()}{ext}"
+    cache_dir = _THIS_DIR / "gen_images"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir / filename
+
+
+def _download(url, path):
+    response = requests.get(url)
+    response.raise_for_status()
+    with open(path, "wb") as file:
+        file.write(response.content)
+
+
+def _fetch_image(url):
+    path = _get_cache_path(url.encode("utf-8"), ext=".svg")
+    if not path.exists():
+        _download(url, path)
+    return str(path.relative_to(_THIS_DIR))
+
+
+class BaseShield(Image):
+    def run(self, params, alt, section) -> List[nodes.Node]:
+        url = f"https://img.shields.io/static/v1?{urlencode(params, quote_via=quote)}"
+        path = _fetch_image(url)
+        self.arguments = [path]
+        self.options["alt"] = alt
+        if "class" not in self.options:
+            self.options["class"] = []
+        self.options["class"].append("shield-badge")
+        self.options["target"] = f"supported_features.html#{section}"
+        return super().run()
+
+
+def _parse_device_args(arg: str):
+    devices = sorted(arg.strip().split())
+
+    valid_values = {"CPU", "CUDA"}
+    if any(val not in valid_values for val in devices):
+        raise ValueError(
+            f"One or more device values are not valid. The valid values are {valid_values}. Given value: '{arg}'"
+        )
+    return ", ".join(sorted(devices))
+
+
+def _parse_feature_args(arg: str):
+    features = sorted(arg.strip().split())
+
+    valid_values = {"Autograd", "TorchScript", "Kaldi-Compatible"}
+    if any(val not in valid_values for val in features):
+        raise ValueError(
+            "One or more feature values are not valid. "
+            f"The valid values are {valid_values}. "
+            f"Given value: '{arg}'"
+        )
+    return ", ".join(sorted(features))
+
+
+class SupportedDevices(BaseShield):
+    """List the supported devices"""
+
+    required_arguments = 1
+    final_argument_whitespace = True
+
+    def run(self) -> List[nodes.Node]:
+        devices = _parse_device_args(self.arguments[0])
+        alt = f"This feature supports the following devices: {devices}"
+        params = {
+            "label": "Supported Devices",
+            "message": devices,
+            "labelColor": GRAY,
+            "color": BLUE,
+            "style": "flat-square",
+        }
+        return super().run(params, alt, "devices")
+
+
+class SupportedFeatures(BaseShield):
+    """List the supported features"""
+
+    required_arguments = 1
+    final_argument_whitespace = True
+
+    def run(self) -> List[nodes.Node]:
+        features = _parse_feature_args(self.arguments[0])
+        alt = f"This feature supports the following features: {features}"
+        params = {
+            "label": "Supported Features",
+            "message": features,
+            "labelColor": GRAY,
+            "color": GREEN,
+            "style": "flat-square",
+        }
+        return super().run(params, alt, "features")

--- a/docs/source/custom_directives.py
+++ b/docs/source/custom_directives.py
@@ -54,7 +54,7 @@ class BaseShield(Image):
         return super().run()
 
 
-def _parse_device_args(arg: str):
+def _parse_devices(arg: str):
     devices = sorted(arg.strip().split())
 
     valid_values = {"CPU", "CUDA"}
@@ -65,17 +65,17 @@ def _parse_device_args(arg: str):
     return ", ".join(sorted(devices))
 
 
-def _parse_feature_args(arg: str):
-    features = sorted(arg.strip().split())
+def _parse_properties(arg: str):
+    properties = sorted(arg.strip().split())
 
-    valid_values = {"Autograd", "TorchScript", "Kaldi-Compatible"}
-    if any(val not in valid_values for val in features):
+    valid_values = {"Autograd", "TorchScript"}
+    if any(val not in valid_values for val in properties):
         raise ValueError(
-            "One or more feature values are not valid. "
+            "One or more property values are not valid. "
             f"The valid values are {valid_values}. "
             f"Given value: '{arg}'"
         )
-    return ", ".join(sorted(features))
+    return ", ".join(sorted(properties))
 
 
 class SupportedDevices(BaseShield):
@@ -85,10 +85,10 @@ class SupportedDevices(BaseShield):
     final_argument_whitespace = True
 
     def run(self) -> List[nodes.Node]:
-        devices = _parse_device_args(self.arguments[0])
+        devices = _parse_devices(self.arguments[0])
         alt = f"This feature supports the following devices: {devices}"
         params = {
-            "label": "Supported Devices",
+            "label": "Devices",
             "message": devices,
             "labelColor": GRAY,
             "color": BLUE,
@@ -97,20 +97,20 @@ class SupportedDevices(BaseShield):
         return super().run(params, alt, "devices")
 
 
-class SupportedFeatures(BaseShield):
-    """List the supported features"""
+class SupportedProperties(BaseShield):
+    """List the supported properties"""
 
     required_arguments = 1
     final_argument_whitespace = True
 
     def run(self) -> List[nodes.Node]:
-        features = _parse_feature_args(self.arguments[0])
-        alt = f"This feature supports the following features: {features}"
+        properties = _parse_properties(self.arguments[0])
+        alt = f"This API supports the following properties: {properties}"
         params = {
-            "label": "Supported Features",
-            "message": features,
+            "label": "Properties",
+            "message": properties,
             "labelColor": GRAY,
             "color": GREEN,
             "style": "flat-square",
         }
-        return super().run(params, alt, "features")
+        return super().run(params, alt, "properties")

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,6 +29,7 @@ Features described in this documentation are classified by release status:
    :caption: Torchaudio Documentation
 
    Index <self>
+   supported_features
 
 API References
 --------------

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1,3 +1,10 @@
+@misc{RESAMPLE,
+	author = {Julius O. Smith},
+	title = {Digital Audio Resampling Home Page "Theory of Ideal Bandlimited Interpolation" section},
+	url = {https://ccrma.stanford.edu/~jos/resample/Theory_Ideal_Bandlimited_Interpolation.html},
+	month = {September},
+	year = {2020}
+}
 @article{voxpopuli,
   author    = {Changhan Wang and
                Morgane Rivi{\`{e}}re and

--- a/docs/source/supported_features.rst
+++ b/docs/source/supported_features.rst
@@ -8,19 +8,19 @@ Supported features are indicated in API references like the following.
 
 .. features:: Autograd TorchScript
 
-These icon mean that they are verified through automated testing.
+These icons mean that they are verified through automated testing.
 
 .. note::
 
    Missing feature icons mean that they are not tested, and this can mean
-   different things, depending on APIs.
+   different things, depending on the API.
 
    1. The API is compatible with the feature but not tested.
    2. The API is not compatible with the feature.
 
    In case of 2, API might explicitly raise an error, but that is not always the case.
    For example, APIs with missing Autograd badge might throw an error on backward path,
-   or silently returns a wrong gradient.
+   or silently return a wrong gradient.
 
 If you use an API with the feature not supported, you might want to first verify that the
 feature works fine.
@@ -80,11 +80,11 @@ Autograd
 
 TorchAudio APIs with autograd support can correctly propagate the gradient in its backward path.
 
-For the basic of autograd, please checkout this `tutorial <https://pytorch.org/tutorials/beginner/blitz/autograd_tutorial.html>`_.
+For the basics of autograd, please checkout this `tutorial <https://pytorch.org/tutorials/beginner/blitz/autograd_tutorial.html>`_.
 
 .. note::
 
-   APIs without this mark might or might not raise and error in back propagation.
+   APIs without this mark may or may not raise and error in back propagation.
    The lack of error in back propagatoin does not mean the feature computes the gradient correctly.
 
 TorchScript
@@ -94,4 +94,4 @@ TorchScript
 
 TorchAudio APIs with TorchScript support can be serialized and executed on non-Python environments.
 
-For the deetail of TorchScript, please checkout the `documentation <https://pytorch.org/docs/stable/jit.html>`_.
+For the detail of TorchScript, please checkout the `documentation <https://pytorch.org/docs/stable/jit.html>`_.

--- a/docs/source/supported_features.rst
+++ b/docs/source/supported_features.rst
@@ -1,0 +1,97 @@
+Supported Features
+==================
+
+Each TorchAudio API supports different set of PyTorch features, such as different devices and data types.
+Supported features are indicated in API references like the following.
+
+.. devices:: CPU CUDA
+
+.. features:: Autograd TorchScript
+
+These icon mean that they are verified through automated testing.
+
+.. note::
+
+   Missing feature icons mean that they are not tested, and this can mean
+   different things, depending on APIs.
+
+   1. The API is compatible with the feature but not tested.
+   2. The API is not compatible with the feature.
+
+   In case of 2, API might explicitly raise an error, but that is not always the case.
+   For example, APIs with missing Autograd badge might throw an error on backward path,
+   or silently returns a wrong gradient.
+
+If you use an API with the feature not supported, you might want to first verify that the
+feature works fine.
+
+Devices
+-------
+
+CPU
+^^^
+
+.. devices:: CPU
+
+TorchAudio APIs that support CPU can perform the computation on CPU tensors.
+
+
+CUDA
+^^^^
+
+.. devices:: CUDA
+
+TorchAudio APIs that support CUDA can perform the computation on CUDA devices.
+
+In case of functions, move the tensor arguments to CUDA device before passing them to a function.
+
+For example
+
+.. code:: python
+
+   cuda = torch.device("cuda")
+          
+   waveform = waveform.to(cuda)
+   spectrogram = torchaudio.functional.spectrogram(waveform)
+
+The classes with CUDA support are implemented with :py:func:`torch.nn.Module`.
+It is also necessary to move the instance to CUDA device, before passing CUDA tensors.
+
+For example
+
+.. code:: python
+
+   cuda = torch.device("cuda")
+
+   resampler = torchaudio.transforms.Resample(8000, 16000)
+   resampler.to(cuda)
+
+   waveform.to(cuda)
+   resampled = resampler(waveform)
+
+
+Features
+--------
+
+Autograd
+^^^^^^^^
+
+.. features:: Autograd
+
+TorchAudio APIs with autograd support can correctly propagate the gradient in its backward path.
+
+For the basic of autograd, please checkout this `tutorial <https://pytorch.org/tutorials/beginner/blitz/autograd_tutorial.html>`_.
+
+.. note::
+
+   APIs without this mark might or might not raise and error in back propagation.
+   The lack of error in back propagatoin does not mean the feature computes the gradient correctly.
+
+TorchScript
+^^^^^^^^^^^
+
+.. features:: TorchScript
+
+TorchAudio APIs with TorchScript support can be serialized and executed on non-Python environments.
+
+For the deetail of TorchScript, please checkout the `documentation <https://pytorch.org/docs/stable/jit.html>`_.

--- a/docs/source/supported_features.rst
+++ b/docs/source/supported_features.rst
@@ -1,12 +1,13 @@
 Supported Features
 ==================
 
-Each TorchAudio API supports different set of PyTorch features, such as different devices and data types.
+Each TorchAudio API supports different set of PyTorch features, such as
+devices and data types.
 Supported features are indicated in API references like the following.
 
 .. devices:: CPU CUDA
 
-.. features:: Autograd TorchScript
+.. properties:: Autograd TorchScript
 
 These icons mean that they are verified through automated testing.
 
@@ -70,13 +71,13 @@ For example
    resampled = resampler(waveform)
 
 
-Features
---------
+Porperties
+----------
 
 Autograd
 ^^^^^^^^
 
-.. features:: Autograd
+.. properties:: Autograd
 
 TorchAudio APIs with autograd support can correctly propagate the gradient in its backward path.
 
@@ -85,12 +86,12 @@ For the basics of autograd, please checkout this `tutorial <https://pytorch.org/
 .. note::
 
    APIs without this mark may or may not raise and error in back propagation.
-   The lack of error in back propagatoin does not mean the feature computes the gradient correctly.
+   The lack of error in back propagatoin does not mean the gradient is correct.
 
 TorchScript
 ^^^^^^^^^^^
 
-.. features:: TorchScript
+.. properties:: TorchScript
 
 TorchAudio APIs with TorchScript support can be serialized and executed on non-Python environments.
 

--- a/docs/source/supported_features.rst
+++ b/docs/source/supported_features.rst
@@ -1,9 +1,9 @@
 Supported Features
 ==================
 
-Each TorchAudio API supports different set of PyTorch features, such as
+Each TorchAudio API supports a subset of PyTorch features, such as
 devices and data types.
-Supported features are indicated in API references like the following.
+Supported features are indicated in API references like the following:
 
 .. devices:: CPU CUDA
 
@@ -19,11 +19,11 @@ These icons mean that they are verified through automated testing.
    1. The API is compatible with the feature but not tested.
    2. The API is not compatible with the feature.
 
-   In case of 2, API might explicitly raise an error, but that is not always the case.
-   For example, APIs with missing Autograd badge might throw an error on backward path,
+   In case of 2, the API might explicitly raise an error, but that is not guaranteed.
+   For example, APIs without an Autograd badge might throw an error during backpropagation,
    or silently return a wrong gradient.
 
-If you use an API with the feature not supported, you might want to first verify that the
+If you use an API that hasn't been labeled as supporting a feature, you might want to first verify that the
 feature works fine.
 
 Devices
@@ -34,7 +34,7 @@ CPU
 
 .. devices:: CPU
 
-TorchAudio APIs that support CPU can perform the computation on CPU tensors.
+TorchAudio APIs that support CPU can perform their computation on CPU tensors.
 
 
 CUDA
@@ -42,11 +42,11 @@ CUDA
 
 .. devices:: CUDA
 
-TorchAudio APIs that support CUDA can perform the computation on CUDA devices.
+TorchAudio APIs that support CUDA can perform their computation on CUDA devices.
 
 In case of functions, move the tensor arguments to CUDA device before passing them to a function.
 
-For example
+For example:
 
 .. code:: python
 
@@ -55,10 +55,10 @@ For example
    waveform = waveform.to(cuda)
    spectrogram = torchaudio.functional.spectrogram(waveform)
 
-The classes with CUDA support are implemented with :py:func:`torch.nn.Module`.
+Classes with CUDA support are implemented with :py:func:`torch.nn.Module`.
 It is also necessary to move the instance to CUDA device, before passing CUDA tensors.
 
-For example
+For example:
 
 .. code:: python
 
@@ -71,7 +71,7 @@ For example
    resampled = resampler(waveform)
 
 
-Porperties
+Properties
 ----------
 
 Autograd
@@ -79,20 +79,20 @@ Autograd
 
 .. properties:: Autograd
 
-TorchAudio APIs with autograd support can correctly propagate the gradient in its backward path.
+TorchAudio APIs with autograd support can correctly backpropagate gradients.
 
-For the basics of autograd, please checkout this `tutorial <https://pytorch.org/tutorials/beginner/blitz/autograd_tutorial.html>`_.
+For the basics of autograd, please refer to this `tutorial <https://pytorch.org/tutorials/beginner/blitz/autograd_tutorial.html>`_.
 
 .. note::
 
-   APIs without this mark may or may not raise and error in back propagation.
-   The lack of error in back propagatoin does not mean the gradient is correct.
+   APIs without this mark may or may not raise an error during backpropagation.
+   The absence of an error raised during backpropagation does not necessarily mean the gradient is correct.
 
 TorchScript
 ^^^^^^^^^^^
 
 .. properties:: TorchScript
 
-TorchAudio APIs with TorchScript support can be serialized and executed on non-Python environments.
+TorchAudio APIs with TorchScript support can be serialized and executed in non-Python environments.
 
-For the detail of TorchScript, please checkout the `documentation <https://pytorch.org/docs/stable/jit.html>`_.
+For details on TorchScript, please refer to the `documentation <https://pytorch.org/docs/stable/jit.html>`_.

--- a/test/torchaudio_unittest/functional/autograd_impl.py
+++ b/test/torchaudio_unittest/functional/autograd_impl.py
@@ -10,6 +10,7 @@ from torchaudio_unittest.common_utils import (
     TestBaseMixin,
     get_whitenoise,
     get_spectrogram,
+    nested_params,
     rnnt_utils,
 )
 
@@ -250,6 +251,33 @@ class Autograd(TestBaseMixin):
         central_freq = torch.tensor(central_freq)
         Q = torch.tensor(Q)
         self.assert_grad(F.bandreject_biquad, (x, sr, central_freq, Q))
+
+    def test_deemph_biquad(self):
+        torch.random.manual_seed(2434)
+        x = get_whitenoise(sample_rate=22050, duration=0.01, n_channels=1)
+        self.assert_grad(F.deemph_biquad, (x, 44100))
+
+    def test_flanger(self):
+        torch.random.manual_seed(2434)
+        x = get_whitenoise(sample_rate=8000, duration=0.01, n_channels=1)
+        self.assert_grad(F.flanger, (x, 44100))
+
+    def test_gain(self):
+        torch.random.manual_seed(2434)
+        x = get_whitenoise(sample_rate=8000, duration=0.01, n_channels=1)
+        self.assert_grad(F.gain, (x, 1.1))
+
+    def test_overdrive(self):
+        torch.random.manual_seed(2434)
+        x = get_whitenoise(sample_rate=8000, duration=0.01, n_channels=1)
+        self.assert_grad(F.gain, (x,))
+
+    @parameterized.expand([(True,), (False,)])
+    def test_phaser(self, sinusoidal):
+        torch.random.manual_seed(2434)
+        sr = 8000
+        x = get_whitenoise(sample_rate=sr, duration=0.01, n_channels=1)
+        self.assert_grad(F.phaser, (x, sr, sinusoidal))
 
     @parameterized.expand(
         [

--- a/test/torchaudio_unittest/functional/autograd_impl.py
+++ b/test/torchaudio_unittest/functional/autograd_impl.py
@@ -10,7 +10,6 @@ from torchaudio_unittest.common_utils import (
     TestBaseMixin,
     get_whitenoise,
     get_spectrogram,
-    nested_params,
     rnnt_utils,
 )
 

--- a/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
@@ -86,6 +86,10 @@ class Transforms(TestBaseMixin):
         tensor = torch.rand((1, 10))
         self._assert_consistency(T.MuLawDecoding(), tensor)
 
+    def test_ComputeDelta(self):
+        tensor = torch.rand((1, 10))
+        self._assert_consistency(T.ComputeDeltas(), tensor)
+
     def test_Fade(self):
         waveform = common_utils.get_whitenoise()
         fade_in_len = 3000

--- a/torchaudio/functional/filtering.py
+++ b/torchaudio/functional/filtering.py
@@ -67,6 +67,10 @@ def _generate_wave_table(
 def allpass_biquad(waveform: Tensor, sample_rate: int, central_freq: float, Q: float = 0.707) -> Tensor:
     r"""Design two-pole all-pass filter.  Similar to SoX implementation.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     Args:
         waveform(torch.Tensor): audio waveform of dimension of `(..., time)`
         sample_rate (int): sampling rate of the waveform, e.g. 44100 (Hz)
@@ -106,6 +110,10 @@ def band_biquad(
     noise: bool = False,
 ) -> Tensor:
     r"""Design two-pole band filter.  Similar to SoX implementation.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -156,6 +164,10 @@ def bandpass_biquad(
 ) -> Tensor:
     r"""Design two-pole band-pass filter.  Similar to SoX implementation.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
         sample_rate (int): sampling rate of the waveform, e.g. 44100 (Hz)
@@ -191,6 +203,10 @@ def bandpass_biquad(
 
 def bandreject_biquad(waveform: Tensor, sample_rate: int, central_freq: float, Q: float = 0.707) -> Tensor:
     r"""Design two-pole band-reject filter.  Similar to SoX implementation.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -230,6 +246,10 @@ def bass_biquad(
     Q: float = 0.707,
 ) -> Tensor:
     r"""Design a bass tone-control effect.  Similar to SoX implementation.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -271,7 +291,10 @@ def bass_biquad(
 
 def biquad(waveform: Tensor, b0: float, b1: float, b2: float, a0: float, a1: float, a2: float) -> Tensor:
     r"""Perform a biquad filter of input tensor.  Initial conditions set to 0.
-    https://en.wikipedia.org/wiki/Digital_biquad_filter
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -284,6 +307,9 @@ def biquad(waveform: Tensor, b0: float, b1: float, b2: float, a0: float, a1: flo
 
     Returns:
         Tensor: Waveform with dimension of `(..., time)`
+
+    Reference:
+       - https://en.wikipedia.org/wiki/Digital_biquad_filter
     """
 
     device = waveform.device
@@ -306,6 +332,11 @@ def biquad(waveform: Tensor, b0: float, b1: float, b2: float, a0: float, a1: flo
 
 def contrast(waveform: Tensor, enhancement_amount: float = 75.0) -> Tensor:
     r"""Apply contrast effect.  Similar to SoX implementation.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     Comparable with compression, this effect modifies an audio signal to make it sound louder
 
     Args:
@@ -335,6 +366,11 @@ def contrast(waveform: Tensor, enhancement_amount: float = 75.0) -> Tensor:
 
 def dcshift(waveform: Tensor, shift: float, limiter_gain: Optional[float] = None) -> Tensor:
     r"""Apply a DC shift to the audio. Similar to SoX implementation.
+
+    .. devices:: CPU CUDA
+
+    .. features:: TorchScript
+
     This can be useful to remove a DC offset
     (caused perhaps by a hardware problem in the recording chain) from the audio
 
@@ -357,6 +393,8 @@ def dcshift(waveform: Tensor, shift: float, limiter_gain: Optional[float] = None
     if limiter_gain is not None:
         limiter_threshold = 1.0 - (abs(shift) - limiter_gain)
 
+    # Note:
+    # the following index-based update breaks auto-grad support
     if limiter_gain is not None and shift > 0:
         mask = waveform > limiter_threshold
         temp = (waveform[mask] - limiter_threshold) * limiter_gain / (1 - limiter_threshold)
@@ -375,6 +413,10 @@ def dcshift(waveform: Tensor, shift: float, limiter_gain: Optional[float] = None
 
 def deemph_biquad(waveform: Tensor, sample_rate: int) -> Tensor:
     r"""Apply ISO 908 CD de-emphasis (shelving) IIR filter.  Similar to SoX implementation.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -551,7 +593,13 @@ def _apply_probability_distribution(waveform: Tensor, density_function: str = "T
 
 
 def dither(waveform: Tensor, density_function: str = "TPDF", noise_shaping: bool = False) -> Tensor:
-    r"""Dither increases the perceived dynamic range of audio stored at a
+    r"""Apply dither
+
+    .. devices:: CPU CUDA
+
+    .. features:: TorchScript
+
+    Dither increases the perceived dynamic range of audio stored at a
     particular bit-depth by eliminating nonlinear truncation distortion
     (i.e. adding minimally perceived noise to mask distortion caused by quantization).
 
@@ -584,6 +632,10 @@ def equalizer_biquad(
     Q: float = 0.707,
 ) -> Tensor:
     r"""Design biquad peaking equalizer filter and perform filtering.  Similar to SoX implementation.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -621,6 +673,10 @@ def filtfilt(
     clamp: bool = True,
 ) -> Tensor:
     r"""Apply an IIR filter forward and backward to a waveform.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Inspired by https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.filtfilt.html
 
@@ -664,6 +720,10 @@ def flanger(
     interpolation: str = "linear",
 ) -> Tensor:
     r"""Apply a flanger effect to the audio. Similar to SoX implementation.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., channel, time)` .
@@ -808,6 +868,10 @@ def flanger(
 def gain(waveform: Tensor, gain_db: float = 1.0) -> Tensor:
     r"""Apply amplification or attenuation to the whole waveform.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     Args:
        waveform (Tensor): Tensor of audio of dimension (..., time).
        gain_db (float, optional) Gain adjustment in decibels (dB) (Default: ``1.0``).
@@ -825,6 +889,10 @@ def gain(waveform: Tensor, gain_db: float = 1.0) -> Tensor:
 
 def highpass_biquad(waveform: Tensor, sample_rate: int, cutoff_freq: float, Q: float = 0.707) -> Tensor:
     r"""Design biquad highpass filter and perform filtering.  Similar to SoX implementation.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -922,6 +990,10 @@ except RuntimeError as err:
 def lfilter(waveform: Tensor, a_coeffs: Tensor, b_coeffs: Tensor, clamp: bool = True, batching: bool = True) -> Tensor:
     r"""Perform an IIR filter by evaluating difference equation.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     Note:
         To avoid numerical problems, small filter order is preferred.
         Using double precision could also minimize numerical precision errors.
@@ -976,6 +1048,10 @@ def lfilter(waveform: Tensor, a_coeffs: Tensor, b_coeffs: Tensor, clamp: bool = 
 def lowpass_biquad(waveform: Tensor, sample_rate: int, cutoff_freq: float, Q: float = 0.707) -> Tensor:
     r"""Design biquad lowpass filter and perform filtering.  Similar to SoX implementation.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     Args:
         waveform (torch.Tensor): audio waveform of dimension of `(..., time)`
         sample_rate (int): sampling rate of the waveform, e.g. 44100 (Hz)
@@ -1020,6 +1096,11 @@ except RuntimeError as err:
 
 def overdrive(waveform: Tensor, gain: float = 20, colour: float = 20) -> Tensor:
     r"""Apply a overdrive effect to the audio. Similar to SoX implementation.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     This effect applies a non linear distortion to the audio signal.
 
     Args:
@@ -1080,6 +1161,10 @@ def phaser(
     sinusoidal: bool = True,
 ) -> Tensor:
     r"""Apply a phasing effect to the audio. Similar to SoX implementation.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -1161,6 +1246,10 @@ def phaser(
 def riaa_biquad(waveform: Tensor, sample_rate: int) -> Tensor:
     r"""Apply RIAA vinyl playback equalization.  Similar to SoX implementation.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
         sample_rate (int): sampling rate of the waveform, e.g. 44100 (Hz).
@@ -1226,6 +1315,10 @@ def treble_biquad(
     Q: float = 0.707,
 ) -> Tensor:
     r"""Design a treble tone-control effect.  Similar to SoX implementation.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -1362,6 +1455,11 @@ def vad(
     lp_lifter_freq: float = 2000.0,
 ) -> Tensor:
     r"""Voice Activity Detector. Similar to SoX implementation.
+
+    .. devices:: CPU CUDA
+
+    .. features:: TorchScript
+
     Attempts to trim silence and quiet background sounds from the ends of recordings of speech.
     The algorithm currently uses a simple cepstral power measurement to detect voice,
     so may be fooled by other things, especially music.

--- a/torchaudio/functional/filtering.py
+++ b/torchaudio/functional/filtering.py
@@ -69,7 +69,7 @@ def allpass_biquad(waveform: Tensor, sample_rate: int, central_freq: float, Q: f
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         waveform(torch.Tensor): audio waveform of dimension of `(..., time)`
@@ -113,7 +113,7 @@ def band_biquad(
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -166,7 +166,7 @@ def bandpass_biquad(
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -206,7 +206,7 @@ def bandreject_biquad(waveform: Tensor, sample_rate: int, central_freq: float, Q
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -249,7 +249,7 @@ def bass_biquad(
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -294,7 +294,7 @@ def biquad(waveform: Tensor, b0: float, b1: float, b2: float, a0: float, a1: flo
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -335,7 +335,7 @@ def contrast(waveform: Tensor, enhancement_amount: float = 75.0) -> Tensor:
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Comparable with compression, this effect modifies an audio signal to make it sound louder
 
@@ -369,7 +369,7 @@ def dcshift(waveform: Tensor, shift: float, limiter_gain: Optional[float] = None
 
     .. devices:: CPU CUDA
 
-    .. features:: TorchScript
+    .. properties:: TorchScript
 
     This can be useful to remove a DC offset
     (caused perhaps by a hardware problem in the recording chain) from the audio
@@ -416,7 +416,7 @@ def deemph_biquad(waveform: Tensor, sample_rate: int) -> Tensor:
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -597,7 +597,7 @@ def dither(waveform: Tensor, density_function: str = "TPDF", noise_shaping: bool
 
     .. devices:: CPU CUDA
 
-    .. features:: TorchScript
+    .. properties:: TorchScript
 
     Dither increases the perceived dynamic range of audio stored at a
     particular bit-depth by eliminating nonlinear truncation distortion
@@ -635,7 +635,7 @@ def equalizer_biquad(
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -676,7 +676,7 @@ def filtfilt(
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Inspired by https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.filtfilt.html
 
@@ -723,7 +723,7 @@ def flanger(
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., channel, time)` .
@@ -870,7 +870,7 @@ def gain(waveform: Tensor, gain_db: float = 1.0) -> Tensor:
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
        waveform (Tensor): Tensor of audio of dimension (..., time).
@@ -892,7 +892,7 @@ def highpass_biquad(waveform: Tensor, sample_rate: int, cutoff_freq: float, Q: f
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -992,7 +992,7 @@ def lfilter(waveform: Tensor, a_coeffs: Tensor, b_coeffs: Tensor, clamp: bool = 
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Note:
         To avoid numerical problems, small filter order is preferred.
@@ -1050,7 +1050,7 @@ def lowpass_biquad(waveform: Tensor, sample_rate: int, cutoff_freq: float, Q: fl
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         waveform (torch.Tensor): audio waveform of dimension of `(..., time)`
@@ -1099,7 +1099,7 @@ def overdrive(waveform: Tensor, gain: float = 20, colour: float = 20) -> Tensor:
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     This effect applies a non linear distortion to the audio signal.
 
@@ -1164,7 +1164,7 @@ def phaser(
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -1248,7 +1248,7 @@ def riaa_biquad(waveform: Tensor, sample_rate: int) -> Tensor:
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -1318,7 +1318,7 @@ def treble_biquad(
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         waveform (Tensor): audio waveform of dimension of `(..., time)`
@@ -1458,7 +1458,7 @@ def vad(
 
     .. devices:: CPU CUDA
 
-    .. features:: TorchScript
+    .. properties:: TorchScript
 
     Attempts to trim silence and quiet background sounds from the ends of recordings of speech.
     The algorithm currently uses a simple cepstral power measurement to detect voice,

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -65,7 +65,7 @@ def spectrogram(
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         waveform (Tensor): Tensor of audio of dimension `(..., time)`
@@ -152,7 +152,7 @@ def inverse_spectrogram(
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         spectrogram (Tensor): Complex tensor of audio of dimension (..., freq, time).
@@ -236,7 +236,7 @@ def griffinlim(
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Implementation ported from
     *librosa* [:footcite:`brian_mcfee-proc-scipy-2015`], *A fast Griffin-Lim algorithm* [:footcite:`6701851`]
@@ -326,7 +326,7 @@ def amplitude_to_DB(
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     The output of each tensor in a batch depends on the maximum value of that tensor,
     and so may return different values for an audio clip split into snippets vs. a full clip.
@@ -367,7 +367,7 @@ def DB_to_amplitude(x: Tensor, ref: float, power: float) -> Tensor:
 
     .. devices:: CPU CUDA
 
-    .. features:: TorchScript
+    .. properties:: TorchScript
 
     Args:
         x (Tensor): Input tensor before being converted to power/amplitude scale.
@@ -486,6 +486,8 @@ def melscale_fbanks(
 
     .. devices:: CPU
 
+    .. properties:: TorchScript
+
     Note:
         For the sake of the numerical compatibility with librosa, not all the coefficients
         in the resulting filter bank has magnitude of 1.
@@ -554,6 +556,8 @@ def linear_fbanks(
 
     .. devices:: CPU
 
+    .. properties:: TorchScript
+
     Note:
         For the sake of the numerical compatibility with librosa, not all the coefficients
         in the resulting filter bank has magnitude of 1.
@@ -593,6 +597,8 @@ def create_dct(n_mfcc: int, n_mels: int, norm: Optional[str]) -> Tensor:
 
     .. devices:: CPU
 
+    .. properties:: TorchScript
+
     Args:
         n_mfcc (int): Number of mfc coefficients to retain
         n_mels (int): Number of mel filterbanks
@@ -620,7 +626,7 @@ def mu_law_encoding(x: Tensor, quantization_channels: int) -> Tensor:
 
     .. devices:: CPU CUDA
 
-    .. features:: TorchScript
+    .. properties:: TorchScript
 
     For more info see the
     `Wikipedia Entry <https://en.wikipedia.org/wiki/%CE%9C-law_algorithm>`_
@@ -653,7 +659,7 @@ def mu_law_decoding(x_mu: Tensor, quantization_channels: int) -> Tensor:
 
     .. devices:: CPU CUDA
 
-    .. features:: TorchScript
+    .. properties:: TorchScript
 
     For more info see the
     `Wikipedia Entry <https://en.wikipedia.org/wiki/%CE%9C-law_algorithm>`_
@@ -682,7 +688,7 @@ def phase_vocoder(complex_specgrams: Tensor, rate: float, phase_advance: Tensor)
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         complex_specgrams (Tensor):
@@ -769,7 +775,7 @@ def mask_along_axis_iid(
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Mask will be applied from indices ``[v_0, v_0 + v)``,
     where ``v`` is sampled from ``uniform(0, max_v)`` and
@@ -828,7 +834,7 @@ def mask_along_axis(
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Mask will be applied from indices ``[v_0, v_0 + v)``,
     where ``v`` is sampled from ``uniform(0, max_v)`` and
@@ -886,7 +892,7 @@ def compute_deltas(specgram: Tensor, win_length: int = 5, mode: str = "replicate
 
     .. devices:: CPU CUDA
 
-    .. features:: TorchScript
+    .. properties:: TorchScript
 
     .. math::
        d_t = \frac{\sum_{n=1}^{\text{N}} n (c_{t+n} - c_{t-n})}{2 \sum_{n=1}^{\text{N}} n^2}
@@ -1050,7 +1056,7 @@ def detect_pitch_frequency(
 
     .. devices:: CPU CUDA
 
-    .. features:: TorchScript
+    .. properties:: TorchScript
 
     It is implemented using normalized cross-correlation function and median smoothing.
 
@@ -1095,7 +1101,7 @@ def sliding_window_cmn(
 
     .. devices:: CPU CUDA
 
-    .. features:: TorchScript
+    .. properties:: TorchScript
 
     Args:
         specgram (Tensor): Tensor of spectrogram of dimension `(..., time, freq)`
@@ -1189,7 +1195,7 @@ def spectral_centroid(
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     The spectral centroid is defined as the weighted average of the
     frequency values, weighted by their magnitude.
@@ -1292,7 +1298,7 @@ def compute_kaldi_pitch(
 
     .. devices:: CPU
 
-    .. features:: TorchScript
+    .. properties:: TorchScript
 
     This function computes the equivalent of `compute-kaldi-pitch-feats` from Kaldi.
 
@@ -1503,13 +1509,11 @@ def resample(
     resampling_method: str = "sinc_interpolation",
     beta: Optional[float] = None,
 ) -> Tensor:
-    r"""Resamples the waveform at the new frequency using bandlimited interpolation.
+    r"""Resamples the waveform at the new frequency using bandlimited interpolation. [:footcite:`RESAMPLE`].
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
-
-    https://ccrma.stanford.edu/~jos/resample/Theory_Ideal_Bandlimited_Interpolation.html
+    .. properties:: Autograd TorchScript
 
     Note:
         ``transforms.Resample`` precomputes and reuses the resampling kernel, so using it will result in
@@ -1610,7 +1614,7 @@ def pitch_shift(
 
     .. devices:: CPU CUDA
 
-    .. features:: TorchScript
+    .. properties:: TorchScript
 
     Args:
         waveform (Tensor): The input waveform of shape `(..., time)`.
@@ -1685,7 +1689,7 @@ def rnnt_loss(
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     The RNN Transducer loss extends the CTC loss by defining a distribution over output
     sequences of all lengths, and by jointly modelling both input-output and output-output
@@ -1738,7 +1742,7 @@ def psd(
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         specgram (Tensor): Multi-channel complex-valued spectrum.
@@ -1822,7 +1826,7 @@ def mvdr_weights_souden(
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     .. math::
         \textbf{w}_{\text{MVDR}}(f) =
@@ -1880,7 +1884,7 @@ def mvdr_weights_rtf(
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     .. math::
         \textbf{w}_{\text{MVDR}}(f) =
@@ -1936,7 +1940,7 @@ def rtf_evd(psd_s: Tensor) -> Tensor:
 
     .. devices:: CPU CUDA
 
-    .. features:: TorchScript
+    .. properties:: TorchScript
 
     Args:
         psd_s (Tensor): The complex-valued power spectral density (PSD) matrix of target speech.
@@ -1956,7 +1960,7 @@ def rtf_power(psd_s: Tensor, psd_n: Tensor, reference_channel: Union[int, Tensor
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         psd_s (Tensor): The complex-valued covariance matrix of target speech.
@@ -2003,7 +2007,7 @@ def apply_beamforming(beamform_weights: Tensor, specgram: Tensor) -> Tensor:
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     .. math::
         \hat{\textbf{S}}(f) = \textbf{w}_{\text{bf}}(f)^{\mathsf{H}} \textbf{Y}(f)

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -63,6 +63,10 @@ def spectrogram(
     r"""Create a spectrogram or a batch of spectrograms from a raw audio signal.
     The spectrogram can be either magnitude-only or complex.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     Args:
         waveform (Tensor): Tensor of audio of dimension `(..., time)`
         pad (int): Two sided padding of signal
@@ -146,6 +150,10 @@ def inverse_spectrogram(
     r"""Create an inverse spectrogram or a batch of inverse spectrograms from the provided
     complex-valued spectrogram.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     Args:
         spectrogram (Tensor): Complex tensor of audio of dimension (..., freq, time).
         length (int or None): The output length of the waveform.
@@ -225,6 +233,10 @@ def griffinlim(
     rand_init: bool,
 ) -> Tensor:
     r"""Compute waveform from a linear scale magnitude spectrogram using the Griffin-Lim transformation.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Implementation ported from
     *librosa* [:footcite:`brian_mcfee-proc-scipy-2015`], *A fast Griffin-Lim algorithm* [:footcite:`6701851`]
@@ -312,6 +324,10 @@ def amplitude_to_DB(
 ) -> Tensor:
     r"""Turn a spectrogram from the power/amplitude scale to the decibel scale.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     The output of each tensor in a batch depends on the maximum value of that tensor,
     and so may return different values for an audio clip split into snippets vs. a full clip.
 
@@ -348,6 +364,10 @@ def amplitude_to_DB(
 
 def DB_to_amplitude(x: Tensor, ref: float, power: float) -> Tensor:
     r"""Turn a tensor from the decibel scale to the power/amplitude scale.
+
+    .. devices:: CPU CUDA
+
+    .. features:: TorchScript
 
     Args:
         x (Tensor): Input tensor before being converted to power/amplitude scale.
@@ -464,6 +484,8 @@ def melscale_fbanks(
 ) -> Tensor:
     r"""Create a frequency bin conversion matrix.
 
+    .. devices:: CPU
+
     Note:
         For the sake of the numerical compatibility with librosa, not all the coefficients
         in the resulting filter bank has magnitude of 1.
@@ -530,6 +552,8 @@ def linear_fbanks(
 ) -> Tensor:
     r"""Creates a linear triangular filterbank.
 
+    .. devices:: CPU
+
     Note:
         For the sake of the numerical compatibility with librosa, not all the coefficients
         in the resulting filter bank has magnitude of 1.
@@ -567,6 +591,8 @@ def create_dct(n_mfcc: int, n_mels: int, norm: Optional[str]) -> Tensor:
     r"""Create a DCT transformation matrix with shape (``n_mels``, ``n_mfcc``),
     normalized depending on norm.
 
+    .. devices:: CPU
+
     Args:
         n_mfcc (int): Number of mfc coefficients to retain
         n_mels (int): Number of mel filterbanks
@@ -590,7 +616,13 @@ def create_dct(n_mfcc: int, n_mels: int, norm: Optional[str]) -> Tensor:
 
 
 def mu_law_encoding(x: Tensor, quantization_channels: int) -> Tensor:
-    r"""Encode signal based on mu-law companding.  For more info see the
+    r"""Encode signal based on mu-law companding.
+
+    .. devices:: CPU CUDA
+
+    .. features:: TorchScript
+
+    For more info see the
     `Wikipedia Entry <https://en.wikipedia.org/wiki/%CE%9C-law_algorithm>`_
 
     This algorithm expects the signal has been scaled to between -1 and 1 and
@@ -617,7 +649,13 @@ def mu_law_encoding(x: Tensor, quantization_channels: int) -> Tensor:
 
 
 def mu_law_decoding(x_mu: Tensor, quantization_channels: int) -> Tensor:
-    r"""Decode mu-law encoded signal.  For more info see the
+    r"""Decode mu-law encoded signal.
+
+    .. devices:: CPU CUDA
+
+    .. features:: TorchScript
+
+    For more info see the
     `Wikipedia Entry <https://en.wikipedia.org/wiki/%CE%9C-law_algorithm>`_
 
     This expects an input with values between 0 and quantization_channels - 1
@@ -640,8 +678,11 @@ def mu_law_decoding(x_mu: Tensor, quantization_channels: int) -> Tensor:
 
 
 def phase_vocoder(complex_specgrams: Tensor, rate: float, phase_advance: Tensor) -> Tensor:
-    r"""Given a STFT tensor, speed up in time without modifying pitch by a
-    factor of ``rate``.
+    r"""Given a STFT tensor, speed up in time without modifying pitch by a factor of ``rate``.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Args:
         complex_specgrams (Tensor):
@@ -724,11 +765,17 @@ def mask_along_axis_iid(
     axis: int,
     p: float = 1.0,
 ) -> Tensor:
-    r"""
-    Apply a mask along ``axis``. Mask will be applied from indices ``[v_0, v_0 + v)``, where
-    ``v`` is sampled from ``uniform(0, max_v)`` and ``v_0`` from ``uniform(0, specgrams.size(axis) - v)``, with
-    ``max_v = mask_param`` when ``p = 1.0`` and ``max_v = min(mask_param, floor(specgrams.size(axis) * p))``
-    otherwise.
+    r"""Apply a mask along ``axis``.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
+    Mask will be applied from indices ``[v_0, v_0 + v)``,
+    where ``v`` is sampled from ``uniform(0, max_v)`` and
+    ``v_0`` from ``uniform(0, specgrams.size(axis) - v)``,
+    with ``max_v = mask_param`` when ``p = 1.0`` and
+    ``max_v = min(mask_param, floor(specgrams.size(axis) * p))`` otherwise.
 
     Args:
         specgrams (Tensor): Real spectrograms `(batch, channel, freq, time)`
@@ -777,11 +824,19 @@ def mask_along_axis(
     axis: int,
     p: float = 1.0,
 ) -> Tensor:
-    r"""
-    Apply a mask along ``axis``. Mask will be applied from indices ``[v_0, v_0 + v)``, where
-    ``v`` is sampled from ``uniform(0, max_v)`` and ``v_0`` from ``uniform(0, specgrams.size(axis) - v)``, with
-    ``max_v = mask_param`` when ``p = 1.0`` and ``max_v = min(mask_param, floor(specgrams.size(axis) * p))``
-    otherwise. All examples will have the same mask interval.
+    r"""Apply a mask along ``axis``.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
+    Mask will be applied from indices ``[v_0, v_0 + v)``,
+    where ``v`` is sampled from ``uniform(0, max_v)`` and
+    ``v_0`` from ``uniform(0, specgrams.size(axis) - v)``, with
+    ``max_v = mask_param`` when ``p = 1.0`` and
+    ``max_v = min(mask_param, floor(specgrams.size(axis) * p))``
+    otherwise.
+    All examples will have the same mask interval.
 
     Args:
         specgram (Tensor): Real spectrogram `(channel, freq, time)`
@@ -828,6 +883,10 @@ def mask_along_axis(
 
 def compute_deltas(specgram: Tensor, win_length: int = 5, mode: str = "replicate") -> Tensor:
     r"""Compute delta coefficients of a tensor, usually a spectrogram:
+
+    .. devices:: CPU CUDA
+
+    .. features:: TorchScript
 
     .. math::
        d_t = \frac{\sum_{n=1}^{\text{N}} n (c_{t+n} - c_{t-n})}{2 \sum_{n=1}^{\text{N}} n^2}
@@ -989,6 +1048,10 @@ def detect_pitch_frequency(
 ) -> Tensor:
     r"""Detect pitch frequency.
 
+    .. devices:: CPU CUDA
+
+    .. features:: TorchScript
+
     It is implemented using normalized cross-correlation function and median smoothing.
 
     Args:
@@ -1029,6 +1092,10 @@ def sliding_window_cmn(
 ) -> Tensor:
     r"""
     Apply sliding-window cepstral mean (and optionally variance) normalization per utterance.
+
+    .. devices:: CPU CUDA
+
+    .. features:: TorchScript
 
     Args:
         specgram (Tensor): Tensor of spectrogram of dimension `(..., time, freq)`
@@ -1118,8 +1185,11 @@ def spectral_centroid(
     hop_length: int,
     win_length: int,
 ) -> Tensor:
-    r"""
-    Compute the spectral centroid for each channel along the time axis.
+    r"""Compute the spectral centroid for each channel along the time axis.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     The spectral centroid is defined as the weighted average of the
     frequency values, weighted by their magnitude.
@@ -1163,6 +1233,8 @@ def apply_codec(
 ) -> Tensor:
     r"""
     Apply codecs as a form of augmentation.
+
+    .. devices:: CPU
 
     Args:
         waveform (Tensor): Audio data. Must be 2 dimensional. See also ```channels_first```.
@@ -1217,6 +1289,10 @@ def compute_kaldi_pitch(
 ) -> torch.Tensor:
     """Extract pitch based on method described in *A pitch extraction algorithm tuned
     for automatic speech recognition* [:footcite:`6854049`].
+
+    .. devices:: CPU
+
+    .. features:: TorchScript
 
     This function computes the equivalent of `compute-kaldi-pitch-feats` from Kaldi.
 
@@ -1429,6 +1505,10 @@ def resample(
 ) -> Tensor:
     r"""Resamples the waveform at the new frequency using bandlimited interpolation.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     https://ccrma.stanford.edu/~jos/resample/Theory_Ideal_Bandlimited_Interpolation.html
 
     Note:
@@ -1478,6 +1558,8 @@ def edit_distance(seq1: Sequence, seq2: Sequence) -> int:
     """
     Calculate the word level edit (Levenshtein) distance between two sequences.
 
+    .. devices:: CPU
+
     The function computes an edit distance allowing deletion, insertion and
     substitution. The result is an integer.
 
@@ -1486,8 +1568,6 @@ def edit_distance(seq1: Sequence, seq2: Sequence) -> int:
     strings (character edit distance). If two lists of strings are given, the
     output is the edit distance between sentences (word edit distance). Users
     may want to normalize the output by the length of the reference sequence.
-
-    torchscipt is not supported for this function.
 
     Args:
         seq1 (Sequence): the first sequence to compare.
@@ -1527,6 +1607,10 @@ def pitch_shift(
 ) -> Tensor:
     """
     Shift the pitch of a waveform by ``n_steps`` steps.
+
+    .. devices:: CPU CUDA
+
+    .. features:: TorchScript
 
     Args:
         waveform (Tensor): The input waveform of shape `(..., time)`.
@@ -1598,6 +1682,11 @@ def rnnt_loss(
 ):
     """Compute the RNN Transducer loss from *Sequence Transduction with Recurrent Neural Networks*
     [:footcite:`graves2012sequence`].
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     The RNN Transducer loss extends the CTC loss by defining a distribution over output
     sequences of all lengths, and by jointly modelling both input-output and output-output
     dependencies.
@@ -1646,6 +1735,10 @@ def psd(
     eps: float = 1e-10,
 ) -> Tensor:
     """Compute cross-channel power spectral density (PSD) matrix.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Args:
         specgram (Tensor): Multi-channel complex-valued spectrum.
@@ -1727,6 +1820,10 @@ def mvdr_weights_souden(
     r"""Compute the Minimum Variance Distortionless Response (*MVDR* [:footcite:`capon1969high`]) beamforming weights
     by the method proposed by *Souden et, al.* [:footcite:`souden2009optimal`].
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     .. math::
         \textbf{w}_{\text{MVDR}}(f) =
         \frac{{{\bf{\Phi}_{\textbf{NN}}^{-1}}(f){\bf{\Phi}_{\textbf{SS}}}}(f)}
@@ -1781,6 +1878,10 @@ def mvdr_weights_rtf(
     r"""Compute the Minimum Variance Distortionless Response (*MVDR* [:footcite:`capon1969high`]) beamforming weights
     based on the relative transfer function (RTF) and power spectral density (PSD) matrix of noise.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     .. math::
         \textbf{w}_{\text{MVDR}}(f) =
         \frac{{{\bf{\Phi}_{\textbf{NN}}^{-1}}(f){\bm{v}}(f)}}
@@ -1833,6 +1934,10 @@ def mvdr_weights_rtf(
 def rtf_evd(psd_s: Tensor) -> Tensor:
     r"""Estimate the relative transfer function (RTF) or the steering vector by eigenvalue decomposition.
 
+    .. devices:: CPU CUDA
+
+    .. features:: TorchScript
+
     Args:
         psd_s (Tensor): The complex-valued power spectral density (PSD) matrix of target speech.
             Tensor of dimension `(..., freq, channel, channel)`
@@ -1848,6 +1953,10 @@ def rtf_evd(psd_s: Tensor) -> Tensor:
 
 def rtf_power(psd_s: Tensor, psd_n: Tensor, reference_channel: Union[int, Tensor], n_iter: int = 3) -> Tensor:
     r"""Estimate the relative transfer function (RTF) or the steering vector by the power method.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Args:
         psd_s (Tensor): The complex-valued covariance matrix of target speech.
@@ -1891,6 +2000,10 @@ def rtf_power(psd_s: Tensor, psd_n: Tensor, reference_channel: Union[int, Tensor
 
 def apply_beamforming(beamform_weights: Tensor, specgram: Tensor) -> Tensor:
     r"""Apply the beamforming weight to the multi-channel noisy spectrum to obtain the single-channel enhanced spectrum.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     .. math::
         \hat{\textbf{S}}(f) = \textbf{w}_{\text{bf}}(f)^{\mathsf{H}} \textbf{Y}(f)

--- a/torchaudio/prototype/ctc_decoder/ctc_decoder.py
+++ b/torchaudio/prototype/ctc_decoder/ctc_decoder.py
@@ -43,6 +43,8 @@ class Hypothesis(NamedTuple):
 class LexiconDecoder:
     """torchaudio.prototype.ctc_decoder.LexiconDecoder()
 
+    .. devices:: CPU
+
     Lexically contrained CTC beam search decoder from *Flashlight* [:footcite:`kahn2022flashlight`].
 
     Note:

--- a/torchaudio/sox_effects/sox_effects.py
+++ b/torchaudio/sox_effects/sox_effects.py
@@ -59,6 +59,10 @@ def apply_effects_tensor(
 ) -> Tuple[torch.Tensor, int]:
     """Apply sox effects to given Tensor
 
+    .. devices:: CPU
+
+    .. features:: TorchScript
+
     Note:
         This function only works on CPU Tensors.
         This function works in the way very similar to ``sox`` command, however there are slight
@@ -160,6 +164,10 @@ def apply_effects_file(
     format: Optional[str] = None,
 ) -> Tuple[torch.Tensor, int]:
     """Apply sox effects to the audio file and load the resulting data as Tensor
+
+    .. devices:: CPU
+
+    .. features:: TorchScript
 
     Note:
         This function works in the way very similar to ``sox`` command, however there are slight

--- a/torchaudio/sox_effects/sox_effects.py
+++ b/torchaudio/sox_effects/sox_effects.py
@@ -61,7 +61,7 @@ def apply_effects_tensor(
 
     .. devices:: CPU
 
-    .. features:: TorchScript
+    .. properties:: TorchScript
 
     Note:
         This function only works on CPU Tensors.
@@ -167,7 +167,7 @@ def apply_effects_file(
 
     .. devices:: CPU
 
-    .. features:: TorchScript
+    .. properties:: TorchScript
 
     Note:
         This function works in the way very similar to ``sox`` command, however there are slight

--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -20,7 +20,7 @@ class Spectrogram(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         n_fft (int, optional): Size of FFT, creates ``n_fft // 2 + 1`` bins. (Default: ``400``)
@@ -118,7 +118,7 @@ class InverseSpectrogram(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         n_fft (int, optional): Size of FFT, creates ``n_fft // 2 + 1`` bins. (Default: ``400``)
@@ -203,7 +203,7 @@ class GriffinLim(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Implementation ported from
     *librosa* [:footcite:`brian_mcfee-proc-scipy-2015`], *A fast Griffin-Lim algorithm* [:footcite:`6701851`]
@@ -291,7 +291,7 @@ class AmplitudeToDB(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     This output depends on the maximum value in the input tensor, and so
     may return different values for an audio clip split into snippets vs. a
@@ -335,7 +335,7 @@ class MelScale(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         n_mels (int, optional): Number of mel filterbanks. (Default: ``128``)
@@ -505,7 +505,7 @@ class MelSpectrogram(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     This is a composition of :py:func:`torchaudio.transforms.Spectrogram` and
     and :py:func:`torchaudio.transforms.MelScale`.
@@ -618,7 +618,7 @@ class MFCC(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     By default, this calculates the MFCC on the DB-scaled Mel spectrogram.
     This is not the textbook implementation, but is implemented here to
@@ -696,7 +696,7 @@ class LFCC(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     By default, this calculates the LFCC on the DB-scaled linear filtered spectrogram.
     This is not the textbook implementation, but is implemented here to
@@ -798,7 +798,7 @@ class MuLawEncoding(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: TorchScript
+    .. properties:: TorchScript
 
     For more info see the
     `Wikipedia Entry <https://en.wikipedia.org/wiki/%CE%9C-law_algorithm>`_
@@ -837,7 +837,7 @@ class MuLawDecoding(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: TorchScript
+    .. properties:: TorchScript
 
     For more info see the
     `Wikipedia Entry <https://en.wikipedia.org/wiki/%CE%9C-law_algorithm>`_
@@ -875,7 +875,7 @@ class Resample(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Note:
         If resampling on waveforms of higher precision than float32, there may be a small loss of precision
@@ -959,7 +959,7 @@ class ComputeDeltas(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     See `torchaudio.functional.compute_deltas` for more details.
 
@@ -990,7 +990,7 @@ class TimeStretch(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Proposed in *SpecAugment* [:footcite:`specaugment`].
 
@@ -1059,7 +1059,7 @@ class Fade(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         fade_in_len (int, optional): Length of fade-in (time frames). (Default: ``0``)
@@ -1176,7 +1176,7 @@ class FrequencyMasking(_AxisMasking):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Proposed in *SpecAugment* [:footcite:`specaugment`].
 
@@ -1210,7 +1210,7 @@ class TimeMasking(_AxisMasking):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Proposed in *SpecAugment* [:footcite:`specaugment`].
 
@@ -1248,7 +1248,7 @@ class Vol(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         gain (float): Interpreted according to the given gain_type:
@@ -1292,7 +1292,7 @@ class SlidingWindowCmn(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         cmn_window (int, optional): Window in frames for running average CMN computation (int, default = 600)
@@ -1329,7 +1329,7 @@ class Vad(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: TorchScript
+    .. properties:: TorchScript
 
     Attempts to trim silence and quiet background sounds from the ends of recordings of speech.
     The algorithm currently uses a simple cepstral power measurement to detect voice,
@@ -1456,7 +1456,7 @@ class SpectralCentroid(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     The spectral centroid is defined as the weighted average of the
     frequency values, weighted by their magnitude.
@@ -1516,7 +1516,7 @@ class PitchShift(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: TorchScript
+    .. properties:: TorchScript
 
     Args:
         waveform (Tensor): The input waveform of shape `(..., time)`.
@@ -1585,7 +1585,7 @@ class RNNTLoss(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     The RNN Transducer loss extends the CTC loss by defining a distribution over output
     sequences of all lengths, and by jointly modelling both input-output and output-output
@@ -1671,7 +1671,7 @@ class PSD(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Args:
         multi_mask (bool, optional): whether to use multi-channel Time-Frequency masks. (Default: ``False``)
@@ -1722,7 +1722,7 @@ class MVDR(torch.nn.Module):
 
     .. devices:: CPU CUDA
 
-    .. features:: Autograd TorchScript
+    .. properties:: Autograd TorchScript
 
     Based on https://github.com/espnet/espnet/blob/master/espnet2/enh/layers/beamformer.py
 

--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -18,6 +18,10 @@ __all__ = []
 class Spectrogram(torch.nn.Module):
     r"""Create a spectrogram from a audio signal.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     Args:
         n_fft (int, optional): Size of FFT, creates ``n_fft // 2 + 1`` bins. (Default: ``400``)
         win_length (int or None, optional): Window size. (Default: ``n_fft``)
@@ -112,6 +116,10 @@ class Spectrogram(torch.nn.Module):
 class InverseSpectrogram(torch.nn.Module):
     r"""Create an inverse spectrogram to recover an audio signal from a spectrogram.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     Args:
         n_fft (int, optional): Size of FFT, creates ``n_fft // 2 + 1`` bins. (Default: ``400``)
         win_length (int or None, optional): Window size. (Default: ``n_fft``)
@@ -192,6 +200,10 @@ class InverseSpectrogram(torch.nn.Module):
 
 class GriffinLim(torch.nn.Module):
     r"""Compute waveform from a linear scale magnitude spectrogram using the Griffin-Lim transformation.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Implementation ported from
     *librosa* [:footcite:`brian_mcfee-proc-scipy-2015`], *A fast Griffin-Lim algorithm* [:footcite:`6701851`]
@@ -277,6 +289,10 @@ class GriffinLim(torch.nn.Module):
 class AmplitudeToDB(torch.nn.Module):
     r"""Turn a tensor from the power/amplitude scale to the decibel scale.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     This output depends on the maximum value in the input tensor, and so
     may return different values for an audio clip split into snippets vs. a
     a full clip.
@@ -315,8 +331,11 @@ class AmplitudeToDB(torch.nn.Module):
 
 
 class MelScale(torch.nn.Module):
-    r"""Turn a normal STFT into a mel frequency STFT, using a conversion
-    matrix.  This uses triangular filter banks.
+    r"""Turn a normal STFT into a mel frequency STFT with triangular filter banks.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Args:
         n_mels (int, optional): Number of mel filterbanks. (Default: ``128``)
@@ -372,8 +391,9 @@ class MelScale(torch.nn.Module):
 
 
 class InverseMelScale(torch.nn.Module):
-    r"""Solve for a normal STFT from a mel frequency STFT, using a conversion
-    matrix.  This uses triangular filter banks.
+    r"""Estimate a STFT in normal frequency domain from mel frequency domain.
+
+    .. devices:: CPU CUDA
 
     It minimizes the euclidian norm between the input mel-spectrogram and the product between
     the estimated spectrogram and the filter banks using SGD.
@@ -482,6 +502,10 @@ class InverseMelScale(torch.nn.Module):
 
 class MelSpectrogram(torch.nn.Module):
     r"""Create MelSpectrogram for a raw audio signal.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     This is a composition of :py:func:`torchaudio.transforms.Spectrogram` and
     and :py:func:`torchaudio.transforms.MelScale`.
@@ -592,6 +616,10 @@ class MelSpectrogram(torch.nn.Module):
 class MFCC(torch.nn.Module):
     r"""Create the Mel-frequency cepstrum coefficients from an audio signal.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     By default, this calculates the MFCC on the DB-scaled Mel spectrogram.
     This is not the textbook implementation, but is implemented here to
     give consistency with librosa.
@@ -665,6 +693,10 @@ class MFCC(torch.nn.Module):
 
 class LFCC(torch.nn.Module):
     r"""Create the linear-frequency cepstrum coefficients from an audio signal.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     By default, this calculates the LFCC on the DB-scaled linear filtered spectrogram.
     This is not the textbook implementation, but is implemented here to
@@ -762,7 +794,13 @@ class LFCC(torch.nn.Module):
 
 
 class MuLawEncoding(torch.nn.Module):
-    r"""Encode signal based on mu-law companding.  For more info see the
+    r"""Encode signal based on mu-law companding.
+
+    .. devices:: CPU CUDA
+
+    .. features:: TorchScript
+
+    For more info see the
     `Wikipedia Entry <https://en.wikipedia.org/wiki/%CE%9C-law_algorithm>`_
 
     This algorithm assumes the signal has been scaled to between -1 and 1 and
@@ -795,7 +833,13 @@ class MuLawEncoding(torch.nn.Module):
 
 
 class MuLawDecoding(torch.nn.Module):
-    r"""Decode mu-law encoded signal.  For more info see the
+    r"""Decode mu-law encoded signal.
+
+    .. devices:: CPU CUDA
+
+    .. features:: TorchScript
+
+    For more info see the
     `Wikipedia Entry <https://en.wikipedia.org/wiki/%CE%9C-law_algorithm>`_
 
     This expects an input with values between 0 and ``quantization_channels - 1``
@@ -828,6 +872,10 @@ class MuLawDecoding(torch.nn.Module):
 
 class Resample(torch.nn.Module):
     r"""Resample a signal from one frequency to another. A resampling method can be given.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Note:
         If resampling on waveforms of higher precision than float32, there may be a small loss of precision
@@ -909,6 +957,10 @@ class Resample(torch.nn.Module):
 class ComputeDeltas(torch.nn.Module):
     r"""Compute delta coefficients of a tensor, usually a spectrogram.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     See `torchaudio.functional.compute_deltas` for more details.
 
     Args:
@@ -935,6 +987,10 @@ class ComputeDeltas(torch.nn.Module):
 
 class TimeStretch(torch.nn.Module):
     r"""Stretch stft in time without modifying pitch for a given rate.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Proposed in *SpecAugment* [:footcite:`specaugment`].
 
@@ -1000,6 +1056,10 @@ class TimeStretch(torch.nn.Module):
 
 class Fade(torch.nn.Module):
     r"""Add a fade in and/or fade out to an waveform.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Args:
         fade_in_len (int, optional): Length of fade-in (time frames). (Default: ``0``)
@@ -1114,6 +1174,10 @@ class _AxisMasking(torch.nn.Module):
 class FrequencyMasking(_AxisMasking):
     r"""Apply masking to a spectrogram in the frequency domain.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     Proposed in *SpecAugment* [:footcite:`specaugment`].
 
     Args:
@@ -1143,6 +1207,10 @@ class FrequencyMasking(_AxisMasking):
 
 class TimeMasking(_AxisMasking):
     r"""Apply masking to a spectrogram in the time domain.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Proposed in *SpecAugment* [:footcite:`specaugment`].
 
@@ -1177,6 +1245,10 @@ class TimeMasking(_AxisMasking):
 
 class Vol(torch.nn.Module):
     r"""Add a volume to an waveform.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Args:
         gain (float): Interpreted according to the given gain_type:
@@ -1218,6 +1290,10 @@ class SlidingWindowCmn(torch.nn.Module):
     r"""
     Apply sliding-window cepstral mean (and optionally variance) normalization per utterance.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     Args:
         cmn_window (int, optional): Window in frames for running average CMN computation (int, default = 600)
         min_cmn_window (int, optional):  Minimum CMN window used at start of decoding (adds latency only at start).
@@ -1250,6 +1326,11 @@ class SlidingWindowCmn(torch.nn.Module):
 
 class Vad(torch.nn.Module):
     r"""Voice Activity Detector. Similar to SoX implementation.
+
+    .. devices:: CPU CUDA
+
+    .. features:: TorchScript
+
     Attempts to trim silence and quiet background sounds from the ends of recordings of speech.
     The algorithm currently uses a simple cepstral power measurement to detect voice,
     so may be fooled by other things, especially music.
@@ -1373,6 +1454,10 @@ class Vad(torch.nn.Module):
 class SpectralCentroid(torch.nn.Module):
     r"""Compute the spectral centroid for each channel along the time axis.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     The spectral centroid is defined as the weighted average of the
     frequency values, weighted by their magnitude.
 
@@ -1428,6 +1513,10 @@ class SpectralCentroid(torch.nn.Module):
 
 class PitchShift(torch.nn.Module):
     r"""Shift the pitch of a waveform by ``n_steps`` steps.
+
+    .. devices:: CPU CUDA
+
+    .. features:: TorchScript
 
     Args:
         waveform (Tensor): The input waveform of shape `(..., time)`.
@@ -1493,6 +1582,11 @@ class PitchShift(torch.nn.Module):
 class RNNTLoss(torch.nn.Module):
     """Compute the RNN Transducer loss from *Sequence Transduction with Recurrent Neural Networks*
     [:footcite:`graves2012sequence`].
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     The RNN Transducer loss extends the CTC loss by defining a distribution over output
     sequences of all lengths, and by jointly modelling both input-output and output-output
     dependencies.
@@ -1575,6 +1669,10 @@ def _get_mat_trace(input: torch.Tensor, dim1: int = -1, dim2: int = -2) -> torch
 class PSD(torch.nn.Module):
     r"""Compute cross-channel power spectral density (PSD) matrix.
 
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
+
     Args:
         multi_mask (bool, optional): whether to use multi-channel Time-Frequency masks. (Default: ``False``)
         normalize (bool, optional): whether normalize the mask along the time dimension.
@@ -1621,6 +1719,10 @@ class PSD(torch.nn.Module):
 
 class MVDR(torch.nn.Module):
     """Minimum Variance Distortionless Response (MVDR) module that performs MVDR beamforming with Time-Frequency masks.
+
+    .. devices:: CPU CUDA
+
+    .. features:: Autograd TorchScript
 
     Based on https://github.com/espnet/espnet/blob/master/espnet2/enh/layers/beamformer.py
 


### PR DESCRIPTION
Add badges of supported properties and devices to functionals and transforms.

This commit adds `.. devices::` and `.. properties::` directives to sphinx.

APIs with these directives will have badges (based off of shields.io) which link to the 
page with description of these features.

Continuation of https://github.com/pytorch/audio/issues/2316
Excluded dtypes for further improvement, and actually added badges to most of functional/transforms.