### PR TITLE
Fix and move implementation for RNNT loss reduction param

### DIFF
--- a/test/torchaudio_unittest/functional/autograd_impl.py
+++ b/test/torchaudio_unittest/functional/autograd_impl.py
@@ -1,3 +1,4 @@
+import itertools
 from functools import partial
 from typing import Callable, Tuple
 
@@ -389,16 +390,17 @@ class AutogradFloat32(TestBaseMixin):
                     i.requires_grad = True
             inputs_.append(i)
         # gradcheck with float32 requires higher atol and epsilon
-        assert gradcheck(transform, inputs, eps=1e-3, atol=1e-3, nondet_tol=0.0)
+        assert gradcheck(transform, inputs, eps=1.5e-3, atol=1e-3, nondet_tol=0.0)
 
     @parameterized.expand(
-        [
-            (rnnt_utils.get_B1_T10_U3_D4_data,),
-            (rnnt_utils.get_B2_T4_U3_D3_data,),
-            (rnnt_utils.get_B1_T2_U3_D5_data,),
-        ]
+        list(
+            itertools.product(
+                [rnnt_utils.get_B1_T10_U3_D4_data, rnnt_utils.get_B2_T4_U3_D3_data, rnnt_utils.get_B1_T2_U3_D5_data],
+                ["none", "mean", "sum"],
+            )
+        )
     )
-    def test_rnnt_loss(self, data_func):
+    def test_rnnt_loss(self, data_func, reduction):
         def get_data(data_func, device):
             data = data_func()
             if type(data) == tuple:
@@ -413,6 +415,7 @@ class AutogradFloat32(TestBaseMixin):
             data["target_lengths"],  # target_lengths
             data["blank"],  # blank
             -1,  # clamp
+            reduction,  # reduction
         )
 
         self.assert_grad(F.rnnt_loss, inputs, enable_all_grad=False)

--- a/torchaudio/csrc/rnnt/autograd.cpp
+++ b/torchaudio/csrc/rnnt/autograd.cpp
@@ -13,10 +13,17 @@ class RNNTLossFunction : public torch::autograd::Function<RNNTLossFunction> {
       const torch::Tensor& logit_lengths,
       const torch::Tensor& target_lengths,
       int64_t blank,
-      double clamp) {
+      double clamp,
+      std::string reduction) {
     torch::Tensor undef;
-    auto result =
-        rnnt_loss(logits, targets, logit_lengths, target_lengths, blank, clamp);
+    auto result = rnnt_loss(
+        logits,
+        targets,
+        logit_lengths,
+        target_lengths,
+        blank,
+        clamp,
+        reduction);
     auto costs = std::get<0>(result);
     auto grads = std::get<1>(result).value_or(undef);
     ctx->save_for_backward({grads});
@@ -31,7 +38,7 @@ class RNNTLossFunction : public torch::autograd::Function<RNNTLossFunction> {
     auto grad_out = grad_outputs[0].view({-1, 1, 1, 1});
     auto result = grad * grad_out;
     torch::Tensor undef;
-    return {result, undef, undef, undef, undef, undef, undef, undef};
+    return {result, undef, undef, undef, undef, undef, undef, undef, undef};
   }
 };
 
@@ -41,10 +48,11 @@ std::tuple<torch::Tensor, c10::optional<torch::Tensor>> rnnt_loss_autograd(
     const torch::Tensor& logit_lengths,
     const torch::Tensor& target_lengths,
     int64_t blank,
-    double clamp) {
+    double clamp,
+    std::string reduction) {
   at::AutoDispatchBelowADInplaceOrView guard;
   auto results = RNNTLossFunction::apply(
-      logits, targets, logit_lengths, target_lengths, blank, clamp);
+      logits, targets, logit_lengths, target_lengths, blank, clamp, reduction);
   return std::make_tuple(results[0], results[1]);
 }
 

--- a/torchaudio/csrc/rnnt/compute.cpp
+++ b/torchaudio/csrc/rnnt/compute.cpp
@@ -7,11 +7,13 @@ std::tuple<torch::Tensor, c10::optional<torch::Tensor>> rnnt_loss(
     const torch::Tensor& logit_lengths,
     const torch::Tensor& target_lengths,
     int64_t blank,
-    double clamp) {
+    double clamp,
+    std::string reduction) {
   static auto op = torch::Dispatcher::singleton()
                        .findSchemaOrThrow("torchaudio::rnnt_loss", "")
                        .typed<decltype(rnnt_loss)>();
-  return op.call(logits, targets, logit_lengths, target_lengths, blank, clamp);
+  return op.call(
+      logits, targets, logit_lengths, target_lengths, blank, clamp, reduction);
 }
 
 TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
@@ -21,5 +23,6 @@ TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
       "Tensor logit_lengths,"
       "Tensor target_lengths,"
       "int blank,"
-      "float clamp) -> (Tensor, Tensor?)");
+      "float clamp,"
+      "str reduction) -> (Tensor, Tensor?)");
 }

--- a/torchaudio/csrc/rnnt/compute.h
+++ b/torchaudio/csrc/rnnt/compute.h
@@ -8,4 +8,5 @@ std::tuple<torch::Tensor, c10::optional<torch::Tensor>> rnnt_loss(
     const torch::Tensor& logit_lengths,
     const torch::Tensor& target_lengths,
     int64_t blank,
-    double clamp);
+    double clamp,
+    std::string reduction);

--- a/torchaudio/csrc/rnnt/cpu/compute.cpp
+++ b/torchaudio/csrc/rnnt/cpu/compute.cpp
@@ -12,7 +12,8 @@ std::tuple<torch::Tensor, c10::optional<torch::Tensor>> compute(
     const torch::Tensor& logit_lengths,
     const torch::Tensor& target_lengths,
     int64_t blank,
-    double clamp) {
+    double clamp,
+    std::string reduction) {
   TORCH_CHECK(
       logits.device().type() == targets.device().type(),
       "logits and targets must be on the same device");
@@ -135,6 +136,12 @@ std::tuple<torch::Tensor, c10::optional<torch::Tensor>> compute(
       break;
     }
   };
+
+  if (reduction == "mean") {
+    return std::make_tuple(costs.mean(), gradients->div(costs.size(0)));
+  } else if (reduction == "sum") {
+    return std::make_tuple(costs.sum(), gradients);
+  }
 
   return std::make_tuple(costs, gradients);
 }

--- a/torchaudio/csrc/rnnt/gpu/compute.cu
+++ b/torchaudio/csrc/rnnt/gpu/compute.cu
@@ -13,7 +13,8 @@ std::tuple<torch::Tensor, c10::optional<torch::Tensor>> compute(
     const torch::Tensor& logit_lengths,
     const torch::Tensor& target_lengths,
     int64_t blank,
-    double clamp) {
+    double clamp,
+    std::string reduction) {
   TORCH_CHECK(
       logits.device().type() == targets.device().type(),
       "logits and targets must be on the same device");
@@ -138,6 +139,12 @@ std::tuple<torch::Tensor, c10::optional<torch::Tensor>> compute(
       break;
     }
   };
+
+  if (reduction == "mean") {
+    return std::make_tuple(costs.mean(), gradients->div(costs.size(0)));
+  } else if (reduction == "sum") {
+    return std::make_tuple(costs.sum(), gradients);
+  }
 
   return std::make_tuple(costs, gradients);
 }

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -1725,12 +1725,8 @@ def rnnt_loss(
         target_lengths=target_lengths,
         blank=blank,
         clamp=clamp,
+        reduction=reduction,
     )
-
-    if reduction == "mean":
-        return costs.mean()
-    elif reduction == "sum":
-        return costs.sum()
 
     return costs
 


### PR DESCRIPTION
currently, the gradients are not handled correctly when `reduction = "mean"` for RNNT loss and gradcheck would fail for this case (untested in unit tests). In this PR, we
- move the reduction logic to be handled in C++
- average the gradient when the `reduction` parameter is `"mean"`
- add autograd tests for mean and sum (slight change to eps needed for 1/9 of the tests)