### PR TITLE
Fix type of arguments in torchaudio.io classes

### DIFF
--- a/torchaudio/io/_compat.py
+++ b/torchaudio/io/_compat.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Tuple
+from typing import BinaryIO, Dict, Optional, Tuple
 
 import torch
 import torchaudio
@@ -105,7 +105,7 @@ def load_audio(
 
 
 def load_audio_fileobj(
-    src: str,
+    src: BinaryIO,
     frame_offset: int = 0,
     num_frames: int = -1,
     convert: bool = True,

--- a/torchaudio/io/_stream_reader.py
+++ b/torchaudio/io/_stream_reader.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Iterator, Optional, Tuple
+from typing import BinaryIO, Dict, Iterator, Optional, Tuple, Union
 
 import torch
 import torchaudio
@@ -350,7 +350,7 @@ class StreamReader:
 
     def __init__(
         self,
-        src: str,
+        src: Union[str, BinaryIO, torch.Tensor],
         format: Optional[str] = None,
         option: Optional[Dict[str, str]] = None,
         buffer_size: int = 4096,

--- a/torchaudio/io/_stream_writer.py
+++ b/torchaudio/io/_stream_writer.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import BinaryIO, Dict, Optional, Union
 
 import torch
 import torchaudio
@@ -50,7 +50,7 @@ class StreamWriter:
     """Encode and write audio/video streams chunk by chunk
 
     Args:
-        dst (str): The destination where the encoded data are written.
+        dst (str or file-like object): The destination where the encoded data are written.
             If string-type, it must be a resource indicator that FFmpeg can
             handle. The supported value depends on the FFmpeg found in the system.
 
@@ -100,7 +100,7 @@ class StreamWriter:
 
     def __init__(
         self,
-        dst: str,
+        dst: Union[str, BinaryIO],
         format: Optional[str] = None,
         buffer_size: int = 4096,
     ):


### PR DESCRIPTION
The `src` or `dst` argument can be `str` or `file-like object`. Setting it to `str` in type annotation will confuse users that it only accepts `str` type.