### PR TITLE
[release 0.12] Disable lint CI signal on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
           command: pre-commit install-hooks
       - run:
           name: Lint Python code and config files
-          command: pre-commit run --all-files
+          command: pre-commit run --all-files | true
       - run:
           name: Required lint modifications
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
           command: pre-commit install-hooks
       - run:
           name: Lint Python code and config files
-          command: pre-commit run --all-files | true
+          command: pre-commit run --all-files || true
       - run:
           name: Required lint modifications
           when: always

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -114,7 +114,7 @@ jobs:
           command: pre-commit install-hooks
       - run:
           name: Lint Python code and config files
-          command: pre-commit run --all-files
+          command: pre-commit run --all-files | true
       - run:
           name: Required lint modifications
           when: always

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -114,7 +114,7 @@ jobs:
           command: pre-commit install-hooks
       - run:
           name: Lint Python code and config files
-          command: pre-commit run --all-files | true
+          command: pre-commit run --all-files || true
       - run:
           name: Required lint modifications
           when: always


### PR DESCRIPTION
Lint style has diverged since fb-internal lint engine has been changed.
It's no longer relevant on release branch, so disabling it.