### PR TITLE
Fix the handling of discard_before_pts

### DIFF
--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_processor.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_processor.cpp
@@ -83,7 +83,7 @@ int StreamProcessor::process_packet(
     if (ret < 0)
       return ret;
 
-    if (pFrame1->pts >= discard_before_pts) {
+    if (discard_before_pts < 0 || pFrame1->pts >= discard_before_pts) {
       send_frame(pFrame1);
     }
 

--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.h
@@ -18,6 +18,8 @@ class StreamReader {
   std::vector<std::pair<int, int>> stream_indices;
 
   // timestamp to seek to expressed in AV_TIME_BASE
+  // < 0 : No seek
+  // Positive value: Skip AVFrames with timestamps before it
   int64_t seek_timestamp = -1;
 
  public:


### PR DESCRIPTION
Currently `discard_before_pts=-1` is used to indicate no AVFrame should be skipped. It was reported that some corrupted video can have constant negative pts value.

It is technically UB for such corrupted data, but still all the AVFrame should be decoded as long as `seek` is not used.

This commit changes the decoder so that it processes AVFrame if `discard_before_pts==-1` disregard of AVFrame::pts value.