### PR TITLE
Refactor YUV handling functions

### DIFF
--- a/torchaudio/csrc/ffmpeg/stream_reader/buffer/common.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/buffer/common.h
@@ -11,8 +11,16 @@ namespace detail {
 //////////////////////////////////////////////////////////////////////////////
 torch::Tensor convert_audio(AVFrame* frame);
 
-torch::Tensor get_interlaced_image_buffer(AVFrame* pFrame);
-torch::Tensor get_planar_image_buffer(AVFrame* pFrame);
+torch::Tensor get_buffer(
+    at::IntArrayRef shape,
+    const torch::Device& device = torch::Device(torch::kCPU));
+torch::Tensor get_image_buffer(AVFrame* pFrame, const torch::Device& device);
+
+void write_yuv420p(AVFrame* pFrame, torch::Tensor& yuv);
+void write_nv12_cpu(AVFrame* pFrame, torch::Tensor& yuv);
+#ifdef USE_CUDA
+void write_nv12_cuda(AVFrame* pFrame, torch::Tensor& yuv);
+#endif
 void write_interlaced_image(AVFrame* pFrame, torch::Tensor& frame);
 void write_planar_image(AVFrame* pFrame, torch::Tensor& frame);
 torch::Tensor convert_image(AVFrame* frame, const torch::Device& device);


### PR DESCRIPTION
* Split `convert_[yuv420p|nv12|nv12_cuda]` functions into allocation
and data write functions.
* Merge the `get_[interlaced|planar]_image_buffer` functions into
`get_buffer` and `get_image_buffer`.
* Disassemble `convert_XXX_image` helper functions.