### PR TITLE
Fix random Gaussian generation

### DIFF
--- a/torchaudio/compliance/kaldi.py
+++ b/torchaudio/compliance/kaldi.py
@@ -177,9 +177,7 @@ def _get_window(
     strided_input = _get_strided(waveform, window_size, window_shift, snip_edges)
 
     if dither != 0.0:
-        # Returns a random number strictly between 0 and 1
-        x = torch.max(epsilon, torch.rand(strided_input.shape, device=device, dtype=dtype))
-        rand_gauss = torch.sqrt(-2 * x.log()) * torch.cos(2 * math.pi * x)
+        rand_gauss = torch.randn(strided_input.shape, device=device, dtype=dtype)
         strided_input = strided_input + rand_gauss * dither
 
     if remove_dc_offset:


### PR DESCRIPTION
This PR is meant to address the bug raised in issue #2634. 

In particular, previously the Box Muller transform was used to generate Gaussian variates for dithering based on `torch.rand` uniform variates, but it was incorrectly implemented (e.g. the same uniform variate was used as input to the transform, rather than two different uniform variates), which led to a different (non-Gaussian) distribution. This PR instead uses `torch.randn` to generate the Gaussian variates. 