### PR TITLE
Add back docstring for MelSpectrogram param onesided

### DIFF
--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -566,6 +566,7 @@ class MelSpectrogram(torch.nn.Module):
             (Default: ``True``)
         pad_mode (string, optional): controls the padding method used when
             :attr:`center` is ``True``. (Default: ``"reflect"``)
+        onesided: Deprecated and unused.
         norm (str or None, optional): If "slaney", divide the triangular mel weights by the width of the mel band
             (area normalization). (Default: ``None``)
         mel_scale (str, optional): Scale to use: ``htk`` or ``slaney``. (Default: ``htk``)


### PR DESCRIPTION
Adds back docstring for `MelSpectrogram` initializer param `onesided`.