### PR TITLE
Add iemocap variants

### DIFF
--- a/test/torchaudio_unittest/datasets/iemocap_test.py
+++ b/test/torchaudio_unittest/datasets/iemocap_test.py
@@ -4,7 +4,7 @@ import random
 from torchaudio.datasets import iemocap
 from torchaudio_unittest.common_utils import get_whitenoise, save_wav, TempDirMixin, TorchaudioTestCase
 
-LABELS = ["neu", "hap", "ang", "sad", "exc", "xxx"]
+LABELS = ["neu", "hap", "ang", "sad", "exc", "fru", "xxx"]
 SAMPLE_RATE = 16000
 
 
@@ -21,8 +21,6 @@ def _save_wav(filepath: str, seed: int):
 
 def _save_label(label_folder: str, filename: str, wav_stem: str):
     label = random.choice(LABELS)
-    if label == "exc":
-        label = "hap"
     line = f"[xxx]\t{wav_stem}\t{label}\t[yyy]"
     filepath = os.path.join(label_folder, filename)
 

--- a/torchaudio/datasets/iemocap.py
+++ b/torchaudio/datasets/iemocap.py
@@ -79,11 +79,9 @@ class IEMOCAP(Dataset):
                         line = re.split("[\t\n]", line)
                         wav_stem = line[1]
                         label = line[2]
-                        if label == "exc":
-                            label = "hap"
                         if wav_stem not in all_data:
                             continue
-                        if label not in ["neu", "hap", "ang", "sad"]:
+                        if label not in ["neu", "hap", "ang", "sad", "exc", "fru"]:
                             continue
                         self.mapping[wav_stem] = {}
                         self.mapping[wav_stem]["label"] = label
@@ -111,7 +109,7 @@ class IEMOCAP(Dataset):
             str:
                 File name
             str:
-                Label (one of ``"neu"``, ``"hap"``, ``"ang"``, ``"sad"``)
+                Label (one of ``"neu"``, ``"hap"``, ``"ang"``, ``"sad"``, ``"exc"``, ``"fru"``)
             str:
                 Speaker
         """
@@ -137,7 +135,7 @@ class IEMOCAP(Dataset):
             str:
                 File name
             str:
-                Label (one of ``"neu"``, ``"hap"``, ``"ang"``, ``"sad"``)
+                Label (one of ``"neu"``, ``"hap"``, ``"ang"``, ``"sad"``, ``"exc"``, ``"fru"``)
             str:
                 Speaker
         """

--- a/torchaudio/datasets/iemocap.py
+++ b/torchaudio/datasets/iemocap.py
@@ -1,7 +1,7 @@
 import os
 import re
 from pathlib import Path
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 
 from torch import Tensor
 from torch.utils.data import Dataset
@@ -28,18 +28,25 @@ class IEMOCAP(Dataset):
     Args:
         root (str or Path): Root directory where the dataset's top level directory is found
         sessions (Tuple[int]): Tuple of sessions (1-5) to use. (Default: ``(1, 2, 3, 4, 5)``)
+        utterance_type (str or None, optional): Which type(s) of utterances to include in the dataset.
+            Options: ("scripted", "improvised", ``None``). If ``None``, both scripted and improvised
+            data are used.
     """
 
     def __init__(
         self,
         root: Union[str, Path],
         sessions: Tuple[str] = (1, 2, 3, 4, 5),
+        utterance_type: Optional[str] = None,
     ):
         root = Path(root)
         self._path = root / "IEMOCAP"
 
         if not os.path.isdir(self._path):
             raise RuntimeError("Dataset not found.")
+
+        if utterance_type not in ["scripted", "improvised", None]:
+            raise ValueError("utterance_type must be one of ['scripted', 'improvised', or None]")
 
         all_data = []
         self.data = []
@@ -57,7 +64,12 @@ class IEMOCAP(Dataset):
 
             # add labels
             label_dir = session_dir / "dialog" / "EmoEvaluation"
-            label_paths = label_dir.glob("*.txt")
+            query = "*.txt"
+            if utterance_type == "scripted":
+                query = "*script*.txt"
+            elif utterance_type == "improvised":
+                query = "*impro*.txt"
+            label_paths = label_dir.glob(query)
 
             for label_path in label_paths:
                 with open(label_path, "r") as f:


### PR DESCRIPTION
- Add `utterance_type` argument in the initialization method, which supports loading only improvised or only scripted utterances, or all utterances.
- In the previous version, the emotion label ``"exc"`` is converted to ``"hap"``, the utterances with "fru" label are filtered out. The PR changes the dataset to return utterances with raw labels that belong to [``"neu"``, ``"hap"``, ``"ang"``, ``"sad"``, ``"exc"``, ``"fru"``].
