### PR TITLE
ci: Update macos runners to AWS self hosted

### DIFF
--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -61,13 +61,12 @@ jobs:
           export SOURCE_ROOT_DIR=$(pwd)
           export FFMPEG_ROOT="${SOURCE_ROOT_DIR}/third_party/ffmpeg"
           . packaging/ffmpeg/build.sh
-          WHL_NAME=torchaudio-${BUILD_VERSION}-cp${PY_VERS/.}-cp${PY_VERS/.}-macosx_11_0_arm64.whl
           conda create -yp ${ENV_NAME} python=${PY_VERS} numpy cmake ninja wheel pkg-config
           conda run -p ${ENV_NAME} python3 -mpip install torch --pre --extra-index-url=https://download.pytorch.org/whl/${CHANNEL}
           conda run -p ${ENV_NAME} python3 -mpip install delocate
           conda run -p ${ENV_NAME} python3 setup.py bdist_wheel
           export PYTORCH_VERSION="$(conda run -p ${ENV_NAME} python3 -mpip show torch | grep ^Version: | sed 's/Version: *//')"
-          conda run -p ${ENV_NAME} DYLD_FALLBACK_LIBRARY_PATH="${ENV_NAME}/lib" delocate-wheel -v --ignore-missing-dependencies dist/${WHL_NAME}
+          conda run -p ${ENV_NAME} DYLD_FALLBACK_LIBRARY_PATH="${ENV_NAME}/lib" delocate-wheel -v --ignore-missing-dependencies dist/*.whl
           conda env remove -p ${ENV_NAME}
       - name: Test wheel
         shell: arch -arch arm64 bash {0}

--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -179,3 +179,7 @@ jobs:
           conda install -yq anaconda-client
           set -x
           anaconda  -t "${CONDA_PYTORCHBOT_TOKEN}" upload ~/miniconda3/conda-bld/osx-arm64/*.tar.bz2 -u "pytorch-${CHANNEL}" --label main --no-progress --force
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true

--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -157,9 +157,13 @@ jobs:
           setup_conda_pytorch_constraint
           setup_conda_cudatoolkit_constraint
           setup_visual_studio_constraint
-          conda build -c defaults $CONDA_CHANNEL_FLAGS --no-anaconda-upload --python "$PYTHON_VERSION" packaging/torchaudio
-          mkdir -p dist
-          cp ~/miniconda3/conda-bld/osx-arm64/*.tar.bz2 dist/
+          conda build \
+            -c defaults \
+            $CONDA_CHANNEL_FLAGS \
+            --no-anaconda-upload \
+            --python "$PYTHON_VERSION" \
+            --output-folder=dist/ \
+            packaging/torchaudio
       - name: Upload package to GitHub
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   build_wheels:
     name: "Build TorchAudio M1 wheels"
-    runs-on: macos-m1-11
+    runs-on: macos-m1-12
     strategy:
       matrix:
         py_vers: [ "3.8", "3.9", "3.10" ]
@@ -44,6 +44,8 @@ jobs:
           USE_FFMPEG: true
           USE_OPENMP: false
           USE_CUDA: false
+          # Needed so that delocate puts files in places it can actually modify
+          TMPDIR: ${{ runner.temp }}
         run: |
           echo $PATH
           . ~/miniconda3/etc/profile.d/conda.sh
@@ -99,7 +101,7 @@ jobs:
           done
   build_conda:
     name: "Build TorchAudio M1 conda packages"
-    runs-on: macos-m1-11
+    runs-on: macos-m1-12
     strategy:
       matrix:
         py_vers: [ "3.8", "3.9", "3.10" ]

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -209,7 +209,7 @@ setup_conda_pytorch_constraint() {
   CONDA_CHANNEL_FLAGS="${CONDA_CHANNEL_FLAGS}"
   if [[ -z "$PYTORCH_VERSION" ]]; then
     export CONDA_CHANNEL_FLAGS="${CONDA_CHANNEL_FLAGS} -c pytorch-nightly"
-    export PYTORCH_VERSION="$(conda search --json 'pytorch[channel=pytorch-nightly]' | python -c "import sys, json, re; print(re.sub(r'\\+.*$', '', json.load(sys.stdin)['pytorch'][-1]['version']))")"
+    export PYTORCH_VERSION="$(conda search --json 'pytorch[channel=pytorch-nightly]' | python3 -c "import sys, json, re; print(re.sub(r'\\+.*$', '', json.load(sys.stdin)['pytorch'][-1]['version']))")"
   else
     export CONDA_CHANNEL_FLAGS="${CONDA_CHANNEL_FLAGS} -c pytorch -c pytorch-test -c pytorch-nightly"
   fi


### PR DESCRIPTION
Updates the runner to the latest apple silicon machines we have that
also run on macOS 12.4

Similar to https://github.com/pytorch/vision/pull/6290

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>