### PR TITLE
Add reuse logits option to RNNT loss

### DIFF
--- a/test/torchaudio_unittest/common_utils/rnnt_utils.py
+++ b/test/torchaudio_unittest/common_utils/rnnt_utils.py
@@ -188,7 +188,7 @@ def compute_with_numpy_transducer(data):
     return costs, gradients
 
 
-def compute_with_pytorch_transducer(data):
+def compute_with_pytorch_transducer(data, reuse_logits_for_grads=False):
     costs = rnnt_loss(
         logits=data["logits"],
         logit_lengths=data["logit_lengths"],
@@ -196,6 +196,7 @@ def compute_with_pytorch_transducer(data):
         targets=data["targets"],
         blank=data["blank"],
         reduction="none",
+        reuse_logits_for_grads=reuse_logits_for_grads,
     )
 
     loss = torch.sum(costs)

--- a/torchaudio/csrc/rnnt/autograd.cpp
+++ b/torchaudio/csrc/rnnt/autograd.cpp
@@ -13,10 +13,11 @@ class RNNTLossFunction : public torch::autograd::Function<RNNTLossFunction> {
       const torch::Tensor& logit_lengths,
       const torch::Tensor& target_lengths,
       int64_t blank,
-      double clamp) {
+      double clamp,
+      bool reuse_logits_for_grads) {
     torch::Tensor undef;
     auto result =
-        rnnt_loss(logits, targets, logit_lengths, target_lengths, blank, clamp);
+        rnnt_loss(logits, targets, logit_lengths, target_lengths, blank, clamp, reuse_logits_for_grads);
     auto costs = std::get<0>(result);
     auto grads = std::get<1>(result).value_or(undef);
     ctx->save_for_backward({grads});
@@ -41,10 +42,11 @@ std::tuple<torch::Tensor, c10::optional<torch::Tensor>> rnnt_loss_autograd(
     const torch::Tensor& logit_lengths,
     const torch::Tensor& target_lengths,
     int64_t blank,
-    double clamp) {
+    double clamp,
+    bool reuse_logits_for_grads) {
   at::AutoDispatchBelowADInplaceOrView guard;
   auto results = RNNTLossFunction::apply(
-      logits, targets, logit_lengths, target_lengths, blank, clamp);
+      logits, targets, logit_lengths, target_lengths, blank, clamp, reuse_logits_for_grads);
   return std::make_tuple(results[0], results[1]);
 }
 

--- a/torchaudio/csrc/rnnt/compute.cpp
+++ b/torchaudio/csrc/rnnt/compute.cpp
@@ -7,11 +7,12 @@ std::tuple<torch::Tensor, c10::optional<torch::Tensor>> rnnt_loss(
     const torch::Tensor& logit_lengths,
     const torch::Tensor& target_lengths,
     int64_t blank,
-    double clamp) {
+    double clamp,
+    bool reuse_logits_for_grads) {
   static auto op = torch::Dispatcher::singleton()
                        .findSchemaOrThrow("torchaudio::rnnt_loss", "")
                        .typed<decltype(rnnt_loss)>();
-  return op.call(logits, targets, logit_lengths, target_lengths, blank, clamp);
+  return op.call(logits, targets, logit_lengths, target_lengths, blank, clamp, reuse_logits_for_grads);
 }
 
 TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
@@ -21,5 +22,6 @@ TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
       "Tensor logit_lengths,"
       "Tensor target_lengths,"
       "int blank,"
-      "float clamp) -> (Tensor, Tensor?)");
+      "float clamp,"
+      "bool reuse_logits_for_grads) -> (Tensor, Tensor?)");
 }

--- a/torchaudio/csrc/rnnt/compute.h
+++ b/torchaudio/csrc/rnnt/compute.h
@@ -8,4 +8,5 @@ std::tuple<torch::Tensor, c10::optional<torch::Tensor>> rnnt_loss(
     const torch::Tensor& logit_lengths,
     const torch::Tensor& target_lengths,
     int64_t blank,
-    double clamp);
+    double clamp,
+    bool reuse_logits_for_grads);

--- a/torchaudio/csrc/rnnt/cpu/compute.cpp
+++ b/torchaudio/csrc/rnnt/cpu/compute.cpp
@@ -12,7 +12,8 @@ std::tuple<torch::Tensor, c10::optional<torch::Tensor>> compute(
     const torch::Tensor& logit_lengths,
     const torch::Tensor& target_lengths,
     int64_t blank,
-    double clamp) {
+    double clamp,
+    bool reuse_logits_for_grads) {
   TORCH_CHECK(
       logits.device().type() == targets.device().type(),
       "logits and targets must be on the same device");
@@ -87,7 +88,12 @@ std::tuple<torch::Tensor, c10::optional<torch::Tensor>> compute(
   torch::Tensor costs = torch::empty(
       options.batchSize_ * options.nHypos_,
       torch::TensorOptions().device(logits.device()).dtype(logits.dtype()));
-  c10::optional<torch::Tensor> gradients = torch::zeros_like(logits);
+  c10::optional<torch::Tensor> gradients = c10::nullopt;
+  if (reuse_logits_for_grads) {
+      gradients = logits;
+  } else {
+      gradients = torch::zeros_like(logits);
+  }
 
   torch::Tensor int_workspace = torch::empty(
       IntWorkspace::ComputeSizeFromOptions(options),

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -1738,6 +1738,7 @@ def rnnt_loss(
     blank: int = -1,
     clamp: float = -1,
     reduction: str = "mean",
+    reuse_logits_for_grads: bool = False,
 ):
     """Compute the RNN Transducer loss from *Sequence Transduction with Recurrent Neural Networks*
     [:footcite:`graves2012sequence`].
@@ -1760,6 +1761,8 @@ def rnnt_loss(
         clamp (float, optional): clamp for gradients (Default: ``-1``)
         reduction (string, optional): Specifies the reduction to apply to the output:
             ``'none'`` | ``'mean'`` | ``'sum'``. (Default: ``'mean'``)
+        reuse_logits_for_grads (bool): whether to save memory by reusing logits memory for gradients
+            (Default: ``False``)
     Returns:
         Tensor: Loss with the reduction option applied. If ``reduction`` is  ``'none'``, then size `(batch)`,
         otherwise scalar.
@@ -1777,6 +1780,7 @@ def rnnt_loss(
         target_lengths=target_lengths,
         blank=blank,
         clamp=clamp,
+        reuse_logits_for_grads=reuse_logits_for_grads,
     )
 
     if reduction == "mean":

--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -1642,6 +1642,8 @@ class RNNTLoss(torch.nn.Module):
         clamp (float, optional): clamp for gradients (Default: ``-1``)
         reduction (string, optional): Specifies the reduction to apply to the output:
             ``'none'`` | ``'mean'`` | ``'sum'``. (Default: ``'mean'``)
+        reuse_logits_for_grads (bool): whether to save memory by reusing logits memory for gradients
+            (Default: ``False``)
 
     Example
         >>> # Hypothetical values
@@ -1666,11 +1668,13 @@ class RNNTLoss(torch.nn.Module):
         blank: int = -1,
         clamp: float = -1.0,
         reduction: str = "mean",
+        reuse_logits_for_grads: bool = False,
     ):
         super().__init__()
         self.blank = blank
         self.clamp = clamp
         self.reduction = reduction
+        self.reuse_logits_for_grads = reuse_logits_for_grads
 
     def forward(
         self,
@@ -1690,4 +1694,13 @@ class RNNTLoss(torch.nn.Module):
             Tensor: Loss with the reduction option applied. If ``reduction`` is  ``'none'``, then size (batch),
             otherwise scalar.
         """
-        return F.rnnt_loss(logits, targets, logit_lengths, target_lengths, self.blank, self.clamp, self.reduction)
+        return F.rnnt_loss(
+            logits,
+            targets,
+            logit_lengths,
+            target_lengths,
+            self.blank,
+            self.clamp,
+            self.reduction,
+            self.reuse_logits_for_grads,
+        )


### PR DESCRIPTION
Add `reuse_logits_for_grads` option to RNNT loss. If set to `True`, logits tensor is zeroed out and reused as gradients tensor to save memory. From unit testing, was able to confirm that cuda memory was less, but have not been able to demonstrate batch/seq length increases in model training yet (cc @hwangjeff)

Default is set to `False` to maintain default autograd differentiability; reusing the tensor would naturally cause gradcheck to fail. 

cc @pytorch/team-audio-core 