### PR TITLE
Fix bug with unsqueezing length tensor in RNNTBeamSearch

### DIFF
--- a/torchaudio/models/rnnt_decoder.py
+++ b/torchaudio/models/rnnt_decoder.py
@@ -333,6 +333,8 @@ class RNNTBeamSearch(torch.nn.Module):
             input = input.unsqueeze(0)
 
         assert length.shape == () or length.shape == (1,), "length must be of shape () or (1,)"
+        if length.dim() == 0:
+            length = length.unsqueeze(0)
 
         enc_out, _, state = self.model.transcribe_streaming(input, length, state)
         return self._search(enc_out, hypothesis, beam_width), state

--- a/torchaudio/models/rnnt_decoder.py
+++ b/torchaudio/models/rnnt_decoder.py
@@ -333,8 +333,6 @@ class RNNTBeamSearch(torch.nn.Module):
             input = input.unsqueeze(0)
 
         assert length.shape == () or length.shape == (1,), "length must be of shape () or (1,)"
-        if input.dim() == 0:
-            input = input.unsqueeze(0)
 
         enc_out, _, state = self.model.transcribe_streaming(input, length, state)
         return self._search(enc_out, hypothesis, beam_width), state


### PR DESCRIPTION
This PR amends `RNNTBeamSearch`'s streaming decoding method to correctly unsqueeze `length` when its dimension is 0.

Original comment: Is "input.dim() == 0" unreachable as it could only be 2 or 3 in assertion of Line 329?