### PR TITLE
Recent CircleCI migration #2529

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,7 @@ binary_common: &binary_common
     BUILD_VERSION: << parameters.build_version >>
     PYTORCH_VERSION: << parameters.pytorch_version >>
     CU_VERSION: << parameters.cuda_version >>
+    MACOSX_DEPLOYMENT_TARGET: 10.9
 
 smoke_test_common: &smoke_test_common
   <<: *binary_common

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -86,6 +86,7 @@ binary_common: &binary_common
     BUILD_VERSION: << parameters.build_version >>
     PYTORCH_VERSION: << parameters.pytorch_version >>
     CU_VERSION: << parameters.cuda_version >>
+    MACOSX_DEPLOYMENT_TARGET: 10.9
 
 smoke_test_common: &smoke_test_common
   <<: *binary_common

--- a/packaging/torchaudio/meta.yaml
+++ b/packaging/torchaudio/meta.yaml
@@ -49,6 +49,7 @@ build:
     - USE_FFMPEG
     - USE_OPENMP
     - FFMPEG_ROOT
+    - MACOSX_DEPLOYMENT_TARGET
 
 test:
   imports:


### PR DESCRIPTION
silently bumped the minimum supported macOS version to 11.

PyTorch still supports 10.9 and the ecosystem still uses 10.9.
Issue: #2536

This commit sets MACOSX_DEPLOYMENT_TARGET=10.9, so that binary
distribution are compatible on macOS=10.9.