### PR TITLE
Improve hubert recipe for pre-training and fine-tuning

### DIFF
--- a/examples/hubert/README.md
+++ b/examples/hubert/README.md
@@ -29,7 +29,7 @@ After the first iteration of pre-training, the intermediate transformer layer's 
 
 Sample SLURM command for the second iteration of pre-preprocessing. The 6-th transformer layer's output is used as the input feature for training KMeans model. Note that the number of clusters is increased to 500 to improve the performance.
 ```
-srun --cpus-per-task=24 python preprocess.py --root-dir /home/datasets --feat-type hubert --exp-dir ./exp --layer-index 6 --checkpoint-path ./exp_iter1/checkpoints_librispeech_hubert_pretrain_base/xxx.ckpt --num-cluster 500
+srun --cpus-per-task=24 python preprocess.py --root-dir /home/datasets --feat-type hubert --exp-dir ./exp --layer-index 6 --checkpoint-path ./exp_iter1/ --num-rank 40 checkpoints_librispeech_hubert_pretrain_base/xxx.ckpt --num-cluster 500 --percent 0.1
 ```
 
 ### Pre-training (2nd iteration)
@@ -67,9 +67,9 @@ srun python evaluate.py --librispeech_path /root/datasets/ --checkpoint ./exp_fi
 ### CTC Decoding with language model
 torchaudio provides a CTCDecoder feature that is based on [Flashlight](https://github.com/flashlight/flashlight). The decoder supports KenLM language model. Use `--use-lm` to enable CTC decoding with KenLM 4-gram language model.
 
-Sample SLURM command for evaluation with KenLM language model:
+Sample SLURM command for evaluation with KenLM language model (use the checkpoint that has the lowest validation loss):
 ```
-srun python evaluate.py --librispeech_path /root/datasets/ --checkpoint ./exp_finetune/checkpoints_hubert_pretrain_base/epoch\=109-step\=19999.ckpt --split test-clean --use-lm --beam-size 1500 --lm-weight 2.46 --word-score -0.59
+srun python evaluate.py --librispeech_path /root/datasets/ --checkpoint ./exp_finetune/checkpoints_hubert_pretrain_base/epoch\=106-step\=19500.ckpt --split test-clean --use-lm --beam-size 1500 --lm-weight 2.46 --word-score -0.59
 ```
 
 ### WER results
@@ -77,7 +77,7 @@ The table below contains WER results for fine-tuning HuBERT Base model on `10h` 
 
 |                   | WER% (Viterbi)|  WER% (KenLM) |
 |:-----------------:|--------------:|--------------:|
-| dev-clean         |       10.7    |       4.4     |
-| dev-other         |       18.3    |       9.7     |
-| test-clean        |       10.8    |       4.4     |
-| test-other        |       18.5    |       10.1    |
+| dev-clean         |       10.9    |       4.2     |
+| dev-other         |       17.5    |       9.4     |
+| test-clean        |       10.9    |       4.4     |
+| test-other        |       17.8    |       9.5     |

--- a/examples/hubert/dataset/hubert_dataset.py
+++ b/examples/hubert/dataset/hubert_dataset.py
@@ -463,6 +463,8 @@ class CollateFnLibriLightLimited:
         label2id = _get_label2id()
         for sample in batch:
             waveform, transcript = sample[0], sample[2]
+            # add one "|" symbol after the end of transcription as the word termination
+            transcript = transcript + "|"
             label = torch.tensor([label2id[e] for e in transcript.replace(" ", "|").upper()])
             audio_length = waveform.size(1)
             label_length = label.size(0)

--- a/examples/hubert/evaluate.py
+++ b/examples/hubert/evaluate.py
@@ -1,6 +1,6 @@
 import argparse
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import torch
 import torch.nn.functional as F
@@ -36,10 +36,9 @@ def _viterbi_decode(emission: torch.Tensor, id2token: Dict, blank_idx: int = 0) 
     Returns:
         (List of str): The decoding result. List of string in lower case.
     """
-    hypothesis = F.log_softmax(emission, dim=-1)
-    hypothesis = hypothesis.argmax(-1).unique_consecutive()
+    hypothesis = emission.argmax(-1).unique_consecutive()
     hypothesis = hypothesis[hypothesis != blank_idx]
-    hypothesis = "".join(id2token[int(i)] for i in hypothesis).replace("|", " ")
+    hypothesis = "".join(id2token[int(i)] for i in hypothesis).replace("|", " ").strip()
     return hypothesis.split()
 
 
@@ -47,7 +46,7 @@ def _ctc_decode(emission, decoder: CTCDecoder) -> List[str]:
     """Run CTC decoding with a KenLM language model.
 
     Args:
-        emission (torch.Tensor): Output of CTC layer. Tensor with dimensions (..., time, num_tokens).
+        emission (torch.Tensor): Output of CTC layer. Tensor with dimensions `(..., time, num_tokens)`.
         decoder (CTCDecoder): The initialized CTCDecoder.
 
     Returns:
@@ -55,13 +54,19 @@ def _ctc_decode(emission, decoder: CTCDecoder) -> List[str]:
     """
     hypothesis = decoder(emission)
     hypothesis = hypothesis[0][0].words
+    hypothesis = [word for word in hypothesis if word != " "]
     return hypothesis
 
 
 def run_inference(args):
+    if args.use_gpu:
+        device = torch.device("cuda")
+    else:
+        device = torch.device("cpu")
+
     # Load the fine-tuned HuBERTPretrainModel from checkpoint.
     model = _load_checkpoint(args.checkpoint)
-    model.eval()
+    model.eval().to(device)
 
     if args.use_lm:
         # get decoder files
@@ -92,13 +97,14 @@ def run_inference(args):
         transcript = transcript.strip().lower().strip().replace("\n", "")
 
         with torch.inference_mode():
-            emission, _ = model(waveform)
+            emission, _ = model(waveform.to(device))
+            emission = F.log_softmax(emission, dim=-1)
         if args.use_lm:
-            hypothesis = _ctc_decode(emission, decoder)
+            hypothesis = _ctc_decode(emission.cpu(), decoder)
         else:
             hypothesis = _viterbi_decode(emission, id2token)
 
-        total_edit_distance += torchaudio.functional.edit_distance(transcript.split(), hypothesis)
+        total_edit_distance += torchaudio.functional.edit_distance(hypothesis, transcript.split())
         total_length += len(transcript.split())
 
         if idx % 100 == 0:
@@ -138,8 +144,8 @@ def _parse_args():
     )
     parser.add_argument(
         "--beam-size-token",
-        type=Optional[int],
-        default=None,
+        type=int,
+        default=29,
         help="Number of tokens to consider at each beam search step. (Default: None)",
     )
     parser.add_argument(
@@ -161,6 +167,7 @@ def _parse_args():
         "--unk-score", type=float, default=float("-inf"), help="Unknown word insertion score. (Default: -inf)"
     )
     parser.add_argument("--sil-score", type=float, default=0, help="Silence insertion score. (Default: 0)")
+    parser.add_argument("--use-gpu", action="store_true", help="Whether to use GPU for decoding.")
     parser.add_argument("--debug", action="store_true", help="Whether to use debug level for logging.")
     return parser.parse_args()
 

--- a/examples/hubert/evaluate.py
+++ b/examples/hubert/evaluate.py
@@ -146,7 +146,7 @@ def _parse_args():
         "--beam-size-token",
         type=int,
         default=29,
-        help="Number of tokens to consider at each beam search step. (Default: None)",
+        help="Number of tokens to consider at each beam search step. (Default: 29)",
     )
     parser.add_argument(
         "--beam-threshold", type=int, default=100, help="Beam threshold for pruning hypotheses. (Default: 100)"

--- a/examples/hubert/finetune.py
+++ b/examples/hubert/finetune.py
@@ -109,7 +109,7 @@ def _parse_args():
         "--checkpoint",
         type=str,
         required=True,
-        help="Path to the pre-trained HuBERTPretrainModel checpoint as the initialization.",
+        help="Path to the pre-trained HuBERTPretrainModel checkpoint as the initialization.",
     )
     parser.add_argument(
         "--resume-checkpoint",

--- a/examples/hubert/finetune.py
+++ b/examples/hubert/finetune.py
@@ -16,6 +16,7 @@ from lightning import HuBERTFineTuneModule
 
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
+from pytorch_lightning.utilities.seed import seed_everything
 
 
 logger = logging.getLogger(__name__)
@@ -29,10 +30,11 @@ class _Formatter(ArgumentDefaultsHelpFormatter, RawDescriptionHelpFormatter):
 
 
 def run_train(args):
+    seed_everything(1337)
     checkpoint_dir = args.exp_dir / f"checkpoints_{args.model_name}"
     checkpoint = ModelCheckpoint(
         checkpoint_dir,
-        monitor="Losses/val_loss",
+        monitor="val_loss",
         mode="min",
         save_top_k=5,
         save_weights_only=False,
@@ -40,7 +42,7 @@ def run_train(args):
     )
     train_checkpoint = ModelCheckpoint(
         checkpoint_dir,
-        monitor="Losses/train_loss",
+        monitor="train_loss",
         mode="min",
         save_top_k=5,
         save_weights_only=False,
@@ -60,7 +62,8 @@ def run_train(args):
         replace_sampler_ddp=False,
         callbacks=callbacks,
         reload_dataloaders_every_n_epochs=1,
-        accumulate_grad_batches=args.accumulate_grad_batches,
+        val_check_interval=500,
+        check_val_every_n_epoch=None,
     )
 
     model = HuBERTFineTuneModule(
@@ -73,6 +76,7 @@ def run_train(args):
         mask_prob=args.mask_prob,
         mask_channel_prob=args.mask_channel_prob,
         mask_channel_length=args.mask_channel_length,
+        num_classes=args.num_classes,
         aux_num_out=args.aux_num_out,
         checkpoint=args.checkpoint,
         dataset_path=args.dataset_path,
@@ -87,7 +91,7 @@ def run_train(args):
         hold_updates=args.hold_updates,
         decay_updates=args.decay_updates,
     )
-    trainer.fit(model)
+    trainer.fit(model, ckpt_path=args.resume_checkpoint)
 
 
 def _parse_args():
@@ -100,6 +104,18 @@ def _parse_args():
         type=pathlib.Path,
         required=True,
         help="Path to the LibriSpeech and LibriLightLimited datasets.",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        type=str,
+        required=True,
+        help="Path to the pre-trained HuBERTPretrainModel checpoint as the initialization.",
+    )
+    parser.add_argument(
+        "--resume-checkpoint",
+        default=None,
+        type=str,
+        help="The path to the checkpoint to resume the fine-tuning if training fails in the middle.",
     )
     parser.add_argument(
         "--exp-dir",
@@ -141,7 +157,7 @@ def _parse_args():
     )
     parser.add_argument(
         "--encoder-layer-drop",
-        default=0.1,
+        default=0.05,
         type=float,
         help="Probability to drop each encoder layer during training. (Default: 0.1)",
     )
@@ -164,10 +180,11 @@ def _parse_args():
         help="Minimum space between spans (if no overlap is enabled) for channel masking." "(Default: 64)",
     )
     parser.add_argument(
-        "--accumulate-grad-batches",
-        default=1,
+        "--num-classes",
+        choices=[100, 500],
         type=int,
-        help="Number of batches to accumulate the gradients during training. (Default: 1)",
+        default=500,
+        help="The ``num_class`` in the pre-trained checkpoint. (Default: 500",
     )
     parser.add_argument(
         "--aux-num-out",
@@ -176,13 +193,7 @@ def _parse_args():
         help="The dimension of linear layer for CTC training. (Default: 29)",
     )
     parser.add_argument(
-        "--checkpoint",
-        type=str,
-        required=True,
-        help="Path to the pre-trained HuBERTPretrainModel checpoint.",
-    )
-    parser.add_argument(
-        "--learning-rate", default=1e-4, type=float, help="The learning rate of Adam optimizer. (Default: 2e-5)"
+        "--learning-rate", default=5e-5, type=float, help="The learning rate of Adam optimizer. (Default: 5e-5)"
     )
     parser.add_argument(
         "--betas",
@@ -198,7 +209,7 @@ def _parse_args():
     )
     parser.add_argument(
         "--weight-decay",
-        default=1e-6,
+        default=0.0,
         type=float,
         help="Weight decay (L2 penalty) (Default: 0.0)",
     )

--- a/examples/hubert/finetune.py
+++ b/examples/hubert/finetune.py
@@ -184,7 +184,7 @@ def _parse_args():
         choices=[100, 500],
         type=int,
         default=500,
-        help="The ``num_class`` in the pre-trained checkpoint. (Default: 500",
+        help="The ``num_class`` in the pre-trained checkpoint. (Default: 500)",
     )
     parser.add_argument(
         "--aux-num-out",

--- a/examples/hubert/preprocess.py
+++ b/examples/hubert/preprocess.py
@@ -60,6 +60,12 @@ def _parse_args():
         type=int,
         help="The number of clusters for KMeans clustering.",
     )
+    parser.add_argument(
+        "--percent",
+        default=-1,
+        type=float,
+        help="The number of clusters for KMeans clustering.",
+    )
     args = parser.parse_args()
     return args
 
@@ -114,6 +120,7 @@ def main(args):
         args.num_rank,
         km_dir,
         args.num_cluster,
+        args.percent,
     )
 
     # Predict labels for MFCC or HuBERT features

--- a/examples/hubert/preprocess.py
+++ b/examples/hubert/preprocess.py
@@ -64,7 +64,7 @@ def _parse_args():
         "--percent",
         default=-1,
         type=float,
-        help="The number of clusters for KMeans clustering.",
+        help="The percent of data for KMeans clustering. If negative, use all data. (Default: -1)",
     )
     args = parser.parse_args()
     return args

--- a/examples/hubert/utils/feature_utils.py
+++ b/examples/hubert/utils/feature_utils.py
@@ -60,12 +60,6 @@ def extract_feature_mfcc(
     ).to(device)
     waveform = waveform[0].to(device)
     mfccs = feature_extractor(waveform)  # (freq, time)
-    # mfccs = torchaudio.compliance.kaldi.mfcc(
-    #     waveform=waveform,
-    #     sample_frequency=sample_rate,
-    #     use_energy=False,
-    # )  # (time, freq)
-    # mfccs = mfccs.transpose(0, 1)  # (freq, time)
     deltas = torchaudio.functional.compute_deltas(mfccs)
     ddeltas = torchaudio.functional.compute_deltas(deltas)
     concat = torch.cat([mfccs, deltas, ddeltas], dim=0)


### PR DESCRIPTION
following pr #2716
- For preprocessing
  - The HuBERT feature takes lots of memory which may not fit some machines. Enable to use a subset of feature for training a k-means model.

- For pre-training
  - Normalize the loss based on the total number of masked frames across all GPUs.
  - Use mixed precision training. fp16 is not well supported in pytorch_lightning.
  - Log accuracies of masked/unmasked frames during training.
  - Clip the gradients with norm `10.0`.

- For ASR fine-tuning
  - Normalize the loss based on the total number of batches across all GPUs, same as in the conformer recipe of TorchAudio.
  - Use mixed precision training.
  - Add "|" after the end of transcription to capture the silence/word termination, same as in fairseq recipe.

- Update the WER results on LibriSpeech dev and test sets.

|                   | WER% (Viterbi)|  WER% (KenLM) |
|:-----------------:|--------------:|--------------:|
| dev-clean         |       10.9    |       4.2     |
| dev-other         |       17.5    |       9.4     |
| test-clean        |       10.9    |       4.4     |
| test-other        |       17.8    |       9.5     |