### PR TITLE
Reduce the sample rate of some tests

### DIFF
--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -194,7 +194,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         self.assert_batch_consistency(func, inputs=(waveforms,))
 
     def test_phaser(self):
-        sample_rate = 44100
+        sample_rate = 8000
         n_channels = 2
         waveform = common_utils.get_whitenoise(
             sample_rate=sample_rate, n_channels=self.batch_size * n_channels, duration=1
@@ -208,7 +208,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
 
     def test_flanger(self):
         waveforms = torch.rand(self.batch_size, 2, 100) - 0.5
-        sample_rate = 44100
+        sample_rate = 8000
         kwargs = {
             "sample_rate": sample_rate,
         }


### PR DESCRIPTION
Summary:
Phaser batch consistency test takes longer than the rest.
Change the sample rate from 44100 to 8000.

Reviewed By: hwangjeff

Differential Revision: D42379064

