### PR TITLE
Consolidate bibliography / reference

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -72,6 +72,7 @@ delimiters : [
 """
 
 bibtex_bibfiles = ["refs.bib"]
+bibtex_reference_style = "author_year"
 
 
 def _get_var(var, default=False):

--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -166,9 +166,3 @@ MUSDB_HQ
 .. autoclass:: MUSDB_HQ
   :members:
   :special-members: __getitem__
-
-
-References
-~~~~~~~~~~
-
-.. footbibliography::

--- a/docs/source/functional.rst
+++ b/docs/source/functional.rst
@@ -291,8 +291,3 @@ edit_distance
 -------------
 
 .. autofunction:: edit_distance
-
-References
-~~~~~~~~~~
-
-.. footbibliography::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,7 @@ Features described in this documentation are classified by release status:
 
    Index <self>
    supported_features
+   references
 
 API References
 --------------

--- a/docs/source/models.decoder.rst
+++ b/docs/source/models.decoder.rst
@@ -64,8 +64,3 @@ download_pretrained_files
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: download_pretrained_files
-
-References
-----------
-
-.. footbibliography::

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -250,8 +250,3 @@ WaveRNN
   .. automethod:: forward
 
   .. automethod:: infer
-
-References
-~~~~~~~~~~
-
-.. footbibliography::

--- a/docs/source/pipelines.rst
+++ b/docs/source/pipelines.rst
@@ -349,8 +349,3 @@ HDEMUCS_HIGH_MUSDB
 
    .. autodata:: HDEMUCS_HIGH_MUSDB
       :no-value:
-
-References
-----------
-
-.. footbibliography::

--- a/docs/source/prototype.models.rst
+++ b/docs/source/prototype.models.rst
@@ -27,8 +27,3 @@ ConvEmformer
   .. automethod:: forward
 
   .. automethod:: infer
-
-References
-~~~~~~~~~~
-
-.. footbibliography::

--- a/docs/source/prototype.pipelines.rst
+++ b/docs/source/prototype.pipelines.rst
@@ -24,8 +24,3 @@ EMFORMER_RNNT_BASE_TEDLIUM3
 
    .. autodata:: EMFORMER_RNNT_BASE_TEDLIUM3
       :no-value:
-
-References
-----------
-
-.. footbibliography::

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -1,0 +1,4 @@
+References
+----------
+
+.. bibliography::

--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -217,8 +217,3 @@ Transforms are common audio transforms. They can be chained together using :clas
 .. autoclass:: SoudenMVDR
 
   .. automethod:: forward
-
-References
-~~~~~~~~~~
-
-.. footbibliography::

--- a/torchaudio/datasets/cmuarctic.py
+++ b/torchaudio/datasets/cmuarctic.py
@@ -49,7 +49,7 @@ def load_cmuarctic_item(line: str, path: str, folder_audio: str, ext_audio: str)
 
 
 class CMUARCTIC(Dataset):
-    """Create a Dataset for *CMU ARCTIC* [:footcite:`Kominek03cmuarctic`].
+    """Create a Dataset for *CMU ARCTIC* :cite:`Kominek03cmuarctic`.
 
     Args:
         root (str or Path): Path to the directory where the dataset is found or downloaded.

--- a/torchaudio/datasets/cmudict.py
+++ b/torchaudio/datasets/cmudict.py
@@ -104,7 +104,7 @@ def _parse_dictionary(lines: Iterable[str], exclude_punctuations: bool) -> List[
 
 
 class CMUDict(Dataset):
-    """Create a Dataset for *CMU Pronouncing Dictionary* [:footcite:`cmudict`] (CMUDict).
+    """Create a Dataset for *CMU Pronouncing Dictionary* :cite:`cmudict` (CMUDict).
 
     Args:
         root (str or Path): Path to the directory where the dataset is found or downloaded.

--- a/torchaudio/datasets/commonvoice.py
+++ b/torchaudio/datasets/commonvoice.py
@@ -28,7 +28,7 @@ def load_commonvoice_item(
 
 
 class COMMONVOICE(Dataset):
-    """Create a Dataset for *CommonVoice* [:footcite:`ardila2020common`].
+    """Create a Dataset for *CommonVoice* :cite:`ardila2020common`.
 
     Args:
         root (str or Path): Path to the directory where the dataset is located.

--- a/torchaudio/datasets/dr_vctk.py
+++ b/torchaudio/datasets/dr_vctk.py
@@ -14,7 +14,7 @@ _SUPPORTED_SUBSETS = {"train", "test"}
 
 
 class DR_VCTK(Dataset):
-    """Create a dataset for *Device Recorded VCTK (Small subset version)* [:footcite:`Sarfjoo2018DeviceRV`].
+    """Create a dataset for *Device Recorded VCTK (Small subset version)* :cite:`Sarfjoo2018DeviceRV`.
 
     Args:
         root (str or Path): Root directory where the dataset's top level directory is found.

--- a/torchaudio/datasets/fluentcommands.py
+++ b/torchaudio/datasets/fluentcommands.py
@@ -8,7 +8,7 @@ from torch.utils.data import Dataset
 
 
 class FluentSpeechCommands(Dataset):
-    """Create *Fluent Speech Commands* [:footcite:`fluent`] Dataset
+    """Create *Fluent Speech Commands* :cite:`fluent` Dataset
 
     Args:
         root (str of Path): Path to the directory where the dataset is found.

--- a/torchaudio/datasets/gtzan.py
+++ b/torchaudio/datasets/gtzan.py
@@ -996,7 +996,7 @@ def load_gtzan_item(fileid: str, path: str, ext_audio: str) -> Tuple[Tensor, str
 
 
 class GTZAN(Dataset):
-    """Create a Dataset for *GTZAN* [:footcite:`tzanetakis_essl_cook_2001`].
+    """Create a Dataset for *GTZAN* :cite:`tzanetakis_essl_cook_2001`.
 
     Note:
         Please see http://marsyas.info/downloads/datasets.html if you are planning to use

--- a/torchaudio/datasets/librimix.py
+++ b/torchaudio/datasets/librimix.py
@@ -9,7 +9,7 @@ SampleType = Tuple[int, torch.Tensor, List[torch.Tensor]]
 
 
 class LibriMix(Dataset):
-    r"""Create the *LibriMix* [:footcite:`cosentino2020librimix`] dataset.
+    r"""Create the *LibriMix* :cite:`cosentino2020librimix` dataset.
 
     Args:
         root (str or Path): The path to the directory where the directory ``Libri2Mix`` or

--- a/torchaudio/datasets/librispeech.py
+++ b/torchaudio/datasets/librispeech.py
@@ -76,7 +76,7 @@ def _get_librispeech_metadata(
 
 
 class LIBRISPEECH(Dataset):
-    """Create a Dataset for *LibriSpeech* [:footcite:`7178964`].
+    """Create a Dataset for *LibriSpeech* :cite:`7178964`.
 
     Args:
         root (str or Path): Path to the directory where the dataset is found or downloaded.

--- a/torchaudio/datasets/libritts.py
+++ b/torchaudio/datasets/libritts.py
@@ -63,7 +63,7 @@ def load_libritts_item(
 
 
 class LIBRITTS(Dataset):
-    """Create a Dataset for *LibriTTS* [:footcite:`Zen2019LibriTTSAC`].
+    """Create a Dataset for *LibriTTS* :cite:`Zen2019LibriTTSAC`.
 
     Args:
         root (str or Path): Path to the directory where the dataset is found or downloaded.

--- a/torchaudio/datasets/ljspeech.py
+++ b/torchaudio/datasets/ljspeech.py
@@ -20,7 +20,7 @@ _RELEASE_CONFIGS = {
 
 
 class LJSPEECH(Dataset):
-    """Create a Dataset for *LJSpeech-1.1* [:footcite:`ljspeech17`].
+    """Create a Dataset for *LJSpeech-1.1* :cite:`ljspeech17`.
 
     Args:
         root (str or Path): Path to the directory where the dataset is found or downloaded.

--- a/torchaudio/datasets/musdb_hq.py
+++ b/torchaudio/datasets/musdb_hq.py
@@ -31,7 +31,7 @@ _VALIDATION_SET = [
 
 
 class MUSDB_HQ(Dataset):
-    """Create *MUSDB_HQ* [:footcite:`MUSDB18HQ`] Dataset
+    """Create *MUSDB_HQ* :cite:`MUSDB18HQ` Dataset
 
     Args:
         root (str or Path): Root directory where the dataset's top level directory is found

--- a/torchaudio/datasets/quesst14.py
+++ b/torchaudio/datasets/quesst14.py
@@ -23,7 +23,7 @@ _LANGUAGES = [
 
 
 class QUESST14(Dataset):
-    """Create *QUESST14* [:footcite:`Mir2015QUESST2014EQ`] Dataset
+    """Create *QUESST14* :cite:`Mir2015QUESST2014EQ` Dataset
 
     Args:
         root (str or Path): Root directory where the dataset's top level directory is found

--- a/torchaudio/datasets/speechcommands.py
+++ b/torchaudio/datasets/speechcommands.py
@@ -49,7 +49,7 @@ def load_speechcommands_item(filepath: str, path: str) -> Tuple[Tensor, int, str
 
 
 class SPEECHCOMMANDS(Dataset):
-    """Create a Dataset for *Speech Commands* [:footcite:`speechcommandsv2`].
+    """Create a Dataset for *Speech Commands* :cite:`speechcommandsv2`.
 
     Args:
         root (str or Path): Path to the directory where the dataset is found or downloaded.

--- a/torchaudio/datasets/tedlium.py
+++ b/torchaudio/datasets/tedlium.py
@@ -42,7 +42,7 @@ _RELEASE_CONFIGS = {
 
 class TEDLIUM(Dataset):
     """
-    Create a Dataset for *Tedlium* [:footcite:`rousseau2012tedlium`]. It supports releases 1,2 and 3.
+    Create a Dataset for *Tedlium* :cite:`rousseau2012tedlium`. It supports releases 1,2 and 3.
 
     Args:
         root (str or Path): Path to the directory where the dataset is found or downloaded.

--- a/torchaudio/datasets/vctk.py
+++ b/torchaudio/datasets/vctk.py
@@ -17,7 +17,7 @@ SampleType = Tuple[Tensor, int, str, str, str]
 
 
 class VCTK_092(Dataset):
-    """Create *VCTK 0.92* [:footcite:`yamagishi2019vctk`] Dataset
+    """Create *VCTK 0.92* :cite:`yamagishi2019vctk` Dataset
 
     Args:
         root (str): Root directory where the dataset's top level directory is found.

--- a/torchaudio/datasets/voxceleb1.py
+++ b/torchaudio/datasets/voxceleb1.py
@@ -90,7 +90,7 @@ def _get_file_id(file_path: str, _ext_audio: str):
 
 
 class VoxCeleb1(Dataset):
-    """Create *VoxCeleb1* [:footcite:`nagrani2017voxceleb`] Dataset.
+    """Create *VoxCeleb1* :cite:`nagrani2017voxceleb` Dataset.
 
     Args:
         root (str or Path): Path to the directory where the dataset is found or downloaded.
@@ -119,7 +119,7 @@ class VoxCeleb1(Dataset):
 
 
 class VoxCeleb1Identification(VoxCeleb1):
-    """Create *VoxCeleb1* [:footcite:`nagrani2017voxceleb`] Dataset for speaker identification task.
+    """Create *VoxCeleb1* :cite:`nagrani2017voxceleb` Dataset for speaker identification task.
     Each data sample contains the waveform, sample rate, speaker id, and the file id.
 
     Args:
@@ -167,7 +167,7 @@ class VoxCeleb1Identification(VoxCeleb1):
 
 
 class VoxCeleb1Verification(VoxCeleb1):
-    """Create *VoxCeleb1* [:footcite:`nagrani2017voxceleb`] Dataset for speaker verification task.
+    """Create *VoxCeleb1* :cite:`nagrani2017voxceleb` Dataset for speaker verification task.
     Each data sample contains a pair of waveforms, sample rate, the label indicating if they are
     from the same speaker, and the file ids.
 

--- a/torchaudio/datasets/yesno.py
+++ b/torchaudio/datasets/yesno.py
@@ -19,7 +19,7 @@ _RELEASE_CONFIGS = {
 
 
 class YESNO(Dataset):
-    """Create a Dataset for *YesNo* [:footcite:`YesNo`].
+    """Create a Dataset for *YesNo* :cite:`YesNo`.
 
     Args:
         root (str or Path): Path to the directory where the dataset is found or downloaded.

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -269,8 +269,8 @@ def griffinlim(
     .. properties:: Autograd TorchScript
 
     Implementation ported from
-    *librosa* [:footcite:`brian_mcfee-proc-scipy-2015`], *A fast Griffin-Lim algorithm* [:footcite:`6701851`]
-    and *Signal estimation from modified short-time Fourier transform* [:footcite:`1172092`].
+    *librosa* :cite:`brian_mcfee-proc-scipy-2015`, *A fast Griffin-Lim algorithm* :cite:`6701851`
+    and *Signal estimation from modified short-time Fourier transform* :cite:`1172092`.
 
     Args:
         specgram (Tensor): A magnitude-only STFT spectrogram of dimension `(..., freq, frames)`
@@ -1332,7 +1332,7 @@ def compute_kaldi_pitch(
     snip_edges: bool = True,
 ) -> torch.Tensor:
     """Extract pitch based on method described in *A pitch extraction algorithm tuned
-    for automatic speech recognition* [:footcite:`6854049`].
+    for automatic speech recognition* :cite:`6854049`.
 
     .. devices:: CPU
 
@@ -1552,7 +1552,7 @@ def resample(
     resampling_method: str = "sinc_interpolation",
     beta: Optional[float] = None,
 ) -> Tensor:
-    r"""Resamples the waveform at the new frequency using bandlimited interpolation. [:footcite:`RESAMPLE`].
+    r"""Resamples the waveform at the new frequency using bandlimited interpolation. :cite:`RESAMPLE`.
 
     .. devices:: CPU CUDA
 
@@ -1840,7 +1840,7 @@ def rnnt_loss(
     reduction: str = "mean",
 ):
     """Compute the RNN Transducer loss from *Sequence Transduction with Recurrent Neural Networks*
-    [:footcite:`graves2012sequence`].
+    :cite:`graves2012sequence`.
 
     .. devices:: CPU CUDA
 
@@ -2009,8 +2009,8 @@ def mvdr_weights_souden(
     diag_eps: float = 1e-7,
     eps: float = 1e-8,
 ) -> Tensor:
-    r"""Compute the Minimum Variance Distortionless Response (*MVDR* [:footcite:`capon1969high`]) beamforming weights
-    by the method proposed by *Souden et, al.* [:footcite:`souden2009optimal`].
+    r"""Compute the Minimum Variance Distortionless Response (*MVDR* :cite:`capon1969high`) beamforming weights
+    by the method proposed by *Souden et, al.* :cite:`souden2009optimal`.
 
     .. devices:: CPU CUDA
 
@@ -2072,7 +2072,7 @@ def mvdr_weights_rtf(
     diag_eps: float = 1e-7,
     eps: float = 1e-8,
 ) -> Tensor:
-    r"""Compute the Minimum Variance Distortionless Response (*MVDR* [:footcite:`capon1969high`]) beamforming weights
+    r"""Compute the Minimum Variance Distortionless Response (*MVDR* :cite:`capon1969high`) beamforming weights
     based on the relative transfer function (RTF) and power spectral density (PSD) matrix of noise.
 
     .. devices:: CPU CUDA

--- a/torchaudio/models/_hdemucs.py
+++ b/torchaudio/models/_hdemucs.py
@@ -300,7 +300,7 @@ class _HDecLayer(torch.nn.Module):
 
 class HDemucs(torch.nn.Module):
     r"""
-    Hybrid Demucs model from *Hybrid Spectrogram and Waveform Source Separation* [:footcite:`defossez2021hybrid`].
+    Hybrid Demucs model from *Hybrid Spectrogram and Waveform Source Separation* :cite:`defossez2021hybrid`.
 
     Args:
         sources (List[str]): list of source names. List can contain the following source

--- a/torchaudio/models/conformer.py
+++ b/torchaudio/models/conformer.py
@@ -215,7 +215,7 @@ class ConformerLayer(torch.nn.Module):
 class Conformer(torch.nn.Module):
     r"""Implements the Conformer architecture introduced in
     *Conformer: Convolution-augmented Transformer for Speech Recognition*
-    [:footcite:`gulati2020conformer`].
+    :cite:`gulati2020conformer`.
 
     Args:
         input_dim (int): input dimension.

--- a/torchaudio/models/conv_tasnet.py
+++ b/torchaudio/models/conv_tasnet.py
@@ -162,7 +162,7 @@ class MaskGenerator(torch.nn.Module):
 class ConvTasNet(torch.nn.Module):
     """Conv-TasNet: a fully-convolutional time-domain audio separation network
     *Conv-TasNet: Surpassing Ideal Time–Frequency Magnitude Masking for Speech Separation*
-    [:footcite:`Luo_2019`].
+    :cite:`Luo_2019`.
 
     Args:
         num_sources (int, optional): The number of sources to split.
@@ -304,7 +304,7 @@ class ConvTasNet(torch.nn.Module):
 def conv_tasnet_base(num_sources: int = 2) -> ConvTasNet:
     r"""Builds the non-causal version of ConvTasNet in
     *Conv-TasNet: Surpassing Ideal Time–Frequency Magnitude Masking for Speech Separation*
-    [:footcite:`Luo_2019`].
+    :cite:`Luo_2019`.
 
     The parameter settings follow the ones with the highest Si-SNR metirc score in the paper,
     except the mask activation function is changed from "sigmoid" to "relu" for performance improvement.

--- a/torchaudio/models/decoder/_ctc_decoder.py
+++ b/torchaudio/models/decoder/_ctc_decoder.py
@@ -197,7 +197,7 @@ class CTCDecoder:
     """
     .. devices:: CPU
 
-    CTC beam search decoder from *Flashlight* [:footcite:`kahn2022flashlight`].
+    CTC beam search decoder from *Flashlight* :cite:`kahn2022flashlight`.
 
     Note:
         To build the decoder, please use the factory function :py:func:`ctc_decoder`.
@@ -349,7 +349,7 @@ def ctc_decoder(
     unk_word: str = "<unk>",
 ) -> CTCDecoder:
     """
-    Builds CTC beam search decoder from *Flashlight* [:footcite:`kahn2022flashlight`].
+    Builds CTC beam search decoder from *Flashlight* :cite:`kahn2022flashlight`.
 
     Args:
         lexicon (str or None): lexicon file containing the possible words and corresponding spellings.

--- a/torchaudio/models/deepspeech.py
+++ b/torchaudio/models/deepspeech.py
@@ -28,7 +28,7 @@ class FullyConnected(torch.nn.Module):
 class DeepSpeech(torch.nn.Module):
     """
     DeepSpeech model architecture from *Deep Speech: Scaling up end-to-end speech recognition*
-    [:footcite:`hannun2014deep`].
+    :cite:`hannun2014deep`.
 
     Args:
         n_feature: Number of input features

--- a/torchaudio/models/emformer.py
+++ b/torchaudio/models/emformer.py
@@ -806,7 +806,7 @@ class _EmformerImpl(torch.nn.Module):
 class Emformer(_EmformerImpl):
     r"""Implements the Emformer architecture introduced in
     *Emformer: Efficient Memory Transformer Based Acoustic Model for Low Latency Streaming Speech Recognition*
-    [:footcite:`shi2021emformer`].
+    :cite:`shi2021emformer`.
 
     Args:
         input_dim (int): input dimension.

--- a/torchaudio/models/tacotron2.py
+++ b/torchaudio/models/tacotron2.py
@@ -872,7 +872,7 @@ class Tacotron2(nn.Module):
 
     The original implementation was introduced in
     *Natural TTS Synthesis by Conditioning WaveNet on Mel Spectrogram Predictions*
-    [:footcite:`shen2018natural`].
+    :cite:`shen2018natural`.
 
     Args:
         mask_padding (bool, optional): Use mask padding (Default: ``False``).

--- a/torchaudio/models/wav2letter.py
+++ b/torchaudio/models/wav2letter.py
@@ -7,7 +7,7 @@ __all__ = [
 
 class Wav2Letter(nn.Module):
     r"""Wav2Letter model architecture from *Wav2Letter: an End-to-End ConvNet-based Speech
-    Recognition System* [:footcite:`collobert2016wav2letter`].
+    Recognition System* :cite:`collobert2016wav2letter`.
 
      :math:`\text{padding} = \frac{\text{ceil}(\text{kernel} - \text{stride})}{2}`
 

--- a/torchaudio/models/wav2vec2/model.py
+++ b/torchaudio/models/wav2vec2/model.py
@@ -10,7 +10,7 @@ from . import components
 class Wav2Vec2Model(Module):
     """torchaudio.models.Wav2Vec2Model(feature_extractor: torch.nn.Module, encoder: torch.nn.Module, aux: Optional[torch.nn.Module] = None)
 
-    Encoder model used in *wav2vec 2.0* [:footcite:`baevski2020wav2vec`].
+    Encoder model used in *wav2vec 2.0* :cite:`baevski2020wav2vec`.
 
     Note:
         To build the model, please use one of the factory functions.
@@ -244,7 +244,7 @@ def wav2vec2_model(
         `ConvFeatureExtractionModel <https://github.com/pytorch/fairseq/blob/dd3bd3c0497ae9a7ae7364404a6b0a4c501780b3/fairseq/models/wav2vec/wav2vec2.py#L736>`__
         in the original ``fairseq`` implementation.
         This is referred as "(convolutional) feature encoder" in the *wav2vec 2.0*
-        [:footcite:`baevski2020wav2vec`] paper.
+        :cite:`baevski2020wav2vec` paper.
 
         The "encoder" below corresponds to `TransformerEncoder <https://github.com/pytorch/fairseq/blob/dd3bd3c0497ae9a7ae7364404a6b0a4c501780b3/fairseq/models/wav2vec/wav2vec2.py#L817>`__,
         and this is referred as "Transformer" in the paper.
@@ -393,7 +393,7 @@ def wav2vec2_base(
     encoder_layer_drop: float = 0.1,
     aux_num_out: Optional[int] = None,
 ) -> Wav2Vec2Model:
-    """Build Wav2Vec2Model with "base" architecture from *wav2vec 2.0* [:footcite:`baevski2020wav2vec`]
+    """Build Wav2Vec2Model with "base" architecture from *wav2vec 2.0* :cite:`baevski2020wav2vec`
 
     Args:
         encoder_projection_dropout (float):
@@ -441,7 +441,7 @@ def wav2vec2_large(
     encoder_layer_drop: float = 0.1,
     aux_num_out: Optional[int] = None,
 ) -> Wav2Vec2Model:
-    """Build Wav2Vec2Model with "large" architecture from *wav2vec 2.0* [:footcite:`baevski2020wav2vec`]
+    """Build Wav2Vec2Model with "large" architecture from *wav2vec 2.0* :cite:`baevski2020wav2vec`
 
     Args:
         encoder_projection_dropout (float):
@@ -489,7 +489,7 @@ def wav2vec2_large_lv60k(
     encoder_layer_drop: float = 0.1,
     aux_num_out: Optional[int] = None,
 ) -> Wav2Vec2Model:
-    """Build Wav2Vec2Model with "large lv-60k" architecture from *wav2vec 2.0* [:footcite:`baevski2020wav2vec`]
+    """Build Wav2Vec2Model with "large lv-60k" architecture from *wav2vec 2.0* :cite:`baevski2020wav2vec`
 
     Args:
         encoder_projection_dropout (float):
@@ -537,7 +537,7 @@ def hubert_base(
     encoder_layer_drop: float = 0.05,
     aux_num_out: Optional[int] = None,
 ) -> Wav2Vec2Model:
-    """Build HuBERT model with "base" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
+    """Build HuBERT model with "base" architecture from *HuBERT* :cite:`hsu2021hubert`
 
     Args:
         encoder_projection_dropout (float):
@@ -585,7 +585,7 @@ def hubert_large(
     encoder_layer_drop: float = 0.0,
     aux_num_out: Optional[int] = None,
 ) -> Wav2Vec2Model:
-    """Build HuBERT model with "large" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
+    """Build HuBERT model with "large" architecture from *HuBERT* :cite:`hsu2021hubert`
 
     Args:
         encoder_projection_dropout (float):
@@ -633,7 +633,7 @@ def hubert_xlarge(
     encoder_layer_drop: float = 0.0,
     aux_num_out: Optional[int] = None,
 ) -> Wav2Vec2Model:
-    """Build HuBERT model with "extra large" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
+    """Build HuBERT model with "extra large" architecture from *HuBERT* :cite:`hsu2021hubert`
 
     Args:
         encoder_projection_dropout (float):
@@ -714,7 +714,7 @@ def hubert_pretrain_model(
         `ConvFeatureExtractionModel <https://github.com/pytorch/fairseq/blob/dd3bd3c0497ae9a7ae7364404a6b0a4c501780b3/fairseq/models/wav2vec/wav2vec2.py#L736>`__
         in the original ``fairseq`` implementation.
         This is referred as "(convolutional) feature encoder" in the *wav2vec 2.0*
-        [:footcite:`baevski2020wav2vec`] paper.
+        :cite:`baevski2020wav2vec` paper.
 
         The "encoder" below corresponds to `TransformerEncoder <https://github.com/pytorch/fairseq/blob/dd3bd3c0497ae9a7ae7364404a6b0a4c501780b3/fairseq/models/wav2vec/wav2vec2.py#L817>`__,
         and this is referred as "Transformer" in the paper.
@@ -975,7 +975,7 @@ def hubert_pretrain_base(
     feature_grad_mult: Optional[float] = 0.1,
     num_classes: int = 100,
 ) -> HuBERTPretrainModel:
-    """Build HuBERTPretrainModel model with "base" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
+    """Build HuBERTPretrainModel model with "base" architecture from *HuBERT* :cite:`hsu2021hubert`
 
     Args:
         encoder_projection_dropout (float):
@@ -1050,7 +1050,7 @@ def hubert_pretrain_large(
     mask_channel_length: int = 10,
     feature_grad_mult: Optional[float] = None,
 ) -> HuBERTPretrainModel:
-    """Build HuBERTPretrainModel model for pre-training with "large" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
+    """Build HuBERTPretrainModel model for pre-training with "large" architecture from *HuBERT* :cite:`hsu2021hubert`
 
     Args:
         encoder_projection_dropout (float):
@@ -1123,7 +1123,7 @@ def hubert_pretrain_xlarge(
     mask_channel_length: int = 10,
     feature_grad_mult: Optional[float] = None,
 ) -> HuBERTPretrainModel:
-    """Build HuBERTPretrainModel model for pre-training with "extra large" architecture from *HuBERT* [:footcite:`hsu2021hubert`]
+    """Build HuBERTPretrainModel model for pre-training with "extra large" architecture from *HuBERT* :cite:`hsu2021hubert`
 
     Args:
         encoder_projection_dropout (float):

--- a/torchaudio/models/wavernn.py
+++ b/torchaudio/models/wavernn.py
@@ -15,7 +15,7 @@ __all__ = [
 
 
 class ResBlock(nn.Module):
-    r"""ResNet block based on *Efficient Neural Audio Synthesis* [:footcite:`kalchbrenner2018efficient`].
+    r"""ResNet block based on *Efficient Neural Audio Synthesis* :cite:`kalchbrenner2018efficient`.
 
     Args:
         n_freq: the number of bins in a spectrogram. (Default: ``128``)
@@ -200,7 +200,7 @@ class WaveRNN(nn.Module):
     r"""WaveRNN model based on the implementation from `fatchord <https://github.com/fatchord/WaveRNN>`_.
 
     The original implementation was introduced in *Efficient Neural Audio Synthesis*
-    [:footcite:`kalchbrenner2018efficient`]. The input channels of waveform and spectrogram have to be 1.
+    :cite:`kalchbrenner2018efficient`. The input channels of waveform and spectrogram have to be 1.
     The product of `upsample_scales` must equal `hop_length`.
 
     Args:

--- a/torchaudio/pipelines/_source_separation_pipeline.py
+++ b/torchaudio/pipelines/_source_separation_pipeline.py
@@ -66,8 +66,8 @@ CONVTASNET_BASE_LIBRI2MIX = SourceSeparationBundle(
     _model_factory_func=partial(conv_tasnet_base, num_sources=2),
     _sample_rate=8000,
 )
-CONVTASNET_BASE_LIBRI2MIX.__doc__ = """Pre-trained Source Separation pipeline with *ConvTasNet* [:footcite:`Luo_2019`] trained on
-    *Libri2Mix dataset* [:footcite:`cosentino2020librimix`].
+CONVTASNET_BASE_LIBRI2MIX.__doc__ = """Pre-trained Source Separation pipeline with *ConvTasNet* :cite:`Luo_2019` trained on
+    *Libri2Mix dataset* :cite:`cosentino2020librimix`.
 
     The source separation model is constructed by :py:func:`torchaudio.models.conv_tasnet_base`
     and is trained using the training script ``lightning_train.py``
@@ -83,8 +83,8 @@ HDEMUCS_HIGH_MUSDB_PLUS = SourceSeparationBundle(
     _model_factory_func=partial(hdemucs_high, sources=["drums", "bass", "other", "vocals"]),
     _sample_rate=44100,
 )
-HDEMUCS_HIGH_MUSDB_PLUS.__doc__ = """Pre-trained *Hybrid Demucs* [:footcite:`defossez2021hybrid`] pipeline for music
-    source separation trained on MUSDB-HQ [:footcite:`MUSDB18HQ`] and additional internal training data.
+HDEMUCS_HIGH_MUSDB_PLUS.__doc__ = """Pre-trained *Hybrid Demucs* :cite:`defossez2021hybrid` pipeline for music
+    source separation trained on MUSDB-HQ :cite:`MUSDB18HQ` and additional internal training data.
 
     The model is constructed by :py:func:`torchaudio.prototype.models.hdemucs_high`.
     Training was performed in the original HDemucs repository `here <https://github.com/facebookresearch/demucs/>`__.
@@ -98,8 +98,8 @@ HDEMUCS_HIGH_MUSDB = SourceSeparationBundle(
     _model_factory_func=partial(hdemucs_high, sources=["drums", "bass", "other", "vocals"]),
     _sample_rate=44100,
 )
-HDEMUCS_HIGH_MUSDB.__doc__ = """Pre-trained *Hybrid Demucs* [:footcite:`defossez2021hybrid`] pipeline for music
-    source separation trained on MUSDB-HQ [:footcite:`MUSDB18HQ`].
+HDEMUCS_HIGH_MUSDB.__doc__ = """Pre-trained *Hybrid Demucs* :cite:`defossez2021hybrid` pipeline for music
+    source separation trained on MUSDB-HQ :cite:`MUSDB18HQ`.
 
     The model is constructed by :py:func:`torchaudio.prototype.models.hdemucs_high`.
     Training was performed in the original HDemucs repository `here <https://github.com/facebookresearch/demucs/>`__.

--- a/torchaudio/pipelines/_tts/impl.py
+++ b/torchaudio/pipelines/_tts/impl.py
@@ -218,7 +218,7 @@ TACOTRON2_GRIFFINLIM_CHAR_LJSPEECH.__doc__ = """Character-based TTS pipeline wit
 
 The text processor encodes the input texts character-by-character.
 
-Tacotron2 was trained on *LJSpeech* [:footcite:`ljspeech17`] for 1,500 epochs.
+Tacotron2 was trained on *LJSpeech* :cite:`ljspeech17` for 1,500 epochs.
 You can find the training script `here <https://github.com/pytorch/audio/tree/main/examples/pipeline_tacotron2>`__.
 The default parameters were used.
 
@@ -264,7 +264,7 @@ graphemes to phonemes.
 The model (*en_us_cmudict_forward*) was trained on
 `CMUDict <http://www.speech.cs.cmu.edu/cgi-bin/cmudict>`__.
 
-Tacotron2 was trained on *LJSpeech* [:footcite:`ljspeech17`] for 1,500 epochs.
+Tacotron2 was trained on *LJSpeech* :cite:`ljspeech17` for 1,500 epochs.
 You can find the training script `here <https://github.com/pytorch/audio/tree/main/examples/pipeline_tacotron2>`__.
 The text processor is set to the *"english_phonemes"*.
 
@@ -309,13 +309,13 @@ TACOTRON2_WAVERNN_CHAR_LJSPEECH.__doc__ = """Character-based TTS pipeline with :
 
 The text processor encodes the input texts character-by-character.
 
-Tacotron2 was trained on *LJSpeech* [:footcite:`ljspeech17`] for 1,500 epochs.
+Tacotron2 was trained on *LJSpeech* :cite:`ljspeech17` for 1,500 epochs.
 You can find the training script `here <https://github.com/pytorch/audio/tree/main/examples/pipeline_tacotron2>`__.
 The following parameters were used; ``win_length=1100``, ``hop_length=275``, ``n_fft=2048``,
 ``mel_fmin=40``, and ``mel_fmax=11025``.
 
 The vocder is based on :py:class:`torchaudio.models.WaveRNN`.
-It was trained on 8 bits depth waveform of *LJSpeech* [:footcite:`ljspeech17`] for 10,000 epochs.
+It was trained on 8 bits depth waveform of *LJSpeech* :cite:`ljspeech17` for 10,000 epochs.
 You can find the training script `here <https://github.com/pytorch/audio/tree/main/examples/pipeline_wavernn>`__.
 
 Please refer to :func:`torchaudio.pipelines.Tacotron2TTSBundle` for the usage.
@@ -360,13 +360,13 @@ graphemes to phonemes.
 The model (*en_us_cmudict_forward*) was trained on
 `CMUDict <http://www.speech.cs.cmu.edu/cgi-bin/cmudict>`__.
 
-Tacotron2 was trained on *LJSpeech* [:footcite:`ljspeech17`] for 1,500 epochs.
+Tacotron2 was trained on *LJSpeech* :cite:`ljspeech17` for 1,500 epochs.
 You can find the training script `here <https://github.com/pytorch/audio/tree/main/examples/pipeline_tacotron2>`__.
 The following parameters were used; ``win_length=1100``, ``hop_length=275``, ``n_fft=2048``,
 ``mel_fmin=40``, and ``mel_fmax=11025``.
 
 The vocder is based on :py:class:`torchaudio.models.WaveRNN`.
-It was trained on 8 bits depth waveform of *LJSpeech* [:footcite:`ljspeech17`] for 10,000 epochs.
+It was trained on 8 bits depth waveform of *LJSpeech* :cite:`ljspeech17` for 10,000 epochs.
 You can find the training script `here <https://github.com/pytorch/audio/tree/main/examples/pipeline_wavernn>`__.
 
 Please refer to :func:`torchaudio.pipelines.Tacotron2TTSBundle` for the usage.

--- a/torchaudio/pipelines/_wav2vec2/impl.py
+++ b/torchaudio/pipelines/_wav2vec2/impl.py
@@ -198,11 +198,11 @@ WAV2VEC2_BASE = Wav2Vec2Bundle(
 )
 WAV2VEC2_BASE.__doc__ = """wav2vec 2.0 model with "Base" configuration.
 
-Pre-trained on 960 hours of unlabeled audio from *LibriSpeech* dataset [:footcite:`7178964`]
+Pre-trained on 960 hours of unlabeled audio from *LibriSpeech* dataset :cite:`7178964`
 (the combination of "train-clean-100", "train-clean-360", and "train-other-500").
 Not fine-tuned.
 
-Originally published by the authors of *wav2vec 2.0* [:footcite:`baevski2020wav2vec`] under MIT License and
+Originally published by the authors of *wav2vec 2.0* :cite:`baevski2020wav2vec` under MIT License and
 redistributed with the same license.
 [`License <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/LICENSE>`__,
 `Source <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/examples/wav2vec#pre-trained-models>`__]
@@ -243,12 +243,12 @@ WAV2VEC2_ASR_BASE_10M = Wav2Vec2ASRBundle(
 )
 WAV2VEC2_ASR_BASE_10M.__doc__ = """Build "base" wav2vec2 model with an extra linear module
 
-Pre-trained on 960 hours of unlabeled audio from *LibriSpeech* dataset [:footcite:`7178964`]
+Pre-trained on 960 hours of unlabeled audio from *LibriSpeech* dataset :cite:`7178964`
 (the combination of "train-clean-100", "train-clean-360", and "train-other-500"), and
 fine-tuned for ASR on 10 minutes of transcribed audio from *Libri-Light* dataset
-[:footcite:`librilight`] ("train-10min" subset).
+:cite:`librilight` ("train-10min" subset).
 
-Originally published by the authors of *wav2vec 2.0* [:footcite:`baevski2020wav2vec`] under MIT License and
+Originally published by the authors of *wav2vec 2.0* :cite:`baevski2020wav2vec` under MIT License and
 redistributed with the same license.
 [`License <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/LICENSE>`__,
 `Source <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/examples/wav2vec#pre-trained-models>`__]
@@ -290,11 +290,11 @@ WAV2VEC2_ASR_BASE_100H = Wav2Vec2ASRBundle(
 
 WAV2VEC2_ASR_BASE_100H.__doc__ = """Build "base" wav2vec2 model with an extra linear module
 
-Pre-trained on 960 hours of unlabeled audio from *LibriSpeech* dataset [:footcite:`7178964`]
+Pre-trained on 960 hours of unlabeled audio from *LibriSpeech* dataset :cite:`7178964`
 (the combination of "train-clean-100", "train-clean-360", and "train-other-500"), and
 fine-tuned for ASR on 100 hours of transcribed audio from "train-clean-100" subset.
 
-Originally published by the authors of *wav2vec 2.0* [:footcite:`baevski2020wav2vec`] under MIT License and
+Originally published by the authors of *wav2vec 2.0* :cite:`baevski2020wav2vec` under MIT License and
 redistributed with the same license.
 [`License <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/LICENSE>`__,
 `Source <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/examples/wav2vec#pre-trained-models>`__]
@@ -335,11 +335,11 @@ WAV2VEC2_ASR_BASE_960H = Wav2Vec2ASRBundle(
 )
 WAV2VEC2_ASR_BASE_960H.__doc__ = """Build "base" wav2vec2 model with an extra linear module
 
-Pre-trained on 960 hours of unlabeled audio from *LibriSpeech* dataset [:footcite:`7178964`]
+Pre-trained on 960 hours of unlabeled audio from *LibriSpeech* dataset :cite:`7178964`
 (the combination of "train-clean-100", "train-clean-360", and "train-other-500"), and
 fine-tuned for ASR on the same audio with the corresponding transcripts.
 
-Originally published by the authors of *wav2vec 2.0* [:footcite:`baevski2020wav2vec`] under MIT License and
+Originally published by the authors of *wav2vec 2.0* :cite:`baevski2020wav2vec` under MIT License and
 redistributed with the same license.
 [`License <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/LICENSE>`__,
 `Source <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/examples/wav2vec#pre-trained-models>`__]
@@ -379,11 +379,11 @@ WAV2VEC2_LARGE = Wav2Vec2Bundle(
 )
 WAV2VEC2_LARGE.__doc__ = """Build "large" wav2vec2 model.
 
-Pre-trained on 960 hours of unlabeled audio from *LibriSpeech* dataset [:footcite:`7178964`]
+Pre-trained on 960 hours of unlabeled audio from *LibriSpeech* dataset :cite:`7178964`
 (the combination of "train-clean-100", "train-clean-360", and "train-other-500").
 Not fine-tuned.
 
-Originally published by the authors of *wav2vec 2.0* [:footcite:`baevski2020wav2vec`] under MIT License and
+Originally published by the authors of *wav2vec 2.0* :cite:`baevski2020wav2vec` under MIT License and
 redistributed with the same license.
 [`License <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/LICENSE>`__,
 `Source <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/examples/wav2vec#pre-trained-models>`__]
@@ -424,12 +424,12 @@ WAV2VEC2_ASR_LARGE_10M = Wav2Vec2ASRBundle(
 )
 WAV2VEC2_ASR_LARGE_10M.__doc__ = """Build "large" wav2vec2 model with an extra linear module
 
-Pre-trained on 960 hours of unlabeled audio from *LibriSpeech* dataset [:footcite:`7178964`]
+Pre-trained on 960 hours of unlabeled audio from *LibriSpeech* dataset :cite:`7178964`
 (the combination of "train-clean-100", "train-clean-360", and "train-other-500"), and
 fine-tuned for ASR on 10 minutes of transcribed audio from *Libri-Light* dataset
-[:footcite:`librilight`] ("train-10min" subset).
+:cite:`librilight` ("train-10min" subset).
 
-Originally published by the authors of *wav2vec 2.0* [:footcite:`baevski2020wav2vec`] under MIT License and
+Originally published by the authors of *wav2vec 2.0* :cite:`baevski2020wav2vec` under MIT License and
 redistributed with the same license.
 [`License <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/LICENSE>`__,
 `Source <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/examples/wav2vec#pre-trained-models>`__]
@@ -470,12 +470,12 @@ WAV2VEC2_ASR_LARGE_100H = Wav2Vec2ASRBundle(
 )
 WAV2VEC2_ASR_LARGE_100H.__doc__ = """Build "large" wav2vec2 model with an extra linear module
 
-Pre-trained on 960 hours of unlabeled audio from *LibriSpeech* dataset [:footcite:`7178964`]
+Pre-trained on 960 hours of unlabeled audio from *LibriSpeech* dataset :cite:`7178964`
 (the combination of "train-clean-100", "train-clean-360", and "train-other-500"), and
 fine-tuned for ASR on 100 hours of transcribed audio from
 the same dataset ("train-clean-100" subset).
 
-Originally published by the authors of *wav2vec 2.0* [:footcite:`baevski2020wav2vec`] under MIT License and
+Originally published by the authors of *wav2vec 2.0* :cite:`baevski2020wav2vec` under MIT License and
 redistributed with the same license.
 [`License <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/LICENSE>`__,
 `Source <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/examples/wav2vec#pre-trained-models>`__]
@@ -516,11 +516,11 @@ WAV2VEC2_ASR_LARGE_960H = Wav2Vec2ASRBundle(
 )
 WAV2VEC2_ASR_LARGE_960H.__doc__ = """Build "large" wav2vec2 model with an extra linear module
 
-Pre-trained on 960 hours of unlabeled audio from *LibriSpeech* dataset [:footcite:`7178964`]
+Pre-trained on 960 hours of unlabeled audio from *LibriSpeech* dataset :cite:`7178964`
 (the combination of "train-clean-100", "train-clean-360", and "train-other-500"), and
 fine-tuned for ASR on the same audio with the corresponding transcripts.
 
-Originally published by the authors of *wav2vec 2.0* [:footcite:`baevski2020wav2vec`] under MIT License and
+Originally published by the authors of *wav2vec 2.0* :cite:`baevski2020wav2vec` under MIT License and
 redistributed with the same license.
 [`License <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/LICENSE>`__,
 `Source <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/examples/wav2vec#pre-trained-models>`__]
@@ -561,10 +561,10 @@ WAV2VEC2_LARGE_LV60K = Wav2Vec2Bundle(
 WAV2VEC2_LARGE_LV60K.__doc__ = """Build "large-lv60k" wav2vec2 model.
 
 Pre-trained on 60,000 hours of unlabeled audio from
-*Libri-Light* dataset [:footcite:`librilight`].
+*Libri-Light* dataset :cite:`librilight`.
 Not fine-tuned.
 
-Originally published by the authors of *wav2vec 2.0* [:footcite:`baevski2020wav2vec`] under MIT License and
+Originally published by the authors of *wav2vec 2.0* :cite:`baevski2020wav2vec` under MIT License and
 redistributed with the same license.
 [`License <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/LICENSE>`__,
 `Source <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/examples/wav2vec#pre-trained-models>`__]
@@ -606,11 +606,11 @@ WAV2VEC2_ASR_LARGE_LV60K_10M = Wav2Vec2ASRBundle(
 WAV2VEC2_ASR_LARGE_LV60K_10M.__doc__ = """Build "large-lv60k" wav2vec2 model with an extra linear module
 
 Pre-trained on 60,000 hours of unlabeled audio from
-*Libri-Light* dataset [:footcite:`librilight`], and
+*Libri-Light* dataset :cite:`librilight`, and
 fine-tuned for ASR on 10 minutes of transcribed audio from
 the same dataset ("train-10min" subset).
 
-Originally published by the authors of *wav2vec 2.0* [:footcite:`baevski2020wav2vec`] under MIT License and
+Originally published by the authors of *wav2vec 2.0* :cite:`baevski2020wav2vec` under MIT License and
 redistributed with the same license.
 [`License <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/LICENSE>`__,
 `Source <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/examples/wav2vec#pre-trained-models>`__]
@@ -652,11 +652,11 @@ WAV2VEC2_ASR_LARGE_LV60K_100H = Wav2Vec2ASRBundle(
 WAV2VEC2_ASR_LARGE_LV60K_100H.__doc__ = """Build "large-lv60k" wav2vec2 model with an extra linear module
 
 Pre-trained on 60,000 hours of unlabeled audio from
-*Libri-Light* dataset [:footcite:`librilight`], and
+*Libri-Light* dataset :cite:`librilight`, and
 fine-tuned for ASR on 100 hours of transcribed audio from
-*LibriSpeech* dataset [:footcite:`7178964`] ("train-clean-100" subset).
+*LibriSpeech* dataset :cite:`7178964` ("train-clean-100" subset).
 
-Originally published by the authors of *wav2vec 2.0* [:footcite:`baevski2020wav2vec`] under MIT License and
+Originally published by the authors of *wav2vec 2.0* :cite:`baevski2020wav2vec` under MIT License and
 redistributed with the same license.
 [`License <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/LICENSE>`__,
 `Source <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/examples/wav2vec#pre-trained-models>`__]
@@ -698,12 +698,12 @@ WAV2VEC2_ASR_LARGE_LV60K_960H = Wav2Vec2ASRBundle(
 WAV2VEC2_ASR_LARGE_LV60K_960H.__doc__ = """Build "large-lv60k" wav2vec2 model with an extra linear module
 
 Pre-trained on 60,000 hours of unlabeled audio from *Libri-Light*
-[:footcite:`librilight`] dataset, and
+:cite:`librilight` dataset, and
 fine-tuned for ASR on 960 hours of transcribed audio from
-*LibriSpeech* dataset [:footcite:`7178964`]
+*LibriSpeech* dataset :cite:`7178964`
 (the combination of "train-clean-100", "train-clean-360", and "train-other-500").
 
-Originally published by the authors of *wav2vec 2.0* [:footcite:`baevski2020wav2vec`] under MIT License and
+Originally published by the authors of *wav2vec 2.0* :cite:`baevski2020wav2vec` under MIT License and
 redistributed with the same license.
 [`License <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/LICENSE>`__,
 `Source <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/examples/wav2vec#pre-trained-models>`__]
@@ -744,14 +744,14 @@ WAV2VEC2_XLSR53 = Wav2Vec2Bundle(
 WAV2VEC2_XLSR53.__doc__ = """wav2vec 2.0 model with "Base" configuration.
 
 Trained on 56,000 hours of unlabeled audio from multiple datasets (
-*Multilingual LibriSpeech* [:footcite:`Pratap_2020`],
-*CommonVoice* [:footcite:`ardila2020common`] and
-*BABEL* [:footcite:`Gales2014SpeechRA`]).
+*Multilingual LibriSpeech* :cite:`Pratap_2020`,
+*CommonVoice* :cite:`ardila2020common` and
+*BABEL* :cite:`Gales2014SpeechRA`).
 Not fine-tuned.
 
 Originally published by the authors of
 *Unsupervised Cross-lingual Representation Learning for Speech Recognition*
-[:footcite:`conneau2020unsupervised`] under MIT License and redistributed with the same license.
+:cite:`conneau2020unsupervised` under MIT License and redistributed with the same license.
 [`License <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/LICENSE>`__,
 `Source <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/examples/wav2vec#pre-trained-models>`__]
 
@@ -790,11 +790,11 @@ HUBERT_BASE = Wav2Vec2Bundle(
 )
 HUBERT_BASE.__doc__ = """HuBERT model with "Base" configuration.
 
-Pre-trained on 960 hours of unlabeled audio from *LibriSpeech* dataset [:footcite:`7178964`]
+Pre-trained on 960 hours of unlabeled audio from *LibriSpeech* dataset :cite:`7178964`
 (the combination of "train-clean-100", "train-clean-360", and "train-other-500").
 Not fine-tuned.
 
-Originally published by the authors of *HuBERT* [:footcite:`hsu2021hubert`] under MIT License and
+Originally published by the authors of *HuBERT* :cite:`hsu2021hubert` under MIT License and
 redistributed with the same license.
 [`License <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/LICENSE>`__,
 `Source <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/examples/hubert#pre-trained-and-fine-tuned-asr-models>`__]
@@ -835,10 +835,10 @@ HUBERT_LARGE = Wav2Vec2Bundle(
 HUBERT_LARGE.__doc__ = """HuBERT model with "Large" configuration.
 
 Pre-trained on 60,000 hours of unlabeled audio from
-*Libri-Light* dataset [:footcite:`librilight`].
+*Libri-Light* dataset :cite:`librilight`.
 Not fine-tuned.
 
-Originally published by the authors of *HuBERT* [:footcite:`hsu2021hubert`] under MIT License and
+Originally published by the authors of *HuBERT* :cite:`hsu2021hubert` under MIT License and
 redistributed with the same license.
 [`License <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/LICENSE>`__,
 `Source <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/examples/hubert#pre-trained-and-fine-tuned-asr-models>`__]
@@ -879,10 +879,10 @@ HUBERT_XLARGE = Wav2Vec2Bundle(
 HUBERT_XLARGE.__doc__ = """HuBERT model with "Extra Large" configuration.
 
 Pre-trained on 60,000 hours of unlabeled audio from
-*Libri-Light* dataset [:footcite:`librilight`].
+*Libri-Light* dataset :cite:`librilight`.
 Not fine-tuned.
 
-Originally published by the authors of *HuBERT* [:footcite:`hsu2021hubert`] under MIT License and
+Originally published by the authors of *HuBERT* :cite:`hsu2021hubert` under MIT License and
 redistributed with the same license.
 [`License <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/LICENSE>`__,
 `Source <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/examples/hubert#pre-trained-and-fine-tuned-asr-models>`__]
@@ -924,12 +924,12 @@ HUBERT_ASR_LARGE = Wav2Vec2ASRBundle(
 HUBERT_ASR_LARGE.__doc__ = """HuBERT model with "Large" configuration.
 
 Pre-trained on 60,000 hours of unlabeled audio from
-*Libri-Light* dataset [:footcite:`librilight`], and
+*Libri-Light* dataset :cite:`librilight`, and
 fine-tuned for ASR on 960 hours of transcribed audio from
-*LibriSpeech* dataset [:footcite:`7178964`]
+*LibriSpeech* dataset :cite:`7178964`
 (the combination of "train-clean-100", "train-clean-360", and "train-other-500").
 
-Originally published by the authors of *HuBERT* [:footcite:`hsu2021hubert`] under MIT License and
+Originally published by the authors of *HuBERT* :cite:`hsu2021hubert` under MIT License and
 redistributed with the same license.
 [`License <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/LICENSE>`__,
 `Source <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/examples/hubert#pre-trained-and-fine-tuned-asr-models>`__]
@@ -971,12 +971,12 @@ HUBERT_ASR_XLARGE = Wav2Vec2ASRBundle(
 HUBERT_ASR_XLARGE.__doc__ = """HuBERT model with "Extra Large" configuration.
 
 Pre-trained on 60,000 hours of unlabeled audio from
-*Libri-Light* dataset [:footcite:`librilight`], and
+*Libri-Light* dataset :cite:`librilight`, and
 fine-tuned for ASR on 960 hours of transcribed audio from
-*LibriSpeech* dataset [:footcite:`7178964`]
+*LibriSpeech* dataset :cite:`7178964`
 (the combination of "train-clean-100", "train-clean-360", and "train-other-500").
 
-Originally published by the authors of *HuBERT* [:footcite:`hsu2021hubert`] under MIT License and
+Originally published by the authors of *HuBERT* :cite:`hsu2021hubert` under MIT License and
 redistributed with the same license.
 [`License <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/LICENSE>`__,
 `Source <https://github.com/pytorch/fairseq/blob/ce6c9eeae163ac04b79539c78e74f292f29eaa18/examples/hubert#pre-trained-and-fine-tuned-asr-models>`__]
@@ -1019,11 +1019,11 @@ VOXPOPULI_ASR_BASE_10K_DE = Wav2Vec2ASRBundle(
 )
 VOXPOPULI_ASR_BASE_10K_DE.__doc__ = """wav2vec 2.0 model with "Base" configuration.
 
-Pre-trained on 10k hours of unlabeled audio from *VoxPopuli* dataset [:footcite:`voxpopuli`]
+Pre-trained on 10k hours of unlabeled audio from *VoxPopuli* dataset :cite:`voxpopuli`
 ("10k" subset, consisting of 23 languages).
 Fine-tuned for ASR on 282 hours of transcribed audio from "de" subset.
 
-Originally published by the authors of *VoxPopuli* [:footcite:`voxpopuli`] under CC BY-NC 4.0 and
+Originally published by the authors of *VoxPopuli* :cite:`voxpopuli` under CC BY-NC 4.0 and
 redistributed with the same license.
 [`License <https://github.com/facebookresearch/voxpopuli/tree/160e4d7915bad9f99b2c35b1d3833e51fd30abf2#license>`__,
 `Source <https://github.com/facebookresearch/voxpopuli/tree/160e4d7915bad9f99b2c35b1d3833e51fd30abf2#asr-and-lm>`__]
@@ -1066,11 +1066,11 @@ VOXPOPULI_ASR_BASE_10K_EN = Wav2Vec2ASRBundle(
 )
 VOXPOPULI_ASR_BASE_10K_EN.__doc__ = """wav2vec 2.0 model with "Base" configuration.
 
-Pre-trained on 10k hours of unlabeled audio from *VoxPopuli* dataset [:footcite:`voxpopuli`]
+Pre-trained on 10k hours of unlabeled audio from *VoxPopuli* dataset :cite:`voxpopuli`
 ("10k" subset, consisting of 23 languages).
 
 Fine-tuned for ASR on 543 hours of transcribed audio from "en" subset.
-Originally published by the authors of *VoxPopuli* [:footcite:`voxpopuli`] under CC BY-NC 4.0 and
+Originally published by the authors of *VoxPopuli* :cite:`voxpopuli` under CC BY-NC 4.0 and
 redistributed with the same license.
 [`License <https://github.com/facebookresearch/voxpopuli/tree/160e4d7915bad9f99b2c35b1d3833e51fd30abf2#license>`__,
 `Source <https://github.com/facebookresearch/voxpopuli/tree/160e4d7915bad9f99b2c35b1d3833e51fd30abf2#asr-and-lm>`__]
@@ -1113,11 +1113,11 @@ VOXPOPULI_ASR_BASE_10K_ES = Wav2Vec2ASRBundle(
 )
 VOXPOPULI_ASR_BASE_10K_ES.__doc__ = """wav2vec 2.0 model with "Base" configuration.
 
-Pre-trained on 10k hours of unlabeled audio from *VoxPopuli* dataset [:footcite:`voxpopuli`]
+Pre-trained on 10k hours of unlabeled audio from *VoxPopuli* dataset :cite:`voxpopuli`
 ("10k" subset, consisting of 23 languages).
 Fine-tuned for ASR on 166 hours of transcribed audio from "es" subset.
 
-Originally published by the authors of *VoxPopuli* [:footcite:`voxpopuli`] under CC BY-NC 4.0 and
+Originally published by the authors of *VoxPopuli* :cite:`voxpopuli` under CC BY-NC 4.0 and
 redistributed with the same license.
 [`License <https://github.com/facebookresearch/voxpopuli/tree/160e4d7915bad9f99b2c35b1d3833e51fd30abf2#license>`__,
 `Source <https://github.com/facebookresearch/voxpopuli/tree/160e4d7915bad9f99b2c35b1d3833e51fd30abf2#asr-and-lm>`__]
@@ -1158,11 +1158,11 @@ VOXPOPULI_ASR_BASE_10K_FR = Wav2Vec2ASRBundle(
 )
 VOXPOPULI_ASR_BASE_10K_FR.__doc__ = """wav2vec 2.0 model with "Base" configuration.
 
-Pre-trained on 10k hours of unlabeled audio from *VoxPopuli* dataset [:footcite:`voxpopuli`]
+Pre-trained on 10k hours of unlabeled audio from *VoxPopuli* dataset :cite:`voxpopuli`
 ("10k" subset, consisting of 23 languages).
 Fine-tuned for ASR on 211 hours of transcribed audio from "fr" subset.
 
-Originally published by the authors of *VoxPopuli* [:footcite:`voxpopuli`] under CC BY-NC 4.0 and
+Originally published by the authors of *VoxPopuli* :cite:`voxpopuli` under CC BY-NC 4.0 and
 redistributed with the same license.
 [`License <https://github.com/facebookresearch/voxpopuli/tree/160e4d7915bad9f99b2c35b1d3833e51fd30abf2#license>`__,
 `Source <https://github.com/facebookresearch/voxpopuli/tree/160e4d7915bad9f99b2c35b1d3833e51fd30abf2#asr-and-lm>`__]
@@ -1205,11 +1205,11 @@ VOXPOPULI_ASR_BASE_10K_IT = Wav2Vec2ASRBundle(
 )
 VOXPOPULI_ASR_BASE_10K_IT.__doc__ = """wav2vec 2.0 model with "Base" configuration.
 
-Pre-trained on 10k hours of unlabeled audio from *VoxPopuli* dataset [:footcite:`voxpopuli`]
+Pre-trained on 10k hours of unlabeled audio from *VoxPopuli* dataset :cite:`voxpopuli`
 ("10k" subset, consisting of 23 languages).
 Fine-tuned for ASR on 91 hours of transcribed audio from "it" subset.
 
-Originally published by the authors of *VoxPopuli* [:footcite:`voxpopuli`] under CC BY-NC 4.0 and
+Originally published by the authors of *VoxPopuli* :cite:`voxpopuli` under CC BY-NC 4.0 and
 redistributed with the same license.
 [`License <https://github.com/facebookresearch/voxpopuli/tree/160e4d7915bad9f99b2c35b1d3833e51fd30abf2#license>`__,
 `Source <https://github.com/facebookresearch/voxpopuli/tree/160e4d7915bad9f99b2c35b1d3833e51fd30abf2#asr-and-lm>`__]

--- a/torchaudio/prototype/models/conv_emformer.py
+++ b/torchaudio/prototype/models/conv_emformer.py
@@ -444,7 +444,7 @@ class _ConvEmformerLayer(torch.nn.Module):
 class ConvEmformer(_EmformerImpl):
     r"""Implements the convolution-augmented streaming transformer architecture introduced in
     *Streaming Transformer Transducer based Speech Recognition Using Non-Causal Convolution*
-    [:footcite:`9747706`].
+    :cite:`9747706`.
 
     Args:
         input_dim (int): input dimension.

--- a/torchaudio/transforms/_multi_channel.py
+++ b/torchaudio/transforms/_multi_channel.py
@@ -104,7 +104,7 @@ class MVDR(torch.nn.Module):
     Based on https://github.com/espnet/espnet/blob/master/espnet2/enh/layers/beamformer.py
 
     We provide three solutions of MVDR beamforming. One is based on *reference channel selection*
-    [:footcite:`souden2009optimal`] (``solution=ref_channel``).
+    :cite:`souden2009optimal` (``solution=ref_channel``).
 
     .. math::
         \\textbf{w}_{\\text{MVDR}}(f) =\
@@ -126,7 +126,7 @@ class MVDR(torch.nn.Module):
         :math:`.^{\\mathsf{H}}` denotes the Hermitian Conjugate operation.
 
     We apply either *eigenvalue decomposition*
-    [:footcite:`higuchi2016robust`] or the *power method* [:footcite:`mises1929praktische`] to get the
+    :cite:`higuchi2016robust` or the *power method* :cite:`mises1929praktische` to get the
     steering vector from the PSD matrix of speech.
 
     After estimating the beamforming weight, the enhanced Short-time Fourier Transform (STFT) is obtained by
@@ -137,7 +137,7 @@ class MVDR(torch.nn.Module):
     where :math:`\\bf{Y}` and :math:`\\hat{\\bf{S}}` are the STFT of the multi-channel noisy speech and\
         the single-channel enhanced speech, respectively.
 
-    For online streaming audio, we provide a *recursive method* [:footcite:`higuchi2017online`] to update the
+    For online streaming audio, we provide a *recursive method* :cite:`higuchi2017online` to update the
     PSD matrices of speech and noise, respectively.
 
     Args:
@@ -341,7 +341,7 @@ class MVDR(torch.nn.Module):
 
 
 class RTFMVDR(torch.nn.Module):
-    r"""Minimum Variance Distortionless Response (*MVDR* [:footcite:`capon1969high`]) module
+    r"""Minimum Variance Distortionless Response (*MVDR* :cite:`capon1969high`) module
     based on the relative transfer function (RTF) and power spectral density (PSD) matrix of noise.
 
     .. devices:: CPU CUDA
@@ -405,8 +405,8 @@ class RTFMVDR(torch.nn.Module):
 
 
 class SoudenMVDR(torch.nn.Module):
-    r"""Minimum Variance Distortionless Response (*MVDR* [:footcite:`capon1969high`]) module
-    based on the method proposed by *Souden et, al.* [:footcite:`souden2009optimal`].
+    r"""Minimum Variance Distortionless Response (*MVDR* :cite:`capon1969high`) module
+    based on the method proposed by *Souden et, al.* :cite:`souden2009optimal`.
 
     .. devices:: CPU CUDA
 

--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -214,8 +214,8 @@ class GriffinLim(torch.nn.Module):
     .. properties:: Autograd TorchScript
 
     Implementation ported from
-    *librosa* [:footcite:`brian_mcfee-proc-scipy-2015`], *A fast Griffin-Lim algorithm* [:footcite:`6701851`]
-    and *Signal estimation from modified short-time Fourier transform* [:footcite:`1172092`].
+    *librosa* :cite:`brian_mcfee-proc-scipy-2015`, *A fast Griffin-Lim algorithm* :cite:`6701851`
+    and *Signal estimation from modified short-time Fourier transform* :cite:`1172092`.
 
     Args:
         n_fft (int, optional): Size of FFT, creates ``n_fft // 2 + 1`` bins. (Default: ``400``)
@@ -1040,7 +1040,7 @@ class TimeStretch(torch.nn.Module):
 
     .. properties:: Autograd TorchScript
 
-    Proposed in *SpecAugment* [:footcite:`specaugment`].
+    Proposed in *SpecAugment* :cite:`specaugment`.
 
     Args:
         hop_length (int or None, optional): Length of hop between STFT windows. (Default: ``win_length // 2``)
@@ -1226,7 +1226,7 @@ class FrequencyMasking(_AxisMasking):
 
     .. properties:: Autograd TorchScript
 
-    Proposed in *SpecAugment* [:footcite:`specaugment`].
+    Proposed in *SpecAugment* :cite:`specaugment`.
 
     Args:
         freq_mask_param (int): maximum possible length of the mask.
@@ -1260,7 +1260,7 @@ class TimeMasking(_AxisMasking):
 
     .. properties:: Autograd TorchScript
 
-    Proposed in *SpecAugment* [:footcite:`specaugment`].
+    Proposed in *SpecAugment* :cite:`specaugment`.
 
     Args:
         time_mask_param (int): maximum possible length of the mask.
@@ -1724,7 +1724,7 @@ class PitchShift(LazyModuleMixin, torch.nn.Module):
 
 class RNNTLoss(torch.nn.Module):
     """Compute the RNN Transducer loss from *Sequence Transduction with Recurrent Neural Networks*
-    [:footcite:`graves2012sequence`].
+    :cite:`graves2012sequence`.
 
     .. devices:: CPU CUDA
 


### PR DESCRIPTION
Preparation for the adoptation of `autosummary`.

Replace `:footcite:` with `:cite:` and introduce dedicated reference page, as `:footcite:` does not work well with `autosummary`.

Example:

https://output.circle-artifacts.com/output/job/4da47ba6-d9c7-418e-b5b0-e9f8a146a6c3/artifacts/0/docs/datasets.html#cmuarctic

https://output.circle-artifacts.com/output/job/4da47ba6-d9c7-418e-b5b0-e9f8a146a6c3/artifacts/0/docs/references.html