### PR TITLE
Improve initialization of wav2vec2/hubert model for pre-training

### DIFF
--- a/torchaudio/models/wav2vec2/components.py
+++ b/torchaudio/models/wav2vec2/components.py
@@ -302,9 +302,9 @@ class SelfAttention(Module):
         weights = (self.scaling * q) @ k  # B, nH, L, L
         if attention_mask is not None:
             weights += attention_mask
-        # subtract a constant value from the tensor won't change the output of softmax.
+        # subtracting a constant value from the tensor won't change the output of softmax.
         # apply the subtraction to avoid value overflow in torch.nn.functional.softmax.
-        # for more details, please find Equation 7 in https://arxiv.org/abs/2112.08778
+        # for more details, please see Equation 7 in https://arxiv.org/abs/2112.08778
         weights = weights - weights.max(dim=-1, keepdim=True)[0]
 
         weights = torch.nn.functional.softmax(weights, dim=-1)

--- a/torchaudio/models/wav2vec2/components.py
+++ b/torchaudio/models/wav2vec2/components.py
@@ -206,7 +206,7 @@ class ConvolutionalPositionalEmbedding(Module):
             padding=kernel_size // 2,
             groups=groups,
         )
-        # normalize the weight to normal distribution. It is essential to model training.
+        # normalize the weight to normal distribution. it is essential to model training.
         std = math.sqrt(4.0 / (embed_dim * kernel_size))
         nn.init.normal_(self.conv.weight, mean=0.0, std=std)
         nn.init.constant_(self.conv.bias, 0.0)
@@ -275,7 +275,7 @@ class SelfAttention(Module):
         self.q_proj = nn.Linear(embed_dim, embed_dim, bias=True)
         self.out_proj = nn.Linear(embed_dim, embed_dim, bias=True)
 
-        # normalize the parameters
+        # normalize the parameters.
         nn.init.xavier_uniform_(self.k_proj.weight, gain=1 / math.sqrt(2))
         nn.init.xavier_uniform_(self.v_proj.weight, gain=1 / math.sqrt(2))
         nn.init.xavier_uniform_(self.q_proj.weight, gain=1 / math.sqrt(2))
@@ -311,16 +311,17 @@ class SelfAttention(Module):
         k = self.k_proj(x).view(*shape).permute(0, 2, 3, 1)  # B, nH, Hd, L
         v = self.v_proj(x).view(*shape).transpose(2, 1)  # B, nH, L, Hd
 
-        # scale down q by a factor of c to avoid value overflow
+        # scale down q by a factor of c to avoid value overflow.
         c = 32.0
         weights = (self.scaling * q / c) @ k  # B, nH, L, L
         if attention_mask is not None:
             weights += attention_mask
-        # subtract a constant value from the tensor doesnt change the output of softmax
-        # apply the subtraction to avoid value overflow in softmax
+        # subtract a constant value from the tensor won't change the output of softmax.
+        # apply the subtraction to avoid value overflow in torch.nn.functional.softmax.
+        # for more details, please find Equation 7 in https://arxiv.org/abs/2112.08778
         weights = weights - weights.max(dim=-1, keepdim=True)[0]
 
-        # scale the weight back and pass it to softmax
+        # scale the weight back and pass it to softmax.
         weights = torch.nn.functional.softmax(weights * c, dim=-1)
         weights = self.dropout(weights)
 
@@ -426,7 +427,7 @@ class Transformer(Module):
         self.dropout = nn.Dropout(dropout)
         self.layers = layers
 
-        # initialize transformer parameters. It is essential to model training.
+        # initialize transformer parameters. it is essential to model training.
         self.apply(_init_transformer_params)
 
     def _preprocess(self, x: Tensor):

--- a/torchaudio/models/wav2vec2/model.py
+++ b/torchaudio/models/wav2vec2/model.py
@@ -1,3 +1,4 @@
+import math
 from typing import List, Optional, Tuple
 
 import torch
@@ -681,6 +682,27 @@ def hubert_xlarge(
     )
 
 
+def _init_hubert_pretrain_model(module):
+    if isinstance(module, components.LayerNorm):
+        torch.nn.init.kaiming_normal_(module.conv.weight)
+    elif isinstance(module, components.ConvolutionalPositionalEmbedding):
+        # normalize the weight to normal distribution.
+        std = math.sqrt(4.0 / (module.embed_dim * module.kernel_size))
+        torch.nn.init.normal_(module.conv.weight, mean=0.0, std=std)
+        torch.nn.init.constant_(module.conv.bias, 0.0)
+    elif isinstance(module, components.SelfAttention):
+        # normalize the query, key, value, and out_proj parameters in self attention module.
+        torch.nn.init.xavier_uniform_(module.k_proj.weight, gain=1 / math.sqrt(2))
+        torch.nn.init.xavier_uniform_(module.v_proj.weight, gain=1 / math.sqrt(2))
+        torch.nn.init.xavier_uniform_(module.q_proj.weight, gain=1 / math.sqrt(2))
+        torch.nn.init.xavier_uniform_(module.out_proj.weight)
+        torch.nn.init.constant_(module.out_proj.bias, 0.0)
+    elif isinstance(module, components.Transformer):
+        module.apply(components._init_transformer_params)
+    else:
+        pass
+
+
 def hubert_pretrain_model(
     extractor_mode: str,
     extractor_conv_layer_config: Optional[List[Tuple[int, int, int]]],
@@ -963,12 +985,15 @@ def hubert_pretrain_model(
         skip_masked,
         skip_nomask,
     )
-    return HuBERTPretrainModel(
+    model = HuBERTPretrainModel(
         wav2vec2=wav2vec2,
         mask_generator=mask_generator,
         logit_generator=logit_generator,
         feature_grad_mult=feature_grad_mult,
     )
+    # initialize the model for pre-training
+    model.apply(_init_hubert_pretrain_model)
+    return model
 
 
 def hubert_pretrain_base(


### PR DESCRIPTION
This PR improves the Wav2Vec2/HuBERT model regarding model pre-training.

- The model initialization of positional embedding and transformer module is essential to model pre-training. The accuracy of unmasked frames should be higher than masked frames, as it is an easier task. but without the initialization, the accuracy of masked frames is higher than unmasked frames.
  Compared the performance after two epochs with 16 GPUs.
  - With model initialization, the accuracies of masked/unmasked frames are 0.08/0.11.
  - Without model initialization, the accuracies of masked/unmasked frames are 0.06/0.04.
- After adding the model initialization, the gradient is easy to overflow (aka `nan` gradient). In paper [Self-Supervised Learning for speech recognition with Intermediate layer supervision](https://arxiv.org/abs/2112.08778) the authors propose a simple but effective method to mitigate the overflow issue, by scaling down the multiplication of query and key and subtracting the maximum value from it (subtracting a constant value won't change the output of softmax). Then it guarantees the value won't be overflowed.
- In the original fairseq, the mask indices are generated by `numpy.random.choice`. Here replace `torch.multinomial` with `torch.randperm`. (cc @carolineechen).

Other improvements within training scripts will be included in a separate PR.