### PR TITLE
Fix return dtype in MVDR module

### DIFF
--- a/test/torchaudio_unittest/transforms/transforms_test_impl.py
+++ b/test/torchaudio_unittest/transforms/transforms_test_impl.py
@@ -131,3 +131,28 @@ class TransformsTestBase(TestBaseMixin):
             psd_np = psd_numpy(spectrogram.detach().numpy(), mask, multi_mask)
         psd = transform(spectrogram, mask)
         self.assertEqual(psd, psd_np, atol=1e-5, rtol=1e-5)
+
+    @parameterized.expand(
+        [
+            param("ref_channel", True, torch.complex64),
+            param("ref_channel", False, torch.complex128),
+            param("stv_evd", True, torch.complex128),
+            param("stv_evd", False, torch.complex64),
+            param("stv_power", True, torch.complex64),
+            param("stv_power", False, torch.complex128),
+        ]
+    )
+    def test_mvdr(self, solution, multi_mask, dtype):
+        """Make sure the output dtype is the same as the input dtype"""
+        transform = T.MVDR(solution=solution, multi_mask=multi_mask)
+        waveform = get_whitenoise(sample_rate=8000, duration=0.5, n_channels=3)
+        specgram = get_spectrogram(waveform, n_fft=400)  # (channel, freq, time)
+        specgram = specgram.to(dtype)
+        if multi_mask:
+            mask_s = torch.rand(specgram.shape[-3:])
+            mask_n = torch.rand(specgram.shape[-3:])
+        else:
+            mask_s = torch.rand(specgram.shape[-2:])
+            mask_n = torch.rand(specgram.shape[-2:])
+        specgram_enhanced = transform(specgram, mask_s, mask_n)
+        assert specgram_enhanced.dtype == dtype

--- a/test/torchaudio_unittest/transforms/transforms_test_impl.py
+++ b/test/torchaudio_unittest/transforms/transforms_test_impl.py
@@ -134,25 +134,17 @@ class TransformsTestBase(TestBaseMixin):
 
     @parameterized.expand(
         [
-            param("ref_channel", True, torch.complex64),
-            param("ref_channel", False, torch.complex128),
-            param("stv_evd", True, torch.complex128),
-            param("stv_evd", False, torch.complex64),
-            param("stv_power", True, torch.complex64),
-            param("stv_power", False, torch.complex128),
+            param(torch.complex64),
+            param(torch.complex128),
         ]
     )
-    def test_mvdr(self, solution, multi_mask, dtype):
+    def test_mvdr(self, dtype):
         """Make sure the output dtype is the same as the input dtype"""
-        transform = T.MVDR(solution=solution, multi_mask=multi_mask)
+        transform = T.MVDR()
         waveform = get_whitenoise(sample_rate=8000, duration=0.5, n_channels=3)
         specgram = get_spectrogram(waveform, n_fft=400)  # (channel, freq, time)
         specgram = specgram.to(dtype)
-        if multi_mask:
-            mask_s = torch.rand(specgram.shape[-3:])
-            mask_n = torch.rand(specgram.shape[-3:])
-        else:
-            mask_s = torch.rand(specgram.shape[-2:])
-            mask_n = torch.rand(specgram.shape[-2:])
+        mask_s = torch.rand(specgram.shape[-2:])
+        mask_n = torch.rand(specgram.shape[-2:])
         specgram_enhanced = transform(specgram, mask_s, mask_n)
         assert specgram_enhanced.dtype == dtype

--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -2087,8 +2087,7 @@ class MVDR(torch.nn.Module):
         # unpack batch
         specgram_enhanced = specgram_enhanced.reshape(shape[:-3] + shape[-2:])
 
-        specgram_enhanced.to(dtype)
-        return specgram_enhanced
+        return specgram_enhanced.to(dtype)
 
 
 class RTFMVDR(torch.nn.Module):


### PR DESCRIPTION
Address #2375 
The MVDR module internally transforms the dtype of complex tensors to `torch.complex128` for computation and transforms it back to the original dtype before returning the Tensor. However, it didn't convert back successfully due to `specgram_enhanced.to(dtype)`, which should be `specgram_enhanced = specgram_enhanced.to(dtype)`. Fix it to make the output dtype consistent with original input.