### PR TITLE
Refactor smoke test executions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,11 +355,12 @@ jobs:
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
             conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cpuonly
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
+      - checkout
       - run:
           name: smoke test
           command: |
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
-            python -c "import torchaudio"
+            ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_linux_conda_gpu:
     <<: *smoke_test_common
@@ -375,11 +376,12 @@ jobs:
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
             conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4} -c conda-forge
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
+      - checkout
       - run:
           name: smoke test
           command: |
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
-            python -c "import torchaudio"
+            ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_linux_pip:
     <<: *smoke_test_common
@@ -394,11 +396,12 @@ jobs:
             set -x
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
             pip install $(ls ~/workspace/torchaudio*.whl) -f "https://download.pytorch.org/whl/${UPLOAD_CHANNEL}/${CU_VERSION}/torch_${UPLOAD_CHANNEL}.html"
+      - checkout
       - run:
           name: smoke test
           command: |
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
-            python -c "import torchaudio"
+            ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_windows_conda:
     <<: *binary_common
@@ -419,12 +422,13 @@ jobs:
             conda activate python${PYTHON_VERSION}
             conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cpuonly
             conda install -v -y $(ls ~/workspace/conda-bld/win-64/torchaudio*.tar.bz2)
+      - checkout
       - run:
           name: smoke test
           command: |
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
             conda activate python${PYTHON_VERSION}
-            python -c "import torchaudio"
+            ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_windows_conda_gpu:
     <<: *binary_common
@@ -460,9 +464,7 @@ jobs:
             conda activate python${PYTHON_VERSION}
             # Install sound backend
             pip install PySoundFile
-            # Change to project directory outside of torchaudio root, this is to avoid the installed torchauduio package being shadowed by source directory
-            cd ..
-            python -c "import torchaudio"
+            ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_windows_pip:
     <<: *binary_common
@@ -482,12 +484,13 @@ jobs:
             conda create -yn python${PYTHON_VERSION} python=${PYTHON_VERSION}
             conda activate python${PYTHON_VERSION}
             pip install $(ls ~/workspace/torchaudio*.whl) -f "https://download.pytorch.org/whl/${UPLOAD_CHANNEL}/torch_${UPLOAD_CHANNEL}.html"
+      - checkout
       - run:
           name: smoke test
           command: |
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
             conda activate python${PYTHON_VERSION}
-            python -c "import torchaudio"
+            ./test/smoke_test/run_smoke_test.sh
 
   unittest_linux_cpu:
     <<: *binary_common

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -355,11 +355,12 @@ jobs:
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
             conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cpuonly
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
+      - checkout
       - run:
           name: smoke test
           command: |
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
-            python -c "import torchaudio"
+            ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_linux_conda_gpu:
     <<: *smoke_test_common
@@ -375,11 +376,12 @@ jobs:
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
             conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4} -c conda-forge
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
+      - checkout
       - run:
           name: smoke test
           command: |
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
-            python -c "import torchaudio"
+            ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_linux_pip:
     <<: *smoke_test_common
@@ -394,11 +396,12 @@ jobs:
             set -x
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
             pip install $(ls ~/workspace/torchaudio*.whl) -f "https://download.pytorch.org/whl/${UPLOAD_CHANNEL}/${CU_VERSION}/torch_${UPLOAD_CHANNEL}.html"
+      - checkout
       - run:
           name: smoke test
           command: |
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
-            python -c "import torchaudio"
+            ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_windows_conda:
     <<: *binary_common
@@ -419,12 +422,13 @@ jobs:
             conda activate python${PYTHON_VERSION}
             conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cpuonly
             conda install -v -y $(ls ~/workspace/conda-bld/win-64/torchaudio*.tar.bz2)
+      - checkout
       - run:
           name: smoke test
           command: |
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
             conda activate python${PYTHON_VERSION}
-            python -c "import torchaudio"
+            ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_windows_conda_gpu:
     <<: *binary_common
@@ -460,9 +464,7 @@ jobs:
             conda activate python${PYTHON_VERSION}
             # Install sound backend
             pip install PySoundFile
-            # Change to project directory outside of torchaudio root, this is to avoid the installed torchauduio package being shadowed by source directory
-            cd ..
-            python -c "import torchaudio"
+            ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_windows_pip:
     <<: *binary_common
@@ -482,12 +484,13 @@ jobs:
             conda create -yn python${PYTHON_VERSION} python=${PYTHON_VERSION}
             conda activate python${PYTHON_VERSION}
             pip install $(ls ~/workspace/torchaudio*.whl) -f "https://download.pytorch.org/whl/${UPLOAD_CHANNEL}/torch_${UPLOAD_CHANNEL}.html"
+      - checkout
       - run:
           name: smoke test
           command: |
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
             conda activate python${PYTHON_VERSION}
-            python -c "import torchaudio"
+            ./test/smoke_test/run_smoke_test.sh
 
   unittest_linux_cpu:
     <<: *binary_common

--- a/test/smoke_test/run_smoke_test.sh
+++ b/test/smoke_test/run_smoke_test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# This script is used by CI to perform smoke tests on installed binaries.
+
+# When `import torchaudio` is executed from the root directory of the repo,
+# the source `torchaudio` directory will shadow the actual installation.
+# Changing to this directory to avoid that.
+cd -- "$( dirname -- "${BASH_SOURCE[0]}" )"
+
+python smoke_test.py

--- a/test/smoke_test/run_smoke_test.sh
+++ b/test/smoke_test/run_smoke_test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eux
+
 # This script is used by CI to perform smoke tests on installed binaries.
 
 # When `import torchaudio` is executed from the root directory of the repo,

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -1,0 +1,11 @@
+"""Run smoke tests"""
+
+import torchaudio  # noqa: F401
+import torchaudio.compliance.kaldi  # noqa: F401
+import torchaudio.datasets  # noqa: F401
+import torchaudio.functional  # noqa: F401
+import torchaudio.models  # noqa: F401
+import torchaudio.pipelines  # noqa: F401
+import torchaudio.sox_effects  # noqa: F401
+import torchaudio.transforms  # noqa: F401
+import torchaudio.utils  # noqa: F401


### PR DESCRIPTION
The smoke test jobs simply perform `import torchaudio` to check 
if the package artifacts are sane.
Originally, this was done in the  root directory of the CI env. 
This worked fine as long as they do not checkout the source code.
There are cases where source code has to be checked-out, and 
for these jobs, the smoke tests were not working as intended.

Since this error is very difficult to notice, this commit introduce a
common way to perform smoke test.
