### PR TITLE
Add special handling to filelike object mp3

### DIFF
--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -84,6 +84,15 @@ def info(
     """
     if not torch.jit.is_scripting():
         if hasattr(filepath, "read"):
+            # Special case for Backward compatibility
+            # v0.11 -> v0.12, mp3 handling is moved to FFmpeg.
+            # file-like objects are not necessarily fallback-able
+            # when they are not seekable.
+            # The previous libsox-based implementation required `format="mp3"`
+            # because internally libsox does not auto-detect the format.
+            # For the special BC for mp3, we handle mp3 differently.
+            if format == "mp3":
+                return _fallback_info_fileobj(filepath, format)
             sinfo = torchaudio._torchaudio.get_info_fileobj(filepath, format)
             if sinfo is not None:
                 return AudioMetaData(*sinfo)
@@ -194,6 +203,15 @@ def load(
     """
     if not torch.jit.is_scripting():
         if hasattr(filepath, "read"):
+            # Special case for Backward compatibility
+            # v0.11 -> v0.12, mp3 handling is moved to FFmpeg.
+            # file-like objects are not necessarily fallback-able
+            # when they are not seekable.
+            # The previous libsox-based implementation required `format="mp3"`
+            # because internally libsox does not auto-detect the format.
+            # For the special BC for mp3, we handle mp3 differently.
+            if format == "mp3":
+                return _fallback_load_fileobj(filepath, frame_offset, num_frames, normalize, channels_first, format)
             ret = torchaudio._torchaudio.load_audio_fileobj(
                 filepath, frame_offset, num_frames, normalize, channels_first, format
             )


### PR DESCRIPTION
Loading and querying file-like object is not possible to use the fallback
mechanism introduced in #2419 because file-like objects are not seekable.

This commit add special case handling to mp3.

For filelike object mp3 input, it was required to pass `format="mp3"`
because libsox did not auto detect the format.

With the transition of mp3 handling from libsox to ffmpeg, the logic
is to let the ffmpeg handle it without waiting for libsox to fail,
if the `format="mp3"`

Note: This is back port of #2477.