### PR TITLE
Add SourceSeparationBundle to prototype

### DIFF
--- a/test/integration_tests/conftest.py
+++ b/test/integration_tests/conftest.py
@@ -40,15 +40,11 @@ _FILES = {
     "fr": "20121212-0900-PLENARY-5-fr_20121212-11_37_04_10.flac",
     "it": "20170516-0900-PLENARY-16-it_20170516-18_56_31_1.flac",
 }
-_MIXTURE_FILES = {
-    "speech_separation": "mixture_3729-6852-0037_8463-287645-0000.wav",
-}
-_CLEAN_FILES = {
-    "speech_separation": [
-        "s1_3729-6852-0037_8463-287645-0000.wav",
-        "s2_3729-6852-0037_8463-287645-0000.wav",
-    ],
-}
+_MIXTURE_FILE = "mixture_3729-6852-0037_8463-287645-0000.wav"
+_CLEAN_FILES = [
+    "s1_3729-6852-0037_8463-287645-0000.wav",
+    "s2_3729-6852-0037_8463-287645-0000.wav",
+]
 
 
 @pytest.fixture
@@ -63,24 +59,16 @@ def sample_speech(tmp_path, lang):
 
 
 @pytest.fixture
-def mixture_source(tmp_path, task):
-    if task not in _MIXTURE_FILES:
-        raise NotImplementedError(f"Unexpected task: {task}")
-    path = tmp_path.parent / _MIXTURE_FILES[task]
-    if not path.exists():
-        torchaudio.utils.download_asset(f"test-assets/{_MIXTURE_FILES[task]}", path=path)
+def mixture_source():
+    path = torchaudio.utils.download_asset(f"test-assets/{_MIXTURE_FILE}")
     return path
 
 
 @pytest.fixture
-def clean_sources(tmp_path, task):
-    if task not in _CLEAN_FILES:
-        raise NotImplementedError(f"Unexpected task: {task}")
+def clean_sources():
     paths = []
-    for file in _CLEAN_FILES[task]:
-        path = tmp_path.parent / file
-        if not path.exists():
-            torchaudio.utils.download_asset(f"test-assets/{file}", path=path)
+    for file in _CLEAN_FILES:
+        path = torchaudio.utils.download_asset(f"test-assets/{file}")
         paths.append(path)
     return paths
 

--- a/test/integration_tests/conftest.py
+++ b/test/integration_tests/conftest.py
@@ -40,8 +40,12 @@ _FILES = {
     "fr": "20121212-0900-PLENARY-5-fr_20121212-11_37_04_10.flac",
     "it": "20170516-0900-PLENARY-16-it_20170516-18_56_31_1.flac",
 }
-_MIXTURE_FILENAME = "mix_3729-6852-0037_8463-287645-0000.wav"
-_EXPECTED_FILENAME = "expected_3729-6852-0037_8463-287645-0000.pt"
+_MIXTURE_FILES = {
+    "speech_separation": "mix_3729-6852-0037_8463-287645-0000.wav",
+}
+_EXPECTED_TENSORS = {
+    "speech_separation": "expected_3729-6852-0037_8463-287645-0000.pt",
+}
 
 
 @pytest.fixture
@@ -56,18 +60,22 @@ def sample_speech(tmp_path, lang):
 
 
 @pytest.fixture
-def mixture_speech(tmp_path):
-    path = tmp_path.parent / _MIXTURE_FILENAME
+def mixture_speech(tmp_path, task):
+    if task not in _MIXTURE_FILES:
+        raise NotImplementedError(f"Unexpected task: {task}")
+    path = tmp_path.parent / _MIXTURE_FILES[task]
     if not path.exists():
-        torchaudio.utils.download_asset(f"test-assets/{_MIXTURE_FILENAME}", path=path)
+        torchaudio.utils.download_asset(f"test-assets/{_MIXTURE_FILES[task]}", path=path)
     return path
 
 
 @pytest.fixture
-def expected_tensor(tmp_path):
-    path = tmp_path.parent / _EXPECTED_FILENAME
+def expected_tensor(tmp_path, task):
+    if task not in _EXPECTED_TENSORS:
+        raise NotImplementedError(f"Unexpected task: {task}")
+    path = tmp_path.parent / _EXPECTED_TENSORS[task]
     if not path.exists():
-        torchaudio.utils.download_asset(f"test-assets/{_EXPECTED_FILENAME}", path=path)
+        torchaudio.utils.download_asset(f"test-assets/{_EXPECTED_TENSORS[task]}", path=path)
     return path
 
 

--- a/test/integration_tests/conftest.py
+++ b/test/integration_tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import torch
 import torchaudio
@@ -60,7 +62,7 @@ def sample_speech(tmp_path, lang):
 
 @pytest.fixture
 def mixture_source():
-    path = torchaudio.utils.download_asset(f"test-assets/{_MIXTURE_FILE}")
+    path = torchaudio.utils.download_asset(os.path.join("test-assets", f"{_MIXTURE_FILE}"))
     return path
 
 
@@ -68,7 +70,7 @@ def mixture_source():
 def clean_sources():
     paths = []
     for file in _CLEAN_FILES:
-        path = torchaudio.utils.download_asset(f"test-assets/{file}")
+        path = torchaudio.utils.download_asset(os.path.join("test-assets", f"{file}"))
         paths.append(path)
     return paths
 

--- a/test/integration_tests/conftest.py
+++ b/test/integration_tests/conftest.py
@@ -40,6 +40,8 @@ _FILES = {
     "fr": "20121212-0900-PLENARY-5-fr_20121212-11_37_04_10.flac",
     "it": "20170516-0900-PLENARY-16-it_20170516-18_56_31_1.flac",
 }
+_MIXTURE_FILENAME = "mix_3729-6852-0037_8463-287645-0000.wav"
+_EXPECTED_FILENAME = "expected_3729-6852-0037_8463-287645-0000.pt"
 
 
 @pytest.fixture
@@ -50,6 +52,22 @@ def sample_speech(tmp_path, lang):
     path = tmp_path.parent / filename
     if not path.exists():
         torchaudio.utils.download_asset(f"test-assets/{filename}", path=path)
+    return path
+
+
+@pytest.fixture
+def mixture_speech(tmp_path):
+    path = tmp_path.parent / _MIXTURE_FILENAME
+    if not path.exists():
+        torchaudio.utils.download_asset(f"test-assets/{_MIXTURE_FILENAME}", path=path)
+    return path
+
+
+@pytest.fixture
+def expected_tensor(tmp_path):
+    path = tmp_path.parent / _EXPECTED_FILENAME
+    if not path.exists():
+        torchaudio.utils.download_asset(f"test-assets/{_EXPECTED_FILENAME}", path=path)
     return path
 
 

--- a/test/integration_tests/conftest.py
+++ b/test/integration_tests/conftest.py
@@ -41,10 +41,13 @@ _FILES = {
     "it": "20170516-0900-PLENARY-16-it_20170516-18_56_31_1.flac",
 }
 _MIXTURE_FILES = {
-    "speech_separation": "mix_3729-6852-0037_8463-287645-0000.wav",
+    "speech_separation": "mixture_3729-6852-0037_8463-287645-0000.wav",
 }
-_EXPECTED_TENSORS = {
-    "speech_separation": "expected_3729-6852-0037_8463-287645-0000.pt",
+_CLEAN_FILES = {
+    "speech_separation": [
+        "s1_3729-6852-0037_8463-287645-0000.wav",
+        "s2_3729-6852-0037_8463-287645-0000.wav",
+    ],
 }
 
 
@@ -60,7 +63,7 @@ def sample_speech(tmp_path, lang):
 
 
 @pytest.fixture
-def mixture_speech(tmp_path, task):
+def mixture_source(tmp_path, task):
     if task not in _MIXTURE_FILES:
         raise NotImplementedError(f"Unexpected task: {task}")
     path = tmp_path.parent / _MIXTURE_FILES[task]
@@ -70,13 +73,16 @@ def mixture_speech(tmp_path, task):
 
 
 @pytest.fixture
-def expected_tensor(tmp_path, task):
-    if task not in _EXPECTED_TENSORS:
+def clean_sources(tmp_path, task):
+    if task not in _CLEAN_FILES:
         raise NotImplementedError(f"Unexpected task: {task}")
-    path = tmp_path.parent / _EXPECTED_TENSORS[task]
-    if not path.exists():
-        torchaudio.utils.download_asset(f"test-assets/{_EXPECTED_TENSORS[task]}", path=path)
-    return path
+    paths = []
+    for file in _CLEAN_FILES[task]:
+        path = tmp_path.parent / file
+        if not path.exists():
+            torchaudio.utils.download_asset(f"test-assets/{file}", path=path)
+        paths.append(path)
+    return paths
 
 
 def pytest_addoption(parser):

--- a/test/integration_tests/source_separation_pipeline_test.py
+++ b/test/integration_tests/source_separation_pipeline_test.py
@@ -39,5 +39,4 @@ def test_tts_models(bundle, mixture_speech, expected_tensor):
     )
     expected_peak_frequency = expected_spectrogram.argmax(dim=2)
     estimated_peak_frequency = estimated_spectrogram.argmax(dim=2)
-    assert torch.equal(expected_spectrogram, estimated_spectrogram) is True
     assert torch.equal(expected_peak_frequency, estimated_peak_frequency) is True

--- a/test/integration_tests/source_separation_pipeline_test.py
+++ b/test/integration_tests/source_separation_pipeline_test.py
@@ -1,42 +1,33 @@
+import os
+import sys
+
 import pytest
 import torch
 import torchaudio
 from torchaudio.prototype.pipelines import CONVTASNET_BASE_LIBRI2MIX
 
 
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", "examples"))
+from source_separation.utils.metrics import PIT, sdr
+
+
 @pytest.mark.parametrize(
-    "bundle,task",
+    "bundle,task,expected_score",
     [
-        [CONVTASNET_BASE_LIBRI2MIX, "speech_separation"],
+        [CONVTASNET_BASE_LIBRI2MIX, "speech_separation", 8.1374],
     ],
 )
-def test_source_separation_models(bundle, task, mixture_speech, expected_tensor):
+def test_source_separation_models(bundle, task, expected_score, mixture_source, clean_sources):
     """Smoke test of source separation pipeline"""
     separator = bundle.get_separator()
-    mixture_speech, sample_rate = torchaudio.load(mixture_speech)
-    expected_tensor = torch.load(expected_tensor)
-    mixture_speech = mixture_speech.reshape(1, 1, -1)
-    estimated_sources = separator(mixture_speech)
-    expected_spectrogram = torchaudio.functional.spectrogram(
-        expected_tensor,
-        n_fft=400,
-        hop_length=160,
-        window=torch.ones(400),
-        win_length=400,
-        pad=False,
-        normalized=False,
-        power=2,
-    )
-    estimated_spectrogram = torchaudio.functional.spectrogram(
-        estimated_sources,
-        n_fft=400,
-        hop_length=160,
-        window=torch.ones(400),
-        win_length=400,
-        pad=False,
-        normalized=False,
-        power=2,
-    )
-    expected_peak_frequency = expected_spectrogram.argmax(dim=2)
-    estimated_peak_frequency = estimated_spectrogram.argmax(dim=2)
-    assert torch.equal(expected_peak_frequency, estimated_peak_frequency) is True
+    mixture_waveform, _ = torchaudio.load(mixture_source)
+    clean_waveforms = []
+    for source in clean_sources:
+        clean_waveform, _ = torchaudio.load(source)
+        clean_waveforms.append(clean_waveform)
+    mixture_waveform = mixture_waveform.reshape(1, 1, -1)
+    estimated_sources = separator(mixture_waveform)
+    clean_waveforms = torch.cat(clean_waveforms).unsqueeze(0)
+    _sdr_pit = PIT(utility_func=sdr)
+    sdr_values = _sdr_pit(estimated_sources, clean_waveforms)
+    assert torch.isclose(sdr_values, torch.tensor([expected_score]))

--- a/test/integration_tests/source_separation_pipeline_test.py
+++ b/test/integration_tests/source_separation_pipeline_test.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-import pytest
 import torch
 import torchaudio
 from torchaudio.prototype.pipelines import CONVTASNET_BASE_LIBRI2MIX
@@ -10,24 +9,30 @@ from torchaudio.prototype.pipelines import CONVTASNET_BASE_LIBRI2MIX
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", "examples"))
 from source_separation.utils.metrics import PIT, sdr
 
+BUNDLE = CONVTASNET_BASE_LIBRI2MIX
+EXPECTED_SCORE = 8.1373
 
-@pytest.mark.parametrize(
-    "bundle,task,expected_score",
-    [
-        [CONVTASNET_BASE_LIBRI2MIX, "speech_separation", 8.1374],
-    ],
-)
-def test_source_separation_models(bundle, task, expected_score, mixture_source, clean_sources):
-    """Smoke test of source separation pipeline"""
-    separator = bundle.get_separator()
-    mixture_waveform, _ = torchaudio.load(mixture_source)
+
+def test_source_separation_models(mixture_source, clean_sources):
+    """Integration test for the source separation pipeline.
+    Given the mixture waveform with dimensions `(batch, 1, time)`, the pre-trained pipeline generates
+    the separated sources Tensor with dimensions `(batch, num_sources, time)`.
+    The test computes the scale-invariant signal-to-distortion ratio (Si-SDR) score in decibel (dB) with
+    permutation invariant training (PIT) criterion. PIT computes Si-SDR scores between the estimated sources and the
+    target sources for all permuations, then returns the highest values as the final output. The final
+    Si-SDR score should be equal to or larger than the expected score.
+    """
+    separator = BUNDLE.get_separator()
+    mixture_waveform, sample_rate = torchaudio.load(mixture_source)
+    assert sample_rate == BUNDLE.sample_rate, "The sample rate of audio must match that in the bundle."
     clean_waveforms = []
     for source in clean_sources:
-        clean_waveform, _ = torchaudio.load(source)
+        clean_waveform, sample_rate = torchaudio.load(source)
+        assert sample_rate == BUNDLE.sample_rate, "The sample rate of audio must match that in the bundle."
         clean_waveforms.append(clean_waveform)
     mixture_waveform = mixture_waveform.reshape(1, 1, -1)
     estimated_sources = separator(mixture_waveform)
     clean_waveforms = torch.cat(clean_waveforms).unsqueeze(0)
     _sdr_pit = PIT(utility_func=sdr)
     sdr_values = _sdr_pit(estimated_sources, clean_waveforms)
-    assert torch.isclose(sdr_values, torch.tensor([expected_score]))
+    assert sdr_values >= EXPECTED_SCORE

--- a/test/integration_tests/source_separation_pipeline_test.py
+++ b/test/integration_tests/source_separation_pipeline_test.py
@@ -17,4 +17,27 @@ def test_tts_models(bundle, mixture_speech, expected_tensor):
     expected_tensor = torch.load(expected_tensor)
     mixture_speech = mixture_speech.reshape(1, 1, -1)
     estimated_sources = separator(mixture_speech)
-    assert torch.equal(estimated_sources, expected_tensor) is True
+    expected_spectrogram = torchaudio.functional.spectrogram(
+        expected_tensor,
+        n_fft=400,
+        hop_length=160,
+        window=torch.ones(400),
+        win_length=400,
+        pad=False,
+        normalized=False,
+        power=2,
+    )
+    estimated_spectrogram = torchaudio.functional.spectrogram(
+        estimated_sources,
+        n_fft=400,
+        hop_length=160,
+        window=torch.ones(400),
+        win_length=400,
+        pad=False,
+        normalized=False,
+        power=2,
+    )
+    expected_peak_frequency = expected_spectrogram.argmax(dim=2)
+    estimated_peak_frequency = estimated_spectrogram.argmax(dim=2)
+    assert torch.equal(expected_spectrogram, estimated_spectrogram) is True
+    assert torch.equal(expected_peak_frequency, estimated_peak_frequency) is True

--- a/test/integration_tests/source_separation_pipeline_test.py
+++ b/test/integration_tests/source_separation_pipeline_test.py
@@ -5,12 +5,12 @@ from torchaudio.prototype.pipelines import CONVTASNET_BASE_LIBRI2MIX
 
 
 @pytest.mark.parametrize(
-    "bundle",
+    "bundle,task",
     [
-        CONVTASNET_BASE_LIBRI2MIX,
+        [CONVTASNET_BASE_LIBRI2MIX, "speech_separation"],
     ],
 )
-def test_tts_models(bundle, mixture_speech, expected_tensor):
+def test_source_separation_models(bundle, task, mixture_speech, expected_tensor):
     """Smoke test of source separation pipeline"""
     separator = bundle.get_separator()
     mixture_speech, sample_rate = torchaudio.load(mixture_speech)

--- a/test/integration_tests/source_separation_pipeline_test.py
+++ b/test/integration_tests/source_separation_pipeline_test.py
@@ -1,0 +1,20 @@
+import pytest
+import torch
+import torchaudio
+from torchaudio.prototype.pipelines import CONVTASNET_BASE_LIBRI2MIX
+
+
+@pytest.mark.parametrize(
+    "bundle",
+    [
+        CONVTASNET_BASE_LIBRI2MIX,
+    ],
+)
+def test_tts_models(bundle, mixture_speech, expected_tensor):
+    """Smoke test of source separation pipeline"""
+    separator = bundle.get_separator()
+    mixture_speech, sample_rate = torchaudio.load(mixture_speech)
+    expected_tensor = torch.load(expected_tensor)
+    mixture_speech = mixture_speech.reshape(1, 1, -1)
+    estimated_sources = separator(mixture_speech)
+    assert torch.equal(estimated_sources, expected_tensor) is True

--- a/test/integration_tests/source_separation_pipeline_test.py
+++ b/test/integration_tests/source_separation_pipeline_test.py
@@ -9,9 +9,6 @@ from torchaudio.prototype.pipelines import CONVTASNET_BASE_LIBRI2MIX
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", "examples"))
 from source_separation.utils.metrics import PIT, sdr
 
-BUNDLE = CONVTASNET_BASE_LIBRI2MIX
-EXPECTED_SCORE = 8.1373
-
 
 def test_source_separation_models(mixture_source, clean_sources):
     """Integration test for the source separation pipeline.
@@ -22,7 +19,9 @@ def test_source_separation_models(mixture_source, clean_sources):
     target sources for all permuations, then returns the highest values as the final output. The final
     Si-SDR score should be equal to or larger than the expected score.
     """
-    separator = BUNDLE.get_separator()
+    BUNDLE = CONVTASNET_BASE_LIBRI2MIX
+    EXPECTED_SCORE = 8.1373  # expected Si-SDR score.
+    model = BUNDLE.get_model()
     mixture_waveform, sample_rate = torchaudio.load(mixture_source)
     assert sample_rate == BUNDLE.sample_rate, "The sample rate of audio must match that in the bundle."
     clean_waveforms = []
@@ -31,7 +30,7 @@ def test_source_separation_models(mixture_source, clean_sources):
         assert sample_rate == BUNDLE.sample_rate, "The sample rate of audio must match that in the bundle."
         clean_waveforms.append(clean_waveform)
     mixture_waveform = mixture_waveform.reshape(1, 1, -1)
-    estimated_sources = separator(mixture_waveform)
+    estimated_sources = model(mixture_waveform)
     clean_waveforms = torch.cat(clean_waveforms).unsqueeze(0)
     _sdr_pit = PIT(utility_func=sdr)
     sdr_values = _sdr_pit(estimated_sources, clean_waveforms)

--- a/torchaudio/prototype/pipelines/__init__.py
+++ b/torchaudio/prototype/pipelines/__init__.py
@@ -1,7 +1,9 @@
 from .rnnt_pipeline import EMFORMER_RNNT_BASE_MUSTC, EMFORMER_RNNT_BASE_TEDLIUM3
+from .source_separation_pipeline import CONVTASNET_BASE_LIBRI2MIX
 
 
 __all__ = [
+    "CONVTASNET_BASE_LIBRI2MIX",
     "EMFORMER_RNNT_BASE_MUSTC",
     "EMFORMER_RNNT_BASE_TEDLIUM3",
 ]

--- a/torchaudio/prototype/pipelines/source_separation_pipeline.py
+++ b/torchaudio/prototype/pipelines/source_separation_pipeline.py
@@ -14,13 +14,13 @@ class _Separator(torch.nn.Module):
         self.model = model
 
     def forward(self, feature: torch.Tensor) -> torch.Tensor:
-        """Separates the input mixture speech into different sources.
+        """Separates the input mixture audio into different sources.
 
         Args:
-            input (torch.Tensor): input tensor with dimensions `[batch, time]`.
+            input (torch.Tensor): Input mixture tensor.
 
         Returns:
-            (torch.Tensor): Separated sources with dimensions `[batch, n_source, time]`.
+            (torch.Tensor): Separated sources.
         """
         output = self.model(feature)
         return output
@@ -53,7 +53,7 @@ class SourceSeparationBundle:
         >>>     score = si_snr_pit(estimated_sources, clean_sources) # for demonstration
         >>>     print(f"Si-SNR score is : {score}.)
         >>>     break
-        >>> 16.24
+        >>> Si-SNR score is : 16.24.
         >>>
     """
 

--- a/torchaudio/prototype/pipelines/source_separation_pipeline.py
+++ b/torchaudio/prototype/pipelines/source_separation_pipeline.py
@@ -8,24 +8,6 @@ import torchaudio
 from torchaudio.prototype.models import conv_tasnet_base
 
 
-class _Separator(torch.nn.Module):
-    def __init__(self, model: torch.nn.Module):
-        super().__init__()
-        self.model = model
-
-    def forward(self, feature: torch.Tensor) -> torch.Tensor:
-        """Separates the input mixture audio into different sources.
-
-        Args:
-            input (torch.Tensor): Input mixture tensor.
-
-        Returns:
-            (torch.Tensor): Separated sources.
-        """
-        output = self.model(feature)
-        return output
-
-
 @dataclass
 class SourceSeparationBundle:
     """torchaudio.prototype.pipelines.SourceSeparationBundle()
@@ -57,9 +39,6 @@ class SourceSeparationBundle:
         >>>
     """
 
-    class Separator(_Separator):
-        pass
-
     _model_path: str
     _separator_factory_func: Callable[[], torch.nn.Module]
     _sample_rate: int
@@ -71,13 +50,13 @@ class SourceSeparationBundle:
         """
         return self._sample_rate
 
-    def get_separator(self) -> Separator:
+    def get_separator(self) -> torch.nn.Module:
         model = self._separator_factory_func()
         path = torchaudio.utils.download_asset(self._model_path)
         state_dict = torch.load(path)
         model.load_state_dict(state_dict)
         model.eval()
-        return _Separator(model)
+        return model
 
 
 CONVTASNET_BASE_LIBRI2MIX = SourceSeparationBundle(

--- a/torchaudio/prototype/pipelines/source_separation_pipeline.py
+++ b/torchaudio/prototype/pipelines/source_separation_pipeline.py
@@ -1,0 +1,188 @@
+from dataclasses import dataclass
+from functools import partial
+from typing import Callable, Optional
+
+import torch
+import torchaudio
+
+from torchaudio.prototype.models import conv_tasnet_base
+
+
+class _FeatureEncoder(torch.nn.Module):
+    """Feature encoder for source separation.
+    If the separator is an end-to-end model (waveform to waveform), the
+    feature encoder can be torch.nn.Identity(). If the separator is
+    time-frequency masking based model, the encoder can be torchaudio.transforms.Spectrogram().
+    """
+
+    def __init__(self, feature_encoder: torch.nn.Module):
+        super().__init__()
+        self.feature_encoder = feature_encoder
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Generates features for source separation given the input Tensor.
+
+        Args:
+            input (torch.Tensor): input tensor.
+
+        Returns:
+            (torch.Tensor): Features. The dimensions depend on the type of separator.
+        """
+        feature = self.feature_encoder(input)
+        return feature
+
+
+class _FeatureDecoder(torch.nn.Module):
+    """Feature decoder for source separation.
+    If the separator is an end-to-end model (waveform to waveform), the
+    feature decoder can be torch.nn.Identity(). If the separator is
+    time-frequency masking based model, the encoder can be torchaudio.transforms.InverseSpectrogram().
+    """
+
+    def __init__(self, feature_decoder: torch.nn.Module):
+        super().__init__()
+        self.feature_decoder = feature_decoder
+
+    def forward(self, separated_sources: torch.Tensor, length: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """Decodes the separator output to waveforms.
+
+        Args:
+            separated_sources (torch.Tensor): separated sources.
+            length (torch.Tensor or None, optional): The expected lengths of the waveform.
+
+        Returns:
+            (torch.Tensor): The separated waveforms.
+        """
+        if length is None:
+            return self.feature_decoder(separated_sources)
+        else:
+            return self.feature_decoder(separated_sources, length)
+
+
+class _Separator(torch.nn.Module):
+    def __init__(self, model: torch.nn.Module):
+        super().__init__()
+        self.model = model
+
+    def forward(self, feature: torch.Tensor) -> torch.Tensor:
+        """Separates the input mixture speech into different sources.
+
+        Args:
+            input (torch.Tensor): input tensor with dimensions `[batch, time]`.
+
+        Returns:
+            (torch.Tensor): Separated sources with dimensions `[batch, n_source, time]`.
+        """
+        output = self.model(feature)
+        return output
+
+
+@dataclass
+class SourceSeparationBundle:
+    """torchaudio.prototype.pipelines.SourceSeparationBundle()
+
+    Dataclass that bundles components for performing source separation.
+
+    Example
+        >>> import torchaudio
+        >>> from torchaudio.prototype.pipelines import CONVTASNET_BASE_LIBRI2MIX
+        >>> import torch
+        >>>
+        >>> # Build feature encoder, feature decoder, and separator model.
+        >>> feature_encoder = CONVTASNET_BASE_LIBRI2MIX.get_feature_encoder()
+        >>> feature_decoder = CONVTASNET_BASE_LIBRI2MIX.get_feature_decoder()
+        >>> separator = CONVTASNET_BASE_LIBRI2MIX.get_separator()
+        >>> 100%|███████████████████████████████|19.1M/19.1M [00:04<00:00, 4.93MB/s]
+        >>>
+        >>> # Instantiate the test set of Libri2Mix dataset.
+        >>> dataset = torchaudio.datasets.LibriMix("/home/datasets/", subset="test")
+        >>>
+        >>> # Apply source separation on mixture audio.
+        >>> for i, data in enumerate(dataset):
+        >>>     sample_rate, mixture, clean_sources = data
+        >>>     feature = feature_encoder(mixture)
+        >>>     output = separator(feature)
+        >>>     estimated_sources = feature_decoder(output)
+        >>>     score = si_snr_pit(estimated_sources, clean_sources) # for demonstration
+        >>>     print(f"Si-SNR score is : {score}.)
+        >>>     break
+        >>> 16.24
+        >>>
+    """
+
+    class FeatureEncoder(_FeatureEncoder):
+        pass
+
+    class FeatureDecoder(_FeatureDecoder):
+        pass
+
+    class Separator(_Separator):
+        pass
+
+    _feature_encoder: torch.nn.Module
+    _feature_decoder: torch.nn.Module
+    _model_path: str
+    _separator_factory_func: Callable[[], torch.nn.Module]
+    _sample_rate: int
+
+    @property
+    def sample_rate(self) -> int:
+        """Sample rate (in cycles per second) of input waveforms.
+        :type: int
+        """
+        return self._sample_rate
+
+    def get_feature_encoder(self) -> FeatureEncoder:
+        """Constructs feature encoder.
+        Returns:
+            FeatureEncoder
+        """
+        return _FeatureEncoder(self._feature_encoder)
+
+    def get_feature_decoder(self) -> FeatureDecoder:
+        """Constructs feature decoder.
+        Returns:
+            FeatureDecoder
+        """
+        return _FeatureDecoder(self._feature_decoder)
+
+    def get_separator(self) -> Separator:
+        model = self._separator_factory_func()
+        path = torchaudio.utils.download_asset(self._model_path)
+        state_dict = torch.load(path)
+        model.load_state_dict(state_dict)
+        model.eval()
+        return _Separator(model)
+
+
+class View(torch.nn.Module):
+    """View module to reshape the input waveforms for ConvTasNet.
+    The final shape of the input Tensor is `(batch, 1, time)`.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input: torch.Tensor):
+        if input.ndim == 1:
+            input = input.reshape(1, 1, -1)
+        elif input.ndim == 2:
+            input = input.unsqueeze(dim=1)
+        else:
+            input = input
+        return input
+
+
+CONVTASNET_BASE_LIBRI2MIX = SourceSeparationBundle(
+    _model_path="models/conv_tasnet_base_libri2mix.pt",
+    _feature_encoder=View(),
+    _feature_decoder=View(),
+    _separator_factory_func=partial(conv_tasnet_base, num_sources=2),
+    _sample_rate=8000,
+)
+CONVTASNET_BASE_LIBRI2MIX.__doc__ = """Pre-trained ConvTasNet pipeline for source separation.
+    The underlying model is constructed by :py:func:`torchaudio.prototyoe.models.conv_tasnet_base`
+    and utilizes weights trained on Libri2Mix using training script ``lightning_train.py``
+    `here <https://github.com/pytorch/audio/tree/main/examples/source_separation/>`__ with default arguments.
+    Please refer to :py:class:`SourceSeparationBundle` for usage instructions.
+    """

--- a/torchaudio/prototype/pipelines/source_separation_pipeline.py
+++ b/torchaudio/prototype/pipelines/source_separation_pipeline.py
@@ -20,7 +20,7 @@ class SourceSeparationBundle:
         >>> import torch
         >>>
         >>> # Build the separation model.
-        >>> separator = CONVTASNET_BASE_LIBRI2MIX.get_separator()
+        >>> model = CONVTASNET_BASE_LIBRI2MIX.get_model()
         >>> 100%|███████████████████████████████|19.1M/19.1M [00:04<00:00, 4.93MB/s]
         >>>
         >>> # Instantiate the test set of Libri2Mix dataset.
@@ -31,7 +31,7 @@ class SourceSeparationBundle:
         >>>     sample_rate, mixture, clean_sources = data
         >>>     # Make sure the shape of input suits the model requirement.
         >>>     mixture = mixture.reshape(1, 1, -1)
-        >>>     estimated_sources = separator(mixture)
+        >>>     estimated_sources = model(mixture)
         >>>     score = si_snr_pit(estimated_sources, clean_sources) # for demonstration
         >>>     print(f"Si-SNR score is : {score}.)
         >>>     break
@@ -40,7 +40,7 @@ class SourceSeparationBundle:
     """
 
     _model_path: str
-    _separator_factory_func: Callable[[], torch.nn.Module]
+    _model_factory_func: Callable[[], torch.nn.Module]
     _sample_rate: int
 
     @property
@@ -50,8 +50,8 @@ class SourceSeparationBundle:
         """
         return self._sample_rate
 
-    def get_separator(self) -> torch.nn.Module:
-        model = self._separator_factory_func()
+    def get_model(self) -> torch.nn.Module:
+        model = self._model_factory_func()
         path = torchaudio.utils.download_asset(self._model_path)
         state_dict = torch.load(path)
         model.load_state_dict(state_dict)
@@ -61,7 +61,7 @@ class SourceSeparationBundle:
 
 CONVTASNET_BASE_LIBRI2MIX = SourceSeparationBundle(
     _model_path="models/conv_tasnet_base_libri2mix.pt",
-    _separator_factory_func=partial(conv_tasnet_base, num_sources=2),
+    _model_factory_func=partial(conv_tasnet_base, num_sources=2),
     _sample_rate=8000,
 )
 CONVTASNET_BASE_LIBRI2MIX.__doc__ = """Pre-trained ConvTasNet pipeline for source separation.


### PR DESCRIPTION
- Add SourceSeparationBundle class for source separation pipeline
- Add `CONVTASNET_BASE_LIBRI2MIX` that is trained on Libri2Mix dataset.
- Add integration test with example mixture audio and expected scale-invariant signal-to-distortion ratio (Si-SDR) score. The test computes the Si-SDR score with permutation-invariant training (PIT) criterion for all permutations of sources and use the highest value as the final output. The test verifies if the score is equal to or larger than the expected value.