### PR TITLE
Include private module files to doc source

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,7 @@ include:
     - _sources
     - _tts
     - _wav2vec2
+    - _*.html
 exclude:
     - node_modules
     - README.md


### PR DESCRIPTION
Modules that start with underscore are not shown in source.

Before:
- https://pytorch.org/audio/0.12.0/_modules/torchaudio/io/_stream_reader.html#StreamReader

After:
- https://mthrok.github.io/audio/0.12.0/_modules/torchaudio/io/_stream_reader.html#StreamReader
