### PR TITLE
Expand subsections in tutorials by default

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -71,4 +71,28 @@
 	  }
       });
     </script>
+
+    {% if 'tutorial' in pagename %}
+    {#
+     # Override the right side menu bar behavior so that subsections
+     # are shown by default in tutorial page.
+     # Based off of
+     # https://github.com/pytorch/pytorch_sphinx_theme/blob/b4d00058a48604d8fb63771b513a50450f0ee188/pytorch_sphinx_theme/static/js/theme.js#L568-L579
+     #}
+    <script type="text/javascript">
+      $(window).ready(function() {
+          var original = window.sideMenus.bind;
+          window.sideMenus.bind = function() {
+              original();
+              $("#pytorch-right-menu a.reference.internal").each(function(i) {
+                  if (this.classList.contains("not-expanded")) {
+                      this.nextElementSibling.style.display = "block";
+                      this.classList.remove("not-expanded");
+                      this.classList.add("expanded");
+                  }
+              });
+          };
+      });
+    </script>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
This commit updates the `window.sideMenus.handleRightMenu`, so that
subsections are expanded on tutorials by default.

https://output.circle-artifacts.com/output/job/98508917-87df-4666-9958-c70683b3245d/artifacts/0/docs/tutorials/audio_io_tutorial.html

Tutorial subsections are important because they have anchors so
allow us to get the link to the specific figures / audio samples.

When responding issues/questions and when there is a corresponding
code snippet in tutorial, it is often easy to answer with links to
the tutorial.

However, by default the tutorial page collapses right side bar, and
I have to click the small "+" symbols to navigate to the subsection,
and the state of expansion does not persist across the page refresh.

This has been a pain point since we updated the Sphinx version to 3
in https://github.com/pytorch/audio/pull/1685.