### PR TITLE
Fix doc warning

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -91,7 +91,7 @@ Transforms are common audio transforms. They can be chained together using :clas
   .. automethod:: forward
 
 :hidden:`Loudness`
------------------
+------------------
 
 .. autoclass:: Loudness
 


### PR DESCRIPTION
Resolves the following warning

```
/torchaudio/docs/source/transforms.rst:94: WARNING: Title underline too short.

:hidden:`Loudness`
-----------------
```