### PR TITLE
Tweak build doc job to avoid timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -827,17 +827,18 @@ jobs:
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
             conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4} -c conda-forge
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
+            conda install -y pandoc 'ffmpeg<5'
+            apt update && apt-get -qq install -y git make
+            pip install -r docs/requirements.txt -r docs/requirements-tutorials.txt
       - run:
           name: Build docs
           command: |
-            cd docs
-            apt update && apt-get -qq install -y git make
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
-            pip install -r requirements.txt -r requirements-tutorials.txt
-            conda install -y pandoc 'ffmpeg<5'
+            cd docs
             make 'SPHINXOPTS=-W' html
           environment:
             BUILD_GALLERY: 1
+          no_output_timeout: 30m
       - persist_to_workspace:
           root: ./
           paths:
@@ -866,7 +867,6 @@ jobs:
             DONE
       - run:
           name: Upload docs
-          no_output_timeout: 30m
           command: |
             # Don't use "checkout" step since it uses ssh, which cannot git push
             # https://circleci.com/docs/2.0/configuration-reference/#checkout

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -827,17 +827,18 @@ jobs:
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
             conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4} -c conda-forge
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
+            conda install -y pandoc 'ffmpeg<5'
+            apt update && apt-get -qq install -y git make
+            pip install -r docs/requirements.txt -r docs/requirements-tutorials.txt
       - run:
           name: Build docs
           command: |
-            cd docs
-            apt update && apt-get -qq install -y git make
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
-            pip install -r requirements.txt -r requirements-tutorials.txt
-            conda install -y pandoc 'ffmpeg<5'
+            cd docs
             make 'SPHINXOPTS=-W' html
           environment:
             BUILD_GALLERY: 1
+          no_output_timeout: 30m
       - persist_to_workspace:
           root: ./
           paths:
@@ -866,7 +867,6 @@ jobs:
             DONE
       - run:
           name: Upload docs
-          no_output_timeout: 30m
           command: |
             # Don't use "checkout" step since it uses ssh, which cannot git push
             # https://circleci.com/docs/2.0/configuration-reference/#checkout


### PR DESCRIPTION
After #2395, build_doc job is exceeding default no-output-timeout
threshould (10m).

This commit updates the timeout threshold to 30m.
Also it moves the installation of tools to the previous step.