### PR TITLE
[release 0.12] Remove alpha from version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def _run_cmd(cmd):
 
 
 def _get_version(sha):
-    version = "0.12.0a0"
+    version = "0.12.0"
     if os.getenv("BUILD_VERSION"):
         version = os.getenv("BUILD_VERSION")
     elif sha is not None:


### PR DESCRIPTION
As in #1901: "fix the version number in `setup.py` so that if users check out the release tag and build torchaudio manually, the version is correct".