### PR TITLE
Remove archive file in gh-pages branch

### DIFF
--- a/.circleci/build_docs/commit_docs.sh
+++ b/.circleci/build_docs/commit_docs.sh
@@ -20,6 +20,7 @@ git checkout gh-pages
 mkdir -p ./"${target}"
 rm -rf ./"${target}"/*
 cp -r "${src}/docs/build/html/"* ./"$target"
+rm ./"$target"/artifact.tar.gz
 if [ "${target}" == "main" ]; then
     mkdir -p ./_static
     rm -rf ./_static/*


### PR DESCRIPTION
The motivation of generating `artifact.tar.gz` in the `build_docs` job is to easily use it for adding documentation in each stable release. But it is committed into `gh-pages` branch which causes the git repository very huge (see #2783). This PR removes the tar file from the commit.