### PR TITLE
Add additive noise transform

### DIFF
--- a/docs/source/prototype.transforms.rst
+++ b/docs/source/prototype.transforms.rst
@@ -9,6 +9,7 @@ torchaudio.prototype.transforms
     :toctree: generated
     :nosignatures:
 
+    AddNoise
     Convolve
     FFTConvolve
     BarkScale

--- a/test/torchaudio_unittest/prototype/transforms/autograd_test_impl.py
+++ b/test/torchaudio_unittest/prototype/transforms/autograd_test_impl.py
@@ -74,3 +74,16 @@ class Autograd(TestBaseMixin):
         speed = T.SpeedPerturbation(1000, [0.9]).to(device=self.device, dtype=torch.float64)
         assert gradcheck(speed, (waveform, lengths))
         assert gradgradcheck(speed, (waveform, lengths))
+
+    def test_AddNoise(self):
+        leading_dims = (2, 3)
+        L = 31
+
+        waveform = torch.rand(*leading_dims, L, dtype=torch.float64, device=self.device, requires_grad=True)
+        noise = torch.rand(*leading_dims, L, dtype=torch.float64, device=self.device, requires_grad=True)
+        lengths = torch.rand(*leading_dims, dtype=torch.float64, device=self.device, requires_grad=True)
+        snr = torch.rand(*leading_dims, dtype=torch.float64, device=self.device, requires_grad=True) * 10
+
+        add_noise = T.AddNoise().to(self.device, torch.float64)
+        assert gradcheck(add_noise, (waveform, noise, lengths, snr))
+        assert gradgradcheck(add_noise, (waveform, noise, lengths, snr))

--- a/test/torchaudio_unittest/prototype/transforms/batch_consistency_test.py
+++ b/test/torchaudio_unittest/prototype/transforms/batch_consistency_test.py
@@ -113,3 +113,23 @@ class BatchConsistencyTest(TorchaudioTestCase):
         for idx in range(len(unbatched_output)):
             w, l = output[idx], output_lengths[idx]
             self.assertEqual(unbatched_output[idx], w[:l])
+
+    def test_AddNoise(self):
+        leading_dims = (5, 2, 3)
+        L = 51
+
+        waveform = torch.rand(*leading_dims, L, dtype=self.dtype, device=self.device)
+        noise = torch.rand(*leading_dims, L, dtype=self.dtype, device=self.device)
+        lengths = torch.rand(*leading_dims, dtype=self.dtype, device=self.device)
+        snr = torch.rand(*leading_dims, dtype=self.dtype, device=self.device) * 10
+
+        add_noise = T.AddNoise()
+        actual = add_noise(waveform, noise, lengths, snr)
+
+        expected = []
+        for i in range(leading_dims[0]):
+            for j in range(leading_dims[1]):
+                for k in range(leading_dims[2]):
+                    expected.append(add_noise(waveform[i][j][k], noise[i][j][k], lengths[i][j][k], snr[i][j][k]))
+
+        self.assertEqual(torch.stack(expected), actual.reshape(-1, L))

--- a/test/torchaudio_unittest/prototype/transforms/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/prototype/transforms/torchscript_consistency_impl.py
@@ -40,3 +40,17 @@ class Transforms(TestBaseMixin):
         output = speed(waveform, lengths)
         ts_output = torch_script(speed)(waveform, lengths)
         self.assertEqual(ts_output, output)
+
+    def test_AddNoise(self):
+        leading_dims = (2, 3)
+        L = 31
+
+        waveform = torch.rand(*leading_dims, L, dtype=self.dtype, device=self.device, requires_grad=True)
+        noise = torch.rand(*leading_dims, L, dtype=self.dtype, device=self.device, requires_grad=True)
+        lengths = torch.rand(*leading_dims, dtype=self.dtype, device=self.device, requires_grad=True)
+        snr = torch.rand(*leading_dims, dtype=self.dtype, device=self.device, requires_grad=True) * 10
+
+        add_noise = T.AddNoise().to(self.device, self.dtype)
+        output = add_noise(waveform, noise, lengths, snr)
+        ts_output = torch_script(add_noise)(waveform, noise, lengths, snr)
+        self.assertEqual(ts_output, output)

--- a/torchaudio/prototype/transforms/__init__.py
+++ b/torchaudio/prototype/transforms/__init__.py
@@ -1,6 +1,16 @@
-from ._transforms import BarkScale, BarkSpectrogram, Convolve, FFTConvolve, InverseBarkScale, Speed, SpeedPerturbation
+from ._transforms import (
+    AddNoise,
+    BarkScale,
+    BarkSpectrogram,
+    Convolve,
+    FFTConvolve,
+    InverseBarkScale,
+    Speed,
+    SpeedPerturbation,
+)
 
 __all__ = [
+    "AddNoise",
     "BarkScale",
     "BarkSpectrogram",
     "Convolve",

--- a/torchaudio/prototype/transforms/_transforms.py
+++ b/torchaudio/prototype/transforms/_transforms.py
@@ -2,7 +2,7 @@ import math
 from typing import Callable, Optional, Sequence, Tuple
 
 import torch
-from torchaudio.prototype.functional import barkscale_fbanks, convolve, fftconvolve
+from torchaudio.prototype.functional import add_noise, barkscale_fbanks, convolve, fftconvolve
 from torchaudio.prototype.functional.functional import _check_convolve_mode
 from torchaudio.transforms import Resample, Spectrogram
 
@@ -483,3 +483,30 @@ class SpeedPerturbation(torch.nn.Module):
             if idx == speeder_idx:
                 return speeder(waveform, lengths)
         raise RuntimeError("Speeder not found; execution should have never reached here.")
+
+
+class AddNoise(torch.nn.Module):
+    r"""Scales and adds noise to waveform per signal-to-noise ratio.
+    See :meth:`torchaudio.prototype.functional.add_noise` for more details.
+
+    .. devices:: CPU CUDA
+
+    .. properties:: Autograd TorchScript
+    """
+
+    def forward(
+        self, waveform: torch.Tensor, noise: torch.Tensor, lengths: torch.Tensor, snr: torch.Tensor
+    ) -> torch.Tensor:
+        r"""
+        Args:
+            waveform (torch.Tensor): Input waveform, with shape `(..., L)`.
+            noise (torch.Tensor): Noise, with shape `(..., L)` (same shape as ``waveform``).
+            lengths (torch.Tensor): Valid lengths of signals in ``waveform`` and ``noise``, with shape `(...,)`
+                (leading dimensions must match those of ``waveform``).
+            snr (torch.Tensor): Signal-to-noise ratios in dB, with shape `(...,)`.
+
+        Returns:
+            torch.Tensor: Result of scaling and adding ``noise`` to ``waveform``, with shape `(..., L)`
+            (same shape as ``waveform``).
+        """
+        return add_noise(waveform, noise, lengths, snr)


### PR DESCRIPTION
Adds additive noise transform (effectively just a `torch.nn.Module` wrapper around [`add_noise`](https://pytorch.org/audio/main/prototype.functional.html#torchaudio.prototype.functional.add_noise)).