### PR TITLE
[perf][5/5] Replace IValue::toString()->string() with IValue::toStringRef()

### DIFF
--- a/examples/libtorchaudio/speech_recognition/transcribe.cpp
+++ b/examples/libtorchaudio/speech_recognition/transcribe.cpp
@@ -34,6 +34,6 @@ int main(int argc, char* argv[]) {
   auto emission = encoder.forward({waveform});
   std::cout << "Generating the transcription" << std::endl;
   auto result = decoder.forward({emission});
-  std::cout << result.toString()->string() << std::endl;
+  std::cout << result.toStringRef() << std::endl;
   std::cout << "Done." << std::endl;
 }

--- a/examples/libtorchaudio/speech_recognition/transcribe_list.cpp
+++ b/examples/libtorchaudio/speech_recognition/transcribe_list.cpp
@@ -57,7 +57,7 @@ int main(int argc, char* argv[]) {
     t_encode += std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0);
     t_decode += std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1);
 
-    auto hypothesis = result.toString()->string();
+    auto hypothesis = result.toStringRef();
     output_hyp << hypothesis << " (" << id << ")" << std::endl;
     output_ref << reference << " (" << id << ")" << std::endl;
     std::cout << id << '\t' << hypothesis << std::endl;


### PR DESCRIPTION
Summary: ATT for pytorch/audio

Differential Revision: D39707243

