### PR TITLE
Fix mismatched cuda version in smoke tests on windows wheels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -598,7 +598,7 @@ jobs:
             conda env remove -n python${PYTHON_VERSION} || true
             conda create -yn python${PYTHON_VERSION} python=${PYTHON_VERSION}
             conda activate python${PYTHON_VERSION}
-            pip install $(ls ~/workspace/torchaudio*.whl) -f "https://download.pytorch.org/whl/${UPLOAD_CHANNEL}/torch_${UPLOAD_CHANNEL}.html"
+            pip install $(ls ~/workspace/torchaudio*.whl) -f "https://download.pytorch.org/whl/${UPLOAD_CHANNEL}/${CU_VERSION}/torch_${UPLOAD_CHANNEL}.html"
       - checkout
       - run:
           name: smoke test

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -598,7 +598,7 @@ jobs:
             conda env remove -n python${PYTHON_VERSION} || true
             conda create -yn python${PYTHON_VERSION} python=${PYTHON_VERSION}
             conda activate python${PYTHON_VERSION}
-            pip install $(ls ~/workspace/torchaudio*.whl) -f "https://download.pytorch.org/whl/${UPLOAD_CHANNEL}/torch_${UPLOAD_CHANNEL}.html"
+            pip install $(ls ~/workspace/torchaudio*.whl) -f "https://download.pytorch.org/whl/${UPLOAD_CHANNEL}/${CU_VERSION}/torch_${UPLOAD_CHANNEL}.html"
       - checkout
       - run:
           name: smoke test


### PR DESCRIPTION
Example job that was failing previously:
https://app.circleci.com/pipelines/github/pytorch/audio/12796/workflows/ae96794a-6df4-4a2a-84df-ada7a7250045/jobs/927709

The failure:
```
"Detected that PyTorch and TorchAudio were compiled with different CUDA versions. "
RuntimeError: Detected that PyTorch and TorchAudio were compiled with different CUDA versions. PyTorch has CUDA version 11.7 whereas TorchAudio has CUDA version 11.6. Please install the TorchAudio version that matches your PyTorch version.
```

Has install command:
```
pip install $(ls ~/workspace/torchaudio*.whl) -f "https://download.pytorch.org/whl/${UPLOAD_CHANNEL}/torch_${UPLOAD_CHANNEL}.html"

# expands to:
pip install /c/Users/circleci/workspace/torchaudio-0.13.0.dev20220927+cu116-cp37-cp37m-win_amd64.whl -f https://download.pytorch.org/whl/nightly/torch_nightly.html
```


Linux job (succeeds) for uses different "-f" (find links) url, that includes specific cuda version:
https://app.circleci.com/pipelines/github/pytorch/audio/12809/workflows/aadca2ab-5a00-4a0a-ab6a-4a1b7a503713/jobs/927861

Command:
```
pip install $(ls ~/workspace/torchaudio*.whl) -f "https://download.pytorch.org/whl/${UPLOAD_CHANNEL}/${CU_VERSION}/torch_${UPLOAD_CHANNEL}.html"

# expands to:
 pip install /root/workspace/torchaudio-0.13.0.dev20220927+cu116-cp37-cp37m-linux_x86_64.whl -f https://download.pytorch.org/whl/nightly/cu116/torch_nightly.html

```

This PR makes Windows installation match the linux one.

Testing:
* verified command manually on Circle CI:
```
>>> import torch
>>> import torchaudio
C:\tools\miniconda3\lib\site-packages\torchaudio\compliance\kaldi.py:22: UserWarning: Failed to initialize NumPy: numpy.core.multiarray failed to import (Triggered internally at C:\actions-runner\_work\pytorch\pytorch\builder\windows\pytorch\torch\csrc\utils\tensor_numpy.cpp:77.)
  EPSILON = torch.tensor(torch.finfo(torch.float).eps)
C:\tools\miniconda3\lib\site-packages\torchaudio\backend\utils.py:62: UserWarning: No audio backend is available.
  warnings.warn("No audio backend is available.")
```

Co-authered: @weiwangmeta 