### PR TITLE
Change sox_io C++ return type to optional

### DIFF
--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -49,6 +49,7 @@ def info(
             return AudioMetaData(*sinfo)
         filepath = os.fspath(filepath)
     sinfo = torch.ops.torchaudio.sox_io_get_info(filepath, format)
+    assert sinfo is not None  # for TorchScript compatibility
     return AudioMetaData(*sinfo)
 
 
@@ -148,9 +149,11 @@ def load(
                 filepath, frame_offset, num_frames, normalize, channels_first, format
             )
         filepath = os.fspath(filepath)
-    return torch.ops.torchaudio.sox_io_load_audio_file(
+    ret = torch.ops.torchaudio.sox_io_load_audio_file(
         filepath, frame_offset, num_frames, normalize, channels_first, format
     )
+    assert ret is not None  # for TorchScript compatibility
+    return ret
 
 
 @_mod_utils.requires_sox()

--- a/torchaudio/csrc/pybind/sox/effects.cpp
+++ b/torchaudio/csrc/pybind/sox/effects.cpp
@@ -32,7 +32,8 @@ auto apply_effects_fileobj(
     const std::vector<std::vector<std::string>>& effects,
     c10::optional<bool> normalize,
     c10::optional<bool> channels_first,
-    c10::optional<std::string> format) -> std::tuple<torch::Tensor, int64_t> {
+    c10::optional<std::string> format)
+    -> c10::optional<std::tuple<torch::Tensor, int64_t>> {
   // Prepare the buffer used throughout the lifecycle of SoxEffectChain.
   //
   // For certain format (such as FLAC), libsox keeps reading the content at
@@ -110,7 +111,7 @@ auto apply_effects_fileobj(
       normalize.value_or(true),
       channels_first_);
 
-  return std::make_tuple(
+  return std::forward_as_tuple(
       tensor, static_cast<int64_t>(chain.getOutputSampleRate()));
 }
 

--- a/torchaudio/csrc/pybind/sox/effects.h
+++ b/torchaudio/csrc/pybind/sox/effects.h
@@ -10,7 +10,8 @@ auto apply_effects_fileobj(
     const std::vector<std::vector<std::string>>& effects,
     c10::optional<bool> normalize,
     c10::optional<bool> channels_first,
-    c10::optional<std::string> format) -> std::tuple<torch::Tensor, int64_t>;
+    c10::optional<std::string> format)
+    -> c10::optional<std::tuple<torch::Tensor, int64_t>>;
 
 } // namespace torchaudio::sox_effects
 

--- a/torchaudio/csrc/pybind/sox/io.cpp
+++ b/torchaudio/csrc/pybind/sox/io.cpp
@@ -12,7 +12,7 @@ using namespace torchaudio::sox_utils;
 namespace torchaudio::sox_io {
 
 auto get_info_fileobj(py::object fileobj, c10::optional<std::string> format)
-    -> std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> {
+    -> c10::optional<MetaDataTuple> {
   // Prepare in-memory file object
   // When libsox opens a file, it also reads the header.
   // When opening a file there are two functions that might touch FILE* (and the
@@ -63,7 +63,7 @@ auto get_info_fileobj(py::object fileobj, c10::optional<std::string> format)
   // In case of streamed data, length can be 0
   validate_input_memfile(sf);
 
-  return std::make_tuple(
+  return std::forward_as_tuple(
       static_cast<int64_t>(sf->signal.rate),
       static_cast<int64_t>(sf->signal.length / sf->signal.channels),
       static_cast<int64_t>(sf->signal.channels),
@@ -77,7 +77,8 @@ auto load_audio_fileobj(
     c10::optional<int64_t> num_frames,
     c10::optional<bool> normalize,
     c10::optional<bool> channels_first,
-    c10::optional<std::string> format) -> std::tuple<torch::Tensor, int64_t> {
+    c10::optional<std::string> format)
+    -> c10::optional<std::tuple<torch::Tensor, int64_t>> {
   auto effects = get_effects(frame_offset, num_frames);
   return torchaudio::sox_effects::apply_effects_fileobj(
       std::move(fileobj),

--- a/torchaudio/csrc/pybind/sox/io.h
+++ b/torchaudio/csrc/pybind/sox/io.h
@@ -5,8 +5,11 @@
 
 namespace torchaudio::sox_io {
 
+using MetaDataTuple =
+    std::tuple<int64_t, int64_t, int64_t, int64_t, std::string>;
+
 auto get_info_fileobj(py::object fileobj, c10::optional<std::string> format)
-    -> std::tuple<int64_t, int64_t, int64_t, int64_t, std::string>;
+    -> c10::optional<MetaDataTuple>;
 
 auto load_audio_fileobj(
     py::object fileobj,
@@ -14,7 +17,8 @@ auto load_audio_fileobj(
     c10::optional<int64_t> num_frames,
     c10::optional<bool> normalize,
     c10::optional<bool> channels_first,
-    c10::optional<std::string> format) -> std::tuple<torch::Tensor, int64_t>;
+    c10::optional<std::string> format)
+    -> c10::optional<std::tuple<torch::Tensor, int64_t>>;
 
 void save_audio_fileobj(
     py::object fileobj,

--- a/torchaudio/csrc/sox/effects.cpp
+++ b/torchaudio/csrc/sox/effects.cpp
@@ -95,7 +95,7 @@ auto apply_effects_file(
     c10::optional<bool> normalize,
     c10::optional<bool> channels_first,
     const c10::optional<std::string>& format)
-    -> std::tuple<torch::Tensor, int64_t> {
+    -> c10::optional<std::tuple<torch::Tensor, int64_t>> {
   // Open input file
   SoxFormat sf(sox_open_read(
       path.c_str(),

--- a/torchaudio/csrc/sox/effects.h
+++ b/torchaudio/csrc/sox/effects.h
@@ -22,7 +22,7 @@ auto apply_effects_file(
     c10::optional<bool> normalize,
     c10::optional<bool> channels_first,
     const c10::optional<std::string>& format)
-    -> std::tuple<torch::Tensor, int64_t>;
+    -> c10::optional<std::tuple<torch::Tensor, int64_t>>;
 
 } // namespace torchaudio::sox_effects
 

--- a/torchaudio/csrc/sox/io.cpp
+++ b/torchaudio/csrc/sox/io.cpp
@@ -10,7 +10,7 @@ using namespace torchaudio::sox_utils;
 namespace torchaudio {
 namespace sox_io {
 
-std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_file(
+c10::optional<MetaDataTuple> get_info_file(
     const std::string& path,
     const c10::optional<std::string>& format) {
   SoxFormat sf(sox_open_read(
@@ -20,8 +20,7 @@ std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_file(
       /*filetype=*/format.has_value() ? format.value().c_str() : nullptr));
 
   validate_input_file(sf, path);
-
-  return std::make_tuple(
+  return std::forward_as_tuple(
       static_cast<int64_t>(sf->signal.rate),
       static_cast<int64_t>(sf->signal.length / sf->signal.channels),
       static_cast<int64_t>(sf->signal.channels),
@@ -58,7 +57,7 @@ std::vector<std::vector<std::string>> get_effects(
   return effects;
 }
 
-std::tuple<torch::Tensor, int64_t> load_audio_file(
+c10::optional<std::tuple<torch::Tensor, int64_t>> load_audio_file(
     const std::string& path,
     const c10::optional<int64_t>& frame_offset,
     const c10::optional<int64_t>& num_frames,

--- a/torchaudio/csrc/sox/io.h
+++ b/torchaudio/csrc/sox/io.h
@@ -12,11 +12,14 @@ auto get_effects(
     const c10::optional<int64_t>& num_frames)
     -> std::vector<std::vector<std::string>>;
 
-std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_file(
+using MetaDataTuple =
+    std::tuple<int64_t, int64_t, int64_t, int64_t, std::string>;
+
+c10::optional<MetaDataTuple> get_info_file(
     const std::string& path,
     const c10::optional<std::string>& format);
 
-std::tuple<torch::Tensor, int64_t> load_audio_file(
+c10::optional<std::tuple<torch::Tensor, int64_t>> load_audio_file(
     const std::string& path,
     const c10::optional<int64_t>& frame_offset,
     const c10::optional<int64_t>& num_frames,

--- a/torchaudio/sox_effects/sox_effects.py
+++ b/torchaudio/sox_effects/sox_effects.py
@@ -274,4 +274,6 @@ def apply_effects_file(
         if hasattr(path, "read"):
             return torchaudio._torchaudio.apply_effects_fileobj(path, effects, normalize, channels_first, format)
         path = os.fspath(path)
-    return torch.ops.torchaudio.sox_effects_apply_effects_file(path, effects, normalize, channels_first, format)
+    ret = torch.ops.torchaudio.sox_effects_apply_effects_file(path, effects, normalize, channels_first, format)
+    assert ret is not None
+    return ret


### PR DESCRIPTION
Preparation for upcoming change where load/info function will use fallback
if sox_io backend cannot handle the input.