### PR TITLE
Added example for MFCC transform

### DIFF
--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -669,7 +669,7 @@ class MFCC(torch.nn.Module):
 
     Example
         >>> waveform, sample_rate = torchaudio.load("test.wav", normalize=True)
-        >>> mfcc_transform = transforms.MFCC(
+        >>> transform = transforms.MFCC(
         >>>     sample_rate=sample_rate,
         >>>     n_mfcc=13,
         >>>     melkwargs={"n_fft": 400, "hop_length": 160, "n_mels": 23, "center": False},

--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -671,8 +671,8 @@ class MFCC(torch.nn.Module):
         >>> waveform, sample_rate = torchaudio.load("test.wav", normalize=True)
         >>> mfcc_transform = transforms.MFCC(
         >>>     sample_rate=sample_rate,
-        >>>     n_mfcc=256,
-        >>>     melkwargs={"n_fft": 2048, "n_mels": 256, "hop_length": 512},
+        >>>     n_mfcc=13,
+        >>>     melkwargs={"n_fft": 400, "hop_length": 160, "n_mels": 23, "center": False},
         >>> )
         >>> mfcc = mfcc_transform(waveform)
 

--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -667,6 +667,15 @@ class MFCC(torch.nn.Module):
         log_mels (bool, optional): whether to use log-mel spectrograms instead of db-scaled. (Default: ``False``)
         melkwargs (dict or None, optional): arguments for MelSpectrogram. (Default: ``None``)
 
+    Example
+        >>> waveform, sample_rate = torchaudio.load("test.wav", normalize=True)
+        >>> mfcc_transform = transforms.MFCC(
+        >>>     sample_rate=sample_rate,
+        >>>     n_mfcc=256,
+        >>>     melkwargs={"n_fft": 2048, "n_mels": 256, "hop_length": 512},
+        >>> )
+        >>> mfcc = mfcc_transform(waveform)
+
     See also:
         :py:func:`torchaudio.functional.melscale_fbanks` - The function used to
         generate the filter banks.

--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -674,7 +674,7 @@ class MFCC(torch.nn.Module):
         >>>     n_mfcc=13,
         >>>     melkwargs={"n_fft": 400, "hop_length": 160, "n_mels": 23, "center": False},
         >>> )
-        >>> mfcc = mfcc_transform(waveform)
+        >>> mfcc = transform(waveform)
 
     See also:
         :py:func:`torchaudio.functional.melscale_fbanks` - The function used to


### PR DESCRIPTION
Added example for MFCC transform as mentioned in issue #1564. 

Note: Python formatter package `black` uses double quotes for the string dict keys (e.g. in `melkwargs` for this example). Please let me know if there is a different linter/format/convention that is preferred! 