### PR TITLE
Fix CTCDecoder doc

### DIFF
--- a/docs/source/_templates/autosummary/ctc_decoder_class.rst
+++ b/docs/source/_templates/autosummary/ctc_decoder_class.rst
@@ -24,7 +24,8 @@
 Methods
 =======
 
-{%- for item in methods %}
+{%- for item in members %}
+{%- if not item.startswith('_') or item == "__call__" %}
 
 {{ item | underline("-") }}
 
@@ -32,12 +33,13 @@ Methods
 
    .. automethod:: {{[fullname, item] | join('.')}}
 
+{%- endif %}
 {%- endfor %}
 
 Support Structures
 ==================
 
-{%- for item in ["CTCDecoderLM", "CTCDecoderLMState", "CTCHypothesis"] %}
+{%- for item in ["CTCHypothesis", "CTCDecoderLM", "CTCDecoderLMState"] %}
 
 {{ item | underline("-") }}
 

--- a/torchaudio/models/decoder/_ctc_decoder.py
+++ b/torchaudio/models/decoder/_ctc_decoder.py
@@ -173,8 +173,10 @@ class CTCDecoderLM(_LM):
 
         Returns:
             (CTCDecoderLMState, float)
-                CTCDecoderLMState: new LM state
-                float: score
+                CTCDecoderLMState:
+                    new LM state
+                float:
+                    score
         """
         raise NotImplementedError
 


### PR DESCRIPTION
* Document `__call__` instead of `__init__`
* List CTCHypothesis first as it is used in combination with CTCDecoder
* Fix indentation of score method docstring