### PR TITLE
Torchaudio load libary path fix for windows python 3.8

### DIFF
--- a/torchaudio/_extension.py
+++ b/torchaudio/_extension.py
@@ -91,12 +91,11 @@ def _init_extension():
     # To find cuda related dlls we need to make sure the
     # conda environment/bin path is configured Please take a look:
     # https://stackoverflow.com/questions/59330863/cant-import-dll-module-in-python
-    if os.name == "nt" and sys.version_info == (3, 8):
+    if os.name == "nt" and sys.version_info >= (3, 8) and sys.version_info < (3, 9):
         env_path = os.environ["PATH"]
         path_arr = env_path.split(";")
         for path in path_arr:
             if os.path.exists(path):
-                print(f" Calling add_dll_directory with: {path}")
                 os.add_dll_directory(path)
 
     _load_lib("libtorchaudio")

--- a/torchaudio/_extension.py
+++ b/torchaudio/_extension.py
@@ -86,7 +86,6 @@ def _init_extension():
         warnings.warn("torchaudio C++ extension is not available.")
         return
 
-
     # On Windows Python-3.8+ has `os.add_dll_directory` call,
     # which is called to configure dll search path.
     # To find cuda related dlls we need to make sure the

--- a/torchaudio/_extension.py
+++ b/torchaudio/_extension.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import warnings
 from pathlib import Path
 
@@ -84,6 +85,19 @@ def _init_extension():
     if not _mod_utils.is_module_available("torchaudio._torchaudio"):
         warnings.warn("torchaudio C++ extension is not available.")
         return
+
+
+    # On Windows Python-3.8+ has `os.add_dll_directory` call,
+    # which is called to configure dll search path.
+    # To find cuda related dlls we need to make sure the
+    # conda environment/bin path is configured Please take a look:
+    # https://stackoverflow.com/questions/59330863/cant-import-dll-module-in-python
+    if os.name == "nt" and sys.version_info >= (3, 8):
+        env_path = os.environ["PATH"]
+        path_arr = env_path.split(";")
+        for path in path_arr:
+            if os.path.exists(path):
+                os.add_dll_directory(path)
 
     _load_lib("libtorchaudio")
     # This import is for initializing the methods registered via PyBind11

--- a/torchaudio/_extension.py
+++ b/torchaudio/_extension.py
@@ -96,6 +96,7 @@ def _init_extension():
         path_arr = env_path.split(";")
         for path in path_arr:
             if os.path.exists(path):
+                print(f" Calling add_dll_directory with: {path}")
                 os.add_dll_directory(path)
 
     _load_lib("libtorchaudio")

--- a/torchaudio/_extension.py
+++ b/torchaudio/_extension.py
@@ -91,7 +91,7 @@ def _init_extension():
     # To find cuda related dlls we need to make sure the
     # conda environment/bin path is configured Please take a look:
     # https://stackoverflow.com/questions/59330863/cant-import-dll-module-in-python
-    if os.name == "nt" and sys.version_info >= (3, 8):
+    if os.name == "nt" and sys.version_info == (3, 8):
         env_path = os.environ["PATH"]
         path_arr = env_path.split(";")
         for path in path_arr:


### PR DESCRIPTION
Torchaudio load libary path fix for windows and python = 3.8

Fixes: #2726

Fixes following issue:

```
>>> import torchaudio
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\atalman\miniconda3\envs\mywin38\lib\site-packages\torchaudio\__init__.py", line 1, in <module>
    from torchaudio import (  # noqa: F401
  File "C:\Users\atalman\miniconda3\envs\mywin38\lib\site-packages\torchaudio\_extension.py", line 128, in <module>
    _init_extension()
  File "C:\Users\atalman\miniconda3\envs\mywin38\lib\site-packages\torchaudio\_extension.py", line 98, in _init_extension
    _load_lib("libtorchaudio")
  File "C:\Users\atalman\miniconda3\envs\mywin38\lib\site-packages\torchaudio\_extension.py", line 52, in _load_lib
    torch.ops.load_library(path)
  File "C:\Users\atalman\miniconda3\envs\mywin38\lib\site-packages\torch\_ops.py", line 573, in load_library
    ctypes.CDLL(path)
  File "C:\Users\atalman\miniconda3\envs\mywin38\lib\ctypes\__init__.py", line 373, in __init__
    self._handle = _dlopen(self._name, mode)
FileNotFoundError: Could not find module 'C:\Users\atalman\miniconda3\envs\mywin38\Lib\site-packages\torchaudio\lib\libtorchaudio.pyd' (or one of its dependencies). Try using the full path with constructor syntax.
>>>
```

Caused by dlls not being found in the conda environment 
```
C:\Users\atalman\miniconda3\envs\mywin38\bin\
```

While this environment is set correctly in PATH its ignored with Python = 3.8
Please refer to: https://stackoverflow.com/questions/59330863/cant-import-dll-module-in-python