### PR TITLE
Update the handling of videos without PTS values

### DIFF
--- a/torchaudio/csrc/ffmpeg/stream_reader/decoder.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/decoder.cpp
@@ -123,6 +123,10 @@ int Decoder::get_frame(AVFrame* pFrame) {
   return avcodec_receive_frame(pCodecContext, pFrame);
 }
 
+int Decoder::get_frame_number() const {
+  return pCodecContext->frame_number;
+}
+
 void Decoder::flush_buffer() {
   avcodec_flush_buffers(pCodecContext);
 }

--- a/torchaudio/csrc/ffmpeg/stream_reader/decoder.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/decoder.h
@@ -29,6 +29,7 @@ class Decoder {
   int process_packet(AVPacket* pPacket);
   // Fetch a decoded frame
   int get_frame(AVFrame* pFrame);
+  int get_frame_number() const;
   // Flush buffer (for seek)
   void flush_buffer();
 };

--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_processor.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_processor.cpp
@@ -87,6 +87,27 @@ int StreamProcessor::process_packet(AVPacket* packet) {
     if (ret < 0)
       return ret;
 
+    // If pts is undefined then overwrite with best effort estimate.
+    // In this case, best_effort_timestamp is basically the number of frames
+    // emit from decoder.
+    //
+    // We need valid pts because filter_graph does not fall back to
+    // best_effort_timestamp.
+    if (pFrame1->pts == AV_NOPTS_VALUE) {
+      if (pFrame1->best_effort_timestamp == AV_NOPTS_VALUE) {
+        // This happens in drain mode.
+        // When the decoder enters drain mode, it starts flushing the internally
+        // buffered frames, of which PTS cannot be estimated.
+        //
+        // This is because they might be intra-frames not in chronological
+        // order. In this case, we use received frames as-is in the order they
+        // are received.
+        pFrame1->pts = decoder.get_frame_number() + 1;
+      } else {
+        pFrame1->pts = pFrame1->best_effort_timestamp;
+      }
+    }
+
     // When the value of discard_before_pts is 0, we consider that the seek is
     // not performed and all the frames are passed to downstream
     // unconditionally.
@@ -96,14 +117,9 @@ int StreamProcessor::process_packet(AVPacket* packet) {
     //    In this case discard_before_pts is set to zero.
     // 2. When users seek to zero, what they expect is to get to the beginning
     //    of the data.
-    //    There are many videos with invalid PTS values, such as
-    //    -9223372036854775808, and though it is not possible to seek videos
-    //    without decoding, we can still support `seek(0)` as a special case,
-    //    and just not discard any.
     //
     // Note: discard_before_pts < 0 is UB.
-    if (discard_before_pts <= 0 || pFrame1->pts >= discard_before_pts ||
-        pFrame1->best_effort_timestamp >= discard_before_pts) {
+    if (discard_before_pts <= 0 || pFrame1->pts >= discard_before_pts) {
       send_frame(pFrame1);
     }
 


### PR DESCRIPTION
filter graph does not fallback to `best_effort_timestamp`, thus applying filters (like changing fps) on videos without PTS values failed.

This commit changes the behavior by overwriting the PTS values with best_effort_timestamp.