### PR TITLE
Add metadata mode for various datasets

### DIFF
--- a/torchaudio/datasets/quesst14.py
+++ b/torchaudio/datasets/quesst14.py
@@ -4,13 +4,13 @@ from pathlib import Path
 from typing import Optional, Tuple, Union
 
 import torch
-import torchaudio
 from torch.hub import download_url_to_file
 from torch.utils.data import Dataset
-from torchaudio.datasets.utils import extract_archive
+from torchaudio.datasets.utils import _load_waveform, extract_archive
 
 
 URL = "https://speech.fit.vutbr.cz/files/quesst14Database.tgz"
+SAMPLE_RATE = 8000
 _CHECKSUM = "4f869e06bc066bbe9c5dde31dbd3909a0870d70291110ebbb38878dcbc2fc5e4"
 _LANGUAGES = [
     "albanian",
@@ -71,10 +71,20 @@ class QUESST14(Dataset):
         elif subset == "eval":
             self.data = filter_audio_paths(self._path, language, "language_key_eval.lst")
 
-    def _load_sample(self, n: int) -> Tuple[torch.Tensor, int, str]:
+    def get_metadata(self, n: int) -> Tuple[str, int, str]:
+        """Get metadata for the n-th sample from the dataset. Returns filepath instead of waveform,
+        but otherwise returns the same fields as :py:func:`__getitem__`.
+
+        Args:
+            n (int): The index of the sample to be loaded
+
+        Returns:
+            (str, int, str):
+            ``(filepath, sample_rate, file_name)``
+        """
         audio_path = self.data[n]
-        wav, sample_rate = torchaudio.load(audio_path)
-        return wav, sample_rate, audio_path.with_suffix("").name
+        relpath = os.path.relpath(audio_path, self._path)
+        return relpath, SAMPLE_RATE, audio_path.with_suffix("").name
 
     def __getitem__(self, n: int) -> Tuple[torch.Tensor, int, str]:
         """Load the n-th sample from the dataset.
@@ -85,7 +95,9 @@ class QUESST14(Dataset):
         Returns:
             (Tensor, int, str): ``(waveform, sample_rate, file_name)``
         """
-        return self._load_sample(n)
+        metadata = self.get_metadata(n)
+        waveform = _load_waveform(self._path, metadata[0], metadata[1])
+        return (waveform,) + metadata[1:]
 
     def __len__(self) -> int:
         return len(self.data)


### PR DESCRIPTION
Add metadata mode for the following SUPERB benchmark datasets
- QUESST14
- Fluent Speech Commands
- VoxCeleb1

follow ups:
- Add metadata mode for LibriMix -- waiting for unit tests to merge
- Add IEMOCAP + SNIPS datasets