### PR TITLE
Fix for torchaudio windows tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,7 +418,7 @@ jobs:
             conda create -yn python${PYTHON_VERSION} python=${PYTHON_VERSION}
             conda activate python${PYTHON_VERSION}
             conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cpuonly
-            conda install -v -y $(ls ~/workspace/torchaudio*.tar.bz2)
+            conda install -v -y $(ls ~/workspace/conda-bld/win-64/torchaudio*.tar.bz2)
       - run:
           name: smoke test
           command: |

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -418,7 +418,7 @@ jobs:
             conda create -yn python${PYTHON_VERSION} python=${PYTHON_VERSION}
             conda activate python${PYTHON_VERSION}
             conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cpuonly
-            conda install -v -y $(ls ~/workspace/torchaudio*.tar.bz2)
+            conda install -v -y $(ls ~/workspace/conda-bld/win-64/torchaudio*.tar.bz2)
       - run:
           name: smoke test
           command: |


### PR DESCRIPTION
Fix for torchaudio windows tests
Following is an example of such test failing:
https://app.circleci.com/pipelines/github/pytorch/audio/9408/workflows/e6e5a05c-7080-4fdc-b478-2182aed5f234/jobs/531612

The following code is failing:
`conda install -v -y $(ls ~/workspace/torchaudio*.tar.bz2)`

This is because the install package is generated in the following directory:
`/workspace/conda-bld/win-64/`