### PR TITLE
Fix Sphinx-gallery display and pin sphinx-related packages

### DIFF
--- a/docs/requirements-tutorials.txt
+++ b/docs/requirements-tutorials.txt
@@ -5,7 +5,6 @@ cython
 pandas
 librosa
 sentencepiece
-nbsphinx
 pandoc
 mir_eval
 pesq

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,11 +1,18 @@
 Jinja2<3.1.0
-sphinx==3.5.4
--e git+https://github.com/pytorch/pytorch_sphinx_theme.git@b4d0005#egg=pytorch_sphinx_theme
-sphinxcontrib.katex
-sphinxcontrib.bibtex
 matplotlib
 pyparsing<3,>=2.0.2
-sphinx_gallery
+
+# Note:
+# When changing Sphinx-related packages, make sure that the custom behaviors in the following
+# locations are working as expected.
+# - source/_templates/layout.html
+# - source/_static/css/custom.css
+-e git+https://github.com/pytorch/pytorch_sphinx_theme.git@b4d0005#egg=pytorch_sphinx_theme
+sphinx==3.5.4
+sphinxcontrib.katex==0.8.6
+sphinxcontrib.bibtex==2.4.2
+sphinx_gallery==0.11
+nbsphinx==0.8.8
 
 # https://github.com/bmcfee/resampy/issues/106
 # Since 2022-07-07 build_docs CI job started to fail.

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -15,3 +15,19 @@ article.pytorch-article img.shield-badge {
     margin-top: -18px;
     margin-bottom: 9px;
 }
+/* Fix for Sphinx gallery 0.11
+See https://github.com/sphinx-gallery/sphinx-gallery/issues/990
+*/
+article.pytorch-article .sphx-glr-thumbnails .sphx-glr-thumbcontainer {
+    width: unset;
+    margin-right: 0;
+    margin-left: 0;
+}
+article.pytorch-article .sphx-glr-thumbnails {
+    display: flex;
+    grid-template-columns: none;
+}
+article.pytorch-article .sphx-glr-thumbnails .sphx-glr-thumbnails {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+}


### PR DESCRIPTION
This commit fixes the issue with the recent Sphinx-Gallery update.
Also it pins the versions of Sphinx-related packages.

Before:

<img width="256" alt="Screen Shot 2022-08-17 at 10 02 23 PM" src="https://user-images.githubusercontent.com/855818/185140952-28f2d98a-b586-424c-a003-b69089f48eb9.png">


After:

https://user-images.githubusercontent.com/855818/185271889-bd4f86a0-986b-43bb-8121-bd77750d74f0.mov


