### PR TITLE
Fix bug in Conformer RNN-T recipe

### DIFF
--- a/examples/asr/librispeech_conformer_rnnt/train.py
+++ b/examples/asr/librispeech_conformer_rnnt/train.py
@@ -1,6 +1,8 @@
 import pathlib
 from argparse import ArgumentParser
 
+import sentencepiece as spm
+
 from lightning import ConformerRNNTModule
 from pytorch_lightning import seed_everything, Trainer
 from pytorch_lightning.callbacks import LearningRateMonitor, ModelCheckpoint
@@ -44,7 +46,8 @@ def run_train(args):
         reload_dataloaders_every_n_epochs=1,
     )
 
-    model = ConformerRNNTModule(str(args.sp_model_path))
+    sp_model = spm.SentencePieceProcessor(model_file=str(args.sp_model_path))
+    model = ConformerRNNTModule(sp_model)
     data_module = get_data_module(str(args.librispeech_path), str(args.global_stats_path), str(args.sp_model_path))
     trainer.fit(model, data_module, ckpt_path=args.checkpoint_path)
 


### PR DESCRIPTION
#2535 modified the Conformer RNN-T Lightning module to accept a SentencePiece model instance rather than a file path. This PR makes changes to account for this in the train script.