### PR TITLE
Set the default ffmpeg log level to FATAL

### DIFF
--- a/torchaudio/_extension.py
+++ b/torchaudio/_extension.py
@@ -74,6 +74,8 @@ def _init_ffmpeg():
     import torchaudio._torchaudio_ffmpeg  # noqa
 
     torch.ops.torchaudio.ffmpeg_init()
+    if torch.ops.torchaudio.ffmpeg_get_log_level() > 8:
+        torch.ops.torchaudio.ffmpeg_set_log_level(8)
 
     _FFMPEG_INITIALIZED = True
 


### PR DESCRIPTION
With the default log-level, completely sane operation like converting
YUV to RGB issues bunch of warnings like

`[swscaler @ 0x128aa8000] No accelerated colorspace conversion found from yuv420p to rgb24.`

This commit sets the log level to FATAL.