### PR TITLE
[release 0.12] Set release version and base PyTorch version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,12 +32,8 @@ commands:
       - run:
           name: adding UPLOAD_CHANNEL to BASH_ENV
           command: |
-            our_upload_channel=nightly
-            # On tags upload to test instead
-            if [[ -n "${CIRCLE_TAG}" ]] || [[ ${CIRCLE_BRANCH} =~ release/* ]]; then
-              our_upload_channel=test
-            fi
-            echo "export UPLOAD_CHANNEL=${our_upload_channel}" >> ${BASH_ENV}
+            # Hardcoded for release branch
+            echo "export UPLOAD_CHANNEL=test" >> ${BASH_ENV}
   load_conda_channel_flags:
     description: "Determines whether we need extra conda channels"
     steps:
@@ -60,11 +56,11 @@ binary_common: &binary_common
     build_version:
       description: "version number of release binary; by default, build a nightly"
       type: string
-      default: ""
+      default: "0.12.0"
     pytorch_version:
       description: "PyTorch version to build against; by default, use a nightly"
       type: string
-      default: ""
+      default: "1.12.0"
     # Don't edit these
     python_version:
       description: "Python version to build against (e.g., 3.8)"
@@ -247,6 +243,7 @@ jobs:
     resource_class: 2xlarge+
     steps:
       - checkout
+      - designate_upload_channel
       - attach_workspace:
           at: third_party
       - run:
@@ -291,6 +288,7 @@ jobs:
       xcode: "12.0"
     steps:
       - checkout
+      - designate_upload_channel
       - load_conda_channel_flags
       - attach_workspace:
           at: third_party
@@ -347,6 +345,7 @@ jobs:
       name: windows-cpu
     steps:
       - checkout
+      - designate_upload_channel
       - load_conda_channel_flags
       - windows_install_cuda
       - attach_workspace:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -32,12 +32,8 @@ commands:
       - run:
           name: adding UPLOAD_CHANNEL to BASH_ENV
           command: |
-            our_upload_channel=nightly
-            # On tags upload to test instead
-            if [[ -n "${CIRCLE_TAG}" ]] || [[ ${CIRCLE_BRANCH} =~ release/* ]]; then
-              our_upload_channel=test
-            fi
-            echo "export UPLOAD_CHANNEL=${our_upload_channel}" >> ${BASH_ENV}
+            # Hardcoded for release branch
+            echo "export UPLOAD_CHANNEL=test" >> ${BASH_ENV}
   load_conda_channel_flags:
     description: "Determines whether we need extra conda channels"
     steps:
@@ -60,11 +56,11 @@ binary_common: &binary_common
     build_version:
       description: "version number of release binary; by default, build a nightly"
       type: string
-      default: ""
+      default: "0.12.0"
     pytorch_version:
       description: "PyTorch version to build against; by default, use a nightly"
       type: string
-      default: ""
+      default: "1.12.0"
     # Don't edit these
     python_version:
       description: "Python version to build against (e.g., 3.8)"
@@ -247,6 +243,7 @@ jobs:
     resource_class: 2xlarge+
     steps:
       - checkout
+      - designate_upload_channel
       - attach_workspace:
           at: third_party
       - run:
@@ -291,6 +288,7 @@ jobs:
       xcode: "12.0"
     steps:
       - checkout
+      - designate_upload_channel
       - load_conda_channel_flags
       - attach_workspace:
           at: third_party
@@ -347,6 +345,7 @@ jobs:
       name: windows-cpu
     steps:
       - checkout
+      - designate_upload_channel
       - load_conda_channel_flags
       - windows_install_cuda
       - attach_workspace:


### PR DESCRIPTION
Sets release version to 0.12 and base PyTorch version to 1.12 in CircleCI config files in preparation for release.