### PR TITLE
Add notes on file structure in Voxceleb1 based datasets

### DIFF
--- a/torchaudio/datasets/voxceleb1.py
+++ b/torchaudio/datasets/voxceleb1.py
@@ -138,14 +138,15 @@ class VoxCeleb1Identification(VoxCeleb1):
 
     Note:
         The file structure of `VoxCeleb1Identification` dataset is as follows:
-            root/
 
-            └── wav/
+        └─ root/
 
-              └── speaker_id folders
+         └─ wav/
 
-            Users who pre-downloaded the ``"vox1_dev_wav.zip"`` and ``"vox1_test_wav.zip"`` files need to move
-            the extracted files into the same ``root`` directory.
+         └─ speaker_id folders
+
+        Users who pre-downloaded the ``"vox1_dev_wav.zip"`` and ``"vox1_test_wav.zip"`` files need to move
+        the extracted files into the same ``root`` directory.
     """
 
     def __init__(
@@ -229,15 +230,15 @@ class VoxCeleb1Verification(VoxCeleb1):
 
     Note:
         The file structure of `VoxCeleb1Verification` dataset is as follows:
-            root/
 
-            └── wav/
+        └─ root/
 
-              └── speaker_id folders
+         └─ wav/
 
-            Users who pre-downloaded the ``"vox1_dev_wav.zip"`` and ``"vox1_test_wav.zip"`` files need to move
-            the extracted files into the same ``root`` directory.
+         └─ speaker_id folders
 
+        Users who pre-downloaded the ``"vox1_dev_wav.zip"`` and ``"vox1_test_wav.zip"`` files need to move
+        the extracted files into the same ``root`` directory.
     """
 
     def __init__(self, root: Union[str, Path], meta_url: str = _VERI_TEST_URL, download: bool = False) -> None:

--- a/torchaudio/datasets/voxceleb1.py
+++ b/torchaudio/datasets/voxceleb1.py
@@ -135,6 +135,17 @@ class VoxCeleb1Identification(VoxCeleb1):
             (Default: ``"https://www.robots.ox.ac.uk/~vgg/data/voxceleb/meta/iden_split.txt"``)
         download (bool, optional):
             Whether to download the dataset if it is not found at root path. (Default: ``False``).
+
+    Note:
+        The file structure of `VoxCeleb1Identification` dataset is as follows:
+            root/
+
+            └── wav/
+
+              └── speaker_id folders
+
+            Users who pre-downloaded the ``"vox1_dev_wav.zip"`` and ``"vox1_test_wav.zip"`` files need to move
+            the extracted files into the same ``root`` directory.
     """
 
     def __init__(
@@ -215,6 +226,18 @@ class VoxCeleb1Verification(VoxCeleb1):
             (Default: ``"https://www.robots.ox.ac.uk/~vgg/data/voxceleb/meta/veri_test.txt"``)
         download (bool, optional):
             Whether to download the dataset if it is not found at root path. (Default: ``False``).
+
+    Note:
+        The file structure of `VoxCeleb1Verification` dataset is as follows:
+            root/
+
+            └── wav/
+
+              └── speaker_id folders
+
+            Users who pre-downloaded the ``"vox1_dev_wav.zip"`` and ``"vox1_test_wav.zip"`` files need to move
+            the extracted files into the same ``root`` directory.
+
     """
 
     def __init__(self, root: Union[str, Path], meta_url: str = _VERI_TEST_URL, download: bool = False) -> None:


### PR DESCRIPTION
The file structure of VoxCeleb1 is as follows:
```
root/
└── wav/
    └── speaker_id folders
```
Users who use [Kaldi](https://github.com/kaldi-asr/kaldi/blob/f6f4ccaf213f0fe8b26e633a7dc0c802150626a0/egs/voxceleb/v1/local/make_voxceleb1_v2.pl) to get the VoxCeleb1 dataset have "dev" and "test" folders above "wav" folder. However, in the file lists like https://www.robots.ox.ac.uk/~vgg/data/voxceleb/meta/veri_test.txt or https://www.robots.ox.ac.uk/~vgg/data/voxceleb/meta/iden_split.txt there is not such differentiation. It's not necessary to put the extracted files into separate folders.

This PR adds notes in `VoxCeleb1Identification` and `VoxCeleb1Verification` datasets to inform the file structure to users.