### PR TITLE
Update conda to avoid conda timeout issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -476,7 +476,7 @@ jobs:
             set -x
             source /usr/local/etc/profile.d/conda.sh
             conda update -y conda
-            && conda activate python${PYTHON_VERSION}
+            conda activate python${PYTHON_VERSION}
             if [[ "$CU_VERSION" == cu116 || "$CU_VERSION" == cu117 ]]; then
               conda install -v -y -c pytorch-${UPLOAD_CHANNEL} -c nvidia pytorch pytorch-cuda=${CU_VERSION:2:2}.${CU_VERSION:4}
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -450,7 +450,9 @@ jobs:
           name: install binaries
           command: |
             set -x
-            source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
+            source /usr/local/etc/profile.d/conda.sh
+            conda update -y conda
+            && conda activate python${PYTHON_VERSION}
             conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cpuonly
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
       - checkout
@@ -472,7 +474,9 @@ jobs:
           name: install binaries
           command: |
             set -x
-            source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
+            source /usr/local/etc/profile.d/conda.sh
+            conda update -y conda
+            && conda activate python${PYTHON_VERSION}
             if [[ "$CU_VERSION" == cu116 || "$CU_VERSION" == cu117 ]]; then
               conda install -v -y -c pytorch-${UPLOAD_CHANNEL} -c nvidia pytorch pytorch-cuda=${CU_VERSION:2:2}.${CU_VERSION:4}
             else
@@ -498,7 +502,9 @@ jobs:
           name: install binaries
           command: |
             set -x
-            source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
+            source /usr/local/etc/profile.d/conda.sh
+            conda update -y conda
+            conda activate python${PYTHON_VERSION}
             pip install $(ls ~/workspace/torchaudio*.whl) -f "https://download.pytorch.org/whl/${UPLOAD_CHANNEL}/${CU_VERSION}/torch_${UPLOAD_CHANNEL}.html"
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,7 +452,7 @@ jobs:
             set -x
             source /usr/local/etc/profile.d/conda.sh
             conda update -y conda
-            && conda activate python${PYTHON_VERSION}
+            conda activate python${PYTHON_VERSION}
             conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cpuonly
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
       - checkout

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -450,7 +450,9 @@ jobs:
           name: install binaries
           command: |
             set -x
-            source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
+            source /usr/local/etc/profile.d/conda.sh
+            conda update -y conda
+            conda activate python${PYTHON_VERSION}
             conda install -v -y -c pytorch-${UPLOAD_CHANNEL} pytorch cpuonly
             conda install -v -y -c file://$HOME/workspace/conda-bld torchaudio
       - checkout
@@ -472,7 +474,9 @@ jobs:
           name: install binaries
           command: |
             set -x
-            source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
+            source /usr/local/etc/profile.d/conda.sh
+            conda update -y conda
+            conda activate python${PYTHON_VERSION}
             if [[ "$CU_VERSION" == cu116 || "$CU_VERSION" == cu117 ]]; then
               conda install -v -y -c pytorch-${UPLOAD_CHANNEL} -c nvidia pytorch pytorch-cuda=${CU_VERSION:2:2}.${CU_VERSION:4}
             else
@@ -498,7 +502,9 @@ jobs:
           name: install binaries
           command: |
             set -x
-            source /usr/local/etc/profile.d/conda.sh && conda activate python${PYTHON_VERSION}
+            source /usr/local/etc/profile.d/conda.sh
+            conda update -y conda
+            conda activate python${PYTHON_VERSION}
             pip install $(ls ~/workspace/torchaudio*.whl) -f "https://download.pytorch.org/whl/${UPLOAD_CHANNEL}/${CU_VERSION}/torch_${UPLOAD_CHANNEL}.html"
       - checkout
       - run:


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/pytorch/audio/12819/workflows/19972c51-67ab-4531-857b-3465f2f4562d/jobs/930773?invite=true#step-104-326 failed with timeout potentially due to conda taking time to resolve the dependency.
Previously we have merged https://github.com/pytorch/audio/pull/2704 for windows.
Doing the same here for linux