### PR TITLE
Update notes around nightly build and third parties

### DIFF
--- a/examples/tutorials/device_asr.py
+++ b/examples/tutorials/device_asr.py
@@ -10,16 +10,11 @@ on laptop.
 
 .. note::
 
-   This tutorial requires Streaming API, FFmpeg libraries (>=4.1, <5),
-   and SentencePiece.
-
-   The Streaming API is available in nightly build.
-   Please refer to https://pytorch.org/get-started/locally
-   for instructions.
+   This tutorial requires FFmpeg libraries (>=4.1, <4.4) and SentencePiece.
 
    There are multiple ways to install FFmpeg libraries.
    If you are using Anaconda Python distribution,
-   ``conda install 'ffmpeg<5'`` will install
+   ``conda install 'ffmpeg<4.4'`` will install
    the required FFmpeg libraries.
 
    You can install SentencePiece by running ``pip install sentencepiece``.

--- a/examples/tutorials/online_asr_tutorial.py
+++ b/examples/tutorials/online_asr_tutorial.py
@@ -13,16 +13,11 @@ to perform online speech recognition.
 #
 # .. note::
 #
-#    This tutorial requires Streaming API, FFmpeg libraries (>=4.1, <5),
-#    and SentencePiece.
-#
-#    The Streaming API is available in nightly builds.
-#    Please refer to https://pytorch.org/get-started/locally/
-#    for instructions.
+#    This tutorial requires FFmpeg libraries (>=4.1, <4.4) and SentencePiece.
 #
 #    There are multiple ways to install FFmpeg libraries.
 #    If you are using Anaconda Python distribution,
-#    ``conda install 'ffmpeg<5'`` will install
+#    ``conda install 'ffmpeg<4.4'`` will install
 #    the required FFmpeg libraries.
 #
 #    You can install SentencePiece by running ``pip install sentencepiece``.
@@ -44,9 +39,15 @@ to perform online speech recognition.
 # --------------
 #
 
-import IPython
 import torch
 import torchaudio
+
+print(torch.__version__)
+print(torchaudio.__version__)
+
+######################################################################
+#
+import IPython
 
 try:
     from torchaudio.io import StreamReader
@@ -56,13 +57,9 @@ except ModuleNotFoundError:
 
         print(
             """
-            To enable running this notebook in Google Colab, install nightly
-            torch and torchaudio builds and the requisite third party libraries by
-            adding the following code block to the top of the notebook before running it:
+            To enable running this notebook in Google Colab, install the requisite
+            third party libraries by running the following code block:
 
-            !pip3 uninstall -y torch torchvision torchaudio
-            !pip3 install --pre torch torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu
-            !pip3 install sentencepiece
             !add-apt-repository -y ppa:savoury1/ffmpeg4
             !apt-get -qq install -y ffmpeg
             """
@@ -70,9 +67,6 @@ except ModuleNotFoundError:
     except ModuleNotFoundError:
         pass
     raise
-
-print(torch.__version__)
-print(torchaudio.__version__)
 
 
 ######################################################################

--- a/examples/tutorials/streaming_api2_tutorial.py
+++ b/examples/tutorials/streaming_api2_tutorial.py
@@ -29,12 +29,9 @@ except ModuleNotFoundError:
 
         print(
             """
-            To enable running this notebook in Google Colab, install nightly
-            torch and torchaudio builds and the requisite third party libraries by
-            adding the following code block to the top of the notebook before running it:
+            To enable running this notebook in Google Colab, install the requisite
+            third party libraries by running the following code:
 
-            !pip3 uninstall -y torch torchvision torchaudio
-            !pip3 install --pre torch torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu
             !add-apt-repository -y ppa:savoury1/ffmpeg4
             !apt-get -qq install -y ffmpeg
             """

--- a/examples/tutorials/streaming_api_tutorial.py
+++ b/examples/tutorials/streaming_api_tutorial.py
@@ -12,15 +12,11 @@ libavfilter provides.
 #
 # .. note::
 #
-#    This tutorial requires Streaming API and FFmpeg libraries (>=4.1, <5).
-#
-#    The Streaming API is available in nightly builds.
-#    Please refer to https://pytorch.org/get-started/locally/
-#    for instructions.
+#    This tutorial requires FFmpeg libraries (>=4.1, <4.4).
 #
 #    There are multiple ways to install FFmpeg libraries.
 #    If you are using Anaconda Python distribution,
-#    ``conda install -c anaconda 'ffmpeg<5'`` will install
+#    ``conda install -c anaconda 'ffmpeg<4.4'`` will install
 #    the required libraries.
 #
 
@@ -78,12 +74,9 @@ except ModuleNotFoundError:
 
         print(
             """
-            To enable running this notebook in Google Colab, install nightly
-            torch and torchaudio builds and the requisite third party libraries by
-            adding the following code block to the top of the notebook before running it:
+            To enable running this notebook in Google Colab, install the requisite
+            third party libraries by running the following code:
 
-            !pip3 uninstall -y torch torchvision torchaudio
-            !pip3 install --pre torch torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu
             !add-apt-repository -y ppa:savoury1/ffmpeg4
             !apt-get -qq install -y ffmpeg
             """
@@ -92,7 +85,6 @@ except ModuleNotFoundError:
         pass
     raise
 
-import IPython
 import matplotlib.pyplot as plt
 
 base_url = "https://download.pytorch.org/torchaudio/tutorial-assets"


### PR DESCRIPTION
Google Colab now has torchaudio 0.12 pre-installed.
This commit removes the note about nightly build.