### PR TITLE
Remove CTC decoder prototype message

### DIFF
--- a/examples/tutorials/asr_inference_with_ctc_decoder_tutorial.py
+++ b/examples/tutorials/asr_inference_with_ctc_decoder_tutorial.py
@@ -12,22 +12,6 @@ using CTC loss.
 """
 
 ######################################################################
-#
-# .. note::
-#
-#    This tutorial requires torchaudio prototype features.
-#
-#    torchaudio prototype features are available on nightly builds.
-#    Please refer to https://pytorch.org/get-started/locally/
-#    for instructions.
-#
-#    The interfaces of prototype features are unstable and subject to
-#    change. Please refer to `the nightly build documentation
-#    <https://pytorch.org/audio/main/>`__ for the up-to-date
-#    API references.
-#
-
-######################################################################
 # Overview
 # --------
 #


### PR DESCRIPTION
ctc decoder has been moved to beta, remove prototype message from tutorial

(this is done on the release branch in #2457)