### PR TITLE
Replace 'runtime_error' exception with 'TORCH_CHECK' in TorchAudio sox

### DIFF
--- a/torchaudio/csrc/sox/effects.cpp
+++ b/torchaudio/csrc/sox/effects.cpp
@@ -20,16 +20,15 @@ void initialize_sox_effects() {
 
   switch (SOX_RESOURCE_STATE) {
     case NotInitialized:
-      if (sox_init() != SOX_SUCCESS) {
-        throw std::runtime_error("Failed to initialize sox effects.");
-      };
+      TORCH_CHECK(
+          sox_init() == SOX_SUCCESS, "Failed to initialize sox effects.");
       SOX_RESOURCE_STATE = Initialized;
       break;
     case Initialized:
       break;
     case ShutDown:
-      throw std::runtime_error(
-          "SoX Effects has been shut down. Cannot initialize again.");
+      TORCH_CHECK(
+          false, "SoX Effects has been shut down. Cannot initialize again.");
   }
 };
 
@@ -38,12 +37,10 @@ void shutdown_sox_effects() {
 
   switch (SOX_RESOURCE_STATE) {
     case NotInitialized:
-      throw std::runtime_error(
-          "SoX Effects is not initialized. Cannot shutdown.");
+      TORCH_CHECK(false, "SoX Effects is not initialized. Cannot shutdown.");
     case Initialized:
-      if (sox_quit() != SOX_SUCCESS) {
-        throw std::runtime_error("Failed to initialize sox effects.");
-      };
+      TORCH_CHECK(
+          sox_quit() == SOX_SUCCESS, "Failed to initialize sox effects.");
       SOX_RESOURCE_STATE = ShutDown;
       break;
     case ShutDown:

--- a/torchaudio/csrc/sox/io.cpp
+++ b/torchaudio/csrc/sox/io.cpp
@@ -36,15 +36,14 @@ std::vector<std::vector<std::string>> get_effects(
     const c10::optional<int64_t>& frame_offset,
     const c10::optional<int64_t>& num_frames) {
   const auto offset = frame_offset.value_or(0);
-  if (offset < 0) {
-    throw std::runtime_error(
-        "Invalid argument: frame_offset must be non-negative.");
-  }
+  TORCH_CHECK(
+      offset >= 0,
+      "Invalid argument: frame_offset must be non-negative. Found: ",
+      offset);
   const auto frames = num_frames.value_or(-1);
-  if (frames == 0 || frames < -1) {
-    throw std::runtime_error(
-        "Invalid argument: num_frames must be -1 or greater than 0.");
-  }
+  TORCH_CHECK(
+      frames > 0 || frames == -1,
+      "Invalid argument: num_frames must be -1 or greater than 0.");
 
   std::vector<std::vector<std::string>> effects;
   if (frames != -1) {
@@ -119,10 +118,10 @@ void save_audio_file(
       /*oob=*/nullptr,
       /*overwrite_permitted=*/nullptr));
 
-  if (static_cast<sox_format_t*>(sf) == nullptr) {
-    throw std::runtime_error(
-        "Error saving audio file: failed to open file " + path);
-  }
+  TORCH_CHECK(
+      static_cast<sox_format_t*>(sf) != nullptr,
+      "Error saving audio file: failed to open file ",
+      path);
 
   torchaudio::sox_effects_chain::SoxEffectsChain chain(
       /*input_encoding=*/get_tensor_encodinginfo(tensor.dtype()),

--- a/torchaudio/csrc/sox/types.cpp
+++ b/torchaudio/csrc/sox/types.cpp
@@ -24,9 +24,7 @@ Format get_format_from_string(const std::string& format) {
     return Format::HTK;
   if (format == "gsm")
     return Format::GSM;
-  std::ostringstream stream;
-  stream << "Internal Error: unexpected format value: " << format;
-  throw std::runtime_error(stream.str());
+  TORCH_CHECK(false, "Internal Error: unexpected format value: ", format);
 }
 
 std::string to_string(Encoding v) {
@@ -56,7 +54,7 @@ std::string to_string(Encoding v) {
     case Encoding::OPUS:
       return "OPUS";
     default:
-      throw std::runtime_error("Internal Error: unexpected encoding.");
+      TORCH_CHECK(false, "Internal Error: unexpected encoding.");
   }
 }
 
@@ -74,9 +72,7 @@ Encoding get_encoding_from_option(const c10::optional<std::string> encoding) {
     return Encoding::ULAW;
   if (v == "ALAW")
     return Encoding::ALAW;
-  std::ostringstream stream;
-  stream << "Internal Error: unexpected encoding value: " << v;
-  throw std::runtime_error(stream.str());
+  TORCH_CHECK(false, "Internal Error: unexpected encoding value: ", v);
 }
 
 BitDepth get_bit_depth_from_option(const c10::optional<int64_t> bit_depth) {
@@ -95,9 +91,7 @@ BitDepth get_bit_depth_from_option(const c10::optional<int64_t> bit_depth) {
     case 64:
       return BitDepth::B64;
     default: {
-      std::ostringstream s;
-      s << "Internal Error: unexpected bit depth value: " << v;
-      throw std::runtime_error(s.str());
+      TORCH_CHECK(false, "Internal Error: unexpected bit depth value: ", v);
     }
   }
 }


### PR DESCRIPTION
Summary:
std::runtime_error does not preserve the C++ stack trace, so it is unclear to users what went wrong internally.

PyTorch's TORCH_CHECK macro allows to print C++ stack trace when TORCH_SHOW_CPP_STACKTRACES environment variable is set to 1.

Differential Revision: D38219331

