### PR TITLE
Introducing pytorch-cuda metapackage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,10 +387,6 @@ jobs:
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
             conda activate base
             conda install -yq conda-build "conda-package-handling!=1.5.0"
-            # cudatoolkit >= 11 isn't available for windows in the nvidia channel
-            if [[ "${CU_VERSION}" =~ cu11.* ]]; then
-              export CONDA_CHANNEL_FLAGS="-c conda-forge"
-            fi
             export FFMPEG_ROOT="${PWD}/third_party/ffmpeg"
             bash packaging/build_conda.sh
           environment:
@@ -478,9 +474,9 @@ jobs:
             set -x
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
             if [[ "$CU_VERSION" == cu116 ]]; then
-              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} -c nvidia/label/cuda-11.6.2 pytorch cuda=${CU_VERSION:2:2}.${CU_VERSION:4}
+              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} -c nvidia pytorch pytorch-cuda=${CU_VERSION:2:2}.${CU_VERSION:4}
             else
-              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4} -c conda-forge
+              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4}
             fi
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
       - checkout
@@ -566,9 +562,9 @@ jobs:
             # Include numpy and cudatoolkit in the install conda-forge chanell is used for cudatoolkit
 
             if [[ "$CU_VERSION" == cu116 ]]; then
-              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} -c nvidia/label/cuda-11.6.2 pytorch numpy ffmpeg cuda=${CU_VERSION:2:2}.${CU_VERSION:4}
+              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} -c nvidia pytorch numpy ffmpeg pytorch-cuda=${CU_VERSION:2:2}.${CU_VERSION:4}
             else
-              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch numpy ffmpeg cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4} -c conda-forge
+              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch numpy ffmpeg cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4}
             fi
             # Install from torchaudio file
             conda install -v -y $(ls ~/workspace/conda-bld/win-64/torchaudio*.tar.bz2)
@@ -826,9 +822,9 @@ jobs:
             set -x
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
             if [[ "$CU_VERSION" == cu116 ]]; then
-              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} -c nvidia/label/cuda-11.6.2 pytorch cuda=${CU_VERSION:2:2}.${CU_VERSION:4}
+              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} -c nvidia pytorch pytorch-cuda=${CU_VERSION:2:2}.${CU_VERSION:4}
             else
-              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4} -c conda-forge
+              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4}
             fi
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
             # gxx_linux-64 is for installing pesq library that depends on cython

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -387,10 +387,6 @@ jobs:
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
             conda activate base
             conda install -yq conda-build "conda-package-handling!=1.5.0"
-            # cudatoolkit >= 11 isn't available for windows in the nvidia channel
-            if [[ "${CU_VERSION}" =~ cu11.* ]]; then
-              export CONDA_CHANNEL_FLAGS="-c conda-forge"
-            fi
             export FFMPEG_ROOT="${PWD}/third_party/ffmpeg"
             bash packaging/build_conda.sh
           environment:
@@ -480,7 +476,7 @@ jobs:
             if [[ "$CU_VERSION" == cu116 ]]; then
               conda install -v -y -c pytorch-${UPLOAD_CHANNEL} -c nvidia pytorch pytorch-cuda=${CU_VERSION:2:2}.${CU_VERSION:4}
             else
-              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4} -c conda-forge
+              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4}
             fi
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
       - checkout
@@ -568,7 +564,7 @@ jobs:
             if [[ "$CU_VERSION" == cu116 ]]; then
               conda install -v -y -c pytorch-${UPLOAD_CHANNEL} -c nvidia pytorch numpy ffmpeg pytorch-cuda=${CU_VERSION:2:2}.${CU_VERSION:4}
             else
-              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch numpy ffmpeg cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4} -c conda-forge
+              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch numpy ffmpeg cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4}
             fi
             # Install from torchaudio file
             conda install -v -y $(ls ~/workspace/conda-bld/win-64/torchaudio*.tar.bz2)
@@ -828,7 +824,7 @@ jobs:
             if [[ "$CU_VERSION" == cu116 ]]; then
               conda install -v -y -c pytorch-${UPLOAD_CHANNEL} -c nvidia pytorch pytorch-cuda=${CU_VERSION:2:2}.${CU_VERSION:4}
             else
-              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4} -c conda-forge
+              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4}
             fi
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
             # gxx_linux-64 is for installing pesq library that depends on cython

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -478,7 +478,7 @@ jobs:
             set -x
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
             if [[ "$CU_VERSION" == cu116 ]]; then
-              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} -c nvidia/label/cuda-11.6.2 pytorch cuda=${CU_VERSION:2:2}.${CU_VERSION:4}
+              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} -c nvidia pytorch pytorch-cuda=${CU_VERSION:2:2}.${CU_VERSION:4}
             else
               conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4} -c conda-forge
             fi
@@ -566,7 +566,7 @@ jobs:
             # Include numpy and cudatoolkit in the install conda-forge chanell is used for cudatoolkit
 
             if [[ "$CU_VERSION" == cu116 ]]; then
-              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} -c nvidia/label/cuda-11.6.2 pytorch numpy ffmpeg cuda=${CU_VERSION:2:2}.${CU_VERSION:4}
+              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} -c nvidia pytorch numpy ffmpeg pytorch-cuda=${CU_VERSION:2:2}.${CU_VERSION:4}
             else
               conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch numpy ffmpeg cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4} -c conda-forge
             fi
@@ -826,7 +826,7 @@ jobs:
             set -x
             source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
             if [[ "$CU_VERSION" == cu116 ]]; then
-              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} -c nvidia/label/cuda-11.6.2 pytorch cuda=${CU_VERSION:2:2}.${CU_VERSION:4}
+              conda install -v -y -c pytorch-${UPLOAD_CHANNEL} -c nvidia pytorch pytorch-cuda=${CU_VERSION:2:2}.${CU_VERSION:4}
             else
               conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cudatoolkit=${CU_VERSION:2:2}.${CU_VERSION:4} -c conda-forge
             fi

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -36,7 +36,7 @@ else
     export CUDATOOLKIT_CHANNEL="nvidia"
     cudatoolkit="cudatoolkit=${version}"
     if [[ "$version" == "11.6" || "$version" == "11.7" ]]; then
-        cudatoolkit=" pytorch-cuda=${version}"
+        cudatoolkit="pytorch-cuda=${version}"
     fi
 fi
 

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -34,7 +34,7 @@ else
     version="$(python -c "print('.'.join(\"${CUDA_VERSION}\".split('.')[:2]))")"
 
     export CUDATOOLKIT_CHANNEL="nvidia"
-    cudatoolkit="nvidia::cudatoolkit=${version}"
+    cudatoolkit="cudatoolkit=${version}"
     if [[ "$version" == "11.6" || "$version" == "11.7" ]]; then
         cudatoolkit=" pytorch-cuda=${version}"
     fi

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -34,12 +34,10 @@ else
     version="$(python -c "print('.'.join(\"${CUDA_VERSION}\".split('.')[:2]))")"
 
     export CUDATOOLKIT_CHANNEL="nvidia"
-    cuda_toolkit_pckg="cudatoolkit"
-    if [[ "$CU_VERSION" == cu116 ]]; then
-        export CUDATOOLKIT_CHANNEL="nvidia/label/cuda-11.6.2"
-        cuda_toolkit_pckg="cuda"
+    cudatoolkit="nvidia::cudatoolkit=${version}"
+    if [[ "$version" == "11.6" || "$version" == "11.7" ]]; then
+        cudatoolkit=" pytorch-cuda=${version}"
     fi
-    cudatoolkit="${cuda_toolkit_pckg}=${version}"
 fi
 
 printf "Installing PyTorch with %s\n" "${cudatoolkit}"

--- a/packaging/build_conda.sh
+++ b/packaging/build_conda.sh
@@ -13,21 +13,9 @@ setup_conda_pytorch_constraint
 setup_conda_cudatoolkit_constraint
 setup_visual_studio_constraint
 
-# nvidia channel included for cudatoolkit >= 11 however for 11.5 we use conda-forge
-# HACK HACK HACK: Remove PYTHON_VERSION check once https://github.com/pytorch/builder/pull/961 is merged
 export CUDATOOLKIT_CHANNEL="nvidia"
-# NOTE: This is needed because `cudatoolkit=11.5` has a dependency on conda-forge
-#       See: https://github.com/pytorch/audio/pull/2224#issuecomment-1049185550
-export CUDA116_CUDA_DEPENDENCY=""
-if [[ ${CU_VERSION} = "cu116" ]]; then
-    export CUDATOOLKIT_CHANNEL="nvidia/label/cuda-11.6.2"
-    export CUDA116_CUDA_DEPENDENCY="cuda"
-elif [[ ! -z ${CU_VERSION} ]]; then
-    export CUDA116_CUDA_DEPENDENCY="cudatoolkit"
-fi
-
 # NOTE: There are some dependencies that are not available for macOS on Python 3.10 without conda-forge
 if [[ ${OSTYPE} =~ darwin* ]] && [[ ${PYTHON_VERSION} = "3.10" ]]; then
     CONDA_CHANNEL_FLAGS="${CONDA_CHANNEL_FLAGS} -c conda-forge"
 fi
-conda build -c defaults -c $CUDATOOLKIT_CHANNEL ${CONDA_CHANNEL_FLAGS:-}  --no-anaconda-upload --python "$PYTHON_VERSION" $CUDA116_CUDA_DEPENDENCY packaging/torchaudio
+conda build -c defaults -c $CUDATOOLKIT_CHANNEL ${CONDA_CHANNEL_FLAGS:-}  --no-anaconda-upload --python "$PYTHON_VERSION"  packaging/torchaudio

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -81,8 +81,12 @@ setup_cuda() {
       ;;
   esac
   if [[ -n "$CUDA_HOME" ]]; then
-    # Adds nvcc binary to the search path so that CMake's `find_package(CUDA)` will pick the right one
-    export PATH="$CUDA_HOME/bin:$PATH"
+    if [[ "$OSTYPE" == "msys" ]]; then
+      export PATH="$CUDA_HOME\\bin:$PATH"
+    else
+      # Adds nvcc binary to the search path so that CMake's `find_package(CUDA)` will pick the right one
+      export PATH="$CUDA_HOME/bin:$PATH"
+    fi
     export USE_CUDA=1
   fi
 }

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -213,7 +213,11 @@ setup_conda_pytorch_constraint() {
   CONDA_CHANNEL_FLAGS="${CONDA_CHANNEL_FLAGS}"
   if [[ -z "$PYTORCH_VERSION" ]]; then
     export CONDA_CHANNEL_FLAGS="${CONDA_CHANNEL_FLAGS} -c pytorch-nightly"
-    export PYTORCH_VERSION="$(conda search --json 'pytorch[channel=pytorch-nightly]' | python3 -c "import sys, json, re; print(re.sub(r'\\+.*$', '', json.load(sys.stdin)['pytorch'][-1]['version']))")"
+    if [[ "$OSTYPE" == "msys" ]]; then
+      export PYTORCH_VERSION="$(conda search --json -c pytorch-nightly pytorch | python -c "import sys, json; data=json.load(sys.stdin); print(data['pytorch'][-1]['version'])")"
+    else
+      export PYTORCH_VERSION="$(conda search --json 'pytorch[channel=pytorch-nightly]' | python3 -c "import sys, json, re; print(re.sub(r'\\+.*$', '', json.load(sys.stdin)['pytorch'][-1]['version']))")"
+    fi
   else
     export CONDA_CHANNEL_FLAGS="${CONDA_CHANNEL_FLAGS} -c pytorch -c pytorch-test -c pytorch-nightly"
   fi

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -237,8 +237,11 @@ setup_conda_cudatoolkit_constraint() {
     export CONDA_BUILD_VARIANT="cpu"
   else
     case "$CU_VERSION" in
+      cu117)
+        export CONDA_CUDATOOLKIT_CONSTRAINT="- pytorch-cuda=11.7 # [not osx]"
+        ;;
       cu116)
-        export CONDA_CUDATOOLKIT_CONSTRAINT=""
+        export CONDA_CUDATOOLKIT_CONSTRAINT="- pytorch-cuda=11.6 # [not osx]"
         ;;
       cu113)
         export CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=11.3,<11.4 # [not osx]"

--- a/packaging/torchaudio/meta.yaml
+++ b/packaging/torchaudio/meta.yaml
@@ -45,6 +45,7 @@ build:
   script_env:
     - BUILD_VERSION
     - USE_CUDA
+    - CUDA_HOME
     - TORCH_CUDA_ARCH_LIST
     - USE_FFMPEG
     - USE_OPENMP

--- a/packaging/vs2019/conda_build_config.yaml
+++ b/packaging/vs2019/conda_build_config.yaml
@@ -5,8 +5,7 @@ c_compiler:
 cxx_compiler:
   - vs2019                     # [win]
 python:
-  - 3.5
-  - 3.6
+  - 3.7
 # This differs from target_platform in that it determines what subdir the compiler
 #    will target, not what subdir the compiler package will be itself.
 #    For example, we need a win-64 vs2008_win-32 package, so that we compile win-32

--- a/tools/setup_helpers/extension.py
+++ b/tools/setup_helpers/extension.py
@@ -120,7 +120,7 @@ class CMakeBuild(build_ext):
             _arches = [arch[:-4] if arch.endswith("+PTX") else f"{arch}-real" for arch in _arches]
             cmake_args += [f"-DCMAKE_CUDA_ARCHITECTURES={';'.join(_arches)}"]
 
-        if CUDA_HOME is not None:
+        if platform.system() != "Windows" and CUDA_HOME is not None:
             cmake_args += [f"-DCMAKE_CUDA_COMPILER='{CUDA_HOME}/bin/nvcc'"]
             cmake_args += [f"-DCUDA_TOOLKIT_ROOT_DIR='{CUDA_HOME}'"]
 

--- a/tools/setup_helpers/extension.py
+++ b/tools/setup_helpers/extension.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import torch
 from setuptools import Extension
 from setuptools.command.build_ext import build_ext
+from torch.utils.cpp_extension import CUDA_HOME
 
 __all__ = [
     "get_ext_modules",
@@ -44,25 +45,29 @@ _TORCH_CUDA_ARCH_LIST = os.environ.get("TORCH_CUDA_ARCH_LIST", None)
 
 
 def get_ext_modules():
+    cuda_libs = os.path.join(CUDA_HOME, "lib64")
+    cuda_inc = os.path.join(CUDA_HOME, "include")
+
     modules = [
-        Extension(name="torchaudio.lib.libtorchaudio", sources=[]),
-        Extension(name="torchaudio._torchaudio", sources=[]),
+        Extension(name="torchaudio.lib.libtorchaudio", sources=[], include_dirs=[cuda_inc], library_dirs=[cuda_libs]),
+        Extension(name="torchaudio._torchaudio", sources=[], include_dirs=[cuda_inc], library_dirs=[cuda_libs] ),
     ]
     if _BUILD_CTC_DECODER:
         modules.extend(
             [
-                Extension(name="torchaudio.lib.libflashlight-text", sources=[]),
-                Extension(name="torchaudio.flashlight_lib_text_decoder", sources=[]),
-                Extension(name="torchaudio.flashlight_lib_text_dictionary", sources=[]),
+                Extension(name="torchaudio.lib.libflashlight-text", sources=[], include_dirs=[cuda_inc], library_dirs=[cuda_libs]),
+                Extension(name="torchaudio.flashlight_lib_text_decoder", sources=[], include_dirs=[cuda_inc], library_dirs=[cuda_libs]),
+                Extension(name="torchaudio.flashlight_lib_text_dictionary", sources=[], include_dirs=[cuda_inc], library_dirs=[cuda_libs]),
             ]
         )
     if _USE_FFMPEG:
         modules.extend(
             [
-                Extension(name="torchaudio.lib.libtorchaudio_ffmpeg", sources=[]),
-                Extension(name="torchaudio._torchaudio_ffmpeg", sources=[]),
+                Extension(name="torchaudio.lib.libtorchaudio_ffmpeg", sources=[], include_dirs=[cuda_inc], library_dirs=[cuda_libs]),
+                Extension(name="torchaudio._torchaudio_ffmpeg", sources=[], include_dirs=[cuda_inc], library_dirs=[cuda_libs]),
             ]
         )
+
     return modules
 
 

--- a/tools/setup_helpers/extension.py
+++ b/tools/setup_helpers/extension.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import torch
 from setuptools import Extension
 from setuptools.command.build_ext import build_ext
+from torch.utils.cpp_extension import CUDA_HOME
 
 __all__ = [
     "get_ext_modules",


### PR DESCRIPTION
Introducing pytorch-cuda metapackage

Same as: https://github.com/pytorch/vision/pull/6371
Following PR: https://github.com/pytorch/builder/pull/1094
Adds cuda metapackage called pytorch-cuda . This way we can make sure to install correct version of cuda dependencies and don't depend on conda-forge.