### PR TITLE
Update CircleCI Xcode image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
   build_ffmpeg_macos:
     <<: *binary_common
     macos:
-      xcode: "12.0"
+      xcode: "12.5"
     steps:
       - checkout
       - generate_cache_key
@@ -288,7 +288,7 @@ jobs:
   binary_macos_wheel:
     <<: *binary_common
     macos:
-      xcode: "12.0"
+      xcode: "12.5"
     steps:
       - checkout
       - load_conda_channel_flags
@@ -317,7 +317,7 @@ jobs:
   binary_macos_conda:
     <<: *binary_common
     macos:
-      xcode: "12.0"
+      xcode: "12.5"
     steps:
       - checkout
       - load_conda_channel_flags
@@ -761,7 +761,7 @@ jobs:
   unittest_macos_cpu:
     <<: *binary_common
     macos:
-      xcode: "12.0"
+      xcode: "12.5"
     resource_class: large
     steps:
       - checkout

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -184,7 +184,7 @@ jobs:
   build_ffmpeg_macos:
     <<: *binary_common
     macos:
-      xcode: "12.0"
+      xcode: "12.5"
     steps:
       - checkout
       - generate_cache_key
@@ -288,7 +288,7 @@ jobs:
   binary_macos_wheel:
     <<: *binary_common
     macos:
-      xcode: "12.0"
+      xcode: "12.5"
     steps:
       - checkout
       - load_conda_channel_flags
@@ -317,7 +317,7 @@ jobs:
   binary_macos_conda:
     <<: *binary_common
     macos:
-      xcode: "12.0"
+      xcode: "12.5"
     steps:
       - checkout
       - load_conda_channel_flags
@@ -761,7 +761,7 @@ jobs:
   unittest_macos_cpu:
     <<: *binary_common
     macos:
-      xcode: "12.0"
+      xcode: "12.5"
     resource_class: large
     steps:
       - checkout


### PR DESCRIPTION
CircleCI is removing Xcode 12.4.0 image on August, and there was a planned
burnout on July 6th. [[detail](https://discuss.circleci.com/t/xcode-image-deprecation/44294?mkt_tok=NDg1LVpNSC02MjYAAAGFbbxbX7nSPCzN0MCKN078pw0VLJ-TMdICr8_gouRNYBM8C55RL8NDKLXA_9CQGPqnhJE5lsSFdetLRF-nH7iBLzoPGBfYpf2vuJ-XkW_C4__4)]

https://app.circleci.com/pipelines/github/pytorch/audio/11566/workflows/da167296-a84f-4dfe-b1b9-60d67e7a3d1c/jobs/771638

This commit updates Xcode image to 12.5