### PR TITLE
Add Union normalization parameter on spectrogram and inverse spectrogram

### DIFF
--- a/test/torchaudio_unittest/functional/functional_impl.py
+++ b/test/torchaudio_unittest/functional/functional_impl.py
@@ -253,7 +253,7 @@ class Functional(TestBaseMixin):
         ]
     )
     def test_spectrogram_normalization_hann_window(self, nfft):
-        """This test assumes that currently, torch.stft and the existing math behind spectrogram has been correct.
+        """This test assumes that currently, torch.stft and the existing math behind spectrogram are correct.
         The test is checking that in relation to one another, the normalization factors correctly align based on
         mathematical prediction. Using spec_false as a base, which has no normalization factors, we check to see that
         turning normalized as ``True`` or ``"window"`` will have a normalization factor of the sum of squares of hann

--- a/test/torchaudio_unittest/functional/functional_impl.py
+++ b/test/torchaudio_unittest/functional/functional_impl.py
@@ -262,6 +262,7 @@ class Functional(TestBaseMixin):
         assume that it correctly is normalized by a factor of sqrt(nfft). This test does not test the accuracy of
         spectrogram, but is testing the relative factors of normalization and that they align upon the frame_length
         and chosen normalize parameter.
+        https://github.com/pytorch/pytorch/issues/81428
         """
         x = torch.rand(1, 22050)
         spec_false = F.spectrogram(

--- a/test/torchaudio_unittest/functional/functional_impl.py
+++ b/test/torchaudio_unittest/functional/functional_impl.py
@@ -256,10 +256,10 @@ class Functional(TestBaseMixin):
         """This test assumes that currently, torch.stft and the existing math behind spectrogram has been correct.
         The test is checking that in relation to one another, the normalization factors correctly align based on
         mathematical prediction. Using spec_false as a base, which has no normalization factors, we check to see that
-        turning normalized as ``True`` or ``"window"`` will have a normalization factor of sqrt(3*nfft/8) given a
-        hann_window. The sum of squares of hann has been calculated to be 3/8 of frame_length, so we are assuming this.
-        Next, when normalized ``"frame_length"`` we are using the torch stft version of normalization, therefore we
-        assume that it correctly is normalized by a factor of sqrt(nfft). This test does not test the accuracy of
+        turning normalized as ``True`` or ``"window"`` will have a normalization factor of the sum of squares of hann
+        window, which is calculated to be sqrt(3 * nfft / 8).
+        Next, when ``normalized`` is ``"frame_length"``, we are using the normalization in torch.stft, therefore we
+        assume that it is correctly normalized by a factor of sqrt(nfft). This test does not test the accuracy of
         spectrogram, but is testing the relative factors of normalization and that they align upon the frame_length
         and chosen normalize parameter.
         https://github.com/pytorch/pytorch/issues/81428

--- a/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
@@ -46,7 +46,15 @@ class Functional(TempDirMixin, TestBaseMixin):
 
         self.assertEqual(ts_output, output)
 
-    def test_spectrogram(self):
+    @parameterized.expand(
+        [
+            (True,),
+            (False,),
+            ("window",),
+            ("frame_length",),
+        ]
+    )
+    def test_spectrogram(self, normalize):
         waveform = common_utils.get_whitenoise()
         n_fft = 400
         ws = 400
@@ -54,12 +62,19 @@ class Functional(TempDirMixin, TestBaseMixin):
         pad = 0
         window = torch.hann_window(ws, device=waveform.device, dtype=waveform.dtype)
         power = None
-        normalize = False
         self._assert_consistency(
             F.spectrogram, (waveform, pad, window, n_fft, hop, ws, power, normalize, True, "reflect", True, True)
         )
 
-    def test_inverse_spectrogram(self):
+    @parameterized.expand(
+        [
+            (True,),
+            (False,),
+            ("window",),
+            ("frame_length",),
+        ]
+    )
+    def test_inverse_spectrogram(self, normalize):
         waveform = common_utils.get_whitenoise(sample_rate=8000, duration=0.05)
         specgram = common_utils.get_spectrogram(waveform, n_fft=400, hop_length=200)
         length = 400
@@ -68,7 +83,6 @@ class Functional(TempDirMixin, TestBaseMixin):
         ws = 400
         pad = 0
         window = torch.hann_window(ws, device=specgram.device, dtype=torch.float64)
-        normalize = False
         self._assert_consistency_complex(
             F.inverse_spectrogram, (specgram, length, pad, window, n_fft, hop, ws, normalize, True, "reflect", True)
         )

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -54,7 +54,7 @@ def spectrogram(
     hop_length: int,
     win_length: int,
     power: Optional[float],
-    normalized: bool,
+    normalized: Union[bool, str],
     center: bool = True,
     pad_mode: str = "reflect",
     onesided: bool = True,
@@ -77,7 +77,8 @@ def spectrogram(
         power (float or None): Exponent for the magnitude spectrogram,
             (must be > 0) e.g., 1 for energy, 2 for power, etc.
             If None, then the complex spectrum is returned instead.
-        normalized (bool): Whether to normalize by magnitude after stft
+        normalized (bool or str): Whether to normalize by magnitude after stft. If input is str, choices are
+            ``"window"`` and ``"frame_length"``, if specific normalization type is desirable.
         center (bool, optional): whether to pad :attr:`waveform` on both sides so
             that the :math:`t`-th frame is centered at time :math:`t \times \text{hop\_length}`.
             Default: ``True``
@@ -104,6 +105,16 @@ def spectrogram(
         # TODO add "with torch.no_grad():" back when JIT supports it
         waveform = torch.nn.functional.pad(waveform, (pad, pad), "constant")
 
+    frame_length_norm, window_norm = False, False
+
+    if type(normalized) is str and normalized not in ["frame_length", "window"]:
+        raise ValueError("Invalid normalized parameter: {}".format(normalized))
+
+    if normalized == "frame_length":
+        frame_length_norm = True
+    elif normalized == "window" or normalized is True:
+        window_norm = True
+
     # pack batch
     shape = waveform.size()
     waveform = waveform.reshape(-1, shape[-1])
@@ -117,7 +128,7 @@ def spectrogram(
         window=window,
         center=center,
         pad_mode=pad_mode,
-        normalized=False,
+        normalized=frame_length_norm,
         onesided=onesided,
         return_complex=True,
     )
@@ -125,7 +136,7 @@ def spectrogram(
     # unpack batch
     spec_f = spec_f.reshape(shape[:-1] + spec_f.shape[-2:])
 
-    if normalized:
+    if window_norm:
         spec_f /= window.pow(2.0).sum().sqrt()
     if power is not None:
         if power == 1.0:
@@ -142,7 +153,7 @@ def inverse_spectrogram(
     n_fft: int,
     hop_length: int,
     win_length: int,
-    normalized: bool,
+    normalized: Union[bool, str],
     center: bool = True,
     pad_mode: str = "reflect",
     onesided: bool = True,
@@ -162,7 +173,8 @@ def inverse_spectrogram(
         n_fft (int): Size of FFT
         hop_length (int): Length of hop between STFT windows
         win_length (int): Window size
-        normalized (bool): Whether the stft output was normalized by magnitude
+        normalized (bool or str): Whether the stft output was normalized by magnitude. If input is str, choices are
+            ``"window"`` and ``"frame_length"``, dependent on normalization mode.
         center (bool, optional): whether the waveform was padded on both sides so
             that the :math:`t`-th frame is centered at time :math:`t \times \text{hop\_length}`.
             Default: ``True``
@@ -176,10 +188,20 @@ def inverse_spectrogram(
         Tensor: Dimension `(..., time)`. Least squares estimation of the original signal.
     """
 
+    if type(normalized) is str and normalized not in ["frame_length", "window"]:
+        raise ValueError("Invalid normalized parameter: {}".format(normalized))
+
+    frame_length_norm, window_norm = False, False
+
+    if normalized == "frame_length":
+        frame_length_norm = True
+    elif normalized == "window" or normalized is True:
+        window_norm = True
+
     if not spectrogram.is_complex():
         raise ValueError("Expected `spectrogram` to be complex dtype.")
 
-    if normalized:
+    if window_norm:
         spectrogram = spectrogram * window.pow(2.0).sum().sqrt()
 
     # pack batch
@@ -194,7 +216,7 @@ def inverse_spectrogram(
         win_length=win_length,
         window=window,
         center=center,
-        normalized=False,
+        normalized=frame_length_norm,
         onesided=onesided,
         length=length + 2 * pad if length is not None else None,
         return_complex=False,

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -79,7 +79,9 @@ def spectrogram(
             If None, then the complex spectrum is returned instead.
         normalized (bool or str): Whether to normalize by magnitude after stft. If input is str, choices are
             ``"window"`` and ``"frame_length"``, if specific normalization type is desirable. ``True`` maps to
-            ``"window"``.
+            ``"window"``. When normalized on ``"window"``, waveform is normalized upon the window's L2 energy. If
+            normalized on ``"frame_length"``, waveform is normalized by dividing by
+            :math:`(\text{frame\_length})^{0.5}`.
         center (bool, optional): whether to pad :attr:`waveform` on both sides so
             that the :math:`t`-th frame is centered at time :math:`t \times \text{hop\_length}`.
             Default: ``True``

--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -2,7 +2,7 @@
 
 import math
 import warnings
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 import torch
 from torch import Tensor
@@ -37,7 +37,9 @@ class Spectrogram(torch.nn.Module):
         power (float or None, optional): Exponent for the magnitude spectrogram,
             (must be > 0) e.g., 1 for energy, 2 for power, etc.
             If None, then the complex spectrum is returned instead. (Default: ``2``)
-        normalized (bool, optional): Whether to normalize by magnitude after stft. (Default: ``False``)
+        normalized (bool or str, optional): Whether to normalize by magnitude after stft. If input is str, choices are
+            ``"window"`` and ``"frame_length"``, if specific normalization type is desirable. ``True`` maps to
+            ``"window"``. (Default: ``False``)
         wkwargs (dict or None, optional): Arguments for window function. (Default: ``None``)
         center (bool, optional): whether to pad :attr:`waveform` on both sides so
             that the :math:`t`-th frame is centered at time :math:`t \times \text{hop\_length}`.
@@ -65,7 +67,7 @@ class Spectrogram(torch.nn.Module):
         pad: int = 0,
         window_fn: Callable[..., Tensor] = torch.hann_window,
         power: Optional[float] = 2.0,
-        normalized: bool = False,
+        normalized: Union[bool, str] = False,
         wkwargs: Optional[dict] = None,
         center: bool = True,
         pad_mode: str = "reflect",
@@ -132,8 +134,9 @@ class InverseSpectrogram(torch.nn.Module):
         pad (int, optional): Two sided padding of signal. (Default: ``0``)
         window_fn (Callable[..., Tensor], optional): A function to create a window tensor
             that is applied/multiplied to each frame/window. (Default: ``torch.hann_window``)
-        normalized (bool, optional): Whether the spectrogram was normalized by magnitude after stft.
-            (Default: ``False``)
+        normalized (bool or str, optional): Whether the stft output was normalized by magnitude. If input is str,
+            choices are ``"window"`` and ``"frame_length"``, dependent on normalization mode. ``True`` maps to
+            ``"window"``. (Default: ``False``)
         wkwargs (dict or None, optional): Arguments for window function. (Default: ``None``)
         center (bool, optional): whether the signal in spectrogram was padded on both sides so
             that the :math:`t`-th frame is centered at time :math:`t \times \text{hop\_length}`.
@@ -159,7 +162,7 @@ class InverseSpectrogram(torch.nn.Module):
         hop_length: Optional[int] = None,
         pad: int = 0,
         window_fn: Callable[..., Tensor] = torch.hann_window,
-        normalized: bool = False,
+        normalized: Union[bool, str] = False,
         wkwargs: Optional[dict] = None,
         center: bool = True,
         pad_mode: str = "reflect",


### PR DESCRIPTION
Add str to normalized parameter to enable frame_length based normalization to align with torch implementation of stft. Addresses issue #2104 