### PR TITLE
Fix CUDA check

### DIFF
--- a/torchaudio/_extension.py
+++ b/torchaudio/_extension.py
@@ -105,7 +105,8 @@ def _check_cuda_version():
     if version is not None and torch.version.cuda is not None:
         version_str = str(version)
         ta_version = f"{version_str[:-3]}.{version_str[-2]}"
-        t_version = torch.version.cuda
+        t_version = torch.version.cuda.split(".")
+        t_version = f"{t_version[0]}.{t_version[1]}"
         if ta_version != t_version:
             raise RuntimeError(
                 "Detected that PyTorch and TorchAudio were compiled with different CUDA versions. "


### PR DESCRIPTION
`torch.version.cuda` can return a string of form X.X or X.X.X. This PR modifies the CUDA version check to account for this.