### PR TITLE
Fix typos in tacotron2  tutorial

### DIFF
--- a/examples/tutorials/tacotron2_pipeline_tutorial.py
+++ b/examples/tutorials/tacotron2_pipeline_tutorial.py
@@ -311,8 +311,8 @@ IPython.display.Audio(waveforms[0:1].cpu(), rate=vocoder.sample_rate)
 # Waveglow
 # ~~~~~~~~
 #
-# Waveglow is a vocoder published by Nvidia. The pretrained weight is
-# publishe on Torch Hub. One can instantiate the model using ``torch.hub``
+# Waveglow is a vocoder published by Nvidia. The pretrained weights are
+# published on Torch Hub. One can instantiate the model using ``torch.hub``
 # module.
 #
 


### PR DESCRIPTION
`publishe`->`published`

Also, not sure if it should be `pre-trained weight is published` or `pre-trained weights are published`