### PR TITLE
Fix ffmpeg integration for ffmpeg 5.0

### DIFF
--- a/torchaudio/csrc/ffmpeg/ffmpeg.cpp
+++ b/torchaudio/csrc/ffmpeg/ffmpeg.cpp
@@ -57,7 +57,7 @@ AVFormatContext* get_format_context(
     const std::string& device,
     const std::map<std::string, std::string>& option) {
   AVFormatContext* pFormat = NULL;
-  AVInputFormat* pInput =
+  const AVInputFormat* pInput =
       device.empty() ? NULL : av_find_input_format(device.c_str());
   AVDictionary* opt = get_option_dict(option);
   int ret = avformat_open_input(&pFormat, src.c_str(), pInput, &opt);

--- a/torchaudio/csrc/ffmpeg/ffmpeg.cpp
+++ b/torchaudio/csrc/ffmpeg/ffmpeg.cpp
@@ -53,7 +53,7 @@ std::string join(std::vector<std::string> vars) {
 }
 
 // https://github.com/FFmpeg/FFmpeg/blob/4e6debe1df7d53f3f59b37449b82265d5c08a172/doc/APIchanges#L252-L260
-// Starting from libavformat 59 (ffmpeg > 4),
+// Starting from libavformat 59 (ffmpeg 5),
 // AVInputFormat is const and related functions expect constant.
 #if LIBAVFORMAT_VERSION_MAJOR >= 59
 #define AVINPUT_FORMAT_CONST const

--- a/torchaudio/csrc/ffmpeg/ffmpeg.cpp
+++ b/torchaudio/csrc/ffmpeg/ffmpeg.cpp
@@ -52,12 +52,22 @@ std::string join(std::vector<std::string> vars) {
   return ks.str();
 }
 
+// https://github.com/FFmpeg/FFmpeg/blob/4e6debe1df7d53f3f59b37449b82265d5c08a172/doc/APIchanges#L252-L260
+// Starting from libavformat 59 (ffmpeg > 4),
+// AVInputFormat is const and related functions expect constant.
+#if LIBAVFORMAT_VERSION_MAJOR >= 59
+#define AVINPUT_FORMAT_CONST const
+#else
+#define AVINPUT_FORMAT_CONST
+#endif
+
 AVFormatContext* get_format_context(
     const std::string& src,
     const std::string& device,
     const std::map<std::string, std::string>& option) {
   AVFormatContext* pFormat = NULL;
-  const AVInputFormat* pInput =
+
+  AVINPUT_FORMAT_CONST AVInputFormat* pInput =
       device.empty() ? NULL : av_find_input_format(device.c_str());
   AVDictionary* opt = get_option_dict(option);
   int ret = avformat_open_input(&pFormat, src.c_str(), pInput, &opt);


### PR DESCRIPTION
This commit makes the FFmpeg integration support FFmpeg 5.0

In FFmpeg 5, functions like `av_find_input_format` and `avformat_open_input` are changed,
so that they deal with constant version of `AVInputFormat`.

> 2021-04-27 - 56450a0ee4 - lavf 59.0.100 - avformat.h
>  Constified the pointers to AVInputFormats and AVOutputFormats
>  in AVFormatContext, avformat_alloc_output_context2(),
>  av_find_input_format(), av_probe_input_format(),
>  av_probe_input_format2(), av_probe_input_format3(),
>  av_probe_input_buffer2(), av_probe_input_buffer(),
>  avformat_open_input(), av_guess_format() and av_guess_codec().
>  Furthermore, constified the AVProbeData in av_probe_input_format(),
>  av_probe_input_format2() and av_probe_input_format3().

https://github.com/FFmpeg/FFmpeg/blob/4e6debe1df7d53f3f59b37449b82265d5c08a172/doc/APIchanges#L252-L260