### PR TITLE
Fix document for MelScale and InverseMelScale

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -83,6 +83,7 @@ Utility
     :nosignatures:
 
     AmplitudeToDB
+    InverseMelScale
     MelScale
     MuLawEncoding
     MuLawDecoding

--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -83,8 +83,6 @@ Utility
     :nosignatures:
 
     AmplitudeToDB
-    InverseMelScale
-    MelScale
     MuLawEncoding
     MuLawDecoding
     Resample
@@ -101,6 +99,8 @@ Feature Extractions
 
     Spectrogram
     InverseSpectrogram
+    MelScale
+    InverseMelScale
     MelSpectrogram
     GriffinLim
     MFCC


### PR DESCRIPTION
`InverseMelScale` is missing from the nightly documentation webpage. `MelScale` is better in Feature Extractions section. This PR moves both documents into Feature Extractions section.