### PR TITLE
Make buffer size configurable in ffmpeg file object operations and set size in backend

### DIFF
--- a/torchaudio/io/_compat.py
+++ b/torchaudio/io/_compat.py
@@ -36,8 +36,9 @@ def info_audio(
 def info_audio_fileobj(
     src,
     format: Optional[str],
+    buffer_size: int = 4096,
 ) -> AudioMetaData:
-    s = torchaudio._torchaudio_ffmpeg.StreamReaderFileObj(src, format, None, 4096)
+    s = torchaudio._torchaudio_ffmpeg.StreamReaderFileObj(src, format, None, buffer_size)
     return _info_audio(s)
 
 
@@ -110,6 +111,7 @@ def load_audio_fileobj(
     convert: bool = True,
     channels_first: bool = True,
     format: Optional[str] = None,
+    buffer_size: int = 4096,
 ) -> Tuple[torch.Tensor, int]:
-    s = torchaudio._torchaudio_ffmpeg.StreamReaderFileObj(src, format, None, 4096)
+    s = torchaudio._torchaudio_ffmpeg.StreamReaderFileObj(src, format, None, buffer_size)
     return _load_audio(s, frame_offset, num_frames, convert, channels_first)


### PR DESCRIPTION
Partly addresses #2686 and #2356.

Currently, when the buffer used for file object decoding is insufficiently large, `torchaudio.load` returns a shorter waveform than expected. To deal with this, the user is expected to increase the buffer size via `torchaudio.utils.sox_utils.get_buffer_size`, but this does not influence the buffer used by the FFMpeg fallback. To fix this, this PR introduces changes that apply the buffer size set for the SoX backend to FFMpeg.

As a follow-up, we should see whether it's possible to programmatically detect that the buffer's too small and flag it to the user.