### PR TITLE
[Nova] Clean commit for Enabling Nova Linux Wheels Workflows

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -38,7 +38,9 @@ jobs:
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}
-      trigger-event: ${{ github.event_name }}
+      # Using "development" as trigger event so these binaries are not uploaded
+      # to official channels yet
+      trigger-event: development
     secrets:
       AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
       AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -28,7 +28,7 @@ jobs:
             post-script: packaging/post_build_script.sh
             package-name: torchaudio
     name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@secrets_reusable_workflow
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
     env:
       GH_EVENT: ${{ github.event_name }}
     with:
@@ -40,7 +40,7 @@ jobs:
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}
-      trigger-event: "${GH_EVENT}"
+      trigger-event: push
     secrets:
       AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
       AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -29,8 +29,6 @@ jobs:
             package-name: torchaudio
     name: ${{ matrix.repository }}
     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
-    env:
-      GH_EVENT: ${{ github.event_name }}
     with:
       repository: ${{ matrix.repository }}
       ref: nightly

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -28,30 +28,20 @@ jobs:
             post-script: packaging/post_build_script.sh
             package-name: torchaudio
     steps:
-      - name: Set Build-Type
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          if [[ "$EVENT_NAME" = "push" ]]
-          then
-            echo "BUILD_TYPE=nightly" >> "${GITHUB_ENV}"
-          else
-            echo "BUILD_TYPE=development" >> "${GITHUB_ENV}"
-          fi
-      - name: ${{ matrix.repository }}
-        uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@secrets_reusable_workflow
-        env:
-          BUILD_TYPE: ${{ env.BUILD_TYPE }}
-        with: 
-          repository: ${{ matrix.repository }}
-          ref: nightly
-          test-infra-repository: pytorch/test-infra 
-          test-infra-ref: main
-          build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-          pre-script: ${{ matrix.pre-script }}
-          post-script: ${{ matrix.post-script }}
-          package-name: ${{ matrix.package-name }}
-          build-type: "${BUILD_TYPE}"
-        secrets:
-          AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
-          AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}
+      name: ${{ matrix.repository }}
+      uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@secrets_reusable_workflow
+      env:
+        GH_EVENT: ${{ github.event_name }}
+      with:
+        repository: ${{ matrix.repository }}
+        ref: nightly
+        test-infra-repository: pytorch/test-infra
+        test-infra-ref: main
+        build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+        pre-script: ${{ matrix.pre-script }}
+        post-script: ${{ matrix.post-script }}
+        package-name: ${{ matrix.package-name }}
+        trigger-event: "${GH_EVENT}"
+      secrets:
+        AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
+        AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -27,21 +27,20 @@ jobs:
             pre-script: packaging/pre_build_script.sh
             post-script: packaging/post_build_script.sh
             package-name: torchaudio
-    steps:
-      name: ${{ matrix.repository }}
-      uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@secrets_reusable_workflow
-      env:
-        GH_EVENT: ${{ github.event_name }}
-      with:
-        repository: ${{ matrix.repository }}
-        ref: nightly
-        test-infra-repository: pytorch/test-infra
-        test-infra-ref: main
-        build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-        pre-script: ${{ matrix.pre-script }}
-        post-script: ${{ matrix.post-script }}
-        package-name: ${{ matrix.package-name }}
-        trigger-event: "${GH_EVENT}"
-      secrets:
-        AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
-        AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}
+    name: ${{ matrix.repository }}
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@secrets_reusable_workflow
+    env:
+      GH_EVENT: ${{ github.event_name }}
+    with:
+      repository: ${{ matrix.repository }}
+      ref: nightly
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      pre-script: ${{ matrix.pre-script }}
+      post-script: ${{ matrix.post-script }}
+      package-name: ${{ matrix.package-name }}
+      trigger-event: "${GH_EVENT}"
+    secrets:
+      AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
+      AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -38,7 +38,7 @@ jobs:
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}
-      trigger-event: push
+      trigger-event: ${{ github.event_name }}
     secrets:
       AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
       AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -1,0 +1,57 @@
+name: Trigger Linux Wheels Build for Nightlies/Release
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/build_wheels_linux.yml
+  push:
+    branches:
+      - nightly
+  workflow_dispatch:
+
+jobs:
+  generate-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: wheel
+      os: linux
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+  build:
+    needs: generate-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repository: pytorch/audio
+            pre-script: packaging/pre_build_script.sh
+            post-script: packaging/post_build_script.sh
+            package-name: torchaudio
+    steps:
+      - name: Set Build-Type
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [[ "$EVENT_NAME" = "push" ]]
+          then
+            echo "BUILD_TYPE=nightly" >> "${GITHUB_ENV}"
+          else
+            echo "BUILD_TYPE=development" >> "${GITHUB_ENV}"
+          fi
+      - name: ${{ matrix.repository }}
+        uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@secrets_reusable_workflow
+        env:
+          BUILD_TYPE: ${{ env.BUILD_TYPE }}
+        with: 
+          repository: ${{ matrix.repository }}
+          ref: nightly
+          test-infra-repository: pytorch/test-infra 
+          test-infra-ref: main
+          build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+          pre-script: ${{ matrix.pre-script }}
+          post-script: ${{ matrix.post-script }}
+          package-name: ${{ matrix.package-name }}
+          build-type: "${BUILD_TYPE}"
+        secrets:
+          AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
+          AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Creating this fresh PR since we're reverting the older commit that removed build configs from the CircleCI file. This does not change the existing builds/uploads in CircleCI, and should not break any existing jobs/workflows. This is just to add back workflows to build the Linux Wheels with Nova, upload them to GH artifacts (NOT to the actual nightly channels), and ensure that they produce the same binaries as CircleCI. TO CLARIFY: this does not upload anything to nightly channels, so this PR has not effect on any existing jobs or distributed binaries.

We will create a workflow (most likely in test-infra) that does this comparison between the binaries to ensure there is parity between the binaries before we start uploading with Nova.

Successful Builds: https://github.com/pytorch/audio/actions/runs/3177751059