### PR TITLE
Fix decimal FPS handling StreamWriter

### DIFF
--- a/test/torchaudio_unittest/io/stream_writer_test.py
+++ b/test/torchaudio_unittest/io/stream_writer_test.py
@@ -351,4 +351,4 @@ class StreamWriterInterfaceTest(_MediaSourceMixin, TempDirMixin, TorchaudioTestC
 
         # Load data
         reader = torchaudio.io.StreamReader(src=self.get_temp_path(filename))
-        assert frame_rate == reader.get_src_stream_info(0).frame_rate
+        assert reader.get_src_stream_info(0).frame_rate == frame_rate

--- a/test/torchaudio_unittest/io/stream_writer_test.py
+++ b/test/torchaudio_unittest/io/stream_writer_test.py
@@ -327,3 +327,28 @@ class StreamWriterInterfaceTest(_MediaSourceMixin, TempDirMixin, TorchaudioTestC
         assert saved.shape == chunk.shape
         if format in ["wav", "flac"]:
             self.assertEqual(saved, chunk)
+
+    def test_preserve_fps(self):
+        """Decimal point frame rate is properly saved
+
+        https://github.com/pytorch/audio/issues/2830
+        """
+        ext = "mp4"
+        filename = f"test.{ext}"
+        frame_rate = 5000 / 167
+        width, height = 96, 128
+
+        # Write data
+        dst = self.get_dst(filename)
+        writer = torchaudio.io.StreamWriter(dst=dst, format=ext)
+        writer.add_video_stream(frame_rate=frame_rate, width=width, height=height)
+
+        video = torch.randint(256, (90, 3, height, width), dtype=torch.uint8)
+        with writer.open():
+            writer.write_video_chunk(0, video)
+        if self.test_fileobj:
+            dst.flush()
+
+        # Load data
+        reader = torchaudio.io.StreamReader(src=self.get_temp_path(filename))
+        assert frame_rate == reader.get_src_stream_info(0).frame_rate

--- a/torchaudio/csrc/ffmpeg/stream_writer/stream_writer.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_writer/stream_writer.cpp
@@ -111,7 +111,7 @@ void configure_audio_codec(
         ". Supported sample rates are: ",
         c10::Join(", ", rates));
   }();
-  ctx->time_base = AVRational{1, static_cast<int>(sample_rate)};
+  ctx->time_base = av_inv_q(av_d2q(sample_rate, 1 << 24));
   ctx->sample_fmt = [&]() {
     // Use default
     if (!format) {
@@ -177,7 +177,7 @@ void configure_video_codec(
   ctx->width = static_cast<int>(width);
   ctx->height = static_cast<int>(height);
   ctx->time_base = [&]() {
-    AVRational ret = AVRational{1, static_cast<int>(frame_rate)};
+    AVRational ret = av_inv_q(av_d2q(frame_rate, 1 << 24));
     auto rates = get_supported_frame_rates(ctx->codec);
     // Codec does not have constraint on frame rate
     if (rates.empty()) {


### PR DESCRIPTION
StreamWriter assumed that frame rate is always expressed as 1/something, which is a reasonable assumption.

This commit fixes it by properly computing time_base from frame rate.

Address #2830