### PR TITLE
Integration test fix deleting temporary directory

### DIFF
--- a/test/integration_tests/conftest.py
+++ b/test/integration_tests/conftest.py
@@ -96,7 +96,7 @@ def temp_hub_dir(tmp_path, pytestconfig):
         torch.hub.set_dir(subdir)
         yield
         torch.hub.set_dir(org_dir)
-        shutil.rmtree(subdir)
+        shutil.rmtree(subdir, ignore_errors=True)
 
 
 @pytest.fixture()

--- a/test/integration_tests/conftest.py
+++ b/test/integration_tests/conftest.py
@@ -56,7 +56,6 @@ def sample_speech(lang):
         raise NotImplementedError(f"Unexpected lang: {lang}")
     filename = _FILES[lang]
     path = torchaudio.utils.download_asset(f"test-assets/{filename}")
-    print(path)
     return path
 
 


### PR DESCRIPTION
Previous Issue: --use-tmp-hub-dir expected the temp directories used to store large file to be deleted after each test case, but pytest erases directories after 3 full test sessions. This commit fixes by manually deleting a new subdirectory created in each test case. https://github.com/pytorch/audio/pull/2565#discussion_r929007101 