### PR TITLE
Toggle on/off ffmpeg test if needed

### DIFF
--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -17,8 +17,9 @@ def ffmpeg_test():
 
 def main() -> None:
     parser = argparse.ArgumentParser()
+
+    # Warning: Please note this option should not be widely used, only use it when absolutely necessary
     parser.add_argument("--no-ffmpeg", dest="ffmpeg", action="store_false")
-    parser.set_defaults(ffmpeg=True)
 
     options = parser.parse_args()
     if options.ffmpeg:

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -1,6 +1,7 @@
 """Run smoke tests"""
 
 import argparse
+
 import torchaudio  # noqa: F401
 import torchaudio.compliance.kaldi  # noqa: F401
 import torchaudio.datasets  # noqa: F401

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -9,4 +9,18 @@ import torchaudio.pipelines  # noqa: F401
 import torchaudio.sox_effects  # noqa: F401
 import torchaudio.transforms  # noqa: F401
 import torchaudio.utils  # noqa: F401
-from torchaudio.io import StreamReader  # noqa: F401
+
+def streamreader_test():
+    from torchaudio.io import StreamReader  # noqa: F401
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--streamreader', dest='streamreader', action='store_true')
+    parser.set_defaults(streamreader=True)
+
+    options = parser.parse_args()
+    if options.streamreader:
+        streamreader_test()
+
+if __name__ == "__main__":
+    main()

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -1,5 +1,6 @@
 """Run smoke tests"""
 
+import argparse
 import torchaudio  # noqa: F401
 import torchaudio.compliance.kaldi  # noqa: F401
 import torchaudio.datasets  # noqa: F401

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -11,19 +11,18 @@ import torchaudio.transforms  # noqa: F401
 import torchaudio.utils  # noqa: F401
 
 
-def streamreader_test():
+def ffmpeg_test():
     from torchaudio.io import StreamReader  # noqa: F401
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--streamreader", action="store_true")
-    parser.add_argument("--no-streamreader", dest="streamreader", action="store_false")
-    parser.set_defaults(streamreader=True)
+    parser.add_argument("--no-ffmpeg", dest="ffmpeg", action="store_false")
+    parser.set_defaults(ffmpeg=True)
 
     options = parser.parse_args()
-    if options.streamreader:
-        streamreader_test()
+    if options.ffmpeg:
+        ffmpeg_test()
 
 
 if __name__ == "__main__":

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -10,18 +10,21 @@ import torchaudio.sox_effects  # noqa: F401
 import torchaudio.transforms  # noqa: F401
 import torchaudio.utils  # noqa: F401
 
+
 def streamreader_test():
     from torchaudio.io import StreamReader  # noqa: F401
 
+
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument('--streamreader', action='store_true')
-    parser.add_argument('--no-streamreader', dest='streamreader', action='store_false')
+    parser.add_argument("--streamreader", action="store_true")
+    parser.add_argument("--no-streamreader", dest="streamreader", action="store_false")
     parser.set_defaults(streamreader=True)
 
     options = parser.parse_args()
     if options.streamreader:
         streamreader_test()
+
 
 if __name__ == "__main__":
     main()

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -15,7 +15,8 @@ def streamreader_test():
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument('--streamreader', dest='streamreader', action='store_true')
+    parser.add_argument('--streamreader', action='store_true')
+    parser.add_argument('--no-streamreader', dest='streamreader', action='store_false')
     parser.set_defaults(streamreader=True)
 
     options = parser.parse_args()


### PR DESCRIPTION
Toggle on/off ffmpeg test if needed
By default it ON, hence should not affect any current tests.
To toggle ON no change required.
To toggle OFF use:
```
smoke_test.py --no-ffmpeg
```

To be used when calling from builder currently. Since we do not install ffmpeg currently.