### PR TITLE
Tweak tutorials

### DIFF
--- a/examples/tutorials/asr_inference_with_ctc_decoder_tutorial.py
+++ b/examples/tutorials/asr_inference_with_ctc_decoder_tutorial.py
@@ -109,8 +109,10 @@ IPython.display.Audio(speech_file)
 
 ######################################################################
 # The transcript corresponding to this audio file is
-# ::
-#   i really was very much afraid of showing him how much shocked i was at some parts of what he said
+#
+# .. code-block::
+#
+#    i really was very much afraid of showing him how much shocked i was at some parts of what he said
 #
 
 waveform, sample_rate = torchaudio.load(speech_file)
@@ -139,7 +141,7 @@ if sample_rate != bundle.sample_rate:
 # file, where each line consists of the tokens corresponding to the same
 # index, or as a list of tokens, each mapping to a unique index.
 #
-# ::
+# .. code-block::
 #
 #    # tokens.txt
 #    _
@@ -162,7 +164,7 @@ print(tokens)
 # only words from the lexicon. The expected format of the lexicon file is
 # a line per word, with a word followed by its space-split tokens.
 #
-# ::
+# .. code-block::
 #
 #    # lexcion.txt
 #    a a |
@@ -283,8 +285,10 @@ greedy_decoder = GreedyCTCDecoder(tokens)
 # predicted token IDs, corresponding words (if a lexicon is provided), hypothesis score,
 # and timesteps corresponding to the token IDs. Recall the transcript corresponding to the
 # waveform is
-# ::
-#   i really was very much afraid of showing him how much shocked i was at some parts of what he said
+#
+# .. code-block::
+#
+#    i really was very much afraid of showing him how much shocked i was at some parts of what he said
 #
 
 actual_transcript = "i really was very much afraid of showing him how much shocked i was at some parts of what he said"

--- a/examples/tutorials/audio_io_tutorial.py
+++ b/examples/tutorials/audio_io_tutorial.py
@@ -304,8 +304,8 @@ print("matched!")
 #
 # .. note::
 #
-# Saving data in encodings with a lower bit depth reduces the
-# resulting file size but also precision.
+#    Saving data in encodings with a lower bit depth reduces the
+#    resulting file size but also precision.
 #
 
 waveform, sample_rate = torchaudio.load(SAMPLE_WAV)

--- a/examples/tutorials/mvdr_tutorial.py
+++ b/examples/tutorials/mvdr_tutorial.py
@@ -219,6 +219,7 @@ stft_noise = stft(waveform_noise)
 # -  signal-to-distortion ratio (SDR)
 # -  scale-invariant signal-to-noise ratio (Si-SNR, or Si-SDR in some papers)
 # -  Perceptual Evaluation of Speech Quality (PESQ)
+#
 # We also evaluate the intelligibility of the speech with the Short-Time Objective Intelligibility
 # (STOI) metric.
 


### PR DESCRIPTION
Resolves the following warnings

```
/torchaudio/docs/source/tutorials/asr_inference_with_ctc_decoder_tutorial.rst:195: WARNING: Unexpected indentation.
/torchaudio/docs/source/tutorials/asr_inference_with_ctc_decoder_tutorial.rst:446: WARNING: Unexpected indentation.
/torchaudio/docs/source/tutorials/audio_io_tutorial.rst:559: WARNING: Content block expected for the "note" directive; none found.
/torchaudio/docs/source/tutorials/mvdr_tutorial.rst:338: WARNING: Bullet list ends without a blank line; unexpected unindent.
```