### PR TITLE
[DOC/CI] Store doc as tar archive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -827,6 +827,9 @@ jobs:
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
             cd docs
             make 'SPHINXOPTS=-W' html
+            cd build
+            tar -czf artifact.tar.gz html
+            mv artifact.tar.gz html
           environment:
             BUILD_GALLERY: 1
           no_output_timeout: 30m

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -827,6 +827,9 @@ jobs:
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
             cd docs
             make 'SPHINXOPTS=-W' html
+            cd build
+            tar -czf artifact.tar.gz html
+            mv artifact.tar.gz html
           environment:
             BUILD_GALLERY: 1
           no_output_timeout: 30m


### PR DESCRIPTION
At the time of release, we need to download doc built by CI.
CircleCI does not have feature to download multiple files.

This commit add the archive of built documentations as
CI artifact so that the whole documentation can be downloaded
at once.

Resolves #2340 