### PR TITLE
[WIP] Add Ray tracing method for RIR

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -72,7 +72,7 @@ fi
 (
     set -x
     conda install -y -c conda-forge ${NUMBA_DEV_CHANNEL} 'librosa>=0.8.0' parameterized 'requests>=2.20'
-    pip install kaldi-io SoundFile coverage pytest pytest-cov 'scipy==1.7.3' transformers expecttest unidecode inflect Pillow sentencepiece pytorch-lightning 'protobuf<4.21.0' demucs tinytag
+    pip install kaldi-io SoundFile coverage pytest pytest-cov 'scipy==1.7.3' transformers expecttest unidecode inflect Pillow sentencepiece pytorch-lightning 'protobuf<4.21.0' demucs tinytag pyroomacoustics
 )
 # Install fairseq
 git clone https://github.com/pytorch/fairseq

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -90,7 +90,8 @@ esac
         unidecode \
         'protobuf<4.21.0' \
         demucs \
-        tinytag
+        tinytag \
+        pyroomacoutics
 )
 # Install fairseq
 git clone https://github.com/pytorch/fairseq

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ endif()
 # Options
 option(BUILD_SOX "Build libsox statically" ON)
 option(BUILD_KALDI "Build kaldi statically" ON)
+option(BUILD_RAY_TRACING "Enable ray tracing simulation" ON)  # TODO: REMOVE THIS
 option(BUILD_RNNT "Enable RNN transducer" ON)
 option(BUILD_CTC_DECODER "Build Flashlight CTC decoder" ON)
 option(BUILD_TORCHAUDIO_PYTHON_EXTENSION "Build Python extension" OFF)

--- a/docs/source/prototype.functional.rst
+++ b/docs/source/prototype.functional.rst
@@ -18,3 +18,8 @@ fftconvolve
 ~~~~~~~~~~~
 
 .. autofunction:: fftconvolve
+
+Ray Tracing
+~~~~~~~~~~~
+
+.. autofunction:: ray_tracing

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -464,3 +464,11 @@ abstract = {End-to-end spoken language translation (SLT) has recently gained pop
   year=2021,
   author={Guoguo Chen and Shuzhou Chai and Guanbo Wang and Jiayu Du and Wei-Qiang Zhang and Chao Weng and Dan Su and Daniel Povey and Jan Trmal and Junbo Zhang and Mingjie Jin and Sanjeev Khudanpur and Shinji Watanabe and Shuaijiang Zhao and Wei Zou and Xiangang Li and Xuchen Yao and Yongqing Wang and Yujun Wang and Zhao You and Zhiyong Yan}
 }
+@inproceedings{scheibler2018pyroomacoustics,
+  title={Pyroomacoustics: A python package for audio room simulation and array processing algorithms},
+  author={Scheibler, Robin and Bezzam, Eric and Dokmani{\'c}, Ivan},
+  booktitle={2018 IEEE international conference on acoustics, speech and signal processing (ICASSP)},
+  pages={351--355},
+  year={2018},
+  organization={IEEE}
+}

--- a/test/torchaudio_unittest/prototype/functional/autograd_cpu_test.py
+++ b/test/torchaudio_unittest/prototype/functional/autograd_cpu_test.py
@@ -1,9 +1,14 @@
 import torch
 from torchaudio_unittest.common_utils import PytorchTestCase
 
-from .autograd_test_impl import AutogradTestImpl
+from .autograd_test_impl import AutogradTestImpl, AutogradTestRayTracingImpl
 
 
 class TestAutogradCPUFloat64(AutogradTestImpl, PytorchTestCase):
+    dtype = torch.float64
+    device = torch.device("cpu")
+
+
+class TestAutogradRayTracingCPUFloat64(AutogradTestRayTracingImpl, PytorchTestCase):
     dtype = torch.float64
     device = torch.device("cpu")

--- a/test/torchaudio_unittest/prototype/functional/autograd_test_impl.py
+++ b/test/torchaudio_unittest/prototype/functional/autograd_test_impl.py
@@ -28,3 +28,53 @@ class AutogradTestImpl(TestBaseMixin):
 
         self.assertTrue(gradcheck(F.add_noise, (waveform, noise, lengths, snr)))
         self.assertTrue(gradgradcheck(F.add_noise, (waveform, noise, lengths, snr)))
+
+
+class AutogradTestRayTracingImpl(TestBaseMixin):
+    # @parameterized.expand([(2, 1), (3, 4)])
+    def test_simulate_rir_ism(self):
+
+        room_dim = [20, 25]
+        source = [2, 2]
+        mic_array = [8, 8]
+        num_rays = 1_000
+
+        e_absorption = 0.2
+        scattering = 0.2
+
+        room_dim = torch.tensor(room_dim, dtype=self.dtype, requires_grad=True)
+        source = torch.tensor(source, dtype=self.dtype, requires_grad=True)
+        mic_array = torch.tensor(mic_array, dtype=self.dtype, requires_grad=True)
+
+        # TODO: make this work
+        # self.assertTrue(
+        #     gradcheck(
+        #         F.ray_tracing,
+        #         (
+        #             room_dim,
+        #             source,
+        #             mic_array,
+        #             num_rays,
+        #             e_absorption,
+        #             scattering,
+        #         ),
+        #         atol=1e-3,
+        #         rtol=1,
+        #     )
+        # )
+
+        # self.assertTrue(
+        #     gradgradcheck(
+        #         F.ray_tracing,
+        #         (
+        #             room_dim,
+        #             source,
+        #             mic_array,
+        #             num_rays,
+        #             e_absorption,
+        #             scattering,
+        #         ),
+        #         atol=1e-3,
+        #         rtol=1,
+        #     )
+        # )

--- a/test/torchaudio_unittest/prototype/functional/functional_cpu_test.py
+++ b/test/torchaudio_unittest/prototype/functional/functional_cpu_test.py
@@ -1,7 +1,7 @@
 import torch
 from torchaudio_unittest.common_utils import PytorchTestCase
 
-from .functional_test_impl import FunctionalTestImpl
+from .functional_test_impl import FunctionalTestImpl, FunctionalTestRayTracingImpl
 
 
 class FunctionalFloat32CPUTest(FunctionalTestImpl, PytorchTestCase):
@@ -10,5 +10,15 @@ class FunctionalFloat32CPUTest(FunctionalTestImpl, PytorchTestCase):
 
 
 class FunctionalFloat64CPUTest(FunctionalTestImpl, PytorchTestCase):
+    dtype = torch.float64
+    device = torch.device("cpu")
+
+
+class FunctionalRayTracingFloat32Test(FunctionalTestRayTracingImpl, PytorchTestCase):
+    dtype = torch.float32
+    device = torch.device("cpu")
+
+
+class FunctionalRayTracingFloat64Test(FunctionalTestRayTracingImpl, PytorchTestCase):
     dtype = torch.float64
     device = torch.device("cpu")

--- a/torchaudio/csrc/CMakeLists.txt
+++ b/torchaudio/csrc/CMakeLists.txt
@@ -53,6 +53,15 @@ if(BUILD_RNNT)
   endif()
 endif()
 
+# TODO: Probably remove or edit this, cond shouldn't be BUILD_RAY_TRACING
+if(BUILD_RAY_TRACING)
+  list(
+    APPEND
+    LIBTORCHAUDIO_SOURCES
+    ray_tracing.cpp
+    )
+endif()
+
 if(USE_CUDA)
   list(
     APPEND

--- a/torchaudio/csrc/ray_tracing.cpp
+++ b/torchaudio/csrc/ray_tracing.cpp
@@ -1,0 +1,328 @@
+#include <math.h>
+#include <stdio.h>
+#include <torch/script.h> // TODO: remove?
+#include <torch/torch.h>
+using namespace torch::indexing; // TODO: remove?
+
+namespace torchaudio {
+namespace rir {
+
+namespace {
+
+// TODO: use double verywhere instead of float?
+// TODO: use const where relevant?
+// TODO: get rid of all the .item().toDouble() and toBool() calls ?
+// TODO: is shoebox_size the same as room size?????
+
+#define IS_HYBRID_SIM (false) // TODO: remove
+#define ISM_ORDER (10) // TODO: remove
+#define MAX_DIST \
+  (50.) // TODO:remove. Note: this is the max distance it takes to hit a wall,
+        // not the max distance that a ray can go over
+#define EPS (1e-5) // epsilon is set to 0.1 millimeter (100 um)
+#define MIC_RADIUS (0.15) // TODO: Make this a parameter?
+#define MIC_RADIUS_SQ (0.15 * 0.15) // TODO: Remove
+#define SCATTER (0.1) // TODO: Remove
+
+std::tuple<torch::Tensor, int, float> next_wall_hit(
+    torch::Tensor room,
+    torch::Tensor start,
+    torch::Tensor end,
+    bool scattered_ray // TODO: probably remove
+) {
+  int D = room.size(0);
+  const static std::vector<std::vector<int>> shoebox_orders = {
+      {0, 1, 2}, {1, 0, 2}, {2, 0, 1}};
+
+  torch::Tensor result = torch::zeros(D, torch::kFloat);
+  int next_wall_index = -1;
+  double hit_dist = MAX_DIST;
+
+  // There are no obstructing walls in shoebox rooms
+  if (scattered_ray)
+    return std::make_tuple(result, -1, 0.);
+
+  // The direction vector
+  torch::Tensor dir = end - start;
+
+  for (auto& d : shoebox_orders) {
+    double abs_dir0 = std::abs(dir[d[0]].item().toDouble());
+    if (abs_dir0 < EPS) {
+      continue;
+    }
+
+    // distance to plane
+    double distance = 0.;
+
+    // this wil tell us if the front or back plane is hit
+    int ind_inc = 0;
+
+    if (dir[d[0]].item().toDouble() < 0.) {
+      result[d[0]] = 0.;
+      distance = start[d[0]].item().toDouble();
+      ind_inc = 0;
+    } else {
+      result[d[0]] = room[d[0]];
+      distance = (room[d[0]] - start[d[0]]).item().toDouble();
+      ind_inc = 1;
+    }
+
+    if (distance < EPS)
+      continue;
+
+    float ratio = distance / abs_dir0;
+
+    // Now compute the intersection point and verify if intersection happens
+    for (auto i = 1; i < D; ++i) {
+      result[d[i]] = start[d[i]] + ratio * dir[d[i]];
+      // when there is no intersection, we jump to the next plane
+      if ((result[d[i]] <= -EPS).item().toBool() ||
+          (room[d[i]] + EPS <= result[d[i]]).item().toBool())
+        goto next_plane; // TODO: avoid goto??
+    }
+
+    // if we get here, there is intersection with this wall
+    next_wall_index = 2 * d[0] + ind_inc;
+
+    hit_dist = (result - start).norm().item().toDouble();
+
+    break;
+
+  next_plane:
+    (void)0; // no op
+  }
+  return std::make_tuple(result, next_wall_index, hit_dist);
+}
+
+void simul_ray(
+    torch::Tensor& hist,
+    torch::Tensor room,
+    torch::Tensor source,
+    torch::Tensor mic_array,
+    double e_absorption,
+    double sound_speed,
+    double energy_thres,
+    double time_thres,
+    double hist_bin_size,
+    float phi,
+    float theta,
+    double energy_0) {
+  // TODO: requires_grad of tensors????
+
+  int D = room.size(0);
+
+  torch::Tensor start = source.clone();
+
+  // the direction of the ray (unit vector)
+  torch::Tensor dir = torch::zeros(D, torch::kFloat);
+  // TODO: There must be better way to initialize the tensors??
+  if (D == 2) {
+    //   dir.head(2) = Eigen::Vector2f(cos(phi), sin(phi));
+    dir[0] = cos(phi);
+    dir[1] = sin(phi);
+  } else if (D == 3) {
+    //   dir.head(3) = Eigen::Vector3f(sin(theta) * cos(phi), sin(theta) *
+    //   sin(phi), cos(theta));
+    dir[0] = sin(theta) * cos(phi);
+    dir[1] = sin(theta) * sin(phi);
+    dir[2] = cos(theta);
+  }
+
+  // The following initializations are arbitrary and does not count since
+  // we set the boolean to false
+  int next_wall_index = 0;
+
+  // The ray's characteristics
+  //   Eigen::ArrayXf transmitted = Eigen::ArrayXf::Ones(n_bands) * energy_0;
+  //   Eigen::ArrayXf energy = Eigen::ArrayXf::Ones(n_bands);
+  // TODO: handle n_bands
+  auto transmitted = energy_0;
+  double energy = 1.;
+  double travel_dist = 0.;
+
+  // To count the number of times the ray bounces on the walls
+  // For hybrid generation we add a ray to output only if specular_counter
+  // is higher than the ism order.
+  int specular_counter = 0;
+
+  // Convert the energy threshold to transmission threshold
+  double e_thres = energy_0 * energy_thres;
+  double distance_thres = time_thres * sound_speed;
+
+  torch::Tensor hit_point = torch::zeros(D, torch::kFloat);
+
+  while (true) {
+    // Find the next hit point
+    double hit_distance = 0;
+    std::tie(hit_point, next_wall_index, hit_distance) =
+        next_wall_hit(room, start, start + dir * MAX_DIST, false);
+
+    // If no wall is hit (rounding errors), stop the ray
+    if (next_wall_index == -1)
+      break;
+
+    // TODO: Do we need this wall variable??
+    // Intersected wall
+    // Wall<D> &wall = walls[next_wall_index];
+
+    // Check if the specular ray hits any of the microphone
+    if (!(IS_HYBRID_SIM && specular_counter < ISM_ORDER)) {
+      // Compute the distance between the line defined by (start, hit_point)
+      // and the center of the microphone (mic_pos)
+
+      torch::Tensor to_mic = mic_array - start;
+      double impact_distance = to_mic.dot(dir).item().toDouble();
+
+      bool impacts =
+          (-EPS < impact_distance) && (impact_distance < hit_distance + EPS);
+
+      // If yes, we compute the ray's transmitted amplitude at the mic and we
+      // continue the ray
+      if (impacts &&
+          ((to_mic - dir * impact_distance).norm().item().toDouble() <
+           MIC_RADIUS + EPS)) {
+        // The length of this last hop
+        double distance = std::abs(impact_distance);
+
+        // Updating travel_time and transmitted amplitude for this ray We DON'T
+        // want to modify the variables transmitted amplitude and travel_dist
+        // because the ray will continue its way
+        double travel_dist_at_mic = travel_dist + distance;
+        double r_sq = travel_dist_at_mic * travel_dist_at_mic;
+        auto p_hit =
+            (1 - sqrt(1 - MIC_RADIUS_SQ / std::max(MIC_RADIUS_SQ, r_sq)));
+        energy = transmitted / (r_sq * p_hit);
+
+        // microphones[k].log_histogram(travel_dist_at_mic, energy, start);
+        double time_at_mic = travel_dist_at_mic / sound_speed;
+        auto bin = floor(time_at_mic / hist_bin_size);
+        hist[bin] += energy; // TODO: Also log counts??
+      }
+    }
+
+    // Update the characteristics
+    travel_dist += hit_distance;
+    // transmitted *= wall.get_energy_reflection();
+    transmitted *= (1. - e_absorption);
+
+    // Let's shoot the scattered ray induced by the rebound on the wall
+    if (SCATTER > 0) {
+      // Shoot the scattered ray
+
+      // TODOODODODODODODODODODO
+      //   scat_ray(transmitted, wall, start, hit_point, travel_dist);
+
+      // The overall ray's energy gets decreased by the total
+      // amount of scattered energy
+      transmitted *= (1. - SCATTER);
+    }
+
+    // Check if we reach the thresholds for this ray
+    if (travel_dist > distance_thres || transmitted < e_thres) {
+      break;
+    }
+
+    // // set up for next iteration
+    // specular_counter += 1;
+    // dir = wall.normal_reflect(dir); // conserves length
+    // start = hit_point;
+
+    break; // TODO: remove!!!!!
+  }
+}
+
+void ray_tracing_impl(
+    torch::Tensor& hist,
+    torch::Tensor room,
+    torch::Tensor source,
+    torch::Tensor mic_array,
+    int64_t num_rays,
+    double e_absorption,
+    double sound_speed,
+    double energy_thres,
+    double time_thres,
+    double hist_bin_size) {
+  double energy_0 = 2. / num_rays; // TODO: just move that into simul_ray??
+  int D = room.size(0);
+
+  // TODO: Could probably parallelize call over num_rays? We would need
+  // `num_threads` histograms and then sum-reduce them into a single histogram.
+
+  if (D == 3) {
+    auto offset = 2. / num_rays;
+    auto increment = M_PI * (3. - sqrt(5.)); // phi increment
+
+    for (auto i = 0; i < num_rays; ++i) {
+      auto z = (i * offset - 1) + offset / 2.;
+      auto rho = sqrt(1. - z * z);
+
+      float phi = i * increment;
+
+      auto x = cos(phi) * rho;
+      auto y = sin(phi) * rho;
+
+      auto azimuth = atan2(y, x);
+      auto colatitude = atan2(sqrt(x * x + y * y), z);
+
+      //   simul_ray(azimuth, colatitude, source_pos, energy_0);
+    }
+  } else if (D == 2) {
+    float offset = 2. * M_PI / num_rays;
+    for (auto i = 0; i < num_rays; ++i) {
+      simul_ray(
+          hist,
+          room,
+          source,
+          mic_array,
+          e_absorption,
+          sound_speed,
+          energy_thres,
+          time_thres,
+          hist_bin_size,
+          i * offset,
+          0.,
+          energy_0);
+    }
+  }
+}
+
+torch::Tensor ray_tracing(
+    torch::Tensor room,
+    torch::Tensor source,
+    torch::Tensor mic_array,
+    int64_t num_rays,
+    double e_absorption,
+    double sound_speed,
+    double energy_thres,
+    double time_thres,
+    double hist_bin_size) {
+  // TODO: Maybe hist_size should also be bounded from output of ISM, and from
+  // eq (4) from https://reuk.github.io/wayverb/ray_tracer.html
+  auto hist_size = ceil(time_thres / hist_bin_size);
+  auto hist = torch::zeros(hist_size, torch::kFloat);
+  AT_DISPATCH_FLOATING_TYPES(
+      at::ScalarType::Float, "ray_tracing", [&] { // TODO: AND_HALF???
+        ray_tracing_impl(
+            hist,
+            room,
+            source,
+            mic_array,
+            num_rays,
+            e_absorption,
+            sound_speed,
+            energy_thres,
+            time_thres,
+            hist_bin_size);
+      });
+  return hist;
+}
+
+TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
+  m.def(
+      "torchaudio::ray_tracing(Tensor room, Tensor source, Tensor mic_array, int num_rays, float e_absorption, float sound_speed, float energy_thres, float time_thres, float hist_bin_size) -> Tensor",
+      &torchaudio::rir::ray_tracing);
+}
+
+} // Anonymous namespace
+} // namespace rir
+} // namespace torchaudio

--- a/torchaudio/csrc/ray_tracing.cpp
+++ b/torchaudio/csrc/ray_tracing.cpp
@@ -11,7 +11,7 @@ namespace {
 
 // TODO: use double verywhere instead of float?
 // TODO: use const where relevant?
-// TODO: get rid of all the .item().toDouble() and toBool() calls ?
+// TODO: get rid of all the .item().toFloat() and toBool() calls ?
 // TODO: is shoebox_size the same as room size?????
 
 #define IS_HYBRID_SIM (false) // TODO: remove
@@ -24,14 +24,14 @@ std::tuple<torch::Tensor, int, float> next_wall_hit(
     torch::Tensor room,
     torch::Tensor start,
     torch::Tensor end,
-    double max_dist) {
+    float max_dist) {
   int D = room.size(0);
   const static std::vector<std::vector<int>> shoebox_orders = {
       {0, 1, 2}, {1, 0, 2}, {2, 0, 1}};
 
   torch::Tensor result = torch::zeros(D, torch::kFloat);
   int next_wall_index = -1;
-  double hit_dist = max_dist;
+  float hit_dist = max_dist;
 
   // The direction vector
   torch::Tensor dir = end - start;
@@ -40,24 +40,24 @@ std::tuple<torch::Tensor, int, float> next_wall_hit(
     if (d[0] >= D) { // Happens for 2D rooms
       continue;
     }
-    double abs_dir0 = std::abs(dir[d[0]].item().toDouble());
+    float abs_dir0 = std::abs(dir[d[0]].item().toFloat());
     if (abs_dir0 < EPS) {
       continue;
     }
 
     // distance to plane
-    double distance = 0.;
+    float distance = 0.;
 
     // this will tell us if the front or back plane is hit
     int ind_inc = 0;
 
-    if (dir[d[0]].item().toDouble() < 0.) {
+    if (dir[d[0]].item().toFloat() < 0.) {
       result[d[0]] = 0.;
-      distance = start[d[0]].item().toDouble();
+      distance = start[d[0]].item().toFloat();
       ind_inc = 0;
     } else {
       result[d[0]] = room[d[0]];
-      distance = (room[d[0]] - start[d[0]]).item().toDouble();
+      distance = (room[d[0]] - start[d[0]]).item().toFloat();
       ind_inc = 1;
     }
 
@@ -79,7 +79,7 @@ std::tuple<torch::Tensor, int, float> next_wall_hit(
     // if we get here, there is intersection with this wall
     next_wall_index = 2 * d[0] + ind_inc;
 
-    hit_dist = (result - start).norm().item().toDouble();
+    hit_dist = (result - start).norm().item().toFloat();
 
     break;
 
@@ -91,53 +91,64 @@ std::tuple<torch::Tensor, int, float> next_wall_hit(
 
 void log_hist(
     torch::Tensor& hist,
-    double energy,
-    double travel_dist_at_mic,
-    double sound_speed,
-    double hist_bin_size) {
+    float energy,
+    float travel_dist_at_mic,
+    float sound_speed,
+    float hist_bin_size) {
   // TODO: Also log counts??
-  double time_at_mic = travel_dist_at_mic / sound_speed;
+  float time_at_mic = travel_dist_at_mic / sound_speed;
   auto bin = floor(time_at_mic / hist_bin_size);
   hist[bin] += energy;
+}
+
+int side(torch::Tensor normal, torch::Tensor origin, torch::Tensor pos) {
+  auto dot = (pos - origin).dot(normal).item().toFloat();
+
+  if (dot > EPS) {
+    return 1;
+  } else if (dot < -EPS) {
+    return -1;
+  } else {
+    return 0;
+  }
 }
 
 void scat_ray(
     torch::Tensor& hist,
     torch::Tensor mic_array,
-    double scatter,
-    double sound_speed,
-    double energy_thres,
-    double time_thres,
-    double hist_bin_size,
-    double transmitted,
+    float scatter,
+    float sound_speed,
+    float energy_thres,
+    float time_thres,
+    float hist_bin_size,
+    float transmitted,
     torch::Tensor normal,
     torch::Tensor hit_point,
-    double travel_dist) {
+    float travel_dist) {
   // Convert the energy threshold to transmission threshold (make this more
   // efficient at some point)
-  double distance_thres = time_thres * sound_speed;
+  float distance_thres = time_thres * sound_speed;
 
   // As the ray is shot towards the microphone center,
   // the hop dist can be easily computed
   torch::Tensor hit_point_to_mic = mic_array - hit_point;
-  double hop_dist = hit_point_to_mic.norm().item().toDouble();
-  double travel_dist_at_mic = travel_dist + hop_dist;
+  float hop_dist = hit_point_to_mic.norm().item().toFloat();
+  float travel_dist_at_mic = travel_dist + hop_dist;
 
   // compute the scattered energy reaching the microphone
-  double h_sq = hop_dist * hop_dist;
-  double p_hit_equal = 1. - sqrt(1. - MIC_RADIUS_SQ / h_sq);
-  double cosine = hit_point_to_mic.dot(normal).item().toDouble() /
-      hit_point_to_mic.norm().item().toDouble();
+  float h_sq = hop_dist * hop_dist;
+  float p_hit_equal = 1.f - sqrt(1.f - MIC_RADIUS_SQ / h_sq);
+  float cosine = hit_point_to_mic.dot(normal).item().toFloat() /
+      hit_point_to_mic.norm().item().toFloat();
   // cosine angle should be positive, but could be negative if normal is
   // facing out of room so we take abs
-  float p_lambert = 2. * std::abs(cosine);
-  double scat_trans = scatter * transmitted * p_hit_equal * p_lambert;
+  float p_lambert = 2 * std::abs(cosine);
+  float scat_trans = scatter * transmitted * p_hit_equal * p_lambert;
 
-  if (travel_dist_at_mic < distance_thres && scatter > energy_thres) {
-    double r_sq = travel_dist_at_mic * travel_dist_at_mic;
-    auto p_hit =
-        (1. - sqrt(1. - MIC_RADIUS_SQ / std::max(MIC_RADIUS_SQ, r_sq)));
-    double energy = scat_trans / (r_sq * p_hit);
+  if (travel_dist_at_mic < distance_thres && scat_trans > energy_thres) {
+    double r_sq = double(travel_dist_at_mic) * travel_dist_at_mic;
+    auto p_hit = (1 - sqrt(1 - MIC_RADIUS_SQ / std::max(MIC_RADIUS_SQ, r_sq)));
+    float energy = scat_trans / (r_sq * p_hit);
     log_hist(hist, energy, travel_dist_at_mic, sound_speed, hist_bin_size);
   }
 }
@@ -145,19 +156,20 @@ void scat_ray(
 void simul_ray(
     torch::Tensor& hist,
     torch::Tensor normals,
+    torch::Tensor origins,
     torch::Tensor room,
     torch::Tensor source,
     torch::Tensor mic_array,
-    double e_absorption,
-    double scatter,
-    double sound_speed,
-    double energy_thres,
-    double time_thres,
-    double hist_bin_size,
+    float e_absorption,
+    float scatter,
+    float sound_speed,
+    float energy_thres,
+    float time_thres,
+    float hist_bin_size,
     float phi,
     float theta,
-    double energy_0,
-    double max_dist) {
+    float energy_0,
+    float max_dist) {
   // TODO: requires_grad of tensors????
 
   int D = room.size(0);
@@ -183,8 +195,8 @@ void simul_ray(
   //   Eigen::ArrayXf energy = Eigen::ArrayXf::Ones(n_bands);
   // TODO: handle n_bands
   auto transmitted = energy_0;
-  double energy = 1.;
-  double travel_dist = 0.;
+  float energy = 1.;
+  float travel_dist = 0.;
 
   // To count the number of times the ray bounces on the walls
   // For hybrid generation we add a ray to output only if specular_counter
@@ -192,14 +204,14 @@ void simul_ray(
   int specular_counter = 0;
 
   // Convert the energy threshold to transmission threshold
-  double e_thres = energy_0 * energy_thres;
-  double distance_thres = time_thres * sound_speed;
+  float e_thres = energy_0 * energy_thres;
+  float distance_thres = time_thres * sound_speed;
 
   torch::Tensor hit_point = torch::zeros(D, torch::kFloat);
 
   while (true) {
     // Find the next hit point
-    double hit_distance = 0;
+    float hit_distance = 0;
     std::tie(hit_point, next_wall_index, hit_distance) =
         next_wall_hit(room, start, start + dir * max_dist, max_dist);
 
@@ -214,7 +226,7 @@ void simul_ray(
       // and the center of the microphone (mic_pos)
 
       torch::Tensor to_mic = mic_array - start;
-      double impact_distance = to_mic.dot(dir).item().toDouble();
+      float impact_distance = to_mic.dot(dir).item().toFloat();
 
       bool impacts =
           (-EPS < impact_distance) && (impact_distance < hit_distance + EPS);
@@ -222,15 +234,15 @@ void simul_ray(
       // If yes, we compute the ray's transmitted amplitude at the mic and we
       // continue the ray
       if (impacts &&
-          ((to_mic - dir * impact_distance).norm().item().toDouble() <
+          ((to_mic - dir * impact_distance).norm().item().toFloat() <
            MIC_RADIUS + EPS)) {
         // The length of this last hop
-        double distance = std::abs(impact_distance);
+        float distance = std::abs(impact_distance);
 
         // Updating travel_time and transmitted amplitude for this ray We DON'T
         // want to modify the variables transmitted amplitude and travel_dist
         // because the ray will continue its way
-        double travel_dist_at_mic = travel_dist + distance;
+        float travel_dist_at_mic = travel_dist + distance;
         double r_sq = travel_dist_at_mic * travel_dist_at_mic;
         auto p_hit =
             (1 - sqrt(1 - MIC_RADIUS_SQ / std::max(MIC_RADIUS_SQ, r_sq)));
@@ -245,23 +257,25 @@ void simul_ray(
     transmitted *= (1. - e_absorption);
 
     auto normal = normals[next_wall_index];
+    auto origin = origins[next_wall_index];
 
-    // // Let's shoot the scattered ray induced by the rebound on the wall
-    // if (scatter > 0) {
-    //   scat_ray(
-    //       hist,
-    //       mic_array,
-    //       scatter,
-    //       sound_speed,
-    //       energy_thres,
-    //       time_thres,
-    //       hist_bin_size,
-    //       transmitted,
-    //       normal,
-    //       hit_point,
-    //       travel_dist);
-    //   transmitted *= (1. - scatter);
-    // }
+    // Let's shoot the scattered ray induced by the rebound on the wall
+    if ((scatter > 0) &&
+        (side(normal, origin, mic_array) == side(normal, origin, start))) {
+      scat_ray(
+          hist,
+          mic_array,
+          scatter,
+          sound_speed,
+          energy_thres,
+          time_thres,
+          hist_bin_size,
+          transmitted,
+          normal,
+          hit_point,
+          travel_dist);
+      transmitted *= (1. - scatter);
+    }
 
     // Check if we reach the thresholds for this ray
     if (travel_dist > distance_thres || transmitted < e_thres) {
@@ -297,10 +311,22 @@ torch::Tensor make_normals(torch::Tensor room) {
 
   return torch::tensor(
       {
-          {0, -1}, // South
-          {1, 0}, // East
-          {0, 1}, // North
-          {-1, 0}, // West
+          {0.f, -1.f}, // South
+          {1.f, 0.f}, // East
+          {0.f, 1.f}, // North
+          {-1.f, 0.f} // West
+      },
+      torch::kFloat);
+}
+
+// See make_normals
+torch::Tensor make_origins(torch::Tensor room) {
+  return torch::tensor(
+      {
+          {0.f, 0.f}, // South
+          {room[0].item().toFloat(), 0.f}, // East
+          {room[0].item().toFloat(), room[1].item().toFloat()}, // North
+          {0.f, room[1].item().toFloat()} // West
       },
       torch::kFloat);
 }
@@ -311,20 +337,20 @@ void ray_tracing_impl(
     torch::Tensor source,
     torch::Tensor mic_array,
     int64_t num_rays,
-    double e_absorption,
-    double scatter,
-    double sound_speed,
-    double energy_thres,
-    double time_thres,
-    double hist_bin_size) {
-  double energy_0 = 2. / num_rays;
+    float e_absorption,
+    float scatter,
+    float sound_speed,
+    float energy_thres,
+    float time_thres,
+    float hist_bin_size) {
+  float energy_0 = 2. / num_rays;
   int D = room.size(0);
 
   // Max distance needed to hit a wall = diagonal of room + 1
-  double max_dist = room.norm().item().toDouble() + 1.;
-  std::cout << "max_dist = " << max_dist << std::endl;
+  float max_dist = room.norm().item().toFloat() + 1.;
 
   torch::Tensor normals = make_normals(room);
+  torch::Tensor origins = make_origins(room);
   // TODO: Could probably parallelize call over num_rays? We would need
   // `num_threads` histograms and then sum-reduce them into a single histogram.
 
@@ -347,6 +373,7 @@ void ray_tracing_impl(
       simul_ray(
           hist,
           normals,
+          origins,
           room,
           source,
           mic_array,
@@ -367,6 +394,7 @@ void ray_tracing_impl(
       simul_ray(
           hist,
           normals,
+          origins,
           room,
           source,
           mic_array,
@@ -407,12 +435,12 @@ torch::Tensor ray_tracing(
             source,
             mic_array,
             num_rays,
-            e_absorption,
-            scatter,
-            sound_speed,
-            energy_thres,
-            time_thres,
-            hist_bin_size);
+            (float)e_absorption,
+            (float)scatter,
+            (float)sound_speed,
+            (float)energy_thres,
+            (float)time_thres,
+            (float)hist_bin_size);
       });
   return hist;
 }

--- a/torchaudio/csrc/ray_tracing.cpp
+++ b/torchaudio/csrc/ray_tracing.cpp
@@ -113,186 +113,6 @@ int side(torch::Tensor normal, torch::Tensor origin, torch::Tensor pos) {
   }
 }
 
-void scat_ray(
-    torch::Tensor& hist,
-    torch::Tensor mic_array,
-    float scatter,
-    float sound_speed,
-    float energy_thres,
-    float time_thres,
-    float hist_bin_size,
-    float transmitted,
-    torch::Tensor normal,
-    torch::Tensor hit_point,
-    float travel_dist) {
-  // Convert the energy threshold to transmission threshold (make this more
-  // efficient at some point)
-  float distance_thres = time_thres * sound_speed;
-
-  // As the ray is shot towards the microphone center,
-  // the hop dist can be easily computed
-  torch::Tensor hit_point_to_mic = mic_array - hit_point;
-  float hop_dist = hit_point_to_mic.norm().item().toFloat();
-  float travel_dist_at_mic = travel_dist + hop_dist;
-
-  // compute the scattered energy reaching the microphone
-  float h_sq = hop_dist * hop_dist;
-  float p_hit_equal = 1.f - sqrt(1.f - MIC_RADIUS_SQ / h_sq);
-  float cosine = hit_point_to_mic.dot(normal).item().toFloat() /
-      hit_point_to_mic.norm().item().toFloat();
-  // cosine angle should be positive, but could be negative if normal is
-  // facing out of room so we take abs
-  float p_lambert = 2 * std::abs(cosine);
-  float scat_trans = scatter * transmitted * p_hit_equal * p_lambert;
-
-  if (travel_dist_at_mic < distance_thres && scat_trans > energy_thres) {
-    double r_sq = double(travel_dist_at_mic) * travel_dist_at_mic;
-    auto p_hit = (1 - sqrt(1 - MIC_RADIUS_SQ / std::max(MIC_RADIUS_SQ, r_sq)));
-    float energy = scat_trans / (r_sq * p_hit);
-    log_hist(hist, energy, travel_dist_at_mic, sound_speed, hist_bin_size);
-  }
-}
-
-void simul_ray(
-    torch::Tensor& hist,
-    torch::Tensor normals,
-    torch::Tensor origins,
-    torch::Tensor room,
-    torch::Tensor source,
-    torch::Tensor mic_array,
-    float e_absorption,
-    float scatter,
-    float sound_speed,
-    float energy_thres,
-    float time_thres,
-    float hist_bin_size,
-    float phi,
-    float theta,
-    float energy_0,
-    float max_dist) {
-  // TODO: requires_grad of tensors????
-
-  int D = room.size(0);
-
-  torch::Tensor start = source.clone();
-
-  // the direction of the ray (unit vector)
-  torch::Tensor dir;
-  if (D == 2) {
-    dir = torch::tensor({cos(phi), sin(phi)}, torch::kFloat);
-  } else if (D == 3) {
-    dir = torch::tensor(
-        {sin(theta) * cos(phi), sin(theta) * sin(phi), cos(theta)},
-        torch::kFloat);
-  }
-
-  // The following initializations are arbitrary and does not count since
-  // we set the boolean to false
-  int next_wall_index = 0;
-
-  // The ray's characteristics
-  //   Eigen::ArrayXf transmitted = Eigen::ArrayXf::Ones(n_bands) * energy_0;
-  //   Eigen::ArrayXf energy = Eigen::ArrayXf::Ones(n_bands);
-  // TODO: handle n_bands
-  auto transmitted = energy_0;
-  float energy = 1.;
-  float travel_dist = 0.;
-
-  // To count the number of times the ray bounces on the walls
-  // For hybrid generation we add a ray to output only if specular_counter
-  // is higher than the ism order.
-  int specular_counter = 0;
-
-  // Convert the energy threshold to transmission threshold
-  float e_thres = energy_0 * energy_thres;
-  float distance_thres = time_thres * sound_speed;
-
-  torch::Tensor hit_point = torch::zeros(D, torch::kFloat);
-
-  while (true) {
-    // Find the next hit point
-    float hit_distance = 0;
-    std::tie(hit_point, next_wall_index, hit_distance) =
-        next_wall_hit(room, start, start + dir * max_dist, max_dist);
-
-    // If no wall is hit (rounding errors), stop the ray
-    if (next_wall_index == -1)
-      break;
-
-    // Check if the specular ray hits any of the microphone
-    // if (!(IS_HYBRID_SIM && specular_counter < ISM_ORDER)) {
-    if (true) { // TODO: remove
-      // Compute the distance between the line defined by (start, hit_point)
-      // and the center of the microphone (mic_pos)
-
-      torch::Tensor to_mic = mic_array - start;
-      float impact_distance = to_mic.dot(dir).item().toFloat();
-
-      bool impacts =
-          (-EPS < impact_distance) && (impact_distance < hit_distance + EPS);
-
-      // If yes, we compute the ray's transmitted amplitude at the mic and we
-      // continue the ray
-      if (impacts &&
-          ((to_mic - dir * impact_distance).norm().item().toFloat() <
-           MIC_RADIUS + EPS)) {
-        // The length of this last hop
-        float distance = std::abs(impact_distance);
-
-        // Updating travel_time and transmitted amplitude for this ray We DON'T
-        // want to modify the variables transmitted amplitude and travel_dist
-        // because the ray will continue its way
-        float travel_dist_at_mic = travel_dist + distance;
-        double r_sq = travel_dist_at_mic * travel_dist_at_mic;
-        auto p_hit =
-            (1 - sqrt(1 - MIC_RADIUS_SQ / std::max(MIC_RADIUS_SQ, r_sq)));
-        energy = transmitted / (r_sq * p_hit);
-
-        log_hist(hist, energy, travel_dist_at_mic, sound_speed, hist_bin_size);
-      }
-    }
-
-    // Update the characteristics
-    travel_dist += hit_distance;
-    transmitted *= (1. - e_absorption);
-
-    auto normal = normals[next_wall_index];
-    auto origin = origins[next_wall_index];
-
-    // Let's shoot the scattered ray induced by the rebound on the wall
-    if ((scatter > 0) &&
-        (side(normal, origin, mic_array) == side(normal, origin, start))) {
-      scat_ray(
-          hist,
-          mic_array,
-          scatter,
-          sound_speed,
-          energy_thres,
-          time_thres,
-          hist_bin_size,
-          transmitted,
-          normal,
-          hit_point,
-          travel_dist);
-      transmitted *= (1. - scatter);
-    }
-
-    // Check if we reach the thresholds for this ray
-    if (travel_dist > distance_thres || transmitted < e_thres) {
-      break;
-    }
-
-    // set up for next iteration
-    specular_counter += 1;
-    // reflect w.r.t normal while conserving length
-    dir = dir - normal * 2 * dir.dot(normal);
-    start = hit_point;
-    // if (specular_counter == 2) {
-    //   break;
-    // }
-  }
-}
-
 // TODO: Handle 3D rooms
 torch::Tensor make_normals(torch::Tensor room) {
   // Note that the normals are facing outwards the room:
@@ -311,10 +131,10 @@ torch::Tensor make_normals(torch::Tensor room) {
 
   return torch::tensor(
       {
-          {0.f, -1.f}, // South
-          {1.f, 0.f}, // East
-          {0.f, 1.f}, // North
-          {-1.f, 0.f} // West
+          {0, -1}, // South
+          {1, 0}, // East
+          {0, 1}, // North
+          {-1, 0} // West
       },
       torch::kFloat);
 }
@@ -331,86 +151,249 @@ torch::Tensor make_origins(torch::Tensor room) {
       torch::kFloat);
 }
 
-void ray_tracing_impl(
-    torch::Tensor& hist,
-    torch::Tensor room,
-    torch::Tensor source,
-    torch::Tensor mic_array,
-    int64_t num_rays,
-    float e_absorption,
-    float scatter,
-    float sound_speed,
-    float energy_thres,
-    float time_thres,
-    float hist_bin_size) {
-  float energy_0 = 2. / num_rays;
-  int D = room.size(0);
+class RayTracer {
+ public:
+  RayTracer(
+      int _num_rays,
+      float _e_absorption,
+      float _scatter,
+      float _sound_speed,
+      float _energy_thres,
+      float _time_thres,
+      float _hist_bin_size)
+      : num_rays(_num_rays),
+        e_absorption(_e_absorption),
+        scatter(_scatter),
+        sound_speed(_sound_speed),
+        energy_thres(_energy_thres),
+        time_thres(_time_thres),
+        hist_bin_size(_hist_bin_size) {
+    this->energy_0 = 2. / this->num_rays;
 
-  // Max distance needed to hit a wall = diagonal of room + 1
-  float max_dist = room.norm().item().toFloat() + 1.;
+    this->normals = torch::tensor(
+        {
+            {0, -1}, // South
+            {1, 0}, // East
+            {0, 1}, // North
+            {-1, 0} // West
+        },
+        torch::kFloat);
+  }
 
-  torch::Tensor normals = make_normals(room);
-  torch::Tensor origins = make_origins(room);
-  // TODO: Could probably parallelize call over num_rays? We would need
-  // `num_threads` histograms and then sum-reduce them into a single histogram.
+  void impl(
+      torch::Tensor& hist,
+      torch::Tensor room,
+      torch::Tensor source,
+      torch::Tensor mic_array) {
+    int D = room.size(0);
 
-  if (D == 3) {
-    auto offset = 2. / num_rays;
-    auto increment = M_PI * (3. - sqrt(5.)); // phi increment
+    // Max distance needed to hit a wall = diagonal of room + 1
+    float max_dist = room.norm().item().toFloat() + 1.;
 
-    for (auto i = 0; i < num_rays; ++i) {
-      auto z = (i * offset - 1) + offset / 2.;
-      auto rho = sqrt(1. - z * z);
+    // torch::Tensor normals = make_normals(room);
+    torch::Tensor origins = make_origins(room);
+    // TODO: Could probably parallelize call over num_rays? We would need
+    // `num_threads` histograms and then sum-reduce them into a single
+    // histogram.
 
-      float phi = i * increment;
+    if (D == 3) {
+      auto offset = 2. / this->num_rays;
+      auto increment = M_PI * (3. - sqrt(5.)); // phi increment
 
-      auto x = cos(phi) * rho;
-      auto y = sin(phi) * rho;
+      for (auto i = 0; i < this->num_rays; ++i) {
+        auto z = (i * offset - 1) + offset / 2.;
+        auto rho = sqrt(1. - z * z);
 
-      auto azimuth = atan2(y, x);
-      auto colatitude = atan2(sqrt(x * x + y * y), z);
+        float phi = i * increment;
 
-      simul_ray(
-          hist,
-          normals,
-          origins,
-          room,
-          source,
-          mic_array,
-          e_absorption,
-          scatter,
-          sound_speed,
-          energy_thres,
-          time_thres,
-          hist_bin_size,
-          azimuth,
-          colatitude,
-          energy_0,
-          max_dist);
-    }
-  } else if (D == 2) {
-    float offset = 2. * M_PI / num_rays;
-    for (int i = 0; i < num_rays; ++i) {
-      simul_ray(
-          hist,
-          normals,
-          origins,
-          room,
-          source,
-          mic_array,
-          e_absorption,
-          scatter,
-          sound_speed,
-          energy_thres,
-          time_thres,
-          hist_bin_size,
-          i * offset,
-          0.,
-          energy_0,
-          max_dist);
+        auto x = cos(phi) * rho;
+        auto y = sin(phi) * rho;
+
+        auto azimuth = atan2(y, x);
+        auto colatitude = atan2(sqrt(x * x + y * y), z);
+
+        simul_ray(
+            hist,
+            origins,
+            room,
+            source,
+            mic_array,
+            azimuth,
+            colatitude,
+            max_dist);
+      }
+    } else if (D == 2) {
+      float offset = 2. * M_PI / this->num_rays;
+      for (int i = 0; i < this->num_rays; ++i) {
+        simul_ray(
+            hist, origins, room, source, mic_array, i * offset, 0., max_dist);
+      }
     }
   }
-}
+
+ private:
+  int num_rays;
+  float energy_0;
+  float e_absorption;
+  float scatter;
+  float sound_speed;
+  float energy_thres;
+  float time_thres;
+  float hist_bin_size;
+  torch::Tensor normals;
+
+  void simul_ray(
+      torch::Tensor& hist,
+      torch::Tensor origins,
+      torch::Tensor room,
+      torch::Tensor source,
+      torch::Tensor mic_array,
+      float phi,
+      float theta,
+      float max_dist) {
+    // TODO: requires_grad of tensors????
+
+    int D = room.size(0);
+
+    torch::Tensor start = source.clone();
+
+    // the direction of the ray (unit vector)
+    torch::Tensor dir;
+    if (D == 2) {
+      dir = torch::tensor({cos(phi), sin(phi)}, torch::kFloat);
+    } else if (D == 3) {
+      dir = torch::tensor(
+          {sin(theta) * cos(phi), sin(theta) * sin(phi), cos(theta)},
+          torch::kFloat);
+    }
+
+    // The following initializations are arbitrary and does not count since
+    // we set the boolean to false
+    int next_wall_index = 0;
+
+    // TODO: handle n_bands
+    auto transmitted = energy_0;
+    float energy = 1.;
+    float travel_dist = 0.;
+
+    // To count the number of times the ray bounces on the walls
+    // For hybrid generation we add a ray to output only if specular_counter
+    // is higher than the ism order.
+    int specular_counter = 0;
+
+    // Convert the energy threshold to transmission threshold
+    float e_thres = energy_0 * energy_thres;
+    float distance_thres = time_thres * sound_speed;
+
+    torch::Tensor hit_point = torch::zeros(D, torch::kFloat);
+
+    while (true) {
+      // Find the next hit point
+      float hit_distance = 0;
+      std::tie(hit_point, next_wall_index, hit_distance) =
+          next_wall_hit(room, start, start + dir * max_dist, max_dist);
+
+      // If no wall is hit (rounding errors), stop the ray
+      if (next_wall_index == -1)
+        break;
+
+      // Check if the specular ray hits any of the microphone
+      // if (!(IS_HYBRID_SIM && specular_counter < ISM_ORDER)) {
+      if (true) { // TODO: remove
+        // Compute the distance between the line defined by (start, hit_point)
+        // and the center of the microphone (mic_pos)
+
+        torch::Tensor to_mic = mic_array - start;
+        float impact_distance = to_mic.dot(dir).item().toFloat();
+
+        bool impacts =
+            (-EPS < impact_distance) && (impact_distance < hit_distance + EPS);
+
+        // If yes, we compute the ray's transmitted amplitude at the mic and we
+        // continue the ray
+        if (impacts &&
+            ((to_mic - dir * impact_distance).norm().item().toFloat() <
+             MIC_RADIUS + EPS)) {
+          // The length of this last hop
+          float distance = std::abs(impact_distance);
+
+          // Updating travel_time and transmitted amplitude for this ray We
+          // DON'T want to modify the variables transmitted amplitude and
+          // travel_dist because the ray will continue its way
+          float travel_dist_at_mic = travel_dist + distance;
+          double r_sq = travel_dist_at_mic * travel_dist_at_mic;
+          auto p_hit =
+              (1 - sqrt(1 - MIC_RADIUS_SQ / std::max(MIC_RADIUS_SQ, r_sq)));
+          energy = transmitted / (r_sq * p_hit);
+
+          log_hist(
+              hist, energy, travel_dist_at_mic, sound_speed, hist_bin_size);
+        }
+      }
+
+      // Update the characteristics
+      travel_dist += hit_distance;
+      transmitted *= (1. - e_absorption);
+
+      auto normal = normals[next_wall_index];
+      auto origin = origins[next_wall_index];
+
+      // Let's shoot the scattered ray induced by the rebound on the wall
+      if ((scatter > 0) &&
+          (side(normal, origin, mic_array) == side(normal, origin, start))) {
+        scat_ray(hist, mic_array, transmitted, normal, hit_point, travel_dist);
+        transmitted *= (1. - scatter);
+      }
+
+      // Check if we reach the thresholds for this ray
+      if (travel_dist > distance_thres || transmitted < e_thres) {
+        break;
+      }
+
+      // set up for next iteration
+      specular_counter += 1;
+      // reflect w.r.t normal while conserving length
+      dir = dir - normal * 2 * dir.dot(normal);
+      start = hit_point;
+    }
+  }
+
+  void scat_ray(
+      torch::Tensor& hist,
+      torch::Tensor mic_array,
+      float transmitted,
+      torch::Tensor normal,
+      torch::Tensor hit_point,
+      float travel_dist) {
+    // Convert the energy threshold to transmission threshold (make this more
+    // efficient at some point)
+    float distance_thres = time_thres * sound_speed;
+
+    // As the ray is shot towards the microphone center,
+    // the hop dist can be easily computed
+    torch::Tensor hit_point_to_mic = mic_array - hit_point;
+    float hop_dist = hit_point_to_mic.norm().item().toFloat();
+    float travel_dist_at_mic = travel_dist + hop_dist;
+
+    // compute the scattered energy reaching the microphone
+    float h_sq = hop_dist * hop_dist;
+    float p_hit_equal = 1.f - sqrt(1.f - MIC_RADIUS_SQ / h_sq);
+    float cosine = hit_point_to_mic.dot(normal).item().toFloat() /
+        hit_point_to_mic.norm().item().toFloat();
+    // cosine angle should be positive, but could be negative if normal is
+    // facing out of room so we take abs
+    float p_lambert = 2 * std::abs(cosine);
+    float scat_trans = scatter * transmitted * p_hit_equal * p_lambert;
+
+    if (travel_dist_at_mic < distance_thres && scat_trans > energy_thres) {
+      double r_sq = double(travel_dist_at_mic) * travel_dist_at_mic;
+      auto p_hit =
+          (1 - sqrt(1 - MIC_RADIUS_SQ / std::max(MIC_RADIUS_SQ, r_sq)));
+      float energy = scat_trans / (r_sq * p_hit);
+      log_hist(hist, energy, travel_dist_at_mic, sound_speed, hist_bin_size);
+    }
+  }
+};
 
 torch::Tensor ray_tracing(
     torch::Tensor room,
@@ -427,20 +410,18 @@ torch::Tensor ray_tracing(
   // eq (4) from https://reuk.github.io/wayverb/ray_tracer.html
   auto hist_size = ceil(time_thres / hist_bin_size);
   auto hist = torch::zeros(hist_size, torch::kFloat);
+  RayTracer rt(
+      num_rays,
+      e_absorption,
+      scatter,
+      sound_speed,
+      energy_thres,
+      time_thres,
+      hist_bin_size);
+
   AT_DISPATCH_FLOATING_TYPES(
       at::ScalarType::Float, "ray_tracing", [&] { // TODO: AND_HALF???
-        ray_tracing_impl(
-            hist,
-            room,
-            source,
-            mic_array,
-            num_rays,
-            (float)e_absorption,
-            (float)scatter,
-            (float)sound_speed,
-            (float)energy_thres,
-            (float)time_thres,
-            (float)hist_bin_size);
+        rt.impl(hist, room, source, mic_array);
       });
   return hist;
 }

--- a/torchaudio/csrc/ray_tracing.cpp
+++ b/torchaudio/csrc/ray_tracing.cpp
@@ -8,7 +8,7 @@ namespace {
 
 #define IS_HYBRID_SIM (false) // TODO: remove
 #define ISM_ORDER (10) // TODO: remove
-#define EPS (1e-5) // epsilon is set to 0.1 millimeter (100 um)
+#define EPS (1e-5)
 
 template <typename scalar_t>
 class RayTracer {
@@ -44,7 +44,6 @@ class RayTracer {
         origins(make_origins()) {}
 
   void compute_histogram(torch::Tensor& hist) {
-    // Max distance needed to hit a wall = diagonal of room + 1
 
     // TODO: Could probably parallelize call over num_rays? We would need
     // `num_threads` histograms and then sum-reduce them into a single
@@ -90,10 +89,10 @@ class RayTracer {
   scalar_t energy_thres;
   scalar_t time_thres;
   scalar_t hist_bin_size;
-  scalar_t max_dist;
-  int D;
-  const torch::Tensor normals;
-  const torch::Tensor origins;
+  scalar_t max_dist;  // Max distance needed to hit a wall = diagonal of room + 1
+  int D;  // Dimension of the room
+  const torch::Tensor normals;  // normal vector to walls
+  const torch::Tensor origins;  // origin (arbitrary reference) of each wall
 
   std::tuple<torch::Tensor, int, scalar_t> next_wall_hit(
       torch::Tensor start,
@@ -105,7 +104,6 @@ class RayTracer {
     int next_wall_index = -1;
     auto hit_dist = max_dist;
 
-    // The direction vector
     torch::Tensor dir = end - start;
 
     for (auto& d : shoebox_orders) {

--- a/torchaudio/prototype/functional/__init__.py
+++ b/torchaudio/prototype/functional/__init__.py
@@ -1,4 +1,4 @@
-from .functional import add_noise, convolve, fftconvolve
 from ._ray_tracing import ray_tracing
+from .functional import add_noise, convolve, fftconvolve
 
 __all__ = ["add_noise", "convolve", "fftconvolve", "ray_tracing"]

--- a/torchaudio/prototype/functional/__init__.py
+++ b/torchaudio/prototype/functional/__init__.py
@@ -1,3 +1,4 @@
 from .functional import add_noise, convolve, fftconvolve
+from ._ray_tracing import ray_tracing
 
-__all__ = ["add_noise", "convolve", "fftconvolve"]
+__all__ = ["add_noise", "convolve", "fftconvolve", "ray_tracing"]

--- a/torchaudio/prototype/functional/_ray_tracing.py
+++ b/torchaudio/prototype/functional/_ray_tracing.py
@@ -1,0 +1,25 @@
+import torch
+import torchaudio
+from torch import Tensor
+
+
+
+def ray_tracing(
+    room: Tensor,
+    source: torch.Tensor,
+    mic_array: torch.Tensor,
+    num_rays: int, # TODO: find good default
+    e_absorption: float = 0,  # TODO: accept tensor like in ISM
+    sound_speed: float = 343,
+    energy_thres: float = 1e-7,
+    time_thres: float = 10,  # 10s
+    hist_bin_size: float = 0.004,  # 4ms
+    # sample_rate: float = 16000.0,
+) -> Tensor:
+    if mic_array.dim() == 2:
+        if mic_array.shape[0] != 1:
+            raise ValueError("Only 1 channel supported")  # TODO: remove?
+        mic_array = mic_array[0]
+
+    assert time_thres > hist_bin_size  # TODO: raise proper ValueErRor
+    return torch.ops.torchaudio.ray_tracing(room, source, mic_array, num_rays, e_absorption, sound_speed, energy_thres, time_thres, hist_bin_size)

--- a/torchaudio/prototype/functional/_ray_tracing.py
+++ b/torchaudio/prototype/functional/_ray_tracing.py
@@ -20,6 +20,8 @@ def ray_tracing(
         if mic_array.shape[0] != 1:
             raise ValueError("Only 1 channel supported")  # TODO: remove?
         mic_array = mic_array[0]
+    if room.shape[0] > 2:
+        raise ValueError("Only 2D room supported")  # TODO: support 3D !!
 
     assert time_thres > hist_bin_size  # TODO: raise proper ValueErRor
     return torch.ops.torchaudio.ray_tracing(room, source, mic_array, num_rays, e_absorption, sound_speed, energy_thres, time_thres, hist_bin_size)

--- a/torchaudio/prototype/functional/_ray_tracing.py
+++ b/torchaudio/prototype/functional/_ray_tracing.py
@@ -10,6 +10,7 @@ def ray_tracing(
     mic_array: torch.Tensor,
     num_rays: int, # TODO: find good default
     e_absorption: float = 0,  # TODO: accept tensor like in ISM
+    scatter: float = 0,  # TODO: accept tensor like in ISM
     sound_speed: float = 343,
     energy_thres: float = 1e-7,
     time_thres: float = 10,  # 10s
@@ -24,4 +25,4 @@ def ray_tracing(
         raise ValueError("Only 2D room supported")  # TODO: support 3D !!
 
     assert time_thres > hist_bin_size  # TODO: raise proper ValueErRor
-    return torch.ops.torchaudio.ray_tracing(room, source, mic_array, num_rays, e_absorption, sound_speed, energy_thres, time_thres, hist_bin_size)
+    return torch.ops.torchaudio.ray_tracing(room, source, mic_array, num_rays, e_absorption, scatter, sound_speed, energy_thres, time_thres, hist_bin_size)

--- a/torchaudio/prototype/functional/_ray_tracing.py
+++ b/torchaudio/prototype/functional/_ray_tracing.py
@@ -1,28 +1,30 @@
 import torch
 import torchaudio
-from torch import Tensor
-
 
 
 def ray_tracing(
-    room: Tensor,
+    room: torch.Tensor,
     source: torch.Tensor,
     mic_array: torch.Tensor,
     num_rays: int, # TODO: find good default
     e_absorption: float = 0,  # TODO: accept tensor like in ISM
     scatter: float = 0,  # TODO: accept tensor like in ISM
+    mic_radius: float = 0.5,
     sound_speed: float = 343,
     energy_thres: float = 1e-7,
     time_thres: float = 10,  # 10s
     hist_bin_size: float = 0.004,  # 4ms
     # sample_rate: float = 16000.0,
-) -> Tensor:
-    if mic_array.dim() == 2:
-        if mic_array.shape[0] != 1:
-            raise ValueError("Only 1 channel supported")  # TODO: remove?
-        mic_array = mic_array[0]
+) -> torch.Tensor:
     if room.shape[0] > 2:
         raise ValueError("Only 2D room supported")  # TODO: support 3D !!
+    if mic_array.dim() == 2:
+        if mic_array.shape[0] != 1:
+            raise ValueError("Only 1 channel (1 microphone) supported.")
+        mic_array = mic_array[0]
+    if room.dtype != torch.float:
+        raise ValueError(f"room must be of float dtype, got {room.dtype} instead.")
+    if time_thres < hist_bin_size:
+        raise ValueError(f"time_thres={time_thres} must be greater than hist_bin_size={hist_bin_size}.")
 
-    assert time_thres > hist_bin_size  # TODO: raise proper ValueErRor
-    return torch.ops.torchaudio.ray_tracing(room, source, mic_array, num_rays, e_absorption, scatter, sound_speed, energy_thres, time_thres, hist_bin_size)
+    return torch.ops.torchaudio.ray_tracing(room, source, mic_array, num_rays, e_absorption, scatter, mic_radius, sound_speed, energy_thres, time_thres, hist_bin_size)

--- a/torchaudio/prototype/functional/_ray_tracing.py
+++ b/torchaudio/prototype/functional/_ray_tracing.py
@@ -6,7 +6,7 @@ def ray_tracing(
     room: torch.Tensor,
     source: torch.Tensor,
     mic_array: torch.Tensor,
-    num_rays: int, # TODO: find good default
+    num_rays: int,  # TODO: find good default
     e_absorption: float = 0,  # TODO: accept tensor like in ISM
     scatter: float = 0,  # TODO: accept tensor like in ISM
     mic_radius: float = 0.5,
@@ -14,10 +14,7 @@ def ray_tracing(
     energy_thres: float = 1e-7,
     time_thres: float = 10,  # 10s
     hist_bin_size: float = 0.004,  # 4ms
-    # sample_rate: float = 16000.0,
 ) -> torch.Tensor:
-    if room.shape[0] > 2:
-        raise ValueError("Only 2D room supported")  # TODO: support 3D !!
     if mic_array.dim() == 2:
         if mic_array.shape[0] != 1:
             raise ValueError("Only 1 channel (1 microphone) supported.")
@@ -27,4 +24,16 @@ def ray_tracing(
     if time_thres < hist_bin_size:
         raise ValueError(f"time_thres={time_thres} must be greater than hist_bin_size={hist_bin_size}.")
 
-    return torch.ops.torchaudio.ray_tracing(room, source, mic_array, num_rays, e_absorption, scatter, mic_radius, sound_speed, energy_thres, time_thres, hist_bin_size)
+    return torch.ops.torchaudio.ray_tracing(
+        room,
+        source,
+        mic_array,
+        num_rays,
+        e_absorption,
+        scatter,
+        mic_radius,
+        sound_speed,
+        energy_thres,
+        time_thres,
+        hist_bin_size,
+    )

--- a/torchaudio/prototype/functional/_ray_tracing.py
+++ b/torchaudio/prototype/functional/_ray_tracing.py
@@ -8,19 +8,30 @@ def ray_tracing(
     mic_array: torch.Tensor,
     num_rays: int,  # TODO: find good default
     e_absorption: float = 0,  # TODO: accept tensor like in ISM
-    scatter: float = 0,  # TODO: accept tensor like in ISM
+    scattering: float = 0,  # TODO: accept tensor like in ISM
     mic_radius: float = 0.5,
     sound_speed: float = 343,
     energy_thres: float = 1e-7,
     time_thres: float = 10,  # 10s
     hist_bin_size: float = 0.004,  # 4ms
 ) -> torch.Tensor:
+    r"""Compute energy histogram via ray tracing.
+
+    The implementation is based on *pyroomacoustics* :cite:`scheibler2018pyroomacoustics`.
+
+    .. devices:: CPU
+
+    .. properties:: Autograd TorchScript
+
+    TODO: document args and returns.
+
+    """
     if mic_array.dim() == 2:
         if mic_array.shape[0] != 1:
             raise ValueError("Only 1 channel (1 microphone) supported.")
         mic_array = mic_array[0]
-    if room.dtype != torch.float:
-        raise ValueError(f"room must be of float dtype, got {room.dtype} instead.")
+    if room.dtype not in (torch.float32, torch.float64):
+        raise ValueError(f"room must be of float32 or float64 dtype, got {room.dtype} instead.")
     if time_thres < hist_bin_size:
         raise ValueError(f"time_thres={time_thres} must be greater than hist_bin_size={hist_bin_size}.")
 
@@ -30,7 +41,7 @@ def ray_tracing(
         mic_array,
         num_rays,
         e_absorption,
-        scatter,
+        scattering,
         mic_radius,
         sound_speed,
         energy_thres,


### PR DESCRIPTION
This PR adds the `ray_tracing()` helper to compute a RIR (part of https://github.com/pytorch/audio/issues/2624). The implementation is heavily based on `pyroomacoustics`.

Current status: support for 2D and 3D shoebox room is OK, results are very very close to those of `pyroomacoustics`.

My C++ is weak / rusty, so I welcome any suggestion on style / perf / best  practices are more than welcome.


Lots of TODOs left:

- [ ] write docs
- [ ] make autograd work properly
- [ ] support multiple bands
- [ ] support per-wall and per-band absorption and scatter
- [ ] integrate this properly with the Image Source Method.
- [ ] bunch of TODOs here and there in the code
- [ ] (maybe) parallelize code over `num_rays`

CC @nateanl 