### PR TITLE
Add StreamReader Tensor Binding to src

### DIFF
--- a/torchaudio/csrc/CMakeLists.txt
+++ b/torchaudio/csrc/CMakeLists.txt
@@ -149,6 +149,7 @@ if(USE_FFMPEG)
     ffmpeg/stream_reader/stream_reader.cpp
     ffmpeg/stream_reader/stream_reader_wrapper.cpp
     ffmpeg/stream_reader/stream_reader_binding.cpp
+    ffmpeg/stream_reader/stream_reader_tensor_binding.cpp
     ffmpeg/stream_writer/stream_writer.cpp
     ffmpeg/stream_writer/stream_writer_wrapper.cpp
     ffmpeg/stream_writer/stream_writer_binding.cpp


### PR DESCRIPTION
In #2694 CMakeLists.txt was not properly updated, so the tests are failing. This commit fix it.