### PR TITLE
Refactor the constructors of pointer wrappers 

### DIFF
--- a/torchaudio/csrc/ffmpeg/decoder.cpp
+++ b/torchaudio/csrc/ffmpeg/decoder.cpp
@@ -11,7 +11,15 @@ Decoder::Decoder(
     const std::string& decoder_name,
     const std::map<std::string, std::string>& decoder_option,
     const torch::Device& device)
-    : pCodecContext(pParam, decoder_name, decoder_option, device) {}
+    : pCodecContext(get_decode_context(pParam->codec_id, decoder_name)) {
+  init_codec_context(
+      pCodecContext,
+      pParam,
+      decoder_name,
+      decoder_option,
+      device,
+      pHWBufferRef);
+}
 
 int Decoder::process_packet(AVPacket* pPacket) {
   return avcodec_send_packet(pCodecContext, pPacket);

--- a/torchaudio/csrc/ffmpeg/decoder.h
+++ b/torchaudio/csrc/ffmpeg/decoder.h
@@ -7,6 +7,7 @@ namespace ffmpeg {
 
 class Decoder {
   AVCodecContextPtr pCodecContext;
+  AVBufferRefPtr pHWBufferRef;
 
  public:
   // Default constructable

--- a/torchaudio/csrc/ffmpeg/ffmpeg.h
+++ b/torchaudio/csrc/ffmpeg/ffmpeg.h
@@ -65,11 +65,14 @@ struct AVFormatContextDeleter {
 
 struct AVFormatContextPtr
     : public Wrapper<AVFormatContext, AVFormatContextDeleter> {
-  AVFormatContextPtr(
-      const std::string& src,
-      const std::string& device,
-      const std::map<std::string, std::string>& option);
+  explicit AVFormatContextPtr(AVFormatContext* p);
 };
+
+// create format context for reading media
+AVFormatContextPtr get_input_format_context(
+    const std::string& src,
+    const std::string& device,
+    const std::map<std::string, std::string>& option);
 
 ////////////////////////////////////////////////////////////////////////////////
 // AVPacket
@@ -132,14 +135,22 @@ struct AVCodecContextDeleter {
 };
 struct AVCodecContextPtr
     : public Wrapper<AVCodecContext, AVCodecContextDeleter> {
-  AVBufferRefPtr pHWBufferRef;
-
-  AVCodecContextPtr(
-      AVCodecParameters* pParam,
-      const std::string& decoder,
-      const std::map<std::string, std::string>& decoder_option,
-      const torch::Device& device);
+  explicit AVCodecContextPtr(AVCodecContext* p);
 };
+
+// Allocate codec context from either decoder name or ID
+AVCodecContextPtr get_decode_context(
+    enum AVCodecID codec_id,
+    const std::string& decoder);
+
+// Initialize codec context with the parameters
+void init_codec_context(
+    AVCodecContext* pCodecContext,
+    AVCodecParameters* pParams,
+    const std::string& decoder_name,
+    const std::map<std::string, std::string>& decoder_option,
+    const torch::Device& device,
+    AVBufferRefPtr& pHWBufferRef);
 
 ////////////////////////////////////////////////////////////////////////////////
 // AVFilterGraph

--- a/torchaudio/csrc/ffmpeg/streamer.cpp
+++ b/torchaudio/csrc/ffmpeg/streamer.cpp
@@ -46,7 +46,11 @@ Streamer::Streamer(
     const std::string& src,
     const std::string& device,
     const std::map<std::string, std::string>& option)
-    : pFormatContext(src, device, option) {
+    : pFormatContext(get_input_format_context(src, device, option)) {
+  if (avformat_find_stream_info(pFormatContext, nullptr) < 0) {
+    throw std::runtime_error("Failed to find stream information.");
+  }
+
   processors =
       std::vector<std::unique_ptr<StreamProcessor>>(pFormatContext->nb_streams);
   for (int i = 0; i < pFormatContext->nb_streams; ++i) {


### PR DESCRIPTION
This commit refactor the constructor of wrapper classes so that
wrapper classes are only responsible for deallocation of underlying
FFmpeg custom structures.

The responsibility of custom initialization is moved to helper functions.

Context:

FFmpeg API uses bunch of raw pointers, which require dedicated allocater
and deallcoator. In torchaudio we wrap these pointers with
`std::unique_ptr<>` to adopt RAII semantics.

Currently all of the customization logics required for `Streamer` are
handled by the constructor of wrapper class. Like the following;

```
AVFormatContextPtr(
      const std::string& src,
      const std::string& device,
      const std::map<std::string, std::string>& option);
```

This constructor allocates the raw `AVFormatContext*` pointer,
while initializing it with the given option, then it parses the
input media.

As we consider the write/encode features, which require different way
of initializing the `AVFormatContext*`, making it the responsibility
of constructors of `AVFormatContextPtr` reduce the flexibility.

Thus this commit moves the customization to helper factory function.

- `AVFormatContextPtr(...)` -> `get_input_format_context(...)`
- `AVCodecContextPtr(...)` -> `get_decode_context(...)`