### PR TITLE
fix import bug in global_stats.py

### DIFF
--- a/examples/asr/emformer_rnnt/global_stats.py
+++ b/examples/asr/emformer_rnnt/global_stats.py
@@ -19,7 +19,7 @@ from common import (
     piecewise_linear_log,
     spectrogram_transform,
 )
-from must.dataset import MUSTC
+from mustc.dataset import MUSTC
 
 
 logger = logging.getLogger()


### PR DESCRIPTION
Summary:

This code was added by
https://github.com/pytorch/audio/commit/4d0095a528412cfec2a549204fc01d9ebb15df7a

Seems that the original code had a typo?

Test Plan:

```
// the import of `mustc` now succeeds, previously crashed
python examples/asr/emformer_rnnt/global_stats.py --model-type librispeech --dataset-path /home/vasiliy/local/librispeech/
```

Reviewers:

Subscribers:

Tasks:

Tags: