### PR TITLE
Modifying Pitchshift for faster resampling

### DIFF
--- a/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
@@ -139,7 +139,10 @@ class Transforms(TestBaseMixin):
         sample_rate = 8000
         n_steps = 4
         waveform = common_utils.get_whitenoise(sample_rate=sample_rate)
-        self._assert_consistency(T.PitchShift(sample_rate=sample_rate, n_steps=n_steps), waveform)
+        pitch_shift = T.PitchShift(sample_rate=sample_rate, n_steps=n_steps)
+        # dry-run for initializing parameters
+        pitch_shift(waveform)
+        self._assert_consistency(pitch_shift, waveform)
 
     def test_PSD(self):
         tensor = common_utils.get_whitenoise(sample_rate=8000, n_channels=4)

--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -6,10 +6,15 @@ from typing import Callable, Optional
 
 import torch
 from torch import Tensor
+from torch.nn.modules.lazy import LazyModuleMixin
+from torch.nn.parameter import UninitializedParameter
+
 from torchaudio import functional as F
 from torchaudio.functional.functional import (
     _apply_sinc_resample_kernel,
     _get_sinc_resample_kernel,
+    _stretch_waveform,
+    _fix_waveform_shape,
 )
 
 __all__ = []
@@ -1511,7 +1516,7 @@ class SpectralCentroid(torch.nn.Module):
         )
 
 
-class PitchShift(torch.nn.Module):
+class PitchShift(LazyModuleMixin, torch.nn.Module):
     r"""Shift the pitch of a waveform by ``n_steps`` steps.
 
     .. devices:: CPU CUDA
@@ -1537,6 +1542,9 @@ class PitchShift(torch.nn.Module):
     """
     __constants__ = ["sample_rate", "n_steps", "bins_per_octave", "n_fft", "win_length", "hop_length"]
 
+    kernel: UninitializedParameter
+    width: int
+
     def __init__(
         self,
         sample_rate: int,
@@ -1548,7 +1556,7 @@ class PitchShift(torch.nn.Module):
         window_fn: Callable[..., Tensor] = torch.hann_window,
         wkwargs: Optional[dict] = None,
     ) -> None:
-        super(PitchShift, self).__init__()
+        super().__init__()
         self.n_steps = n_steps
         self.bins_per_octave = bins_per_octave
         self.sample_rate = sample_rate
@@ -1557,6 +1565,27 @@ class PitchShift(torch.nn.Module):
         self.hop_length = hop_length if hop_length is not None else self.win_length // 4
         window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
         self.register_buffer("window", window)
+        rate = 2.0 ** (-float(n_steps) / bins_per_octave)
+        self.orig_freq = int(sample_rate / rate)
+        self.gcd = math.gcd(int(self.orig_freq), int(sample_rate))
+
+        if self.orig_freq != sample_rate:
+            self.width = -1
+            self.kernel = UninitializedParameter(device=None, dtype=None)
+
+    def initialize_parameters(self, input):
+        if self.has_uninitialized_params():
+            if self.orig_freq != self.sample_rate:
+                with torch.no_grad():
+                    kernel, self.width = _get_sinc_resample_kernel(
+                        self.orig_freq,
+                        self.sample_rate,
+                        self.gcd,
+                        dtype=input.dtype,
+                        device=input.device,
+                    )
+                    self.kernel.materialize(kernel.shape)
+                    self.kernel.copy_(kernel)
 
     def forward(self, waveform: Tensor) -> Tensor:
         r"""
@@ -1566,16 +1595,33 @@ class PitchShift(torch.nn.Module):
         Returns:
             Tensor: The pitch-shifted audio of shape `(..., time)`.
         """
+        shape = waveform.size()
 
-        return F.pitch_shift(
+        waveform_stretch = _stretch_waveform(
             waveform,
-            self.sample_rate,
             self.n_steps,
             self.bins_per_octave,
             self.n_fft,
             self.win_length,
             self.hop_length,
             self.window,
+        )
+
+        if self.orig_freq != self.sample_rate:
+            waveform_shift = _apply_sinc_resample_kernel(
+                waveform_stretch,
+                self.orig_freq,
+                self.sample_rate,
+                self.gcd,
+                self.kernel,
+                self.width,
+            )
+        else:
+            waveform_shift = waveform_stretch
+
+        return _fix_waveform_shape(
+            waveform_shift,
+            shape,
         )
 
 


### PR DESCRIPTION
Split existing Pitchshift into multiple helper functions in order to cache kernel and speed up overall process addressing #2359. 
Existing unit tests pass. 

edit: functional and transforms unit test pass. Adopted lazy initialization to avoid BC-breaking.