### PR TITLE
Refactor StreamProcessor interface

### DIFF
--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_processor.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_processor.h
@@ -14,11 +14,12 @@ class StreamProcessor {
   using KeyType = int;
 
  private:
-  AVFramePtr pFrame1;
-  AVFramePtr pFrame2;
+  // Link to the corresponding stream object
+  const AVStream* stream;
 
   // Components for decoding source media
-  double decoder_time_base; // for debug
+  AVFramePtr pFrame1;
+  AVFramePtr pFrame2;
   Decoder decoder;
 
   KeyType current_key = 0;
@@ -26,7 +27,7 @@ class StreamProcessor {
 
  public:
   StreamProcessor(
-      AVCodecParameters* codecpar,
+      AVStream* stream,
       const c10::optional<std::string>& decoder_name,
       const c10::optional<OptionDict>& decoder_option,
       const torch::Device& device);
@@ -48,8 +49,6 @@ class StreamProcessor {
   // 3. Configure a buffer.
   // 4. Return filter ID.
   KeyType add_stream(
-      AVRational input_time_base,
-      AVCodecParameters* codecpar,
       int frames_per_chunk,
       int num_chunks,
       const c10::optional<std::string>& filter_description,

--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.cpp
@@ -255,10 +255,7 @@ void StreamReader::add_stream(
   }
   stream->discard = AVDISCARD_DEFAULT;
   int key = processors[i]->add_stream(
-      frames_per_chunk,
-      num_chunks,
-      filter_desc,
-      device);
+      frames_per_chunk, num_chunks, filter_desc, device);
   stream_indices.push_back(std::make_pair<>(i, key));
 }
 

--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.cpp
@@ -251,12 +251,10 @@ void StreamReader::add_stream(
 
   if (!processors[i]) {
     processors[i] = std::make_unique<StreamProcessor>(
-        stream->codecpar, decoder, decoder_option, device);
+        stream, decoder, decoder_option, device);
   }
   stream->discard = AVDISCARD_DEFAULT;
   int key = processors[i]->add_stream(
-      stream->time_base,
-      stream->codecpar,
       frames_per_chunk,
       num_chunks,
       filter_desc,


### PR DESCRIPTION
StreamProcessor is constructed on top of AVStream object, and attach streams defined by client code.

This commit refactor the constructor and add_stream method signature so that `add_stream`'s signature is centered around the parameters required for filter construction.