### PR TITLE
Experimenting with Pytorch 2.0 compile() optimizations on wav2vec2 models

### DIFF
--- a/examples/asr/librispeech_ctc_decoder/inference.py
+++ b/examples/asr/librispeech_ctc_decoder/inference.py
@@ -96,22 +96,18 @@ def run_inference(args):
             print("Model evaluation %d took %f s" % (num_model_evals, elapsed_time))
             if i > 0:  # Don't include the first run in timings.
                 total_time += elapsed_time
-        print('Average runtime = %f' % (total_time / (NUM_RUNS-1)))
-        
-        
+        print('Average runtime = %f' % (total_time / (NUM_RUNS - 1)))
+
         if args.use_cuda:
             emissions = emissions.to(cpu_device)
             emission_lengths = emission_lengths.to(cpu_device)
 
-        #results = decoder(emissions, emission_lengths)
-        #print(emission_lengths)
-
         for i in range(len(transcripts)):
             # Due to the removal of 'lengths' above, emission_lengths will be None and the following
             # line will break.
-            emission = emissions[i:i+1, 0:emission_lengths[i], :]
+            emission = emissions[i:i + 1, 0:emission_lengths[i], :]
             result = decoder(emission)
-            transcript = transcripts[i].strip().lower().strip()            
+            transcript = transcripts[i].strip().lower().strip()
             total_edit_distance += torchaudio.functional.edit_distance(transcript.split(), result[0][0].words)
             total_length += len(transcript.split())
 

--- a/examples/asr/librispeech_ctc_decoder/inference.py
+++ b/examples/asr/librispeech_ctc_decoder/inference.py
@@ -20,6 +20,9 @@ def run_inference(args):
         cpu_device = torch.device("cpu")
         model = model.to(gpu_device)
 
+    if args.compile:
+        model = torch.compile(model)
+
     # get decoder files
     files = download_pretrained_files("librispeech-4-gram")
 
@@ -116,6 +119,12 @@ def _parse_args():
         action="store_true",
         default=False,
         help="Run using CUDA.",
+    )
+    parser.add_argument(
+        "--compile",
+        action="store_true",
+        default=False,
+        help="Use PyTorch 2.0 compile optimizations",
     )
     return parser.parse_args()
 

--- a/examples/asr/librispeech_ctc_decoder/inference.py
+++ b/examples/asr/librispeech_ctc_decoder/inference.py
@@ -1,13 +1,33 @@
 import argparse
 import logging
+import time
 from typing import Optional
 
 import torch
 import torchaudio
+import torch._dynamo.config
 from torchaudio.models.decoder import ctc_decoder, download_pretrained_files
 
 
 logger = logging.getLogger(__name__)
+
+
+class CollateFn:
+    """Custom collation function to pad every waveform to the max size."""
+    def __init__(self, max_waveform_len=-1):
+        self.max_waveform_len = max_waveform_len
+
+    def __call__(self, batch):
+        waveforms = [item[0] for item in batch]
+        transcripts = [item[2] for item in batch]
+        lengths = torch.tensor([waveform.shape[1] for waveform in waveforms])
+        waveforms = torch.nn.utils.rnn.pad_sequence([w[0] for w in waveforms], batch_first=True)
+        # Pad the batched waveforms to the max length
+        cur_length = waveforms.shape[1]
+        if cur_length < self.max_waveform_len:
+            extra_padding = torch.zeros((len(batch), self.max_waveform_len - cur_length))
+            waveforms = torch.hstack((waveforms, extra_padding))
+        return waveforms, lengths, transcripts
 
 
 def run_inference(args):
@@ -21,6 +41,10 @@ def run_inference(args):
         model = model.to(gpu_device)
 
     if args.compile:
+        # torch._dynamo.config.verbose=True
+        # Ideally, you'd want to compile with model with dynamic tensor sizing enabled, but this currently
+        # breaks.
+        # model = torch.compile(model, dynamic=True)
         model = torch.compile(model)
 
     # get decoder files
@@ -42,26 +66,57 @@ def run_inference(args):
     )
 
     dataset = torchaudio.datasets.LIBRISPEECH(args.librispeech_path, url=args.split, download=False)
+    if args.batch_size > 1:
+        collate_fn = CollateFn(max_waveform_len=args.max_waveform_length)
+    else:
+        collate_fn = CollateFn(max_waveform_len=-1)
+    dataset = torch.utils.data.DataLoader(dataset, batch_size=args.batch_size, collate_fn=collate_fn)
 
     total_edit_distance = 0
     total_length = 0
-    for idx, sample in enumerate(dataset):
-        waveform, _, transcript, _, _, _ = sample
-        transcript = transcript.strip().lower().strip()
+    num_samples = 0
+    num_model_evals = 0
+    for sample in dataset:
+        waveforms, lengths, transcripts = sample
         if args.use_cuda:
-            waveform = waveform.to(gpu_device)
+            waveforms = waveforms.to(gpu_device)
+            lengths = lengths.to(gpu_device)
 
-        with torch.inference_mode():
-            emission, _ = model(waveform)
+        NUM_RUNS = 20
+        total_time = 0.0
+        for i in range(NUM_RUNS):
+            start_time = time.time()
+            # inference_mode() doesn't seem to work with compile() yet, at least for this model.
+            with torch.no_grad():
+                # We should be passing in 'lengths' here, but that doesn't work with compile() yet.
+                # WARNING: This means that the results will not be correct!
+                # emissions, emission_lengths = model(waveforms, lengths)
+                emissions, emission_lengths = model(waveforms)
+            elapsed_time = time.time() - start_time
+            print("Model evaluation %d took %f s" % (num_model_evals, elapsed_time))
+            if i > 0:  # Don't include the first run in timings.
+                total_time += elapsed_time
+        print('Average runtime = %f' % (total_time / (NUM_RUNS-1)))
+        
+        
         if args.use_cuda:
-            emission = emission.to(cpu_device)
-        results = decoder(emission)
+            emissions = emissions.to(cpu_device)
+            emission_lengths = emission_lengths.to(cpu_device)
 
-        total_edit_distance += torchaudio.functional.edit_distance(transcript.split(), results[0][0].words)
-        total_length += len(transcript.split())
+        #results = decoder(emissions, emission_lengths)
+        #print(emission_lengths)
 
-        if idx % 100 == 0:
-            logger.info(f"Processed elem {idx}; WER: {total_edit_distance / total_length}")
+        for i in range(len(transcripts)):
+            # Due to the removal of 'lengths' above, emission_lengths will be None and the following
+            # line will break.
+            emission = emissions[i:i+1, 0:emission_lengths[i], :]
+            result = decoder(emission)
+            transcript = transcripts[i].strip().lower().strip()            
+            total_edit_distance += torchaudio.functional.edit_distance(transcript.split(), result[0][0].words)
+            total_length += len(transcript.split())
+
+        num_samples += len(transcripts)
+        logger.info(f"Processed elem {num_samples}; WER: {total_edit_distance / total_length}")
     logger.info(f"Final WER: {total_edit_distance / total_length}")
 
 
@@ -125,6 +180,18 @@ def _parse_args():
         action="store_true",
         default=False,
         help="Use PyTorch 2.0 compile optimizations",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=1,
+        help="Batch size for running inference."
+    )
+    parser.add_argument(
+        "--max_waveform_length",
+        type=int,
+        default=552160,
+        help="Max waveform length to use when batching."
     )
     return parser.parse_args()
 


### PR DESCRIPTION
This pull request contains code that I added to the librispeech_ctc_decoder inference.py example to evaluate if pytorch 2.0 compile() optimizations can help this model. To summarize, my findings are:

- torch.inference_mode() had to be replaced by torch.no_grad()
- I couldn't use compile() with dynamic tensor sizes (yet).
- Passing the 'lengths' parameter to the wav2vec2 model also breaks the compilation.
- Overall, there's a ~10% performance improvement using CUDA, and up to 38% on CPU, but this is currently achievable only by padding all samples to make sure tensor sizes are equal, and this hurts performance.