### PR TITLE
Add gtzan download note

### DIFF
--- a/torchaudio/datasets/gtzan.py
+++ b/torchaudio/datasets/gtzan.py
@@ -1004,7 +1004,7 @@ class GTZAN(Dataset):
 
     Note:
         As of October 2022, the download link is not currently working. Setting ``download=True``
-        in this case will result in a URL connection error.
+        in GTZAN dataset will result in a URL connection error.
 
     Args:
         root (str or Path): Path to the directory where the dataset is found or downloaded.

--- a/torchaudio/datasets/gtzan.py
+++ b/torchaudio/datasets/gtzan.py
@@ -1002,6 +1002,10 @@ class GTZAN(Dataset):
         Please see http://marsyas.info/downloads/datasets.html if you are planning to use
         this dataset to publish results.
 
+    Note:
+        As of October 2022, the download link is not currently working. Setting ``download=True``
+        in this case will result in a URL connection error.
+
     Args:
         root (str or Path): Path to the directory where the dataset is found or downloaded.
         url (str, optional): The URL to download the dataset from.


### PR DESCRIPTION
GTZAN download link is no longer working, so the torchaudio download functionality for GTZAN does not work properly, per #2743. Add a note in the docs to reflect this discovery.