### PR TITLE
Update build_doc job to use Conda CUDA package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -803,24 +803,28 @@ jobs:
           command: .circleci/unittest/linux/scripts/run_style_checks.sh
 
   build_docs:
-    <<: *binary_common
-    docker:
-      - image: "python:<< parameters.python_version >>"
-    resource_class: 2xlarge+
+    <<: *smoke_test_common
     steps:
       - attach_workspace:
           at: ~/workspace
       - checkout
+      - designate_upload_channel
       - load_conda_channel_flags
       - run:
           name: Install packages
           command: |
-            apt-get -qq update && apt-get -qq install -y ffmpeg libsndfile-dev
-            .circleci/build_docs/install_wheels.sh
+            set -x
+            source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
+            conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4} -c conda-forge
+            conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
       - run:
           name: Build docs
           command: |
             cd docs
+            apt update && apt-get -qq install -y git make
+            source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
+            pip install -r requirements.txt -r requirements-tutorials.txt
+            conda install -y 'ffmpeg<5'
             make 'SPHINXOPTS=-W' html
           environment:
             BUILD_GALLERY: 1
@@ -1786,6 +1790,7 @@ workflows:
           requires:
           - binary_windows_conda_py3.10_cu116
       - build_docs:
+          cuda_version: cu116
           filters:
             branches:
               only:
@@ -1795,7 +1800,7 @@ workflows:
           name: build_docs
           python_version: '3.8'
           requires:
-          - binary_linux_wheel_py3.8_cpu
+          - binary_linux_conda_py3.8_cu116
       - upload_docs:
           context: org-member
           filters:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -803,24 +803,28 @@ jobs:
           command: .circleci/unittest/linux/scripts/run_style_checks.sh
 
   build_docs:
-    <<: *binary_common
-    docker:
-      - image: "python:<< parameters.python_version >>"
-    resource_class: 2xlarge+
+    <<: *smoke_test_common
     steps:
       - attach_workspace:
           at: ~/workspace
       - checkout
+      - designate_upload_channel
       - load_conda_channel_flags
       - run:
           name: Install packages
           command: |
-            apt-get -qq update && apt-get -qq install -y ffmpeg libsndfile-dev
-            .circleci/build_docs/install_wheels.sh
+            set -x
+            source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
+            conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4} -c conda-forge
+            conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
       - run:
           name: Build docs
           command: |
             cd docs
+            apt update && apt-get -qq install -y git make
+            source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
+            pip install -r requirements.txt -r requirements-tutorials.txt
+            conda install -y 'ffmpeg<5'
             make 'SPHINXOPTS=-W' html
           environment:
             BUILD_GALLERY: 1

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -107,8 +107,9 @@ def build_doc_job(filter_branch):
     job = {
         "name": "build_docs",
         "python_version": "3.8",
+        "cuda_version": "cu116",
         "requires": [
-            "binary_linux_wheel_py3.8_cpu",
+            "binary_linux_conda_py3.8_cu116",
         ],
     }
 


### PR DESCRIPTION
This commit moves `build_doc` job to run on top of Conda binary
build job.

The motivation is that Conda provides easy access to third party
tools that are required to build complex documentation.

Specifically in https://github.com/pytorch/audio/pull/2393,
ipynb-style tutorial is being added, which requires `nbsphinx`.

`nbsphinx` requires `pandoc` package and there was some issue
with the version from PyPI. A workaround is to use the one from
Conda package.