### PR TITLE
Switch to use conda install action for m1 builds

### DIFF
--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -35,6 +35,8 @@ jobs:
         if: ${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'refs/heads/release') }}
         run: |
           echo "CHANNEL=test" >> "$GITHUB_ENV"
+      - name: Setup miniconda
+        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
       - name: Build TorchAudio M1 wheel
         shell: arch -arch arm64 bash {0}
         env:
@@ -47,8 +49,6 @@ jobs:
           # Needed so that delocate puts files in places it can actually modify
           TMPDIR: ${{ runner.temp }}
         run: |
-          echo $PATH
-          . ~/miniconda3/etc/profile.d/conda.sh
           set -ex
           . packaging/pkg_helpers.bash
           # if we are uploading to test channell, our version consist only of the base: 0.x.x - no date string or suffix added
@@ -74,7 +74,6 @@ jobs:
           ENV_NAME: conda-test-env-${{ github.run_id }}
           PY_VERS: ${{ matrix.py_vers }}
         run: |
-          . ~/miniconda3/etc/profile.d/conda.sh
           set -ex
           conda create -yp ${ENV_NAME} python=${PY_VERS} numpy
           conda run -p ${ENV_NAME} python3 -mpip install torch --pre --extra-index-url=https://download.pytorch.org/whl/${CHANNEL}
@@ -118,6 +117,8 @@ jobs:
         if: ${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'refs/heads/release') }}
         run: |
           echo "CHANNEL=test" >> "$GITHUB_ENV"
+      - name: Setup miniconda
+        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
       - name: Install conda-build and purge previous artifacts
         shell: arch -arch arm64 bash {0}
         run: |


### PR DESCRIPTION
Usage setup-minicoda action for m1 build
We want to try to address space issues on m1. The following action:
```
pytorch/test-infra/.github/actions/setup-miniconda@main
```

Sets up miniconda in temp folder which should be cleaned between runs

Ref: https://github.com/pytorch/pytorch/issues/84841