### PR TITLE
Fix fall back failure in sox_io backend

### DIFF
--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -44,7 +44,7 @@ else:
     _fallback_info = _fail_info
     _fallback_info_fileobj = _fail_info_fileobj
     _fallback_load = _fail_load
-    _fallback_load_filebj = _fail_load_fileobj
+    _fallback_load_fileobj = _fail_load_fileobj
 
 
 @_mod_utils.requires_sox()


### PR DESCRIPTION
Fix the fallback function of load fileobj function in sox_io backend.

The typo in the fallback function prevents showing the intended error message.