### PR TITLE
packaging: Specify otool / install_name_tool

### DIFF
--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -1,4 +1,4 @@
-name: Build on M1
+name: Build for M1
 on:
   pull_request:
     paths:

--- a/packaging/ffmpeg/build.sh
+++ b/packaging/ffmpeg/build.sh
@@ -78,46 +78,61 @@ if [[ "$(uname)" == Darwin ]]; then
     avformat=libavformat.58
     avutil=libavutil.56
 
+    otool="/usr/bin/otool"
+    # NOTE: miniconda has a version of otool and install_name_tool installed and we want
+    #       to use the default sytem version instead of the miniconda version since the miniconda
+    #       version can produce inconsistent results
+
+    # Attempt to use /usr/bin/otool as our default otool
+    if [[ ! -e ${otool} ]]; then
+        otool="$(which otool)"
+    fi
+    install_name_tool="/usr/bin/install_name_tool"
+    # Attempt to use /usr/bin/install_name_tool as our default install_name_tool
+    if [[ ! -e ${install_name_tool} ]]; then
+        install_name_tool="$(which install_name_tool)"
+    fi
+
     # list up the paths to fix
     for lib in ${avcodec} ${avdevice} ${avfilter} ${avformat} ${avutil}; do
-        otool -l ${prefix}/lib/${lib}.dylib | grep -B2 ${prefix}
+        ${otool} -l ${prefix}/lib/${lib}.dylib | grep -B2 ${prefix}
     done
 
     # Replace the hardcoded paths to @rpath
-    install_name_tool \
+    ${install_name_tool} \
         -change ${prefix}/lib/${avutil}.dylib @rpath/${avutil}.dylib \
         -delete_rpath ${prefix}/lib \
         -id @rpath/${avcodec}.dylib \
         ${prefix}/lib/${avcodec}.dylib
-    otool -l ${prefix}/lib/${avcodec}.dylib | grep -B2 ${prefix}
+    ${otool} -l ${prefix}/lib/${avcodec}.dylib | grep -B2 ${prefix}
 
-    install_name_tool \
+    ${install_name_tool} \
         -change ${prefix}/lib/${avformat}.dylib @rpath/${avformat}.dylib \
         -change ${prefix}/lib/${avcodec}.dylib @rpath/${avcodec}.dylib \
         -change ${prefix}/lib/${avutil}.dylib @rpath/${avutil}.dylib \
         -delete_rpath ${prefix}/lib \
         -id @rpath/${avdevice}.dylib \
         ${prefix}/lib/${avdevice}.dylib
-    otool -l ${prefix}/lib/${avdevice}.dylib | grep -B2 ${prefix}
+    ${otool} -l ${prefix}/lib/${avdevice}.dylib | grep -B2 ${prefix}
 
-    install_name_tool \
+    ${install_name_tool} \
         -change ${prefix}/lib/${avutil}.dylib @rpath/${avutil}.dylib \
         -delete_rpath ${prefix}/lib \
         -id @rpath/${avfilter}.dylib \
         ${prefix}/lib/${avfilter}.dylib
-    otool -l ${prefix}/lib/${avfilter}.dylib | grep -B2 ${prefix}
+    ${otool} -l ${prefix}/lib/${avfilter}.dylib | grep -B2 ${prefix}
 
-    install_name_tool \
+    ${install_name_tool} \
         -change ${prefix}/lib/${avcodec}.dylib @rpath/${avcodec}.dylib \
         -change ${prefix}/lib/${avutil}.dylib @rpath/${avutil}.dylib \
         -delete_rpath ${prefix}/lib \
         -id @rpath/${avformat}.dylib \
         ${prefix}/lib/${avformat}.dylib
-    otool -l ${prefix}/lib/${avformat}.dylib | grep -B2 ${prefix}
+    ${otool} -l ${prefix}/lib/${avformat}.dylib | grep -B2 ${prefix}
 
-    install_name_tool \
+    ${install_name_tool} \
         -delete_rpath ${prefix}/lib \
         -id @rpath/${avutil}.dylib \
         ${prefix}/lib/${avutil}.dylib
-    otool -l ${prefix}/lib/${avutil}.dylib | grep -B2 ${prefix}
+    ${otool} -l ${prefix}/lib/${avutil}.dylib | grep -B2 ${prefix}
 fi


### PR DESCRIPTION
Makes it specific to which version of otool and install_name_tool we actually prefer since using the one from conda can produce inconsistent results

Fixes https://github.com/pytorch/audio/issues/2806

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>