### PR TITLE
[CircleCI] Update base images to ubuntu-2004

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -483,7 +483,7 @@ jobs:
   unittest_linux_gpu:
     <<: *binary_common
     machine:
-      image: ubuntu-1604-cuda-10.1:201909-23
+      image: ubuntu-2004-cuda-11.4:202110-01
     resource_class: gpu.nvidia.medium
     environment:
       <<: *environment

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -483,7 +483,7 @@ jobs:
   unittest_linux_gpu:
     <<: *binary_common
     machine:
-      image: ubuntu-1604-cuda-10.1:201909-23
+      image: ubuntu-2004-cuda-11.4:202110-01
     resource_class: gpu.nvidia.medium
     environment:
       <<: *environment


### PR DESCRIPTION
Same change as done in this vision [PR](https://github.com/pytorch/vision/pull/5802)

As Ubuntu-1604 runners will no longer be available in early May
Update ubuntu-1604-cuda-10.1:201909-23 to ubuntu-2004-cuda-11.4:202110-01
Per [CircleCI Configuration reference](https://circleci.com/docs/2.0/configuration-reference/)

Resolves #2279 