### PR TITLE
Disable clang-tidy modernize-use-trailing-return-type

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,6 +27,7 @@ modernize-*,
 -modernize-return-braced-init-list,
 -modernize-use-auto,
 -modernize-use-default-member-init,
+-modernize-use-trailing-return-type,
 -modernize-use-using,
 performance-unnecessary-value-param,
 '


### PR DESCRIPTION
Summary:
Disable clang-tidy's `modernize-use-trailing-return-type` suggestion.

Trailing return type has no impact on performance.
The lint warning shows up everywhere, and it's nothing but noise.

Differential Revision: D35635718

