### PR TITLE
Refactor StreamReader C++ codebase 

### DIFF
--- a/torchaudio/csrc/CMakeLists.txt
+++ b/torchaudio/csrc/CMakeLists.txt
@@ -179,15 +179,15 @@ endif()
 if(USE_FFMPEG)
   set(
     LIBTORCHAUDIO_FFMPEG_SOURCES
-    ffmpeg/prototype.cpp
     ffmpeg/decoder.cpp
     ffmpeg/ffmpeg.cpp
     ffmpeg/filter_graph.cpp
     ffmpeg/buffer.cpp
     ffmpeg/sink.cpp
     ffmpeg/stream_processor.cpp
-    ffmpeg/streamer.cpp
+    ffmpeg/stream_reader.cpp
     ffmpeg/stream_reader_wrapper.cpp
+    ffmpeg/stream_reader_binding.cpp
     )
   message(STATUS "FFMPEG_ROOT=$ENV{FFMPEG_ROOT}")
   find_package(FFMPEG 4.1 REQUIRED COMPONENTS avdevice avfilter avformat avcodec avutil)

--- a/torchaudio/csrc/ffmpeg/README.md
+++ b/torchaudio/csrc/ffmpeg/README.md
@@ -13,14 +13,14 @@ Practically all the code is re-organization of examples;
 
 https://ffmpeg.org/doxygen/4.1/examples.html
 
-## Streamer Architecture
+## StreamReader Architecture
 
-The top level class is `Streamer` class. This class handles the input (via `AVFormatContext*`), and manages `StreamProcessor`s for each stream in the input.
+The top level class is `StreamReader` class. This class handles the input (via `AVFormatContext*`), and manages `StreamProcessor`s for each stream in the input.
 
-The `Streamer` object slices the input data into a series of `AVPacket` objects and it feeds the objects to corresponding `StreamProcessor`s.
+The `StreamReader` object slices the input data into a series of `AVPacket` objects and it feeds the objects to corresponding `StreamProcessor`s.
 
 ```
- Streamer
+ StreamReader
 ┌─────────────────────────────────────────────────┐
 │                                                 │
 │ AVFormatContext*       ┌──► StreamProcessor[0]  │

--- a/torchaudio/csrc/ffmpeg/ffmpeg.h
+++ b/torchaudio/csrc/ffmpeg/ffmpeg.h
@@ -15,6 +15,7 @@ extern "C" {
 #include <libavformat/avformat.h>
 #include <libavformat/avio.h>
 #include <libavutil/avutil.h>
+#include <libavutil/channel_layout.h>
 #include <libavutil/frame.h>
 #include <libavutil/imgutils.h>
 #include <libavutil/log.h>

--- a/torchaudio/csrc/ffmpeg/stream_reader.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader.h
@@ -8,7 +8,7 @@
 namespace torchaudio {
 namespace ffmpeg {
 
-class Streamer {
+class StreamReader {
   AVFormatContextPtr pFormatContext;
   AVPacketPtr pPacket;
 
@@ -19,14 +19,14 @@ class Streamer {
   std::vector<std::pair<int, int>> stream_indices;
 
  public:
-  explicit Streamer(AVFormatContextPtr&& p);
-  ~Streamer() = default;
+  explicit StreamReader(AVFormatContextPtr&& p);
+  ~StreamReader() = default;
   // Non-copyable
-  Streamer(const Streamer&) = delete;
-  Streamer& operator=(const Streamer&) = delete;
+  StreamReader(const StreamReader&) = delete;
+  StreamReader& operator=(const StreamReader&) = delete;
   // Movable
-  Streamer(Streamer&&) = default;
-  Streamer& operator=(Streamer&&) = default;
+  StreamReader(StreamReader&&) = default;
+  StreamReader& operator=(StreamReader&&) = default;
 
   //////////////////////////////////////////////////////////////////////////////
   // Helper methods

--- a/torchaudio/csrc/ffmpeg/stream_reader_binding.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader_binding.cpp
@@ -28,12 +28,13 @@ c10::intrusive_ptr<StreamReaderBinding> init(
 
 std::tuple<c10::optional<torch::Tensor>, int64_t> load(const std::string& src) {
   StreamReaderBinding s{get_input_format_context(src, {}, {})};
-  int i = s.find_best_audio_stream();
-  auto sinfo = s.Streamer::get_src_stream_info(i);
+  int i = static_cast<int>(s.find_best_audio_stream());
+  auto sinfo = s.StreamReader::get_src_stream_info(i);
   int64_t sample_rate = static_cast<int64_t>(sinfo.sample_rate);
   s.add_audio_stream(i, -1, -1, {}, {}, {});
   s.process_all_packets();
   auto tensors = s.pop_chunks();
+  assert(tensors.size() > 0);
   return std::make_tuple<>(tensors[0], sample_rate);
 }
 
@@ -42,11 +43,12 @@ using S = const c10::intrusive_ptr<StreamReaderBinding>&;
 TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
   m.def("torchaudio::ffmpeg_init", []() {
     avdevice_register_all();
-    if (av_log_get_level() == AV_LOG_INFO)
+    if (av_log_get_level() == AV_LOG_INFO) {
       av_log_set_level(AV_LOG_ERROR);
+    }
   });
   m.def("torchaudio::ffmpeg_load", load);
-  m.class_<StreamReaderBinding>("ffmpeg_Streamer")
+  m.class_<StreamReaderBinding>("ffmpeg_StreamReader")
       .def(torch::init<>(init))
       .def("num_src_streams", [](S self) { return self->num_src_streams(); })
       .def("num_out_streams", [](S self) { return self->num_out_streams(); })

--- a/torchaudio/csrc/ffmpeg/stream_reader_wrapper.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader_wrapper.cpp
@@ -25,14 +25,14 @@ OutInfo convert(OutputStreamInfo osi) {
 } // namespace
 
 StreamReaderBinding::StreamReaderBinding(AVFormatContextPtr&& p)
-    : Streamer(std::move(p)) {}
+    : StreamReader(std::move(p)) {}
 
 SrcInfo StreamReaderBinding::get_src_stream_info(int64_t i) {
-  return convert(Streamer::get_src_stream_info(i));
+  return convert(StreamReader::get_src_stream_info(static_cast<int>(i)));
 }
 
 OutInfo StreamReaderBinding::get_out_stream_info(int64_t i) {
-  return convert(Streamer::get_out_stream_info(i));
+  return convert(StreamReader::get_out_stream_info(static_cast<int>(i)));
 }
 
 int64_t StreamReaderBinding::process_packet(
@@ -40,9 +40,9 @@ int64_t StreamReaderBinding::process_packet(
     const double backoff) {
   int64_t code = [&]() {
     if (timeout.has_value()) {
-      return Streamer::process_packet_block(timeout.value(), backoff);
+      return StreamReader::process_packet_block(timeout.value(), backoff);
     }
-    return Streamer::process_packet();
+    return StreamReader::process_packet();
   }();
   if (code < 0) {
     throw std::runtime_error(

--- a/torchaudio/csrc/ffmpeg/stream_reader_wrapper.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader_wrapper.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <torch/script.h>
-#include <torchaudio/csrc/ffmpeg/streamer.h>
+#include <torchaudio/csrc/ffmpeg/stream_reader.h>
 
 namespace torchaudio {
 namespace ffmpeg {
@@ -25,9 +25,10 @@ using OutInfo = std::tuple<
     std::string // filter description
     >;
 
-// Structure to implement wrapper API around Streamer, which is more suitable
-// for Binding the code (i.e. it receives/returns pritimitves)
-struct StreamReaderBinding : public Streamer, public torch::CustomClassHolder {
+// Structure to implement wrapper API around StreamReader, which is more
+// suitable for Binding the code (i.e. it receives/returns pritimitves)
+struct StreamReaderBinding : public StreamReader,
+                             public torch::CustomClassHolder {
   explicit StreamReaderBinding(AVFormatContextPtr&& p);
   SrcInfo get_src_stream_info(int64_t i);
   OutInfo get_out_stream_info(int64_t i);

--- a/torchaudio/csrc/ffmpeg/typedefs.h
+++ b/torchaudio/csrc/ffmpeg/typedefs.h
@@ -11,7 +11,7 @@ struct SrcStreamInfo {
   const char* codec_name = "N/A";
   const char* codec_long_name = "N/A";
   const char* fmt_name = "N/A";
-  int bit_rate = 0;
+  int64_t bit_rate = 0;
   // Audio
   double sample_rate = 0;
   int num_channels = 0;

--- a/torchaudio/io/_stream_reader.py
+++ b/torchaudio/io/_stream_reader.py
@@ -322,7 +322,7 @@ class StreamReader:
         buffer_size: int = 4096,
     ):
         if isinstance(src, str):
-            self._be = torch.classes.torchaudio.ffmpeg_Streamer(src, format, option)
+            self._be = torch.classes.torchaudio.ffmpeg_StreamReader(src, format, option)
         elif hasattr(src, "read"):
             self._be = torchaudio._torchaudio_ffmpeg.StreamReaderFileObj(src, format, option, buffer_size)
         else:


### PR DESCRIPTION
* `Streamer` has been renamed to `StreamReader` when it was moved from prototype to beta.
This commit applies the same name change to the C++ source code.

* Fix miscellaneous lint issues 

* Make the code compilable on FFmpeg 5