### PR TITLE
Add nightly build installation code snippet to prototype feature tutorials

### DIFF
--- a/examples/tutorials/asr_inference_with_ctc_decoder_tutorial.py
+++ b/examples/tutorials/asr_inference_with_ctc_decoder_tutorial.py
@@ -21,13 +21,6 @@ using CTC loss.
 #    Please refer to https://pytorch.org/get-started/locally/
 #    for instructions.
 #
-#    To enable running the tutorial notebook in Google Colab, install nightly
-#    torch and torchaudio builds by adding the following code block to the top
-#    of the notebook before running it:
-#    ::
-#      !pip3 uninstall -y torch torchvision torchaudio
-#      !pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu
-#
 #    The interfaces of prototype features are unstable and subject to
 #    change. Please refer to `the nightly build documentation
 #    <https://pytorch.org/audio/main/>`__ for the up-to-date
@@ -78,6 +71,25 @@ import IPython
 import matplotlib.pyplot as plt
 import torch
 import torchaudio
+
+try:
+    import torchaudio.prototype.ctc_decoder
+except ModuleNotFoundError:
+    try:
+        import google.colab
+        print(
+            """
+            To enable running this notebook in Google Colab, install nightly
+            torch and torchaudio builds by adding the following code block to the top
+            of the notebook before running it:
+
+            !pip3 uninstall -y torch torchvision torchaudio
+            !pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+            """
+        )
+    except ModuleNotFoundError:
+        pass
+    raise
 
 
 ######################################################################

--- a/examples/tutorials/asr_inference_with_ctc_decoder_tutorial.py
+++ b/examples/tutorials/asr_inference_with_ctc_decoder_tutorial.py
@@ -21,6 +21,13 @@ using CTC loss.
 #    Please refer to https://pytorch.org/get-started/locally/
 #    for instructions.
 #
+#    To enable running the tutorial notebook in Google Colab, install nightly
+#    torch and torchaudio builds by adding the following code block to the top
+#    of the notebook before running it:
+#    ::
+#      !pip3 uninstall -y torch torchvision torchaudio
+#      !pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+#
 #    The interfaces of prototype features are unstable and subject to
 #    change. Please refer to `the nightly build documentation
 #    <https://pytorch.org/audio/main/>`__ for the up-to-date

--- a/examples/tutorials/asr_inference_with_ctc_decoder_tutorial.py
+++ b/examples/tutorials/asr_inference_with_ctc_decoder_tutorial.py
@@ -77,6 +77,7 @@ try:
 except ModuleNotFoundError:
     try:
         import google.colab
+
         print(
             """
             To enable running this notebook in Google Colab, install nightly

--- a/examples/tutorials/device_asr.py
+++ b/examples/tutorials/device_asr.py
@@ -10,7 +10,7 @@ on laptop.
 
 .. note::
 
-   This tutorial requires prototype Streaming API and ffmpeg>=4.1.
+   This tutorial requires prototype Streaming API, ffmpeg>=4.1, and SentencePiece.
 
    Prototype features are not part of binary releases, but available in
    nightly build. Please refer to https://pytorch.org for installing
@@ -19,6 +19,8 @@ on laptop.
    If you are using Anaconda Python distribution,
    ``conda install -c anaconda ffmpeg`` will install
    the required libraries.
+
+   You can install SentencePiece by running ``pip install sentencepiece``.
 
 .. note::
 

--- a/examples/tutorials/online_asr_tutorial.py
+++ b/examples/tutorials/online_asr_tutorial.py
@@ -58,6 +58,7 @@ try:
 except ModuleNotFoundError:
     try:
         import google.colab
+
         print(
             """
             To enable running this notebook in Google Colab, install nightly

--- a/examples/tutorials/online_asr_tutorial.py
+++ b/examples/tutorials/online_asr_tutorial.py
@@ -20,6 +20,13 @@ to perform online speech recognition.
 #    Please refer to https://pytorch.org/get-started/locally/
 #    for instructions.
 #
+#    To enable running the tutorial notebook in Google Colab, install nightly
+#    torch and torchaudio builds by adding the following code block to the top
+#    of the notebook before running it:
+#    ::
+#      !pip3 uninstall -y torch torchvision torchaudio
+#      !pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+#
 #    The interfaces of prototype features are unstable and subject to
 #    change. Please refer to `the nightly build documentation
 #    <https://pytorch.org/audio/main/>`__ for the up-to-date

--- a/examples/tutorials/online_asr_tutorial.py
+++ b/examples/tutorials/online_asr_tutorial.py
@@ -13,19 +13,12 @@ to perform online speech recognition.
 #
 # .. note::
 #
-#    This tutorial requires torchaudio with prototype features and
-#    FFmpeg libraries (>=4.1).
+#    This tutorial requires torchaudio with prototype features,
+#    FFmpeg libraries (>=4.1), and SentencePiece.
 #
 #    torchaudio prototype features are available on nightly builds.
 #    Please refer to https://pytorch.org/get-started/locally/
 #    for instructions.
-#
-#    To enable running the tutorial notebook in Google Colab, install nightly
-#    torch and torchaudio builds by adding the following code block to the top
-#    of the notebook before running it:
-#    ::
-#      !pip3 uninstall -y torch torchvision torchaudio
-#      !pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 #
 #    The interfaces of prototype features are unstable and subject to
 #    change. Please refer to `the nightly build documentation
@@ -37,13 +30,7 @@ to perform online speech recognition.
 #    ``conda install -c anaconda ffmpeg`` will install
 #    the required libraries.
 #
-#    When running this tutorial in Google Colab, the following
-#    command should do.
-#
-#    .. code::
-#
-#       !add-apt-repository -y ppa:savoury1/ffmpeg4
-#       !apt-get -qq install -y ffmpeg
+#    You can install SentencePiece by running ``pip install sentencepiece``.
 
 ######################################################################
 # 1. Overview
@@ -66,10 +53,31 @@ import IPython
 import torch
 import torchaudio
 
+try:
+    from torchaudio.prototype.io import Streamer
+except ModuleNotFoundError:
+    try:
+        import google.colab
+        print(
+            """
+            To enable running this notebook in Google Colab, install nightly
+            torch and torchaudio builds and the requisite third party libraries by
+            adding the following code block to the top of the notebook before running it:
+
+            !pip3 uninstall -y torch torchvision torchaudio
+            !pip3 install --pre torch torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+            !pip3 install sentencepiece
+            !add-apt-repository -y ppa:savoury1/ffmpeg4
+            !apt-get -qq install -y ffmpeg
+            """
+        )
+    except ModuleNotFoundError:
+        pass
+    raise
+
 print(torch.__version__)
 print(torchaudio.__version__)
 
-from torchaudio.prototype.io import Streamer
 
 ######################################################################
 # 3. Construct the pipeline

--- a/examples/tutorials/streaming_api_tutorial.py
+++ b/examples/tutorials/streaming_api_tutorial.py
@@ -19,13 +19,6 @@ libavfilter provides.
 #    Please refer to https://pytorch.org/get-started/locally/
 #    for instructions.
 #
-#    To enable running the tutorial notebook in Google Colab, install nightly
-#    torch and torchaudio builds by adding the following code block to the top
-#    of the notebook before running it:
-#    ::
-#      !pip3 uninstall -y torch torchvision torchaudio
-#      !pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu
-#
 #    The interfaces of prototype features are unstable and subject to
 #    change. Please refer to `the nightly build documentation
 #    <https://pytorch.org/audio/main/>`__ for the up-to-date
@@ -36,13 +29,6 @@ libavfilter provides.
 #    ``conda install -c anaconda ffmpeg`` will install
 #    the required libraries.
 #
-#    When running this tutorial in Google Colab, the following
-#    command should do.
-#
-#    .. code::
-#
-#       !add-apt-repository -y ppa:savoury1/ffmpeg4
-#       !apt-get -qq install -y ffmpeg
 
 ######################################################################
 # 1. Overview
@@ -84,7 +70,27 @@ import IPython
 import matplotlib.pyplot as plt
 import torch
 import torchaudio
-from torchaudio.prototype.io import Streamer
+
+try:
+    from torchaudio.prototype.io import Streamer
+except ModuleNotFoundError:
+    try:
+        import google.colab
+        print(
+            """
+            To enable running this notebook in Google Colab, install nightly
+            torch and torchaudio builds and the requisite third party libraries by
+            adding the following code block to the top of the notebook before running it:
+
+            !pip3 uninstall -y torch torchvision torchaudio
+            !pip3 install --pre torch torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+            !add-apt-repository -y ppa:savoury1/ffmpeg4
+            !apt-get -qq install -y ffmpeg
+            """
+        )
+    except ModuleNotFoundError:
+        pass
+    raise
 
 print(torch.__version__)
 print(torchaudio.__version__)

--- a/examples/tutorials/streaming_api_tutorial.py
+++ b/examples/tutorials/streaming_api_tutorial.py
@@ -76,6 +76,7 @@ try:
 except ModuleNotFoundError:
     try:
         import google.colab
+
         print(
             """
             To enable running this notebook in Google Colab, install nightly

--- a/examples/tutorials/streaming_api_tutorial.py
+++ b/examples/tutorials/streaming_api_tutorial.py
@@ -19,6 +19,13 @@ libavfilter provides.
 #    Please refer to https://pytorch.org/get-started/locally/
 #    for instructions.
 #
+#    To enable running the tutorial notebook in Google Colab, install nightly
+#    torch and torchaudio builds by adding the following code block to the top
+#    of the notebook before running it:
+#    ::
+#      !pip3 uninstall -y torch torchvision torchaudio
+#      !pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+#
 #    The interfaces of prototype features are unstable and subject to
 #    change. Please refer to `the nightly build documentation
 #    <https://pytorch.org/audio/main/>`__ for the up-to-date


### PR DESCRIPTION
Tutorial notebooks that leverage TorchAudio prototype features don't run as-is on Google Colab due to its runtime's not having nightly builds pre-installed. To make it easier for users to run said notebooks in Colab, this PR adds a code block that installs nightly Pytorch and TorchAudio builds as a comment that users can copy and run locally.