### PR TITLE
Fix duplicated memory allocation in StreamWriter

### DIFF
--- a/torchaudio/csrc/ffmpeg/stream_writer/stream_writer_wrapper.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_writer/stream_writer_wrapper.cpp
@@ -13,9 +13,7 @@ AVFormatOutputContextPtr get_output_format_context(
         "`format` must be provided when the input is file-like object.");
   }
 
-  AVFormatContext* p = avformat_alloc_context();
-  TORCH_CHECK(p, "Failed to allocate AVFormatContext.");
-
+  AVFormatContext* p = nullptr;
   int ret = avformat_alloc_output_context2(
       &p, nullptr, format ? format.value().c_str() : nullptr, dst.c_str());
   TORCH_CHECK(


### PR DESCRIPTION
Summary:
The correct way to create AVFormatContext* for output is to pass an address of an uninitialized *AVFormatContext struct to `avformat_alloc_output_context2` function.

The current code pre-allocates AVFormatContext* with `avformat_alloc_context`, then this allocated object is lost inside of `avformat_alloc_output_context2`.

Differential Revision: D41865685

