### PR TITLE
Improve speech enhancement tutorial

### DIFF
--- a/.circleci/build_docs/install_wheels.sh
+++ b/.circleci/build_docs/install_wheels.sh
@@ -11,5 +11,6 @@ else
         -f https://download.pytorch.org/whl/torch_stable.html \
         -f "https://download.pytorch.org/whl/${UPLOAD_CHANNEL}/torch_${UPLOAD_CHANNEL}.html"
 fi
+conda install -c anaconda gxx_linux-64
 pip install --progress-bar off --no-deps ~/workspace/torchaudio*
 pip install --progress-bar off -r docs/requirements.txt -r docs/requirements-tutorials.txt

--- a/.circleci/build_docs/install_wheels.sh
+++ b/.circleci/build_docs/install_wheels.sh
@@ -11,6 +11,5 @@ else
         -f https://download.pytorch.org/whl/torch_stable.html \
         -f "https://download.pytorch.org/whl/${UPLOAD_CHANNEL}/torch_${UPLOAD_CHANNEL}.html"
 fi
-conda install -c anaconda gxx_linux-64
 pip install --progress-bar off --no-deps ~/workspace/torchaudio*
 pip install --progress-bar off -r docs/requirements.txt -r docs/requirements-tutorials.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -833,6 +833,7 @@ jobs:
               conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4} -c conda-forge
             fi
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
+            # gxx_linux-64 is for installing pesq library that depends on cython
             conda install -y pandoc 'ffmpeg<5' gxx_linux-64
             apt update -qq && apt-get -qq install -y git make
             pip install --progress-bar off -r docs/requirements.txt -r docs/requirements-tutorials.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -836,7 +836,6 @@ jobs:
             conda install -y pandoc 'ffmpeg<5'
             apt update -qq && apt-get -qq install -y git make
             conda install -y gxx_linux-64
-            conda install -y cmake
             pip install --progress-bar off -r docs/requirements.txt -r docs/requirements-tutorials.txt
       - run:
           name: Build docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -835,8 +835,8 @@ jobs:
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
             conda install -y pandoc 'ffmpeg<5'
             apt update -qq && apt-get -qq install -y git make
-            conda install gxx_linux-64
-            conda install cmake
+            conda install -y gxx_linux-64
+            conda install -y cmake
             pip install --progress-bar off -r docs/requirements.txt -r docs/requirements-tutorials.txt
       - run:
           name: Build docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -835,6 +835,8 @@ jobs:
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
             conda install -y pandoc 'ffmpeg<5'
             apt update -qq && apt-get -qq install -y git make
+            conda install gxx_linux-64
+            conda install cmake
             pip install --progress-bar off -r docs/requirements.txt -r docs/requirements-tutorials.txt
       - run:
           name: Build docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -833,9 +833,8 @@ jobs:
               conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4} -c conda-forge
             fi
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
-            conda install -y pandoc 'ffmpeg<5'
+            conda install -y pandoc 'ffmpeg<5' gxx_linux-64
             apt update -qq && apt-get -qq install -y git make
-            conda install -y gxx_linux-64
             pip install --progress-bar off -r docs/requirements.txt -r docs/requirements-tutorials.txt
       - run:
           name: Build docs

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -833,6 +833,7 @@ jobs:
               conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4} -c conda-forge
             fi
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
+            # gxx_linux-64 is for installing pesq library that depends on cython
             conda install -y pandoc 'ffmpeg<5' gxx_linux-64
             apt update -qq && apt-get -qq install -y git make
             pip install --progress-bar off -r docs/requirements.txt -r docs/requirements-tutorials.txt

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -836,7 +836,6 @@ jobs:
             conda install -y pandoc 'ffmpeg<5'
             apt update -qq && apt-get -qq install -y git make
             conda install -y gxx_linux-64
-            conda install -y cmake
             pip install --progress-bar off -r docs/requirements.txt -r docs/requirements-tutorials.txt
       - run:
           name: Build docs

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -835,8 +835,8 @@ jobs:
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
             conda install -y pandoc 'ffmpeg<5'
             apt update -qq && apt-get -qq install -y git make
-            conda install gxx_linux-64
-            conda install cmake
+            conda install -y gxx_linux-64
+            conda install -y cmake
             pip install --progress-bar off -r docs/requirements.txt -r docs/requirements-tutorials.txt
       - run:
           name: Build docs

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -835,6 +835,8 @@ jobs:
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
             conda install -y pandoc 'ffmpeg<5'
             apt update -qq && apt-get -qq install -y git make
+            conda install gxx_linux-64
+            conda install cmake
             pip install --progress-bar off -r docs/requirements.txt -r docs/requirements-tutorials.txt
       - run:
           name: Build docs

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -833,9 +833,8 @@ jobs:
               conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4} -c conda-forge
             fi
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
-            conda install -y pandoc 'ffmpeg<5'
+            conda install -y pandoc 'ffmpeg<5' gxx_linux-64
             apt update -qq && apt-get -qq install -y git make
-            conda install -y gxx_linux-64
             pip install --progress-bar off -r docs/requirements.txt -r docs/requirements-tutorials.txt
       - run:
           name: Build docs

--- a/docs/requirements-tutorials.txt
+++ b/docs/requirements-tutorials.txt
@@ -1,6 +1,7 @@
 IPython
 deep-phonemizer
 boto3
+cpython
 pandas
 librosa
 sentencepiece

--- a/docs/requirements-tutorials.txt
+++ b/docs/requirements-tutorials.txt
@@ -7,3 +7,5 @@ sentencepiece
 nbsphinx
 pandoc
 mir_eval
+pesq
+pystoi

--- a/docs/requirements-tutorials.txt
+++ b/docs/requirements-tutorials.txt
@@ -1,6 +1,7 @@
 IPython
 deep-phonemizer
 boto3
+cmake
 cpython
 pandas
 librosa

--- a/docs/requirements-tutorials.txt
+++ b/docs/requirements-tutorials.txt
@@ -1,8 +1,7 @@
 IPython
 deep-phonemizer
 boto3
-cmake
-cpython
+cython
 pandas
 librosa
 sentencepiece

--- a/examples/tutorials/mvdr_tutorial.py
+++ b/examples/tutorials/mvdr_tutorial.py
@@ -47,7 +47,7 @@ print(torchaudio.__version__)
 # ~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # First, we install and import the necessary packages.
-# 
+#
 # ``mir_eval``, ``pesq``, and ``pystoi`` packages are required for
 # evaluating the speech enhancement performance.
 #

--- a/examples/tutorials/mvdr_tutorial.py
+++ b/examples/tutorials/mvdr_tutorial.py
@@ -29,10 +29,6 @@ Speech Enhancement with MVDR Beamforming
 #    relative transfer function (RTF) matrix of the reference microphone.
 #
 
-from pesq import pesq
-from pystoi import stoi
-
-import mir_eval
 import torch
 import torchaudio
 import torchaudio.functional as F
@@ -45,7 +41,33 @@ print(torchaudio.__version__)
 # 2. Preparation
 # --------------
 #
-# First, we import the necessary packages and retrieve the data.
+
+######################################################################
+# 2.1. Import the packages
+# ~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# First, we install and import the necessary packages.
+# 
+# ``mir_eval``, ``pesq``, and ``pystoi`` packages are required for
+# evaluating the speech enhancement performance.
+#
+
+# When running this example in notebook, install the following packages.
+# !pip3 install mir_eval
+# !pip3 install pesq
+# !pip3 install pystoi
+
+from pesq import pesq
+from pystoi import stoi
+import mir_eval
+
+import matplotlib.pyplot as plt
+from IPython.display import Audio
+from torchaudio.utils import download_asset
+
+######################################################################
+# 2.2. Download audio data
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # The multi-channel audio example is selected from
 # `ConferencingSpeech <https://github.com/ConferencingSpeech/ConferencingSpeech2021>`__
@@ -65,17 +87,13 @@ print(torchaudio.__version__)
 #    International — CC BY 4.0)
 #
 
-import matplotlib.pyplot as plt
-from IPython.display import Audio
-from torchaudio.utils import download_asset
-
 SAMPLE_RATE = 16000
 SAMPLE_CLEAN = download_asset("tutorial-assets/mvdr/clean_speech.wav")
 SAMPLE_NOISE = download_asset("tutorial-assets/mvdr/noise.wav")
 
 
 ######################################################################
-# 2.1. Helper functions
+# 2.3. Helper functions
 # ~~~~~~~~~~~~~~~~~~~~~
 #
 
@@ -137,8 +155,8 @@ def evaluate(estimate, reference):
     ) = mir_eval.separation.bss_eval_sources(reference.numpy(), estimate.numpy(), False)
     pesq_mix = pesq(SAMPLE_RATE, estimate[0].numpy(), reference[0].numpy(), "wb")
     stoi_mix = stoi(reference[0].numpy(), estimate[0].numpy(), SAMPLE_RATE, extended=False)
-    print(f"Si-SNR score: {si_snr_score}")
     print(f"SDR score: {sdr[0]}")
+    print(f"Si-SNR score: {si_snr_score}")
     print(f"PESQ score: {pesq_mix}")
     print(f"STOI score: {stoi_mix}")
 
@@ -195,6 +213,14 @@ stft_noise = stft(waveform_noise)
 # 3.2.1. Visualize mixture speech
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
+# We evaluate the quality of the mixture speech or the enhanced speech
+# using the following three metrics:
+#
+# -  signal-to-distortion ratio (SDR)
+# -  scale-invariant signal-to-noise ratio (Si-SNR, or Si-SDR in some papers)
+# -  Perceptual Evaluation of Speech Quality (PESQ)
+# We also evaluate the intelligibility of the speech with the Short-Time Objective Intelligibility
+# (STOI) metric.
 
 plot_spectrogram(stft_mix[0], "Spectrogram of Mixture Speech (dB)")
 evaluate(waveform_mix[0:1], waveform_clean[0:1])


### PR DESCRIPTION
- The "speech + noise" mixture still has a high SNR, which can't show the effectiveness of MVDR beamforming. To make the task more challenging, amplify the noise waveform to reduce the SNR of mixture speech.
- Show the Si-SNR score of mixture speech when visualizing the mixture spectrogram.
- FIx the figure in `rtf_power` subsection.
    - The description of enhanced spectrogram by `rtf_power` is wrong. Correct it to `rtf_power`.
- Print PESQ, STOI, and SDR metric scores.