### PR TITLE
Add `buffer_chunk_size=-1` option

### DIFF
--- a/torchaudio/csrc/ffmpeg/stream_reader/buffer/chunked_buffer.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/buffer/chunked_buffer.cpp
@@ -56,15 +56,17 @@ void ChunkedAudioBuffer::push_tensor(torch::Tensor frame) {
   // Trim
   // If frames_per_chunk > 0, we only retain the following number of frames and
   // Discard older frames.
-  int64_t max_frames = num_chunks * frames_per_chunk;
-  while (num_buffered_frames > max_frames) {
-    TORCH_WARN_ONCE(
-        "The number of buffered frames exceeded the buffer size. "
-        "Dropping the old frames. "
-        "To avoid this, you can set a higher buffer_chunk_size value.");
-    torch::Tensor& t = chunks.front();
-    num_buffered_frames -= t.size(0);
-    chunks.pop_front();
+  if (num_chunks > 0) {
+    int64_t max_frames = num_chunks * frames_per_chunk;
+    while (num_buffered_frames > max_frames) {
+      TORCH_WARN_ONCE(
+          "The number of buffered frames exceeded the buffer size. "
+          "Dropping the old frames. "
+          "To avoid this, you can set a higher buffer_chunk_size value.");
+      torch::Tensor& t = chunks.front();
+      num_buffered_frames -= t.size(0);
+      chunks.pop_front();
+    }
   }
 }
 
@@ -78,15 +80,17 @@ void ChunkedVideoBuffer::push_tensor(const torch::Tensor& frame) {
   num_buffered_frames += frame.size(0);
 
   // Trim
-  int64_t max_frames = num_chunks * frames_per_chunk;
-  if (num_buffered_frames > max_frames) {
-    TORCH_WARN_ONCE(
-        "The number of buffered frames exceeded the buffer size. "
-        "Dropping the old frames. "
-        "To avoid this, you can set a higher buffer_chunk_size value.");
-    torch::Tensor& t = chunks.front();
-    num_buffered_frames -= t.size(0);
-    chunks.pop_front();
+  if (num_chunks > 0) {
+    int64_t max_frames = num_chunks * frames_per_chunk;
+    if (num_buffered_frames > max_frames) {
+      TORCH_WARN_ONCE(
+          "The number of buffered frames exceeded the buffer size. "
+          "Dropping the old frames. "
+          "To avoid this, you can set a higher buffer_chunk_size value.");
+      torch::Tensor& t = chunks.front();
+      num_buffered_frames -= t.size(0);
+      chunks.pop_front();
+    }
   }
 }
 

--- a/torchaudio/csrc/ffmpeg/stream_reader/sink.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/sink.cpp
@@ -12,6 +12,16 @@ std::unique_ptr<Buffer> get_buffer(
     int frames_per_chunk,
     int num_chunks,
     const torch::Device& device) {
+  TORCH_CHECK(
+      frames_per_chunk > 0 || frames_per_chunk == -1,
+      "`frames_per_chunk` must be positive or -1. Found: ",
+      frames_per_chunk);
+
+  TORCH_CHECK(
+      num_chunks > 0 || num_chunks == -1,
+      "`num_chunks` must be positive or -1. Found: ",
+      num_chunks);
+
   switch (type) {
     case AVMEDIA_TYPE_AUDIO: {
       if (frames_per_chunk < 0) {

--- a/torchaudio/io/_stream_reader.py
+++ b/torchaudio/io/_stream_reader.py
@@ -216,11 +216,16 @@ def _format_doc(**kwargs):
 
 _frames_per_chunk = """Number of frames returned as one chunk.
                 If the source stream is exhausted before enough frames are buffered,
-                then the chunk is returned as-is."""
+                then the chunk is returned as-is.
+
+                Providing ``-1`` disables chunking and :py:func:`pop_chunks` method
+                will concatenate all the buffered frames and return it."""
 
 _buffer_chunk_size = """Internal buffer size.
                 When the number of chunks buffered exceeds this number, old frames are
-                dropped.
+                dropped. For example, if `frames_per_chunk` is 5 and `buffer_chunk_size` is
+                3, then frames older than 15 are dropped.
+                Providing ``-1`` disables this behavior.
 
                 Default: ``3``."""
 


### PR DESCRIPTION
This commit adds `buffer_chunk_size=-1`, which does not drop buffered frames.