### PR TITLE
Disable OpenMP on mac

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,13 +53,6 @@ commands:
           name: Install CUDA
           command: |
               packaging/windows/internal/cuda_install.bat
-  macos_install_dependencies:
-    description: "Install ci dependencies for macOS"
-    steps:
-      - run:
-          name: Install ci dependencies
-          command: |
-              brew install libomp
 
 binary_common: &binary_common
   parameters:
@@ -299,7 +292,6 @@ jobs:
     steps:
       - checkout
       - load_conda_channel_flags
-      - macos_install_dependencies
       - attach_workspace:
           at: third_party
       - run:
@@ -328,7 +320,6 @@ jobs:
     steps:
       - checkout
       - load_conda_channel_flags
-      - macos_install_dependencies
       - attach_workspace:
           at: third_party
       - run:
@@ -765,7 +756,6 @@ jobs:
     steps:
       - checkout
       - load_conda_channel_flags
-      - macos_install_dependencies
       - attach_workspace:
           at: third_party
       - designate_upload_channel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,6 +306,7 @@ jobs:
             packaging/build_wheel.sh
           environment:
             USE_FFMPEG: true
+            USE_OPENMP: false
       - store_artifacts:
           path: dist
       - persist_to_workspace:
@@ -332,6 +333,7 @@ jobs:
             packaging/build_conda.sh
           environment:
             USE_FFMPEG: true
+            USE_OPENMP: false
       - store_artifacts:
           path: /Users/distiller/miniconda3/conda-bld/osx-64
       - persist_to_workspace:
@@ -767,6 +769,7 @@ jobs:
           command: .circleci/unittest/linux/scripts/install.sh
           environment:
               USE_FFMPEG: true
+              USE_OPENMP: false
               BUILD_MAD: true
       - run:
           name: Run tests

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -53,13 +53,6 @@ commands:
           name: Install CUDA
           command: |
               packaging/windows/internal/cuda_install.bat
-  macos_install_dependencies:
-    description: "Install ci dependencies for macOS"
-    steps:
-      - run:
-          name: Install ci dependencies
-          command: |
-              brew install libomp
 
 binary_common: &binary_common
   parameters:
@@ -299,7 +292,6 @@ jobs:
     steps:
       - checkout
       - load_conda_channel_flags
-      - macos_install_dependencies
       - attach_workspace:
           at: third_party
       - run:
@@ -328,7 +320,6 @@ jobs:
     steps:
       - checkout
       - load_conda_channel_flags
-      - macos_install_dependencies
       - attach_workspace:
           at: third_party
       - run:
@@ -765,7 +756,6 @@ jobs:
     steps:
       - checkout
       - load_conda_channel_flags
-      - macos_install_dependencies
       - attach_workspace:
           at: third_party
       - designate_upload_channel

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -306,6 +306,7 @@ jobs:
             packaging/build_wheel.sh
           environment:
             USE_FFMPEG: true
+            USE_OPENMP: false
       - store_artifacts:
           path: dist
       - persist_to_workspace:
@@ -332,6 +333,7 @@ jobs:
             packaging/build_conda.sh
           environment:
             USE_FFMPEG: true
+            USE_OPENMP: false
       - store_artifacts:
           path: /Users/distiller/miniconda3/conda-bld/osx-64
       - persist_to_workspace:
@@ -767,6 +769,7 @@ jobs:
           command: .circleci/unittest/linux/scripts/install.sh
           environment:
               USE_FFMPEG: true
+              USE_OPENMP: false
               BUILD_MAD: true
       - run:
           name: Run tests

--- a/packaging/torchaudio/meta.yaml
+++ b/packaging/torchaudio/meta.yaml
@@ -47,6 +47,7 @@ build:
     - USE_CUDA
     - TORCH_CUDA_ARCH_LIST
     - USE_FFMPEG
+    - USE_OPENMP
     - FFMPEG_ROOT
 
 test:

--- a/tools/setup_helpers/extension.py
+++ b/tools/setup_helpers/extension.py
@@ -40,10 +40,7 @@ _BUILD_CTC_DECODER = False if platform.system() == "Windows" else _get_build("BU
 _USE_FFMPEG = _get_build("USE_FFMPEG", False)
 _USE_ROCM = _get_build("USE_ROCM", torch.cuda.is_available() and torch.version.hip is not None)
 _USE_CUDA = _get_build("USE_CUDA", torch.cuda.is_available() and torch.version.hip is None)
-print(torch.__config__.parallel_info())
 _USE_OPENMP = _get_build("USE_OPENMP", True) and "ATen parallel backend: OpenMP" in torch.__config__.parallel_info()
-print("The value of _get_build('USE_OPENMP', True) is ", _get_build("USE_OPENMP", True))
-print("The value of _USE_OPENMP is ", _USE_OPENMP)
 _TORCH_CUDA_ARCH_LIST = os.environ.get("TORCH_CUDA_ARCH_LIST", None)
 
 

--- a/tools/setup_helpers/extension.py
+++ b/tools/setup_helpers/extension.py
@@ -40,6 +40,7 @@ _BUILD_CTC_DECODER = False if platform.system() == "Windows" else _get_build("BU
 _USE_FFMPEG = _get_build("USE_FFMPEG", False)
 _USE_ROCM = _get_build("USE_ROCM", torch.cuda.is_available() and torch.version.hip is not None)
 _USE_CUDA = _get_build("USE_CUDA", torch.cuda.is_available() and torch.version.hip is None)
+print(torch.__config__.parallel_info())
 _USE_OPENMP = _get_build("USE_OPENMP", True) and "ATen parallel backend: OpenMP" in torch.__config__.parallel_info()
 _TORCH_CUDA_ARCH_LIST = os.environ.get("TORCH_CUDA_ARCH_LIST", None)
 

--- a/tools/setup_helpers/extension.py
+++ b/tools/setup_helpers/extension.py
@@ -42,6 +42,8 @@ _USE_ROCM = _get_build("USE_ROCM", torch.cuda.is_available() and torch.version.h
 _USE_CUDA = _get_build("USE_CUDA", torch.cuda.is_available() and torch.version.hip is None)
 print(torch.__config__.parallel_info())
 _USE_OPENMP = _get_build("USE_OPENMP", True) and "ATen parallel backend: OpenMP" in torch.__config__.parallel_info()
+print("The value of _get_build('USE_OPENMP', True) is ", _get_build("USE_OPENMP", True))
+print("The value of _USE_OPENMP is ", _USE_OPENMP)
 _TORCH_CUDA_ARCH_LIST = os.environ.get("TORCH_CUDA_ARCH_LIST", None)
 
 


### PR DESCRIPTION
A couple of weeks ago we started to see OpenMP not found error on macOS CI. 
From #2404, we install OpenMP from brew, and build passes, but unit tests are seg-faulting ever since.

https://app.circleci.com/pipelines/github/pytorch/audio/10825/workflows/c0ecae99-d409-4df2-ab91-9bcb126c309d/jobs/671518

The failing test uses `torchaudio.functional.filitfilt`, which uses [OpenMP for parallel execution](https://github.com/pytorch/audio/blob/6057d3cf1c2f3a4c5072a3853a021bb8b4ce61f7/torchaudio/csrc/lfilter.cpp#L20). 

This commit reverts #2404 and disables OpenMP for macOS builds and tests.