### PR TITLE
Use double quotes for string in functional and transforms

### DIFF
--- a/torchaudio/functional/filtering.py
+++ b/torchaudio/functional/filtering.py
@@ -758,10 +758,10 @@ def flanger(
     """
 
     if modulation not in ("sinusoidal", "triangular"):
-        raise ValueError("Only 'sinusoidal' or 'triangular' modulation allowed")
+        raise ValueError('Only "sinusoidal" or "triangular" modulation allowed')
 
     if interpolation not in ("linear", "quadratic"):
-        raise ValueError("Only 'linear' or 'quadratic' interpolation allowed")
+        raise ValueError('Only "linear" or "quadratic" interpolation allowed')
 
     actual_shape = waveform.shape
     device, dtype = waveform.device, waveform.dtype

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -533,7 +533,7 @@ def melscale_fbanks(
         f_max (float): Maximum frequency (Hz)
         n_mels (int): Number of mel filterbanks
         sample_rate (int): Sample rate of the audio waveform
-        norm (str or None, optional): If 'slaney', divide the triangular mel weights by the width of the mel band
+        norm (str or None, optional): If "slaney", divide the triangular mel weights by the width of the mel band
             (area normalization). (Default: ``None``)
         mel_scale (str, optional): Scale to use: ``htk`` or ``slaney``. (Default: ``htk``)
 
@@ -547,7 +547,7 @@ def melscale_fbanks(
     """
 
     if norm is not None and norm != "slaney":
-        raise ValueError("norm must be one of None or 'slaney'")
+        raise ValueError('norm must be one of None or "slaney"')
 
     # freq bins
     all_freqs = torch.linspace(0, sample_rate // 2, n_freqs)
@@ -634,7 +634,7 @@ def create_dct(n_mfcc: int, n_mels: int, norm: Optional[str]) -> Tensor:
     Args:
         n_mfcc (int): Number of mfc coefficients to retain
         n_mels (int): Number of mel filterbanks
-        norm (str or None): Norm to use (either 'ortho' or None)
+        norm (str or None): Norm to use (either "ortho" or None)
 
     Returns:
         Tensor: The transformation matrix, to be right-multiplied to
@@ -642,7 +642,7 @@ def create_dct(n_mfcc: int, n_mels: int, norm: Optional[str]) -> Tensor:
     """
 
     if norm is not None and norm != "ortho":
-        raise ValueError("norm must be either 'ortho' or None")
+        raise ValueError('norm must be either "ortho" or None')
 
     # http://en.wikipedia.org/wiki/Discrete_cosine_transform#DCT-II
     n = torch.arange(float(n_mels))
@@ -1571,7 +1571,7 @@ def resample(
         rolloff (float, optional): The roll-off frequency of the filter, as a fraction of the Nyquist.
             Lower values reduce anti-aliasing, but also reduce some of the highest frequencies. (Default: ``0.99``)
         resampling_method (str, optional): The resampling method to use.
-            Options: [``sinc_interpolation``, ``kaiser_window``] (Default: ``'sinc_interpolation'``)
+            Options: [``"sinc_interpolation"``, ``"kaiser_window"``] (Default: ``"sinc_interpolation"``)
         beta (float or None, optional): The shape parameter used for kaiser window.
 
     Returns:
@@ -1859,13 +1859,13 @@ def rnnt_loss(
         blank (int, optional): blank label (Default: ``-1``)
         clamp (float, optional): clamp for gradients (Default: ``-1``)
         reduction (string, optional): Specifies the reduction to apply to the output:
-            ``'none'`` | ``'mean'`` | ``'sum'``. (Default: ``'mean'``)
+            ``"none"`` | ``"mean"`` | ``"sum"``. (Default: ``"mean"``)
     Returns:
-        Tensor: Loss with the reduction option applied. If ``reduction`` is  ``'none'``, then size `(batch)`,
+        Tensor: Loss with the reduction option applied. If ``reduction`` is  ``"none"``, then size `(batch)`,
         otherwise scalar.
     """
     if reduction not in ["none", "mean", "sum"]:
-        raise ValueError("reduction should be one of 'none', 'mean', or 'sum'")
+        raise ValueError('reduction should be one of "none", "mean", or "sum"')
 
     if blank < 0:  # reinterpret blank index if blank < 0.
         blank = logits.shape[-1] + blank
@@ -2059,7 +2059,7 @@ def mvdr_weights_souden(
         # h: (..., F, C_1, C_2) x (..., C_2) -> (..., F, C_1)
         beamform_weights = torch.einsum("...c,...c->...", [ws, reference_channel[..., None, None, :]])
     else:
-        raise TypeError(f"Expected 'int' or 'Tensor' for reference_channel. Found: {type(reference_channel)}.")
+        raise TypeError(f'Expected "int" or "Tensor" for reference_channel. Found: {type(reference_channel)}.')
 
     return beamform_weights
 
@@ -2142,7 +2142,7 @@ def mvdr_weights_rtf(
             reference_channel = reference_channel.to(psd_n.dtype)
             scale = torch.einsum("...c,...c->...", [rtf.conj(), reference_channel[..., None, :]])
         else:
-            raise TypeError(f"Expected 'int' or 'Tensor' for reference_channel. Found: {type(reference_channel)}.")
+            raise TypeError(f'Expected "int" or "Tensor" for reference_channel. Found: {type(reference_channel)}.')
 
         beamform_weights = beamform_weights * scale[..., None]
 
@@ -2220,7 +2220,7 @@ def rtf_power(
         reference_channel = reference_channel.to(psd_n.dtype)
         rtf = torch.einsum("...c,...c->...", [phi, reference_channel[..., None, None, :]])
     else:
-        raise TypeError(f"Expected 'int' or 'Tensor' for reference_channel. Found: {type(reference_channel)}.")
+        raise TypeError(f'Expected "int" or "Tensor" for reference_channel. Found: {type(reference_channel)}.')
     rtf = rtf.unsqueeze(-1)  # (..., freq, channel, 1)
     if n_iter >= 2:
         # The number of iterations in the for loop is `n_iter - 2`

--- a/torchaudio/transforms/_multi_channel.py
+++ b/torchaudio/transforms/_multi_channel.py
@@ -178,7 +178,7 @@ class MVDR(torch.nn.Module):
             "stv_power",
         ]:
             raise ValueError(
-                "`solution` must be one of ['ref_channel', 'stv_evd', 'stv_power']. Given {}".format(solution)
+                '`solution` must be one of ["ref_channel", "stv_evd", "stv_power"]. Given {}'.format(solution)
             )
         self.ref_channel = ref_channel
         self.solution = solution

--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -52,7 +52,7 @@ class Spectrogram(torch.nn.Module):
             Deprecated and not used.
 
     Example
-        >>> waveform, sample_rate = torchaudio.load('test.wav', normalize=True)
+        >>> waveform, sample_rate = torchaudio.load("test.wav", normalize=True)
         >>> transform = torchaudio.transforms.Spectrogram(n_fft=800)
         >>> spectrogram = transform(waveform)
 
@@ -306,8 +306,8 @@ class AmplitudeToDB(torch.nn.Module):
     a full clip.
 
     Args:
-        stype (str, optional): scale of input tensor (``'power'`` or ``'magnitude'``). The
-            power being the elementwise square of the magnitude. (Default: ``'power'``)
+        stype (str, optional): scale of input tensor (``"power"`` or ``"magnitude"``). The
+            power being the elementwise square of the magnitude. (Default: ``"power"``)
         top_db (float or None, optional): minimum negative cut-off in decibels.  A reasonable
             number is 80. (Default: ``None``)
     """
@@ -351,7 +351,7 @@ class MelScale(torch.nn.Module):
         f_min (float, optional): Minimum frequency. (Default: ``0.``)
         f_max (float or None, optional): Maximum frequency. (Default: ``sample_rate // 2``)
         n_stft (int, optional): Number of bins in STFT. See ``n_fft`` in :class:`Spectrogram`. (Default: ``201``)
-        norm (str or None, optional): If ``'slaney'``, divide the triangular mel weights by the width of the mel band
+        norm (str or None, optional): If ``"slaney"``, divide the triangular mel weights by the width of the mel band
             (area normalization). (Default: ``None``)
         mel_scale (str, optional): Scale to use: ``htk`` or ``slaney``. (Default: ``htk``)
 
@@ -418,7 +418,7 @@ class InverseMelScale(torch.nn.Module):
         tolerance_loss (float, optional): Value of loss to stop optimization at. (Default: ``1e-5``)
         tolerance_change (float, optional): Difference in losses to stop optimization at. (Default: ``1e-8``)
         sgdargs (dict or None, optional): Arguments for the SGD optimizer. (Default: ``None``)
-        norm (str or None, optional): If 'slaney', divide the triangular mel weights by the width of the mel band
+        norm (str or None, optional): If "slaney", divide the triangular mel weights by the width of the mel band
             (area normalization). (Default: ``None``)
         mel_scale (str, optional): Scale to use: ``htk`` or ``slaney``. (Default: ``htk``)
     """
@@ -549,12 +549,12 @@ class MelSpectrogram(torch.nn.Module):
             :attr:`center` is ``True``. (Default: ``"reflect"``)
         onesided (bool, optional): controls whether to return half of results to
             avoid redundancy. (Default: ``True``)
-        norm (str or None, optional): If 'slaney', divide the triangular mel weights by the width of the mel band
+        norm (str or None, optional): If "slaney", divide the triangular mel weights by the width of the mel band
             (area normalization). (Default: ``None``)
         mel_scale (str, optional): Scale to use: ``htk`` or ``slaney``. (Default: ``htk``)
 
     Example
-        >>> waveform, sample_rate = torchaudio.load('test.wav', normalize=True)
+        >>> waveform, sample_rate = torchaudio.load("test.wav", normalize=True)
         >>> transform = transforms.MelSpectrogram(sample_rate)
         >>> mel_specgram = transform(waveform)  # (channel, n_mels, time)
 
@@ -644,7 +644,7 @@ class MFCC(torch.nn.Module):
         sample_rate (int, optional): Sample rate of audio signal. (Default: ``16000``)
         n_mfcc (int, optional): Number of mfc coefficients to retain. (Default: ``40``)
         dct_type (int, optional): type of DCT (discrete cosine transform) to use. (Default: ``2``)
-        norm (str, optional): norm to use. (Default: ``'ortho'``)
+        norm (str, optional): norm to use. (Default: ``"ortho"``)
         log_mels (bool, optional): whether to use log-mel spectrograms instead of db-scaled. (Default: ``False``)
         melkwargs (dict or None, optional): arguments for MelSpectrogram. (Default: ``None``)
 
@@ -725,7 +725,7 @@ class LFCC(torch.nn.Module):
         f_min (float, optional): Minimum frequency. (Default: ``0.``)
         f_max (float or None, optional): Maximum frequency. (Default: ``None``)
         dct_type (int, optional): type of DCT (discrete cosine transform) to use. (Default: ``2``)
-        norm (str, optional): norm to use. (Default: ``'ortho'``)
+        norm (str, optional): norm to use. (Default: ``"ortho"``)
         log_lf (bool, optional): whether to use log-lf spectrograms instead of db-scaled. (Default: ``False``)
         speckwargs (dict or None, optional): arguments for Spectrogram. (Default: ``None``)
 
@@ -822,7 +822,7 @@ class MuLawEncoding(torch.nn.Module):
         quantization_channels (int, optional): Number of channels. (Default: ``256``)
 
     Example
-       >>> waveform, sample_rate = torchaudio.load('test.wav', normalize=True)
+       >>> waveform, sample_rate = torchaudio.load("test.wav", normalize=True)
        >>> transform = torchaudio.transforms.MuLawEncoding(quantization_channels=512)
        >>> mulawtrans = transform(waveform)
 
@@ -861,7 +861,7 @@ class MuLawDecoding(torch.nn.Module):
         quantization_channels (int, optional): Number of channels. (Default: ``256``)
 
     Example
-        >>> waveform, sample_rate = torchaudio.load('test.wav', normalize=True)
+        >>> waveform, sample_rate = torchaudio.load("test.wav", normalize=True)
         >>> transform = torchaudio.transforms.MuLawDecoding(quantization_channels=512)
         >>> mulawtrans = transform(waveform)
     """
@@ -899,7 +899,7 @@ class Resample(torch.nn.Module):
         orig_freq (int, optional): The original frequency of the signal. (Default: ``16000``)
         new_freq (int, optional): The desired frequency. (Default: ``16000``)
         resampling_method (str, optional): The resampling method to use.
-            Options: [``sinc_interpolation``, ``kaiser_window``] (Default: ``'sinc_interpolation'``)
+            Options: [``sinc_interpolation``, ``kaiser_window``] (Default: ``"sinc_interpolation"``)
         lowpass_filter_width (int, optional): Controls the sharpness of the filter, more == sharper
             but less efficient. (Default: ``6``)
         rolloff (float, optional): The roll-off frequency of the filter, as a fraction of the Nyquist.
@@ -914,7 +914,7 @@ class Resample(torch.nn.Module):
             carried out on ``torch.float64``.
 
     Example
-        >>> waveform, sample_rate = torchaudio.load('test.wav', normalize=True)
+        >>> waveform, sample_rate = torchaudio.load("test.wav", normalize=True)
         >>> transform = transforms.Resample(sample_rate, sample_rate/10)
         >>> waveform = transform(waveform)
     """
@@ -977,7 +977,7 @@ class ComputeDeltas(torch.nn.Module):
 
     Args:
         win_length (int, optional): The window length used for computing delta. (Default: ``5``)
-        mode (str, optional): Mode parameter passed to padding. (Default: ``'replicate'``)
+        mode (str, optional): Mode parameter passed to padding. (Default: ``"replicate"``)
     """
     __constants__ = ["win_length"]
 
@@ -1081,8 +1081,8 @@ class Fade(torch.nn.Module):
             (Default: ``"linear"``)
 
     Example
-        >>> waveform, sample_rate = torchaudio.load('test.wav', normalize=True)
-        >>> transform = transforms.Fade(fade_in_len=sample_rate, fade_out_len=2 * sample_rate, fade_shape='linear')
+        >>> waveform, sample_rate = torchaudio.load("test.wav", normalize=True)
+        >>> transform = transforms.Fade(fade_in_len=sample_rate, fade_out_len=2 * sample_rate, fade_shape="linear")
         >>> faded_waveform = transform(waveform)
     """
 
@@ -1300,7 +1300,7 @@ class Vol(torch.nn.Module):
         gain_type (str, optional): Type of gain. One of: ``amplitude``, ``power``, ``db`` (Default: ``amplitude``)
 
     Example
-        >>> waveform, sample_rate = torchaudio.load('test.wav', normalize=True)
+        >>> waveform, sample_rate = torchaudio.load("test.wav", normalize=True)
         >>> transform = transforms.Vol(gain=0.5, gain_type="amplitude")
         >>> quieter_waveform = transform(waveform)
     """
@@ -1350,7 +1350,7 @@ class SlidingWindowCmn(torch.nn.Module):
         norm_vars (bool, optional): If true, normalize variance to one. (bool, default = false)
 
     Example
-        >>> waveform, sample_rate = torchaudio.load('test.wav', normalize=True)
+        >>> waveform, sample_rate = torchaudio.load("test.wav", normalize=True)
         >>> transform = transforms.SlidingWindowCmn(cmn_window=1000)
         >>> cmn_waveform = transform(waveform)
     """
@@ -1430,12 +1430,12 @@ class Vad(torch.nn.Module):
             in the detector algorithm. (Default: 2000.0)
 
     Example
-        >>> waveform, sample_rate = torchaudio.load('test.wav', normalize=True)
-        >>> waveform_reversed, sample_rate = apply_effects_tensor(waveform, sample_rate, [['reverse']])
+        >>> waveform, sample_rate = torchaudio.load("test.wav", normalize=True)
+        >>> waveform_reversed, sample_rate = apply_effects_tensor(waveform, sample_rate, [["reverse"]])
         >>> transform = transforms.Vad(sample_rate=sample_rate, trigger_level=7.5)
         >>> waveform_reversed_front_trim = transform(waveform_reversed)
         >>> waveform_end_trim, sample_rate = apply_effects_tensor(
-        >>>     waveform_reversed_front_trim, sample_rate, [['reverse']]
+        >>>     waveform_reversed_front_trim, sample_rate, [["reverse"]]
         >>> )
 
     Reference:
@@ -1533,7 +1533,7 @@ class SpectralCentroid(torch.nn.Module):
         wkwargs (dict or None, optional): Arguments for window function. (Default: ``None``)
 
     Example
-        >>> waveform, sample_rate = torchaudio.load('test.wav', normalize=True)
+        >>> waveform, sample_rate = torchaudio.load("test.wav", normalize=True)
         >>> transform = transforms.SpectralCentroid(sample_rate)
         >>> spectral_centroid = transform(waveform)  # (channel, time)
     """
@@ -1592,7 +1592,7 @@ class PitchShift(LazyModuleMixin, torch.nn.Module):
             If None, then ``torch.hann_window(win_length)`` is used (Default: ``None``).
 
     Example
-        >>> waveform, sample_rate = torchaudio.load('test.wav', normalize=True)
+        >>> waveform, sample_rate = torchaudio.load("test.wav", normalize=True)
         >>> transform = transforms.PitchShift(sample_rate, 4)
         >>> waveform_shift = transform(waveform)  # (channel, time)
     """
@@ -1697,7 +1697,7 @@ class RNNTLoss(torch.nn.Module):
         blank (int, optional): blank label (Default: ``-1``)
         clamp (float, optional): clamp for gradients (Default: ``-1``)
         reduction (string, optional): Specifies the reduction to apply to the output:
-            ``'none'`` | ``'mean'`` | ``'sum'``. (Default: ``'mean'``)
+            ``"none"`` | ``"mean"`` | ``"sum"``. (Default: ``"mean"``)
 
     Example
         >>> # Hypothetical values
@@ -1743,7 +1743,7 @@ class RNNTLoss(torch.nn.Module):
             logit_lengths (Tensor): Tensor of dimension `(batch)` containing lengths of each sequence from encoder
             target_lengths (Tensor): Tensor of dimension `(batch)` containing lengths of targets for each sequence
         Returns:
-            Tensor: Loss with the reduction option applied. If ``reduction`` is  ``'none'``, then size (batch),
+            Tensor: Loss with the reduction option applied. If ``reduction`` is  ``"none"``, then size (batch),
             otherwise scalar.
         """
         return F.rnnt_loss(logits, targets, logit_lengths, target_lengths, self.blank, self.clamp, self.reduction)


### PR DESCRIPTION
To make the code consistent, we should use double quotation marks for all strings. This PR make such changes in functional and transforms.