### PR TITLE
Throw  RuntimeError if path not found in LibriMix dataset

### DIFF
--- a/torchaudio/datasets/librimix.py
+++ b/torchaudio/datasets/librimix.py
@@ -51,6 +51,11 @@ class LibriMix(Dataset):
         mode: str = "min",
     ):
         self.root = Path(root) / f"Libri{num_speakers}Mix"
+        if not os.path.exists(self.root):
+            raise RuntimeError(
+                f"The path {self.root} doesn't exist. "
+                "Please check the ``root`` path and ``num_speakers`` or download the dataset manually."
+            )
         if mode not in ["max", "min"]:
             raise ValueError(f'Expect ``mode`` to be one in ["min", "max"]. Found {mode}.')
         if sample_rate == 8000:


### PR DESCRIPTION
The `root` path can be confusing to users without reading the document. The PR adds runtime error for a better understanding.