### PR TITLE
Guard invocation of cuda_version

### DIFF
--- a/torchaudio/_extension.py
+++ b/torchaudio/_extension.py
@@ -125,6 +125,8 @@ def _init_extension():
 
 
 def _check_cuda_version():
+    if not _get_lib_path("libtorchaudio").exists():
+        return None
     version = torch.ops.torchaudio.cuda_version()
     if version is not None and torch.version.cuda is not None:
         version_str = str(version)


### PR DESCRIPTION
Currently, importing TorchAudio triggers a check of the CUDA version it was compiled with, which in turn calls `torch.ops.torchaudio.cuda_version()`. This function is available only if `libtorchaudio` is available; developers, however, may want to import TorchAudio regardless of its availability. To allow for such usage, this PR adds code that bypasses the check if `libtorchaudio` is not available.