### PR TITLE
Change Adam to AdamW in HuBERT recipe

### DIFF
--- a/examples/hubert/lightning.py
+++ b/examples/hubert/lightning.py
@@ -75,7 +75,7 @@ class HuBERTPreTrainModule(LightningModule):
             raise ValueError(f"Unsupported model name: {model_name}")
 
         self.loss = hubert_loss
-        self.optimizer = torch.optim.Adam(
+        self.optimizer = torch.optim.AdamW(
             self.model.parameters(), lr=learning_rate, betas=betas, eps=eps, weight_decay=weight_decay
         )
         self.lr_scheduler = LinearDecayLRScheduler(self.optimizer, warmup_updates, max_updates)


### PR DESCRIPTION
The `Adam` optimizer in fairseq is actually implemented as `AdamW`, from the [documentation](https://github.com/facebookresearch/fairseq/blob/main/fairseq/optim/adam.py#L48-L50).

The difference between `Adam` and `AdamW` is the location to perform weight decay. `Adam` brings the weight decay to the gradient, which will affect the update of moving averages (momentum) `m` and `v`. AdamW updates `m` and `v` first with pure gradient and performs weight decay after that.

You can check the [`Adam`](https://pytorch.org/docs/stable/generated/torch.optim.Adam.html) and [`AdamW`](https://pytorch.org/docs/stable/generated/torch.optim.AdamW.html) documentations for details.

In HuBERT pre-training, `weight_decay` is used and set to 0.01, hence we need to change it to `AdamW`.