### PR TITLE
Move FFmpeg integrality test from conda build to custom smoke test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,6 +459,7 @@ jobs:
           name: smoke test
           command: |
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
+            conda install 'ffmpeg<5'
             ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_linux_conda_gpu:
@@ -480,6 +481,7 @@ jobs:
           name: smoke test
           command: |
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
+            conda install 'ffmpeg<5'
             ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_linux_pip:
@@ -500,6 +502,7 @@ jobs:
           name: smoke test
           command: |
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
+            export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${HOME}/workspace/ffmpeg/lib"
             ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_windows_conda:
@@ -527,6 +530,7 @@ jobs:
           command: |
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
             conda activate python${PYTHON_VERSION}
+            conda install 'ffmpeg<5'
             ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_windows_conda_gpu:
@@ -563,6 +567,7 @@ jobs:
             conda activate python${PYTHON_VERSION}
             # Install sound backend
             pip install PySoundFile
+            conda install 'ffmpeg<5'
             ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_windows_pip:
@@ -589,6 +594,12 @@ jobs:
           command: |
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
             conda activate python${PYTHON_VERSION}
+            # Hack to load FFmpeg libraries
+            # Note: Depending on Python version, they search different paths.
+            # For 3.7 and 3.9, copying them in CWD works.
+            cp ~/workspace/ffmpeg/bin/* test/smoke_test/
+            # For 3.8 and 3.10, they must be in the same directory as the entrypoint lib
+            cp ~/workspace/ffmpeg/bin/* /C/tools/miniconda3/envs/python${PYTHON_VERSION}/lib/site-packages/torchaudio/lib/
             ./test/smoke_test/run_smoke_test.sh
 
   unittest_linux_cpu:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -459,6 +459,7 @@ jobs:
           name: smoke test
           command: |
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
+            conda install 'ffmpeg<5'
             ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_linux_conda_gpu:
@@ -480,6 +481,7 @@ jobs:
           name: smoke test
           command: |
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
+            conda install 'ffmpeg<5'
             ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_linux_pip:
@@ -500,6 +502,7 @@ jobs:
           name: smoke test
           command: |
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
+            export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${HOME}/workspace/ffmpeg/lib"
             ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_windows_conda:
@@ -527,6 +530,7 @@ jobs:
           command: |
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
             conda activate python${PYTHON_VERSION}
+            conda install 'ffmpeg<5'
             ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_windows_conda_gpu:
@@ -563,6 +567,7 @@ jobs:
             conda activate python${PYTHON_VERSION}
             # Install sound backend
             pip install PySoundFile
+            conda install 'ffmpeg<5'
             ./test/smoke_test/run_smoke_test.sh
 
   smoke_test_windows_pip:
@@ -589,6 +594,12 @@ jobs:
           command: |
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
             conda activate python${PYTHON_VERSION}
+            # Hack to load FFmpeg libraries
+            # Note: Depending on Python version, they search different paths.
+            # For 3.7 and 3.9, copying them in CWD works.
+            cp ~/workspace/ffmpeg/bin/* test/smoke_test/
+            # For 3.8 and 3.10, they must be in the same directory as the entrypoint lib
+            cp ~/workspace/ffmpeg/bin/* /C/tools/miniconda3/envs/python${PYTHON_VERSION}/lib/site-packages/torchaudio/lib/
             ./test/smoke_test/run_smoke_test.sh
 
   unittest_linux_cpu:

--- a/packaging/torchaudio/meta.yaml
+++ b/packaging/torchaudio/meta.yaml
@@ -31,7 +31,6 @@ requirements:
     - pytorch-mutex 1.0 {{ build_variant }}  # [not osx ]
     {{ environ.get('CONDA_PYTORCH_CONSTRAINT', 'pytorch') }}
     {{ environ.get('CONDA_CUDATOOLKIT_CONSTRAINT', '') }}
-    - ffmpeg>=4.1,<5
 
   {% if build_variant == 'cpu' %}
   run_constrained:
@@ -57,7 +56,6 @@ test:
     - torchaudio.kaldi_io
     - torchaudio.sox_effects
     - torchaudio.transforms
-    - torchaudio.prototype.io
 
   source_files:
     - test

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -9,3 +9,4 @@ import torchaudio.pipelines  # noqa: F401
 import torchaudio.sox_effects  # noqa: F401
 import torchaudio.transforms  # noqa: F401
 import torchaudio.utils  # noqa: F401
+from torchaudio.prototype.io import Streamer  # noqa: F401


### PR DESCRIPTION
    Conda package build performs simple smoke test, which is different
    from smoke_test jobs we define on our CI jobs.

    Currently Conda packaging smoke test verifies the imporatability of
    `torchaudio.prototype.io`, which requires FFmpeg 4.

    1. We list FFmpeg 4 as runtime requirements, but this means that
    conda's dependency resolver takes FFmpeg 4 into consideration.
    FFmpeg 5 was release this year, and we can expect that user base
    will move to FFmpeg gradually. If user environment has some constraint
    on FFmpeg, torchaudio will have conflict and it will prevent users
    from install torchaudio.

    2. In #2377 the way optional dependency is checked/initialized is changed,
    so this Conda smoke test will no longer check the integrity with FFmpeg libraries.

    To solve the issues above, this commit moves the part that tests integrity with
    FFmpeg libraries to the smoke test we define on CircleCI.