### PR TITLE
Add citation for MuST-C dataset in Emformer RNNT pipeline.

### DIFF
--- a/torchaudio/prototype/pipelines/rnnt_pipeline.py
+++ b/torchaudio/prototype/pipelines/rnnt_pipeline.py
@@ -19,8 +19,8 @@ EMFORMER_RNNT_BASE_MUSTC = RNNTBundle(
     _right_context_length=4,
 )
 EMFORMER_RNNT_BASE_MUSTC.__doc__ = """Pre-trained Emformer-RNNT-based ASR pipeline capable of performing both streaming and non-streaming inference.
-    The underlying model is constructed by :py:func:`torchaudio.models.emformer_rnnt_base`
-    and utilizes weights trained on MuST-C release v2.0 dataset using training script ``train.py``
+    The underlying model is constructed by :py:func:`torchaudio.models.emformer_rnnt_base` and utilizes weights
+    trained on *MuST-C release v2.0* :cite:`CATTONI2021101155` dataset using training script ``train.py``
     `here <https://github.com/pytorch/audio/tree/main/examples/asr/emformer_rnnt>`__ with ``num_symbols=501``.
     Please refer to :py:class:`torchaudio.pipelines.RNNTBundle` for usage instructions.
     """


### PR DESCRIPTION
The MuST-C reference is added in https://github.com/pytorch/audio/pull/2689. This PR adds the citation to the RNNT pipeline documentation.