### PR TITLE
Skip hubert xlarge torchscript test

### DIFF
--- a/test/torchaudio_unittest/models/wav2vec2/model_test.py
+++ b/test/torchaudio_unittest/models/wav2vec2/model_test.py
@@ -184,18 +184,18 @@ class TestWav2Vec2Model(TorchaudioTestCase):
     @factory_funcs
     def test_pretrain_torchscript(self, factory_func):
         """Wav2Vec2Model should be scriptable"""
-        if factory_func is hubert_xlarge and os.name == "nt" and os.environ.get("CI") == "true":
+        if factory_func is hubert_xlarge and os.environ.get("CI") == "true":
             self.skipTest(
-                "hubert_xlarge is known to fail on Windows CI. " "See https://github.com/pytorch/pytorch/issues/65776"
+                "hubert_xlarge is known to fail on CI. " "See https://github.com/pytorch/pytorch/issues/65776"
             )
         self._test_torchscript(factory_func())
 
     @factory_funcs
     def test_finetune_torchscript(self, factory_func):
         """Wav2Vec2Model should be scriptable"""
-        if factory_func is hubert_xlarge and os.name == "nt" and os.environ.get("CI") == "true":
+        if factory_func is hubert_xlarge and os.environ.get("CI") == "true":
             self.skipTest(
-                "hubert_xlarge is known to fail on Windows CI. " "See https://github.com/pytorch/pytorch/issues/65776"
+                "hubert_xlarge is known to fail on CI. " "See https://github.com/pytorch/pytorch/issues/65776"
             )
         self._test_torchscript(factory_func(aux_num_out=32))
 


### PR DESCRIPTION
a couple of circleci unittests are failing during hubert xlarge torchscript test, which has been known to fail on Windows in the past (#65776). this PR disables this test on circleci

cc @atalman 