### PR TITLE
Fix leaking matplotlib figure

### DIFF
--- a/examples/tutorials/streamwriter_basic_tutorial.py
+++ b/examples/tutorials/streamwriter_basic_tutorial.py
@@ -654,7 +654,7 @@ with s.open():
             s.write_video_chunk(1, torch.stack(frames))
         i += frame_rate
 
-# sphinx_gallery_defer_figures
+plt.close(fig)
 
 ######################################################################
 #
@@ -666,8 +666,6 @@ with s.open():
 #
 
 Video(get_path("example.mp4"), embed=True)
-
-# sphinx_gallery_defer_figures
 
 ######################################################################
 #


### PR DESCRIPTION
In StreamWriter basic usage tutorial, matplotlib is used to generate raster images of waveforms, and the figure used is left unshown in the resulting tutorial with the use of ``sphinx_gallery_defer_figures`` command.

It turned out that this figure is shown in the next code block executed by Sphinx Gallery, and the figure is placed in totally unrelated place. https://pytorch.org/audio/main/tutorials/audio_feature_extractions_tutorial.html

<img width="951" alt="Screen Shot 2022-10-14 at 10 06 58 PM" src="https://user-images.githubusercontent.com/855818/195855124-ecd9be49-5085-4acd-9a93-608d9d1ee9ce.png">

This commit fixes it by closing the figure.