### PR TITLE
[BC-breaking] Fix momentum in transforms.GriffinLim

### DIFF
--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -264,6 +264,7 @@ def griffinlim(
     """
     assert momentum < 1, "momentum={} > 1 can be unstable".format(momentum)
     assert momentum >= 0, "momentum={} < 0".format(momentum)
+    momentum = momentum / (1 + momentum)
 
     # pack batch
     shape = specgram.size()
@@ -302,7 +303,7 @@ def griffinlim(
         # Update our phase estimates
         angles = rebuilt
         if momentum:
-            angles = angles - tprev.mul_(momentum / (1 + momentum))
+            angles = angles - tprev.mul_(momentum)
         angles = angles.div(angles.abs().add(1e-16))
 
         # Store the previous iterate

--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -264,7 +264,7 @@ class GriffinLim(torch.nn.Module):
         self.register_buffer("window", window)
         self.length = length
         self.power = power
-        self.momentum = momentum / (1 + momentum)
+        self.momentum = momentum
         self.rand_init = rand_init
 
     def forward(self, specgram: Tensor) -> Tensor:


### PR DESCRIPTION
Fixes #2567 

made slight optimization to usage of momentum parameter in functional.griffinlim: `momentum / (1 + momentum)` is only calculated once, as opposed to during each iteration.