### PR TITLE
Add LibriSpeech Base class for metadata

### DIFF
--- a/torchaudio/datasets/__init__.py
+++ b/torchaudio/datasets/__init__.py
@@ -6,7 +6,7 @@ from .fluentcommands import FluentSpeechCommands
 from .gtzan import GTZAN
 from .librilight_limited import LibriLightLimited
 from .librimix import LibriMix
-from .librispeech import LIBRISPEECH
+from .librispeech import LIBRISPEECH, LIBRISPEECHBase
 from .libritts import LIBRITTS
 from .ljspeech import LJSPEECH
 from .musdb_hq import MUSDB_HQ
@@ -21,6 +21,7 @@ from .yesno import YESNO
 __all__ = [
     "COMMONVOICE",
     "LIBRISPEECH",
+    "LIBRISPEECHBase",
     "LibriLightLimited",
     "SPEECHCOMMANDS",
     "VCTK_092",

--- a/torchaudio/datasets/__init__.py
+++ b/torchaudio/datasets/__init__.py
@@ -6,7 +6,7 @@ from .fluentcommands import FluentSpeechCommands
 from .gtzan import GTZAN
 from .librilight_limited import LibriLightLimited
 from .librimix import LibriMix
-from .librispeech import LIBRISPEECH, LIBRISPEECHBase
+from .librispeech import LIBRISPEECH, LibriSpeechBase
 from .libritts import LIBRITTS
 from .ljspeech import LJSPEECH
 from .musdb_hq import MUSDB_HQ
@@ -21,7 +21,7 @@ from .yesno import YESNO
 __all__ = [
     "COMMONVOICE",
     "LIBRISPEECH",
-    "LIBRISPEECHBase",
+    "LibriSpeechBase",
     "LibriLightLimited",
     "SPEECHCOMMANDS",
     "VCTK_092",


### PR DESCRIPTION
Add `LIBRISPEECHBase` class that returns the same information as `LIBRISPEECH`, but returns a file path instead of the loaded waveform. See #2539 for some context.

This design choice results in 2x API for the dataset -- one for metadata mode, and one for wav mode. We may want to think of a better way to arrange the docs on the website since most variables are repeated, so while this under discussion, I have simply left it out of the docs build for now.

TODO: testing

cc: @leo19941227