### PR TITLE
Fix LibriMix documentation

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -50,6 +50,14 @@ GTZAN
   :special-members: __getitem__
 
 
+LibriMix
+~~~~~~~~
+
+.. autoclass:: LibriMix
+  :members:
+  :special-members: __getitem__
+
+
 LIBRISPEECH
 ~~~~~~~~~~~
 


### PR DESCRIPTION
The `LibriMix` dataset is missing on the [documentation webpage](https://pytorch.org/audio/stable/datasets.html).