### PR TITLE
Replaced CHECK_ by TORCH_CHECK_

### DIFF
--- a/torchaudio/csrc/rnnt/cpu/compute.cpp
+++ b/torchaudio/csrc/rnnt/cpu/compute.cpp
@@ -81,7 +81,7 @@ std::tuple<torch::Tensor, c10::optional<torch::Tensor>> compute(
   options.blank_ = blank;
   options.clamp_ = clamp;
 
-  CHECK_EQ(logits.device().type(), torch::DeviceType::CPU);
+  TORCH_CHECK_EQ(logits.device().type(), torch::DeviceType::CPU);
   options.device_ = CPU;
 
   torch::Tensor costs = torch::empty(

--- a/torchaudio/csrc/rnnt/cpu/compute_alphas.cpp
+++ b/torchaudio/csrc/rnnt/cpu/compute_alphas.cpp
@@ -21,7 +21,7 @@ torch::Tensor compute_alphas(
   options.blank_ = blank;
   options.clamp_ = clamp;
 
-  CHECK_EQ(logits.device().type(), torch::DeviceType::CPU);
+  TORCH_CHECK_EQ(logits.device().type(), torch::DeviceType::CPU);
   options.device_ = CPU;
 
   torch::Tensor alphas = torch::zeros(

--- a/torchaudio/csrc/rnnt/cpu/compute_betas.cpp
+++ b/torchaudio/csrc/rnnt/cpu/compute_betas.cpp
@@ -21,7 +21,7 @@ torch::Tensor compute_betas(
   options.blank_ = blank;
   options.clamp_ = clamp;
 
-  CHECK_EQ(logits.device().type(), torch::DeviceType::CPU);
+  TORCH_CHECK_EQ(logits.device().type(), torch::DeviceType::CPU);
   options.device_ = CPU;
 
   torch::Tensor costs = torch::empty(

--- a/torchaudio/csrc/rnnt/cpu/cpu_kernels.h
+++ b/torchaudio/csrc/rnnt/cpu/cpu_kernels.h
@@ -48,7 +48,7 @@ class TensorView {
   }
 
   DTYPE& operator()(const std::vector<int>& indices) {
-    CHECK_EQ(indices.size(), dims_.size());
+    TORCH_CHECK_EQ(indices.size(), dims_.size());
     int index = indices.back();
     for (int i = indices.size() - 2; i >= 0; --i) {
       index += indices[i] * strides_[i];

--- a/torchaudio/csrc/rnnt/cpu/cpu_transducer.h
+++ b/torchaudio/csrc/rnnt/cpu/cpu_transducer.h
@@ -28,7 +28,7 @@ status_t Compute(
     DTYPE* gradients = nullptr) {
   const Options& options = workspace.GetOptions();
 
-  CHECK_EQ(options.device_, CPU);
+  TORCH_CHECK_EQ(options.device_, CPU);
 
   const int& B = options.batchSize_;
   const int& maxT = options.maxSrcLen_;
@@ -91,7 +91,7 @@ status_t ComputeAlphas(
     DTYPE* alphas) {
   const Options& options = workspace.GetOptions();
 
-  CHECK_EQ(options.device_, CPU);
+  TORCH_CHECK_EQ(options.device_, CPU);
 
   const int& B = options.batchSize_;
   const int& maxT = options.maxSrcLen_;
@@ -140,7 +140,7 @@ status_t ComputeBetas(
     DTYPE* betas) {
   const Options& options = workspace.GetOptions();
 
-  CHECK_EQ(options.device_, CPU);
+  TORCH_CHECK_EQ(options.device_, CPU);
 
   const int& B = options.batchSize_;
   const int& maxT = options.maxSrcLen_;

--- a/torchaudio/csrc/rnnt/gpu/compute.cu
+++ b/torchaudio/csrc/rnnt/gpu/compute.cu
@@ -82,7 +82,7 @@ std::tuple<torch::Tensor, c10::optional<torch::Tensor>> compute(
   options.blank_ = blank;
   options.clamp_ = clamp;
 
-  CHECK_EQ(logits.device().type(), torch::DeviceType::CUDA);
+  TORCH_CHECK_EQ(logits.device().type(), torch::DeviceType::CUDA);
   options.stream_ = at::cuda::getCurrentCUDAStream();
   cudaSetDevice(logits.get_device());
   options.device_ = GPU;

--- a/torchaudio/csrc/rnnt/gpu/compute_alphas.cu
+++ b/torchaudio/csrc/rnnt/gpu/compute_alphas.cu
@@ -22,7 +22,7 @@ torch::Tensor compute_alphas(
   options.blank_ = blank;
   options.clamp_ = clamp;
 
-  CHECK_EQ(logits.device().type(), torch::DeviceType::CUDA);
+  TORCH_CHECK_EQ(logits.device().type(), torch::DeviceType::CUDA);
   options.stream_ = at::cuda::getCurrentCUDAStream();
   cudaSetDevice(logits.get_device());
   options.device_ = GPU;

--- a/torchaudio/csrc/rnnt/gpu/compute_betas.cu
+++ b/torchaudio/csrc/rnnt/gpu/compute_betas.cu
@@ -22,7 +22,7 @@ torch::Tensor compute_betas(
   options.blank_ = blank;
   options.clamp_ = clamp;
 
-  CHECK_EQ(logits.device().type(), torch::DeviceType::CUDA);
+  TORCH_CHECK_EQ(logits.device().type(), torch::DeviceType::CUDA);
   options.stream_ = at::cuda::getCurrentCUDAStream();
   cudaSetDevice(logits.get_device());
   options.device_ = GPU;

--- a/torchaudio/csrc/rnnt/workspace.h
+++ b/torchaudio/csrc/rnnt/workspace.h
@@ -27,7 +27,7 @@ class DtypeWorkspace {
   ~DtypeWorkspace() {}
 
   static int ComputeSizeFromOptions(const Options& options) {
-    CHECK_NE(options.device_, UNDEFINED);
+    TORCH_CHECK_NE(options.device_, UNDEFINED);
     return ComputeSizeForDenominators(options) +
         ComputeSizeForLogProbs(options) + ComputeSizeForAlphas(options) +
         ComputeSizeForBetas(options);
@@ -36,7 +36,7 @@ class DtypeWorkspace {
   void Free();
   void Reset(const Options& options, DTYPE* data, int size) {
     int needed_size = ComputeSizeFromOptions(options);
-    CHECK_LE(needed_size, size);
+    TORCH_CHECK_LE(needed_size, size);
     options_ = options;
     data_ = data;
     size_ = size;
@@ -98,7 +98,7 @@ class IntWorkspace {
 
   void Reset(const Options& options, int* data, int size) {
     int needed_size = ComputeSizeFromOptions(options);
-    CHECK_LE(needed_size, size);
+    TORCH_CHECK_LE(needed_size, size);
     options_ = options;
     data_ = data;
     size_ = size;
@@ -109,11 +109,11 @@ class IntWorkspace {
   }
 
   int* GetPointerToAlphaCounters() const {
-    CHECK_EQ(options_.device_, GPU);
+    TORCH_CHECK_EQ(options_.device_, GPU);
     return data_;
   }
   int* GetPointerToBetaCounters() const {
-    CHECK_EQ(options_.device_, GPU);
+    TORCH_CHECK_EQ(options_.device_, GPU);
     return GetPointerToAlphaCounters() + ComputeSizeForAlphaCounters(options_);
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #2582

CHECK_ were deprecated in upstream so we should replace them here as
well

Similar to https://github.com/pytorch/vision/pull/6322, relates to https://github.com/pytorch/pytorch/pull/82032

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D38208356](https://our.internmc.facebook.com/intern/diff/D38208356)