### PR TITLE
Support specifying decoder and its options

### DIFF
--- a/torchaudio/csrc/ffmpeg/decoder.cpp
+++ b/torchaudio/csrc/ffmpeg/decoder.cpp
@@ -6,7 +6,11 @@ namespace ffmpeg {
 ////////////////////////////////////////////////////////////////////////////////
 // Decoder
 ////////////////////////////////////////////////////////////////////////////////
-Decoder::Decoder(AVCodecParameters* pParam) : pCodecContext(pParam) {}
+Decoder::Decoder(
+    AVCodecParameters* pParam,
+    const std::string& decoder_name,
+    const std::map<std::string, std::string>& decoder_option)
+    : pCodecContext(pParam, decoder_name, decoder_option) {}
 
 int Decoder::process_packet(AVPacket* pPacket) {
   return avcodec_send_packet(pCodecContext, pPacket);

--- a/torchaudio/csrc/ffmpeg/decoder.h
+++ b/torchaudio/csrc/ffmpeg/decoder.h
@@ -10,7 +10,10 @@ class Decoder {
 
  public:
   // Default constructable
-  Decoder(AVCodecParameters* pParam);
+  Decoder(
+      AVCodecParameters* pParam,
+      const std::string& decoder_name,
+      const std::map<std::string, std::string>& decoder_option);
   // Custom destructor to clean up the resources
   ~Decoder() = default;
   // Non-copyable

--- a/torchaudio/csrc/ffmpeg/ffmpeg.h
+++ b/torchaudio/csrc/ffmpeg/ffmpeg.h
@@ -118,7 +118,10 @@ struct AVCodecContextDeleter {
 };
 struct AVCodecContextPtr
     : public Wrapper<AVCodecContext, AVCodecContextDeleter> {
-  AVCodecContextPtr(AVCodecParameters* pParam);
+  AVCodecContextPtr(
+      AVCodecParameters* pParam,
+      const std::string& decoder,
+      const std::map<std::string, std::string>& decoder_option);
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/torchaudio/csrc/ffmpeg/stream_processor.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_processor.cpp
@@ -6,8 +6,11 @@ namespace ffmpeg {
 
 using KeyType = StreamProcessor::KeyType;
 
-StreamProcessor::StreamProcessor(AVCodecParameters* codecpar)
-    : decoder(codecpar) {}
+StreamProcessor::StreamProcessor(
+    AVCodecParameters* codecpar,
+    const std::string& decoder_name,
+    const std::map<std::string, std::string>& decoder_option)
+    : decoder(codecpar, decoder_name, decoder_option) {}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Configurations

--- a/torchaudio/csrc/ffmpeg/stream_processor.h
+++ b/torchaudio/csrc/ffmpeg/stream_processor.h
@@ -25,7 +25,10 @@ class StreamProcessor {
   std::map<KeyType, Sink> sinks;
 
  public:
-  StreamProcessor(AVCodecParameters* codecpar);
+  StreamProcessor(
+      AVCodecParameters* codecpar,
+      const std::string& decoder_name,
+      const std::map<std::string, std::string>& decoder_option);
   ~StreamProcessor() = default;
   // Non-copyable
   StreamProcessor(const StreamProcessor&) = delete;

--- a/torchaudio/csrc/ffmpeg/streamer.cpp
+++ b/torchaudio/csrc/ffmpeg/streamer.cpp
@@ -156,26 +156,34 @@ void Streamer::add_audio_stream(
     int i,
     int frames_per_chunk,
     int num_chunks,
-    std::string filter_desc) {
+    std::string filter_desc,
+    const std::string& decoder,
+    const std::map<std::string, std::string>& decoder_option) {
   add_stream(
       i,
       AVMEDIA_TYPE_AUDIO,
       frames_per_chunk,
       num_chunks,
-      std::move(filter_desc));
+      std::move(filter_desc),
+      decoder,
+      decoder_option);
 }
 
 void Streamer::add_video_stream(
     int i,
     int frames_per_chunk,
     int num_chunks,
-    std::string filter_desc) {
+    std::string filter_desc,
+    const std::string& decoder,
+    const std::map<std::string, std::string>& decoder_option) {
   add_stream(
       i,
       AVMEDIA_TYPE_VIDEO,
       frames_per_chunk,
       num_chunks,
-      std::move(filter_desc));
+      std::move(filter_desc),
+      decoder,
+      decoder_option);
 }
 
 void Streamer::add_stream(
@@ -183,12 +191,15 @@ void Streamer::add_stream(
     AVMediaType media_type,
     int frames_per_chunk,
     int num_chunks,
-    std::string filter_desc) {
+    std::string filter_desc,
+    const std::string& decoder,
+    const std::map<std::string, std::string>& decoder_option) {
   validate_src_stream_type(i, media_type);
   AVStream* stream = pFormatContext->streams[i];
   stream->discard = AVDISCARD_DEFAULT;
   if (!processors[i])
-    processors[i] = std::make_unique<StreamProcessor>(stream->codecpar);
+    processors[i] = std::make_unique<StreamProcessor>(
+        stream->codecpar, decoder, decoder_option);
   int key = processors[i]->add_stream(
       stream->time_base,
       stream->codecpar,

--- a/torchaudio/csrc/ffmpeg/streamer.h
+++ b/torchaudio/csrc/ffmpeg/streamer.h
@@ -66,12 +66,16 @@ class Streamer {
       int i,
       int frames_per_chunk,
       int num_chunks,
-      std::string filter_desc);
+      std::string filter_desc,
+      const std::string& decoder,
+      const std::map<std::string, std::string>& decoder_option);
   void add_video_stream(
       int i,
       int frames_per_chunk,
       int num_chunks,
-      std::string filter_desc);
+      std::string filter_desc,
+      const std::string& decoder,
+      const std::map<std::string, std::string>& decoder_option);
   void remove_stream(int i);
 
  private:
@@ -80,7 +84,9 @@ class Streamer {
       AVMediaType media_type,
       int frames_per_chunk,
       int num_chunks,
-      std::string filter_desc);
+      std::string filter_desc,
+      const std::string& decoder,
+      const std::map<std::string, std::string>& decoder_option);
 
  public:
   //////////////////////////////////////////////////////////////////////////////

--- a/torchaudio/prototype/io/streamer.py
+++ b/torchaudio/prototype/io/streamer.py
@@ -355,6 +355,8 @@ class Streamer:
         buffer_chunk_size: int = 3,
         stream_index: Optional[int] = None,
         filter_desc: Optional[str] = None,
+        decoder: Optional[str] = None,
+        decoder_options: Optional[Dict[str, str]] = None,
     ):
         """Add output audio stream
 
@@ -375,10 +377,22 @@ class Streamer:
                 The list of available filters can be found at
                 https://ffmpeg.org/ffmpeg-filters.html
                 Note that complex filters are not supported.
+
+            decoder (str or None, optional): The name of the decoder to be used.
+                When provided, use the specified decoder instead of the default one.
+
+            decoder_options (dict or None, optional): Options passed to decoder.
+                Mapping from str to str.
         """
         i = self.default_audio_stream if stream_index is None else stream_index
         torch.ops.torchaudio.ffmpeg_streamer_add_audio_stream(
-            self._s, i, frames_per_chunk, buffer_chunk_size, filter_desc
+            self._s,
+            i,
+            frames_per_chunk,
+            buffer_chunk_size,
+            filter_desc,
+            decoder,
+            decoder_options,
         )
 
     def add_video_stream(
@@ -387,6 +401,8 @@ class Streamer:
         buffer_chunk_size: int = 3,
         stream_index: Optional[int] = None,
         filter_desc: Optional[str] = None,
+        decoder: Optional[str] = None,
+        decoder_options: Optional[Dict[str, str]] = None,
     ):
         """Add output video stream
 
@@ -407,10 +423,22 @@ class Streamer:
                 The list of available filters can be found at
                 https://ffmpeg.org/ffmpeg-filters.html
                 Note that complex filters are not supported.
+
+            decoder (str or None, optional): The name of the decoder to be used.
+                When provided, use the specified decoder instead of the default one.
+
+            decoder_options (dict or None, optional): Options passed to decoder.
+                Mapping from str to str.
         """
         i = self.default_video_stream if stream_index is None else stream_index
         torch.ops.torchaudio.ffmpeg_streamer_add_video_stream(
-            self._s, i, frames_per_chunk, buffer_chunk_size, filter_desc
+            self._s,
+            i,
+            frames_per_chunk,
+            buffer_chunk_size,
+            filter_desc,
+            decoder,
+            decoder_options,
         )
 
     def remove_stream(self, i: int):


### PR DESCRIPTION
This commit adds support to specify decoder to Streamer's add stream method.
This is roughly equivalent to `ffmpeg`'s `-c:v foo` and `-c:a foo` options.

This allows to override the decoder codec and/or specify the option of
the decoder.

This change allows to specify Nvidia NVDEC codec for supported formats,
which uses dedicated hardware for decoding the video.

---

Note: The CL might look overwhelming, but it's essentially, add new parameters in Python, and pass them down all the way to  `AVCodecContextPtr`, which initializes the actual decoder implementation (`AVCodecContext`.)