### PR TITLE
Remove outdated doc

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -60,7 +60,6 @@ Prototype API References
    :caption: Prototype API Reference
 
    prototype
-   prototype.ctc_decoder
    prototype.functional
    prototype.models
    prototype.pipelines


### PR DESCRIPTION
`ctc_decoder` has become beta, remove it from prototype documents.