### PR TITLE
Fix download links of RNNT pipelines in prototype

### DIFF
--- a/test/integration_tests/rnnt_pipeline_test.py
+++ b/test/integration_tests/rnnt_pipeline_test.py
@@ -1,11 +1,16 @@
 import pytest
 import torchaudio
 from torchaudio.pipelines import EMFORMER_RNNT_BASE_LIBRISPEECH
+from torchaudio.prototype.pipelines import EMFORMER_RNNT_BASE_MUSTC, EMFORMER_RNNT_BASE_TEDLIUM3
 
 
 @pytest.mark.parametrize(
     "bundle,lang,expected",
-    [(EMFORMER_RNNT_BASE_LIBRISPEECH, "en", "i have that curiosity beside me at this moment")],
+    [
+        (EMFORMER_RNNT_BASE_LIBRISPEECH, "en", "i have that curiosity beside me at this moment"),
+        (EMFORMER_RNNT_BASE_MUSTC, "en", "I had that curiosity beside me at this moment."),
+        (EMFORMER_RNNT_BASE_TEDLIUM3, "en", "i had that curiosity beside me at this moment"),
+    ],
 )
 def test_rnnt(bundle, sample_speech, expected):
     feature_extractor = bundle.get_feature_extractor()

--- a/torchaudio/prototype/pipelines/rnnt_pipeline.py
+++ b/torchaudio/prototype/pipelines/rnnt_pipeline.py
@@ -5,10 +5,10 @@ from torchaudio.pipelines import RNNTBundle
 
 
 EMFORMER_RNNT_BASE_MUSTC = RNNTBundle(
-    _rnnt_path="emformer_rnnt_base_mustc.pt",
+    _rnnt_path="models/emformer_rnnt_base_mustc.pt",
     _rnnt_factory_func=partial(emformer_rnnt_base, num_symbols=501),
-    _global_stats_path="global_stats_rnnt_mustc.json",
-    _sp_model_path="spm_bpe_500_mustc.model",
+    _global_stats_path="pipeline-assets/global_stats_rnnt_mustc.json",
+    _sp_model_path="pipeline-assets/spm_bpe_500_mustc.model",
     _right_padding=4,
     _blank=500,
     _sample_rate=16000,
@@ -27,10 +27,10 @@ EMFORMER_RNNT_BASE_MUSTC.__doc__ = """Pre-trained Emformer-RNNT-based ASR pipeli
 
 
 EMFORMER_RNNT_BASE_TEDLIUM3 = RNNTBundle(
-    _rnnt_path="emformer_rnnt_base_tedlium3.pt",
+    _rnnt_path="models/emformer_rnnt_base_tedlium3.pt",
     _rnnt_factory_func=partial(emformer_rnnt_base, num_symbols=501),
-    _global_stats_path="global_stats_rnnt_tedlium3.json",
-    _sp_model_path="spm_bpe_500_tedlium3.model",
+    _global_stats_path="pipeline-assets/global_stats_rnnt_tedlium3.json",
+    _sp_model_path="pipeline-assets/spm_bpe_500_tedlium3.model",
     _right_padding=4,
     _blank=500,
     _sample_rate=16000,


### PR DESCRIPTION
In #2283, torchaudio's downloading function is updated to reduce code duplication. The links in `EMFORMER_RNNT_BASE_LIBRISPEECH` are updated, but the ones in prototype pipelines are not. This PR addresses it by updating the download links of `EMFORMER_RNNT_BASE_MUSTC` and `EMFORMER_RNNT_BASE_TEDLIUM3` in prototype. Corresponding integration tests are added as well.