### PR TITLE
Fix _init_hubert_pretrain_model

### DIFF
--- a/torchaudio/models/wav2vec2/model.py
+++ b/torchaudio/models/wav2vec2/model.py
@@ -683,7 +683,7 @@ def hubert_xlarge(
 
 
 def _init_hubert_pretrain_model(module):
-    if isinstance(module, components.LayerNorm):
+    if isinstance(module, components.ConvLayerBlock):
         torch.nn.init.kaiming_normal_(module.conv.weight)
     elif isinstance(module, components.ConvolutionalPositionalEmbedding):
         # normalize the weight to normal distribution.


### PR DESCRIPTION
address #2885 

In `_init_hubert_pretrain_model ` method which initialize the hubert pretrain models, `kaiming_normal_` should be applied on `ConvLayerBlock` instead of `LayerNorm` layer. This PR fixes it and adds more unit tests.