### PR TITLE
Add HW acceleration support on Streamer

### DIFF
--- a/torchaudio/csrc/ffmpeg/buffer.h
+++ b/torchaudio/csrc/ffmpeg/buffer.h
@@ -76,8 +76,13 @@ class AudioBuffer : public Buffer {
 // But this mean that chunks consisting of multiple frames have to be created
 // at popping time.
 class VideoBuffer : public Buffer {
+  const torch::Device device;
+
  public:
-  VideoBuffer(int frames_per_chunk, int num_chunks);
+  VideoBuffer(
+      int frames_per_chunk,
+      int num_chunks,
+      const torch::Device& device);
 
   void push_frame(AVFrame* frame);
 

--- a/torchaudio/csrc/ffmpeg/decoder.cpp
+++ b/torchaudio/csrc/ffmpeg/decoder.cpp
@@ -9,8 +9,9 @@ namespace ffmpeg {
 Decoder::Decoder(
     AVCodecParameters* pParam,
     const std::string& decoder_name,
-    const std::map<std::string, std::string>& decoder_option)
-    : pCodecContext(pParam, decoder_name, decoder_option) {}
+    const std::map<std::string, std::string>& decoder_option,
+    const torch::Device& device)
+    : pCodecContext(pParam, decoder_name, decoder_option, device) {}
 
 int Decoder::process_packet(AVPacket* pPacket) {
   return avcodec_send_packet(pCodecContext, pPacket);

--- a/torchaudio/csrc/ffmpeg/decoder.h
+++ b/torchaudio/csrc/ffmpeg/decoder.h
@@ -13,7 +13,8 @@ class Decoder {
   Decoder(
       AVCodecParameters* pParam,
       const std::string& decoder_name,
-      const std::map<std::string, std::string>& decoder_option);
+      const std::map<std::string, std::string>& decoder_option,
+      const torch::Device& device);
   // Custom destructor to clean up the resources
   ~Decoder() = default;
   // Non-copyable

--- a/torchaudio/csrc/ffmpeg/ffmpeg.cpp
+++ b/torchaudio/csrc/ffmpeg/ffmpeg.cpp
@@ -256,6 +256,7 @@ void init_codec_context(
       throw std::runtime_error(
           "Failed to create CUDA device context: " + av_err2string(err));
     }
+    assert(hw_device_ctx);
     pCodecContext->hw_device_ctx = av_buffer_ref(hw_device_ctx);
     pHWBufferRef.reset(hw_device_ctx);
   }

--- a/torchaudio/csrc/ffmpeg/filter_graph.cpp
+++ b/torchaudio/csrc/ffmpeg/filter_graph.cpp
@@ -180,8 +180,11 @@ void FilterGraph::add_process() {
 }
 
 void FilterGraph::create_filter() {
-  if (avfilter_graph_config(pFilterGraph, nullptr) < 0)
-    throw std::runtime_error("Failed to configure the graph.");
+  int ret = avfilter_graph_config(pFilterGraph, nullptr);
+  if (ret < 0) {
+    throw std::runtime_error(
+        "Failed to configure the graph: " + av_err2string(ret));
+  }
   // char* desc = avfilter_graph_dump(pFilterGraph.get(), NULL);
   // std::cerr << "Filter created:\n" << desc << std::endl;
   // av_free(static_cast<void*>(desc));

--- a/torchaudio/csrc/ffmpeg/sink.cpp
+++ b/torchaudio/csrc/ffmpeg/sink.cpp
@@ -8,14 +8,15 @@ namespace {
 std::unique_ptr<Buffer> get_buffer(
     AVMediaType type,
     int frames_per_chunk,
-    int num_chunks) {
+    int num_chunks,
+    const torch::Device& device) {
   switch (type) {
     case AVMEDIA_TYPE_AUDIO:
       return std::unique_ptr<Buffer>(
           new AudioBuffer(frames_per_chunk, num_chunks));
     case AVMEDIA_TYPE_VIDEO:
       return std::unique_ptr<Buffer>(
-          new VideoBuffer(frames_per_chunk, num_chunks));
+          new VideoBuffer(frames_per_chunk, num_chunks, device));
     default:
       throw std::runtime_error(
           std::string("Unsupported media type: ") +
@@ -29,9 +30,14 @@ Sink::Sink(
     AVCodecParameters* codecpar,
     int frames_per_chunk,
     int num_chunks,
-    std::string filter_description)
-    : filter(input_time_base, codecpar, filter_description),
-      buffer(get_buffer(codecpar->codec_type, frames_per_chunk, num_chunks)) {}
+    std::string filter_description,
+    const torch::Device& device)
+    : filter(input_time_base, codecpar, std::move(filter_description)),
+      buffer(get_buffer(
+          codecpar->codec_type,
+          frames_per_chunk,
+          num_chunks,
+          device)) {}
 
 // 0: some kind of success
 // <0: Some error happened

--- a/torchaudio/csrc/ffmpeg/sink.h
+++ b/torchaudio/csrc/ffmpeg/sink.h
@@ -18,7 +18,8 @@ class Sink {
       AVCodecParameters* codecpar,
       int frames_per_chunk,
       int num_chunks,
-      std::string filter_description);
+      std::string filter_description,
+      const torch::Device& device);
 
   int process_frame(AVFrame* frame);
   bool is_buffer_ready() const;

--- a/torchaudio/csrc/ffmpeg/stream_processor.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_processor.cpp
@@ -9,8 +9,9 @@ using KeyType = StreamProcessor::KeyType;
 StreamProcessor::StreamProcessor(
     AVCodecParameters* codecpar,
     const std::string& decoder_name,
-    const std::map<std::string, std::string>& decoder_option)
-    : decoder(codecpar, decoder_name, decoder_option) {}
+    const std::map<std::string, std::string>& decoder_option,
+    const torch::Device& device)
+    : decoder(codecpar, decoder_name, decoder_option, device) {}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Configurations
@@ -20,7 +21,8 @@ KeyType StreamProcessor::add_stream(
     AVCodecParameters* codecpar,
     int frames_per_chunk,
     int num_chunks,
-    std::string filter_description) {
+    std::string filter_description,
+    const torch::Device& device) {
   switch (codecpar->codec_type) {
     case AVMEDIA_TYPE_AUDIO:
     case AVMEDIA_TYPE_VIDEO:
@@ -37,7 +39,8 @@ KeyType StreamProcessor::add_stream(
           codecpar,
           frames_per_chunk,
           num_chunks,
-          std::move(filter_description)));
+          std::move(filter_description),
+          device));
   decoder_time_base = av_q2d(input_time_base);
   return key;
 }

--- a/torchaudio/csrc/ffmpeg/stream_processor.h
+++ b/torchaudio/csrc/ffmpeg/stream_processor.h
@@ -28,7 +28,8 @@ class StreamProcessor {
   StreamProcessor(
       AVCodecParameters* codecpar,
       const std::string& decoder_name,
-      const std::map<std::string, std::string>& decoder_option);
+      const std::map<std::string, std::string>& decoder_option,
+      const torch::Device& device);
   ~StreamProcessor() = default;
   // Non-copyable
   StreamProcessor(const StreamProcessor&) = delete;
@@ -51,7 +52,8 @@ class StreamProcessor {
       AVCodecParameters* codecpar,
       int frames_per_chunk,
       int num_chunks,
-      std::string filter_description);
+      std::string filter_description,
+      const torch::Device& device);
 
   // 1. Remove the stream
   void remove_stream(KeyType key);

--- a/torchaudio/csrc/ffmpeg/streamer.h
+++ b/torchaudio/csrc/ffmpeg/streamer.h
@@ -75,7 +75,8 @@ class Streamer {
       int num_chunks,
       std::string filter_desc,
       const std::string& decoder,
-      const std::map<std::string, std::string>& decoder_option);
+      const std::map<std::string, std::string>& decoder_option,
+      const torch::Device& device);
   void remove_stream(int i);
 
  private:
@@ -86,7 +87,8 @@ class Streamer {
       int num_chunks,
       std::string filter_desc,
       const std::string& decoder,
-      const std::map<std::string, std::string>& decoder_option);
+      const std::map<std::string, std::string>& decoder_option,
+      const torch::Device& device);
 
  public:
   //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This commits add `hw_accel` option to `Streamer::add_video_stream` method.
Specifying `hw_accel="cuda"` allows to create the chunk Tensor directly from CUDA,
when the following conditions are met.
1. the video format is H264,
2. underlying ffmpeg is compiled with NVENC, and
3. the client code specifies `decoder="h264_cuvid"`.

A simple benchmark yields x7 improvement in the decoding speed.

<details>

```python
import time

from torchaudio.prototype.io import Streamer

srcs = [
    "https://download.pytorch.org/torchaudio/tutorial-assets/stream-api/NASAs_Most_Scientifically_Complex_Space_Observatory_Requires_Precision-MP4.mp4",
    "./NASAs_Most_Scientifically_Complex_Space_Observatory_Requires_Precision-MP4.mp4",  # offline version
]

patterns = [
    ("h264_cuvid", None, "cuda:0"),  # NVDEC on CUDA:0 -> CUDA:0
    ("h264_cuvid", None, "cuda:1"),  # NVDEC on CUDA:1 -> CUDA:1
    ("h264_cuvid", None, None),  # NVDEC -> CPU
    (None, None, None),  # CPU
]

for src in srcs:
    print(src, flush=True)
    for (decoder, decoder_options, hw_accel) in patterns:
        s = Streamer(src)
        s.add_video_stream(5, decoder=decoder, decoder_options=decoder_options, hw_accel=hw_accel)

        t0 = time.monotonic()
        num_frames = 0
	for i, (chunk, ) in enumerate(s.stream()):
	    num_frames += chunk.shape[0]
        t1 = time.monotonic()
        print(chunk.dtype, chunk.shape, chunk.device)
        print(time.monotonic() - t0, num_frames, flush=True)
```
</details>

```
https://download.pytorch.org/torchaudio/tutorial-assets/stream-api/NASAs_Most_Scientifically_Complex_Space_Observatory_Requires_Precision-MP4.mp4
torch.uint8 torch.Size([5, 3, 1080, 1920]) cuda:0
10.781158386962488 6175
torch.uint8 torch.Size([5, 3, 1080, 1920]) cuda:1
10.771313901990652 6175
torch.uint8 torch.Size([5, 3, 1080, 1920]) cpu
27.88662809302332 6175
torch.uint8 torch.Size([5, 3, 1080, 1920]) cpu
83.22728440898936 6175
./NASAs_Most_Scientifically_Complex_Space_Observatory_Requires_Precision-MP4.mp4
torch.uint8 torch.Size([5, 3, 1080, 1920]) cuda:0
12.945253834011964 6175
torch.uint8 torch.Size([5, 3, 1080, 1920]) cuda:1
12.870224556012545 6175
torch.uint8 torch.Size([5, 3, 1080, 1920]) cpu
28.03406483103754 6175
torch.uint8 torch.Size([5, 3, 1080, 1920]) cpu
82.6120332319988 6175
```

With HW resizing

<details>

```python
import time

from torchaudio.prototype.io import Streamer

srcs = [
    "./NASAs_Most_Scientifically_Complex_Space_Observatory_Requires_Precision-MP4.mp4",
    "https://download.pytorch.org/torchaudio/tutorial-assets/stream-api/NASAs_Most_Scientifically_Complex_Space_Observatory_Requires_Precision-MP4.mp4",
]

patterns = [
    # Decode with NVDEC, CUDA HW scaling -> CUDA:0
    ("h264_cuvid", {"resize": "960x540"}, "", "cuda:0"),
    # Decoded with NVDEC, CUDA HW scaling -> CPU
    ("h264_cuvid", {"resize": "960x540"}, "", None),
    # CPU decoding, CPU scaling
    (None, None, "scale=width=960:height=540", None),
]

for src in srcs:
    print(src, flush=True)
    for (decoder, decoder_options, filter_desc, hw_accel) in patterns:
        s = Streamer(src)
        s.add_video_stream(
            5,
            decoder=decoder,
            decoder_options=decoder_options,
            filter_desc=filter_desc,
            hw_accel=hw_accel,
        )

        t0 = time.monotonic()
        num_frames = 0
        for i, (chunk, ) in enumerate(s.stream()):
            num_frames += chunk.shape[0]
        t1 = time.monotonic()
        print(chunk.dtype, chunk.shape, chunk.device)
        print(time.monotonic() - t0, num_frames, flush=True)
```

</details>

```
./NASAs_Most_Scientifically_Complex_Space_Observatory_Requires_Precision-MP4.mp4
torch.uint8 torch.Size([5, 3, 540, 960]) cuda:0
12.890056837990414 6175
torch.uint8 torch.Size([5, 3, 540, 960]) cpu
10.697489063022658 6175
torch.uint8 torch.Size([5, 3, 540, 960]) cpu
85.19899423001334 6175

https://download.pytorch.org/torchaudio/tutorial-assets/stream-api/NASAs_Most_Scientifically_Complex_Space_Observatory_Requires_Precision-MP4.mp4
torch.uint8 torch.Size([5, 3, 540, 960]) cuda:0
10.712715593050234 6175
torch.uint8 torch.Size([5, 3, 540, 960]) cpu
11.030170071986504 6175
torch.uint8 torch.Size([5, 3, 540, 960]) cpu
84.8515750519582 6175
```
