### PR TITLE
Add YUV420P format support to Streamer API

### DIFF
--- a/torchaudio/prototype/io/streamer.py
+++ b/torchaudio/prototype/io/streamer.py
@@ -334,6 +334,7 @@ class Streamer:
 
                 - `RGB`: 8 bits * 3 channels
                 - `BGR`: 8 bits * 3 channels
+                - `YUV`: 8 bits * 3 channels
                 - `GRAY`: 8 bits * 1 channels
         """
         i = self.default_video_stream if stream_index is None else stream_index


### PR DESCRIPTION
This commit adds YUV420P format support to Streamer API.
When the native format of a video is YUV420P, the Streamer will
output Tensor of YUV color channel.