### PR TITLE
Fail on Python if sox_io info/load does not succeed

### DIFF
--- a/test/torchaudio_unittest/backend/sox_io/info_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/info_test.py
@@ -435,7 +435,7 @@ class TestFileObject(FileObjTestBase, PytorchTestCase):
         num_channels = 2
         comments = "metadata=" + " ".join(["value" for _ in range(1000)])
 
-        with self.assertRaisesRegex(RuntimeError, "^Error loading audio file:"):
+        with self.assertRaisesRegex(RuntimeError, "Failed to fetch metadata from"):
             sinfo = self._query_fileobj(ext, dtype, sample_rate, num_channels, num_frames, comments=comments)
 
         with self._set_buffer_size(16384):
@@ -583,5 +583,5 @@ class TestInfoNoSuchFile(PytorchTestCase):
         When attempted to get info on a non-existing file, error message must contain the file path.
         """
         path = "non_existing_audio.wav"
-        with self.assertRaisesRegex(RuntimeError, "^Error loading audio file: failed to open file {0}$".format(path)):
+        with self.assertRaisesRegex(RuntimeError, path):
             sox_io_backend.info(path)

--- a/test/torchaudio_unittest/backend/sox_io/load_test.py
+++ b/test/torchaudio_unittest/backend/sox_io/load_test.py
@@ -627,5 +627,5 @@ class TestLoadNoSuchFile(PytorchTestCase):
         When attempted to load a non-existing file, error message must contain the file path.
         """
         path = "non_existing_audio.wav"
-        with self.assertRaisesRegex(RuntimeError, "^Error loading audio file: failed to open file {0}$".format(path)):
+        with self.assertRaisesRegex(RuntimeError, path):
             sox_io_backend.load(path)

--- a/torchaudio/csrc/pybind/sox/effects.cpp
+++ b/torchaudio/csrc/pybind/sox/effects.cpp
@@ -83,7 +83,10 @@ auto apply_effects_fileobj(
       /*filetype=*/format.has_value() ? format.value().c_str() : nullptr));
 
   // In case of streamed data, length can be 0
-  validate_input_memfile(sf);
+  if (static_cast<sox_format_t*>(sf) == nullptr ||
+      sf->encoding.encoding == SOX_ENCODING_UNKNOWN) {
+    return {};
+  }
 
   // Prepare output buffer
   std::vector<sox_sample_t> out_buffer;

--- a/torchaudio/csrc/pybind/sox/io.cpp
+++ b/torchaudio/csrc/pybind/sox/io.cpp
@@ -60,8 +60,10 @@ auto get_info_fileobj(py::object fileobj, c10::optional<std::string> format)
       /*encoding=*/nullptr,
       /*filetype=*/format.has_value() ? format.value().c_str() : nullptr));
 
-  // In case of streamed data, length can be 0
-  validate_input_memfile(sf);
+  if (static_cast<sox_format_t*>(sf) == nullptr ||
+      sf->encoding.encoding == SOX_ENCODING_UNKNOWN) {
+    return c10::optional<MetaDataTuple>{};
+  }
 
   return std::forward_as_tuple(
       static_cast<int64_t>(sf->signal.rate),

--- a/torchaudio/csrc/sox/effects.cpp
+++ b/torchaudio/csrc/sox/effects.cpp
@@ -103,7 +103,10 @@ auto apply_effects_file(
       /*encoding=*/nullptr,
       /*filetype=*/format.has_value() ? format.value().c_str() : nullptr));
 
-  validate_input_file(sf, path);
+  if (static_cast<sox_format_t*>(sf) == nullptr ||
+      sf->encoding.encoding == SOX_ENCODING_UNKNOWN) {
+    return {};
+  }
 
   const auto dtype = get_dtype(sf->encoding.encoding, sf->signal.precision);
 

--- a/torchaudio/csrc/sox/io.cpp
+++ b/torchaudio/csrc/sox/io.cpp
@@ -19,7 +19,11 @@ c10::optional<MetaDataTuple> get_info_file(
       /*encoding=*/nullptr,
       /*filetype=*/format.has_value() ? format.value().c_str() : nullptr));
 
-  validate_input_file(sf, path);
+  if (static_cast<sox_format_t*>(sf) == nullptr ||
+      sf->encoding.encoding == SOX_ENCODING_UNKNOWN) {
+    return {};
+  }
+
   return std::forward_as_tuple(
       static_cast<int64_t>(sf->signal.rate),
       static_cast<int64_t>(sf->signal.length / sf->signal.channels),

--- a/torchaudio/csrc/sox/utils.cpp
+++ b/torchaudio/csrc/sox/utils.cpp
@@ -95,10 +95,6 @@ void validate_input_file(const SoxFormat& sf, const std::string& path) {
   }
 }
 
-void validate_input_memfile(const SoxFormat& sf) {
-  return validate_input_file(sf, "<in memory buffer>");
-}
-
 void validate_input_tensor(const torch::Tensor tensor) {
   if (!tensor.device().is_cpu()) {
     throw std::runtime_error("Input tensor has to be on CPU.");

--- a/torchaudio/csrc/sox/utils.h
+++ b/torchaudio/csrc/sox/utils.h
@@ -53,13 +53,6 @@ struct SoxFormat {
 };
 
 ///
-/// Verify that input file is found, has known encoding, and not empty
-void validate_input_file(const SoxFormat& sf, const std::string& path);
-
-/// Verify that input memory buffer has known encoding, and not empty
-void validate_input_memfile(const SoxFormat& sf);
-
-///
 /// Verify that input Tensor is 2D, CPU and either uin8, int16, int32 or float32
 void validate_input_tensor(const torch::Tensor);
 

--- a/torchaudio/sox_effects/sox_effects.py
+++ b/torchaudio/sox_effects/sox_effects.py
@@ -272,8 +272,12 @@ def apply_effects_file(
     """
     if not torch.jit.is_scripting():
         if hasattr(path, "read"):
-            return torchaudio._torchaudio.apply_effects_fileobj(path, effects, normalize, channels_first, format)
+            ret = torchaudio._torchaudio.apply_effects_fileobj(path, effects, normalize, channels_first, format)
+            if ret is None:
+                raise RuntimeError("Failed to load audio from {}".format(path))
+            return ret
         path = os.fspath(path)
     ret = torch.ops.torchaudio.sox_effects_apply_effects_file(path, effects, normalize, channels_first, format)
-    assert ret is not None
-    return ret
+    if ret is not None:
+        return ret
+    raise RuntimeError("Failed to load audio from {}".format(path))


### PR DESCRIPTION
Extracted from #2419. Move the failure of sox_io from C++ to Python layer, so that later, we can add fallback logic.