### PR TITLE
Add extra arguments to hubert pretrain factory functions

### DIFF
--- a/torchaudio/models/wav2vec2/model.py
+++ b/torchaudio/models/wav2vec2/model.py
@@ -969,11 +969,11 @@ def hubert_pretrain_base(
     encoder_layer_drop: float = 0.05,
     mask_prob: float = 0.8,
     mask_channel_prob: float = 0.0,
-    mask_channel_length: float = 10,
+    mask_channel_length: int = 10,
     num_classes: int = 100,
 ) -> HuBERTPretrainModel:
     # Overriding the signature so that the return type is correct on Sphinx
-    """hubert_pretrain_base(encoder_projection_dropout: float = 0.1, encoder_attention_dropout: float = 0.1, encoder_ff_interm_dropout: float = 0.0, encoder_dropout: float = 0.1, encoder_layer_drop: float = 0.05, num_classes: int = 100) -> torchaudio.models.HuBERTPretrainModel
+    """hubert_pretrain_base(encoder_projection_dropout: float = 0.1, encoder_attention_dropout: float = 0.1, encoder_ff_interm_dropout: float = 0.0, encoder_dropout: float = 0.1, encoder_layer_drop: float = 0.05, mask_prob: float = 0.8, mask_channel_prob: float = 0.0, mask_channel_length: int = 10, num_classes: int = 100) -> torchaudio.models.HuBERTPretrainModel
 
     Build HuBERTPretrainModel model with "base" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
 
@@ -992,7 +992,7 @@ def hubert_pretrain_base(
             See :py:func:`hubert_pretrain_model`.
         mask_channel_prob (float):
             See :py:func:`hubert_pretrain_model`.
-        mask_channel_length (float):
+        mask_channel_length (int):
             See :py:func:`hubert_pretrain_model`.
         num_classes (int, optional):
             See :py:func:`hubert_pretrain_model`.
@@ -1044,10 +1044,10 @@ def hubert_pretrain_large(
     encoder_layer_drop: float = 0.0,
     mask_prob: float = 0.8,
     mask_channel_prob: float = 0.0,
-    mask_channel_length: float = 10,
+    mask_channel_length: int = 10,
 ) -> HuBERTPretrainModel:
     # Overriding the signature so that the return type is correct on Sphinx
-    """hubert_pretrain_large(encoder_projection_dropout: float = 0.0, encoder_attention_dropout: float = 0.0, encoder_ff_interm_dropout: float = 0.0, encoder_dropout: float = 0.0, encoder_layer_drop: float = 0.0) -> torchaudio.models.HuBERTPretrainModel
+    """hubert_pretrain_large(encoder_projection_dropout: float = 0.0, encoder_attention_dropout: float = 0.0, encoder_ff_interm_dropout: float = 0.0, encoder_dropout: float = 0.0, encoder_layer_drop: float = 0.0, mask_prob: float = 0.8, mask_channel_prob: float = 0.0, mask_channel_length: int = 10) -> torchaudio.models.HuBERTPretrainModel
 
     Build HuBERTPretrainModel model for pre-training with "large" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
 
@@ -1066,7 +1066,7 @@ def hubert_pretrain_large(
             See :py:func:`hubert_pretrain_model`.
         mask_channel_prob (float):
             See :py:func:`hubert_pretrain_model`.
-        mask_channel_length (float):
+        mask_channel_length (int):
             See :py:func:`hubert_pretrain_model`.
 
     Returns:
@@ -1116,10 +1116,10 @@ def hubert_pretrain_xlarge(
     encoder_layer_drop: float = 0.0,
     mask_prob: float = 0.8,
     mask_channel_prob: float = 0.0,
-    mask_channel_length: float = 10,
+    mask_channel_length: int = 10,
 ) -> HuBERTPretrainModel:
     # Overriding the signature so that the return type is correct on Sphinx
-    """hubert_pretrain_xlarge(encoder_projection_dropout: float = 0.0, encoder_attention_dropout: float = 0.0, encoder_ff_interm_dropout: float = 0.0, encoder_dropout: float = 0.0, encoder_layer_drop: float = 0.0) -> torchaudio.models.HuBERTPretrainModel
+    """hubert_pretrain_xlarge(encoder_projection_dropout: float = 0.0, encoder_attention_dropout: float = 0.0, encoder_ff_interm_dropout: float = 0.0, encoder_dropout: float = 0.0, encoder_layer_drop: float = 0.0, mask_prob: float = 0.8, mask_channel_prob: float = 0.0, mask_channel_length: int = 10) -> torchaudio.models.HuBERTPretrainModel
 
     Build HuBERTPretrainModel model for pre-training with "extra large" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
 
@@ -1133,6 +1133,12 @@ def hubert_pretrain_xlarge(
         encoder_dropout (float):
             See :py:func:`hubert_pretrain_model`.
         encoder_layer_drop (float):
+            See :py:func:`hubert_pretrain_model`.
+        mask_prob (float):
+            See :py:func:`hubert_pretrain_model`.
+        mask_channel_prob (float):
+            See :py:func:`hubert_pretrain_model`.
+        mask_channel_length (int):
             See :py:func:`hubert_pretrain_model`.
 
     Returns:

--- a/torchaudio/models/wav2vec2/model.py
+++ b/torchaudio/models/wav2vec2/model.py
@@ -967,6 +967,9 @@ def hubert_pretrain_base(
     encoder_ff_interm_dropout: float = 0.0,
     encoder_dropout: float = 0.1,
     encoder_layer_drop: float = 0.05,
+    mask_prob: float = 0.8,
+    mask_channel_prob: float = 0.0,
+    mask_channel_length: float = 10,
     num_classes: int = 100,
 ) -> HuBERTPretrainModel:
     # Overriding the signature so that the return type is correct on Sphinx
@@ -984,6 +987,12 @@ def hubert_pretrain_base(
         encoder_dropout (float):
             See :py:func:`hubert_pretrain_model`.
         encoder_layer_drop (float):
+            See :py:func:`hubert_pretrain_model`.
+        mask_prob (float):
+            See :py:func:`hubert_pretrain_model`.
+        mask_channel_prob (float):
+            See :py:func:`hubert_pretrain_model`.
+        mask_channel_length (float):
             See :py:func:`hubert_pretrain_model`.
         num_classes (int, optional):
             See :py:func:`hubert_pretrain_model`.
@@ -1008,16 +1017,16 @@ def hubert_pretrain_base(
         encoder_dropout=encoder_dropout,
         encoder_layer_norm_first=False,
         encoder_layer_drop=encoder_layer_drop,
-        mask_prob=0.80,
+        mask_prob=mask_prob,
         mask_selection="static",
         mask_other=0.0,
         mask_length=10,
         no_mask_overlap=False,
         mask_min_space=1,
-        mask_channel_prob=0.0,
+        mask_channel_prob=mask_channel_prob,
         mask_channel_selection="static",
         mask_channel_other=0.0,
-        mask_channel_length=10,
+        mask_channel_length=mask_channel_length,
         no_mask_channel_overlap=False,
         mask_channel_min_space=1,
         skip_masked=False,
@@ -1033,6 +1042,9 @@ def hubert_pretrain_large(
     encoder_ff_interm_dropout: float = 0.0,
     encoder_dropout: float = 0.0,
     encoder_layer_drop: float = 0.0,
+    mask_prob: float = 0.8,
+    mask_channel_prob: float = 0.0,
+    mask_channel_length: float = 10,
 ) -> HuBERTPretrainModel:
     # Overriding the signature so that the return type is correct on Sphinx
     """hubert_pretrain_large(encoder_projection_dropout: float = 0.0, encoder_attention_dropout: float = 0.0, encoder_ff_interm_dropout: float = 0.0, encoder_dropout: float = 0.0, encoder_layer_drop: float = 0.0) -> torchaudio.models.HuBERTPretrainModel
@@ -1049,6 +1061,12 @@ def hubert_pretrain_large(
         encoder_dropout (float):
             See :py:func:`hubert_pretrain_model`.
         encoder_layer_drop (float):
+            See :py:func:`hubert_pretrain_model`.
+        mask_prob (float):
+            See :py:func:`hubert_pretrain_model`.
+        mask_channel_prob (float):
+            See :py:func:`hubert_pretrain_model`.
+        mask_channel_length (float):
             See :py:func:`hubert_pretrain_model`.
 
     Returns:
@@ -1071,16 +1089,16 @@ def hubert_pretrain_large(
         encoder_dropout=encoder_dropout,
         encoder_layer_norm_first=True,
         encoder_layer_drop=encoder_layer_drop,
-        mask_prob=0.80,
+        mask_prob=mask_prob,
         mask_selection="static",
         mask_other=0.0,
         mask_length=10,
         no_mask_overlap=False,
         mask_min_space=1,
-        mask_channel_prob=0.0,
+        mask_channel_prob=mask_channel_prob,
         mask_channel_selection="static",
         mask_channel_other=0.0,
-        mask_channel_length=10,
+        mask_channel_length=mask_channel_length,
         no_mask_channel_overlap=False,
         mask_channel_min_space=1,
         skip_masked=False,
@@ -1096,6 +1114,9 @@ def hubert_pretrain_xlarge(
     encoder_ff_interm_dropout: float = 0.0,
     encoder_dropout: float = 0.0,
     encoder_layer_drop: float = 0.0,
+    mask_prob: float = 0.8,
+    mask_channel_prob: float = 0.0,
+    mask_channel_length: float = 10,
 ) -> HuBERTPretrainModel:
     # Overriding the signature so that the return type is correct on Sphinx
     """hubert_pretrain_xlarge(encoder_projection_dropout: float = 0.0, encoder_attention_dropout: float = 0.0, encoder_ff_interm_dropout: float = 0.0, encoder_dropout: float = 0.0, encoder_layer_drop: float = 0.0) -> torchaudio.models.HuBERTPretrainModel
@@ -1134,16 +1155,16 @@ def hubert_pretrain_xlarge(
         encoder_dropout=encoder_dropout,
         encoder_layer_norm_first=True,
         encoder_layer_drop=encoder_layer_drop,
-        mask_prob=0.80,
+        mask_prob=mask_prob,
         mask_selection="static",
         mask_other=0.0,
         mask_length=10,
         no_mask_overlap=False,
         mask_min_space=1,
-        mask_channel_prob=0.0,
+        mask_channel_prob=mask_channel_prob,
         mask_channel_selection="static",
         mask_channel_other=0.0,
-        mask_channel_length=10,
+        mask_channel_length=mask_channel_length,
         no_mask_channel_overlap=False,
         mask_channel_min_space=1,
         skip_masked=False,


### PR DESCRIPTION
In different pre-training and fine-tuning settings, the `mask_prob`, `mask_channel_prob`, and `mask_channel_length` are different. For example, the settings in [pre-training](https://github.com/pytorch/fairseq/blob/main/examples/hubert/config/pretrain/hubert_base_librispeech.yaml#L70) and [fine-tuning](https://github.com/pytorch/fairseq/blob/main/examples/hubert/config/finetune/base_10h.yaml#L69-L73) are different. The motivation is to avoid overfitting when fine-tuning on a small dataset (example: [fine-tune on 10 minutes of audio](https://github.com/pytorch/fairseq/blob/main/examples/wav2vec/config/finetuning/vox_10m.yaml#L57-L59)).
This PR adds the required arguments in the factory functions to make them tunable for pre-training and fine-tuning. `mask_length` is set to `10` by default for all cases, hence it's not included in the factory function.