### PR TITLE
Fix docstring

### DIFF
--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -2134,6 +2134,7 @@ def apply_beamforming(beamform_weights: Tensor, specgram: Tensor) -> Tensor:
 
     .. math::
         \hat{\textbf{S}}(f) = \textbf{w}_{\text{bf}}(f)^{\mathsf{H}} \textbf{Y}(f)
+
     where :math:`\textbf{w}_{\text{bf}}(f)` is the beamforming weight for the :math:`f`-th frequency bin,
     :math:`\textbf{Y}` is the multi-channel spectrum for the :math:`f`-th frequency bin.
 


### PR DESCRIPTION
The docstring of `apply_beamforming` has warning when building the documentation page. Fix it in this PR.