### PR TITLE
Add filter_waveform

### DIFF
--- a/docs/source/prototype.functional.rst
+++ b/docs/source/prototype.functional.rst
@@ -47,6 +47,7 @@ DSP
    :nosignatures:
 
    adsr_envelope
+   filter_waveform
    extend_pitch
    oscillator_bank
    sinc_impulse_response

--- a/test/torchaudio_unittest/prototype/functional/autograd_test_impl.py
+++ b/test/torchaudio_unittest/prototype/functional/autograd_test_impl.py
@@ -91,3 +91,8 @@ class AutogradTestImpl(TestBaseMixin):
     def test_freq_ir(self):
         mags = torch.tensor([0, 0.5, 1.0], device=self.device, dtype=self.dtype, requires_grad=True)
         assert gradcheck(F.frequency_impulse_response, (mags,))
+
+    def test_filter_waveform(self):
+        waveform = torch.rand(3, 1, 2, 10, device=self.device, dtype=self.dtype, requires_grad=True)
+        filters = torch.rand(3, 2, device=self.device, dtype=self.dtype, requires_grad=True)
+        assert gradcheck(F.filter_waveform, (waveform, filters))

--- a/test/torchaudio_unittest/prototype/functional/functional_test_impl.py
+++ b/test/torchaudio_unittest/prototype/functional/functional_test_impl.py
@@ -554,7 +554,7 @@ class FunctionalTestImpl(TestBaseMixin):
         """Applying delta kernel preserves the origianl waveform"""
         waveform = torch.arange(-10, 10, dtype=self.dtype, device=self.device)
         kernel = torch.zeros((num_filters, kernel_size), dtype=self.dtype, device=self.device)
-        kernel[:, kernel_size//2] = 1
+        kernel[:, kernel_size // 2] = 1
 
         result = F.filter_waveform(waveform, kernel)
         self.assertEqual(waveform, result)
@@ -589,6 +589,7 @@ class FunctionalTestImpl(TestBaseMixin):
         # The second filter is effective in the second half
         self.assertEqual(mix[-9:], ref2[-9:])
         # the middle portion is where the two filters affect
+
 
 class Functional64OnlyTestImpl(TestBaseMixin):
     @nested_params(

--- a/torchaudio/prototype/functional/__init__.py
+++ b/torchaudio/prototype/functional/__init__.py
@@ -1,4 +1,11 @@
-from ._dsp import adsr_envelope, extend_pitch, frequency_impulse_response, oscillator_bank, sinc_impulse_response
+from ._dsp import (
+    adsr_envelope,
+    extend_pitch,
+    filter_waveform,
+    frequency_impulse_response,
+    oscillator_bank,
+    sinc_impulse_response,
+)
 from .functional import add_noise, barkscale_fbanks, convolve, deemphasis, fftconvolve, preemphasis, speed
 
 
@@ -10,6 +17,7 @@ __all__ = [
     "deemphasis",
     "extend_pitch",
     "fftconvolve",
+    "filter_waveform",
     "frequency_impulse_response",
     "oscillator_bank",
     "preemphasis",

--- a/torchaudio/prototype/functional/_dsp.py
+++ b/torchaudio/prototype/functional/_dsp.py
@@ -325,11 +325,11 @@ def filter_waveform(
         waveform: torch.Tensor,
         kernels: torch.Tensor,
         delay_compensation: int = -1):
-    """Applies filters along time axis of the given waveform.
+    """Applies filters along the time axis of the given waveform.
 
     This function applies the given filters along time axis in the following manner:
 
-    1. Split the given waveform into chunks of the number of the given filters.
+    1. Split the given waveform into chunks. The number of chunks is equal to the number of given filters.
     2. Filter each chunk with corresponding filter.
     3. Place the filtered chunks at the original indices while adding up the overlapping parts.
     4. Crop the resulting waveform so that delay introduced by the filter is removed and its length
@@ -348,12 +348,12 @@ def filter_waveform(
         waveform (Tensor): Shape `(..., time)`.
         kernels (Tensor): Impulse responses.
             Valid inputs are 2D tensor with shape `(num_filters, filter_length)` or
-            `N+1` D tensor with shape `(..., num_filters, filter_length)`, where N is
+            `(N+1)`-D tensor with shape `(..., num_filters, filter_length)`, where `N` is
             the dimension of waveform.
 
-            In case of 2D input, the same set of filters are used across channels and batches.
-            Otherwise, different set of filters are applied. In this case, the shape of
-            the first `N-1` dimensions of filters must match (or broadcastable to) that of waveform.
+            In case of 2D input, the same set of filters is used across channels and batches.
+            Otherwise, different sets of filters are applied. In this case, the shape of
+            the first `N-1` dimensions of filters must match (or be broadcastable to) that of waveform.
 
         delay_compensation (int): Control how the waveform is cropped after full convolution.
             If the value is zero or positive, it is interpreted as the length of crop at the

--- a/torchaudio/prototype/functional/_dsp.py
+++ b/torchaudio/prototype/functional/_dsp.py
@@ -393,11 +393,8 @@ def filter_waveform(
         expand_shape = waveform.shape[:-1] + kernels.shape
         kernels = kernels.expand(expand_shape)
 
-    print("chunked:", chunked.shape, chunked)
     convolved = fftconvolve(chunked, kernels)
-    print("convolved:", convolved.shape, convolved)
     restored = _overlap_and_add(convolved, chunk_length)
-    print("restored:", restored.shape, restored)
 
     # Trim in a way that the number of samples are same as input,
     # and the filter delay is compensated
@@ -407,6 +404,5 @@ def filter_waveform(
         start = filter_size // 2
     num_crops = restored.size(-1) - num_frames
     end = num_crops - start
-    print("crop:", start, end)
     result = restored[..., start:-end]
     return result

--- a/torchaudio/prototype/functional/_dsp.py
+++ b/torchaudio/prototype/functional/_dsp.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union
 
 import torch
 
-from .functional import fftconvolve, convolve
+from .functional import fftconvolve
 
 
 def oscillator_bank(
@@ -321,11 +321,8 @@ def _overlap_and_add(waveform, stride):
     return buffer
 
 
-def filter_waveform(
-        waveform: torch.Tensor,
-        kernels: torch.Tensor,
-        delay_compensation: int = -1):
-    """Applies filters along the time axis of the given waveform.
+def filter_waveform(waveform: torch.Tensor, kernels: torch.Tensor, delay_compensation: int = -1):
+    """Applies filters along time axis of the given waveform.
 
     This function applies the given filters along time axis in the following manner:
 
@@ -368,12 +365,13 @@ def filter_waveform(
     if kernels.ndim not in [2, waveform.ndim + 1]:
         raise ValueError(
             "`kernels` must be 2 or N+1 dimension where "
-            f"N is the dimension of waveform. Found: {kernels.ndim} (N={waveform.ndim})")
+            f"N is the dimension of waveform. Found: {kernels.ndim} (N={waveform.ndim})"
+        )
 
     num_filters, filter_size = kernels.shape[-2:]
     num_frames = waveform.size(-1)
 
-    if delay_compensation is not None and delay_compensation > filter_size:
+    if delay_compensation > filter_size:
         raise ValueError(
             "When `delay_compenstation` is provided, it cannot be larger than the size of filters."
             f"Found: delay_compensation={delay_compensation}, filter_size={filter_size}"

--- a/torchaudio/prototype/functional/_dsp.py
+++ b/torchaudio/prototype/functional/_dsp.py
@@ -337,7 +337,7 @@ def filter_waveform(
 
     The following figure illustrates this.
 
-    .. image:: ../_static/img/apply_filter.png
+        .. image:: https://download.pytorch.org/torchaudio/doc-assets/filter_waveform.png
 
     .. note::
 


### PR DESCRIPTION
This commit adds "filter_waveform" prototype function.

This function can apply non-stationary filters across the time.
It also performs cropping at the end to compensate the delay introduced by filtering.
The figure bellow illustrates this.

See [subtractive_synthesis_tutorial](https://output.circle-artifacts.com/output/job/5233fda9-dadb-4710-9389-7e8ac20a062f/artifacts/0/docs/tutorials/subtractive_synthesis_tutorial.html) for example usages.

![figure](https://download.pytorch.org/torchaudio/doc-assets/filter_waveform.png)