### PR TITLE
Make lengths optional for additive noise operators

### DIFF
--- a/test/torchaudio_unittest/prototype/functional/autograd_test_impl.py
+++ b/test/torchaudio_unittest/prototype/functional/autograd_test_impl.py
@@ -27,8 +27,8 @@ class AutogradTestImpl(TestBaseMixin):
         lengths = torch.rand(*leading_dims, dtype=self.dtype, device=self.device, requires_grad=True)
         snr = torch.rand(*leading_dims, dtype=self.dtype, device=self.device, requires_grad=True) * 10
 
-        self.assertTrue(gradcheck(F.add_noise, (waveform, noise, lengths, snr)))
-        self.assertTrue(gradgradcheck(F.add_noise, (waveform, noise, lengths, snr)))
+        self.assertTrue(gradcheck(F.add_noise, (waveform, noise, snr, lengths)))
+        self.assertTrue(gradgradcheck(F.add_noise, (waveform, noise, snr, lengths)))
 
     @parameterized.expand(
         [

--- a/test/torchaudio_unittest/prototype/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/prototype/functional/batch_consistency_test.py
@@ -35,13 +35,13 @@ class BatchConsistencyTest(TorchaudioTestCase):
         lengths = torch.rand(*leading_dims, dtype=self.dtype, device=self.device)
         snr = torch.rand(*leading_dims, dtype=self.dtype, device=self.device) * 10
 
-        actual = F.add_noise(waveform, noise, lengths, snr)
+        actual = F.add_noise(waveform, noise, snr, lengths)
 
         expected = []
         for i in range(leading_dims[0]):
             for j in range(leading_dims[1]):
                 for k in range(leading_dims[2]):
-                    expected.append(F.add_noise(waveform[i][j][k], noise[i][j][k], lengths[i][j][k], snr[i][j][k]))
+                    expected.append(F.add_noise(waveform[i][j][k], noise[i][j][k], snr[i][j][k], lengths[i][j][k]))
 
         self.assertEqual(torch.stack(expected), actual.reshape(-1, L))
 

--- a/test/torchaudio_unittest/prototype/functional/functional_test_impl.py
+++ b/test/torchaudio_unittest/prototype/functional/functional_test_impl.py
@@ -135,12 +135,12 @@ class FunctionalTestImpl(TestBaseMixin):
         noise = torch.rand(5, 1, 1, L, dtype=self.dtype, device=self.device)
         lengths = torch.rand(5, 1, 3, dtype=self.dtype, device=self.device)
         snr = torch.rand(1, 1, 1, dtype=self.dtype, device=self.device) * 10
-        actual = F.add_noise(waveform, noise, lengths, snr)
+        actual = F.add_noise(waveform, noise, snr, lengths)
 
         noise_expanded = noise.expand(*leading_dims, L)
         snr_expanded = snr.expand(*leading_dims)
         lengths_expanded = lengths.expand(*leading_dims)
-        expected = F.add_noise(waveform, noise_expanded, lengths_expanded, snr_expanded)
+        expected = F.add_noise(waveform, noise_expanded, snr_expanded, lengths_expanded)
 
         self.assertEqual(expected, actual)
 
@@ -157,7 +157,7 @@ class FunctionalTestImpl(TestBaseMixin):
         snr = torch.rand(*snr_dims, dtype=self.dtype, device=self.device) * 10
 
         with self.assertRaisesRegex(ValueError, "Input leading dimensions"):
-            F.add_noise(waveform, noise, lengths, snr)
+            F.add_noise(waveform, noise, snr, lengths)
 
     def test_add_noise_length_check(self):
         """Check that add_noise properly rejects inputs that have inconsistent length dimensions."""
@@ -170,7 +170,7 @@ class FunctionalTestImpl(TestBaseMixin):
         snr = torch.rand(*leading_dims, dtype=self.dtype, device=self.device) * 10
 
         with self.assertRaisesRegex(ValueError, "Length dimensions"):
-            F.add_noise(waveform, noise, lengths, snr)
+            F.add_noise(waveform, noise, snr, lengths)
 
     @nested_params(
         [(2, 3), (2, 3, 5), (2, 3, 5, 7)],

--- a/test/torchaudio_unittest/prototype/functional/torchscript_consistency_test_impl.py
+++ b/test/torchaudio_unittest/prototype/functional/torchscript_consistency_test_impl.py
@@ -37,16 +37,20 @@ class TorchScriptConsistencyTestImpl(TestBaseMixin):
 
         self._assert_consistency(getattr(F, fn), (x, y, mode))
 
-    def test_add_noise(self):
+    @nested_params([True, False])
+    def test_add_noise(self, use_lengths):
         leading_dims = (2, 3)
         L = 31
 
         waveform = torch.rand(*leading_dims, L, dtype=self.dtype, device=self.device, requires_grad=True)
         noise = torch.rand(*leading_dims, L, dtype=self.dtype, device=self.device, requires_grad=True)
-        lengths = torch.rand(*leading_dims, dtype=self.dtype, device=self.device, requires_grad=True)
+        if use_lengths:
+            lengths = torch.rand(*leading_dims, dtype=self.dtype, device=self.device, requires_grad=True)
+        else:
+            lengths = None
         snr = torch.rand(*leading_dims, dtype=self.dtype, device=self.device, requires_grad=True) * 10
 
-        self._assert_consistency(F.add_noise, (waveform, noise, lengths, snr))
+        self._assert_consistency(F.add_noise, (waveform, noise, snr, lengths))
 
     def test_barkscale_fbanks(self):
         if self.device != torch.device("cpu"):

--- a/test/torchaudio_unittest/prototype/transforms/autograd_test_impl.py
+++ b/test/torchaudio_unittest/prototype/transforms/autograd_test_impl.py
@@ -75,18 +75,22 @@ class Autograd(TestBaseMixin):
         assert gradcheck(speed, (waveform, lengths))
         assert gradgradcheck(speed, (waveform, lengths))
 
-    def test_AddNoise(self):
+    @nested_params([True, False])
+    def test_AddNoise(self, use_lengths):
         leading_dims = (2, 3)
         L = 31
 
         waveform = torch.rand(*leading_dims, L, dtype=torch.float64, device=self.device, requires_grad=True)
         noise = torch.rand(*leading_dims, L, dtype=torch.float64, device=self.device, requires_grad=True)
-        lengths = torch.rand(*leading_dims, dtype=torch.float64, device=self.device, requires_grad=True)
+        if use_lengths:
+            lengths = torch.rand(*leading_dims, dtype=torch.float64, device=self.device, requires_grad=True)
+        else:
+            lengths = None
         snr = torch.rand(*leading_dims, dtype=torch.float64, device=self.device, requires_grad=True) * 10
 
         add_noise = T.AddNoise().to(self.device, torch.float64)
-        assert gradcheck(add_noise, (waveform, noise, lengths, snr))
-        assert gradgradcheck(add_noise, (waveform, noise, lengths, snr))
+        assert gradcheck(add_noise, (waveform, noise, snr, lengths))
+        assert gradgradcheck(add_noise, (waveform, noise, snr, lengths))
 
     def test_Preemphasis(self):
         waveform = torch.rand(3, 4, 10, dtype=torch.float64, device=self.device, requires_grad=True)

--- a/test/torchaudio_unittest/prototype/transforms/batch_consistency_test.py
+++ b/test/torchaudio_unittest/prototype/transforms/batch_consistency_test.py
@@ -124,13 +124,13 @@ class BatchConsistencyTest(TorchaudioTestCase):
         snr = torch.rand(*leading_dims, dtype=self.dtype, device=self.device) * 10
 
         add_noise = T.AddNoise()
-        actual = add_noise(waveform, noise, lengths, snr)
+        actual = add_noise(waveform, noise, snr, lengths)
 
         expected = []
         for i in range(leading_dims[0]):
             for j in range(leading_dims[1]):
                 for k in range(leading_dims[2]):
-                    expected.append(add_noise(waveform[i][j][k], noise[i][j][k], lengths[i][j][k], snr[i][j][k]))
+                    expected.append(add_noise(waveform[i][j][k], noise[i][j][k], snr[i][j][k], lengths[i][j][k]))
 
         self.assertEqual(torch.stack(expected), actual.reshape(-1, L))
 

--- a/test/torchaudio_unittest/prototype/transforms/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/prototype/transforms/torchscript_consistency_impl.py
@@ -41,18 +41,22 @@ class Transforms(TestBaseMixin):
         ts_output = torch_script(speed)(waveform, lengths)
         self.assertEqual(ts_output, output)
 
-    def test_AddNoise(self):
+    @nested_params([True, False])
+    def test_AddNoise(self, use_lengths):
         leading_dims = (2, 3)
         L = 31
 
         waveform = torch.rand(*leading_dims, L, dtype=self.dtype, device=self.device, requires_grad=True)
         noise = torch.rand(*leading_dims, L, dtype=self.dtype, device=self.device, requires_grad=True)
-        lengths = torch.rand(*leading_dims, dtype=self.dtype, device=self.device, requires_grad=True)
+        if use_lengths:
+            lengths = torch.rand(*leading_dims, dtype=self.dtype, device=self.device, requires_grad=True)
+        else:
+            lengths = None
         snr = torch.rand(*leading_dims, dtype=self.dtype, device=self.device, requires_grad=True) * 10
 
         add_noise = T.AddNoise().to(self.device, self.dtype)
-        output = add_noise(waveform, noise, lengths, snr)
-        ts_output = torch_script(add_noise)(waveform, noise, lengths, snr)
+        output = add_noise(waveform, noise, snr, lengths)
+        ts_output = torch_script(add_noise)(waveform, noise, snr, lengths)
         self.assertEqual(ts_output, output)
 
     def test_Preemphasis(self):

--- a/test/torchaudio_unittest/prototype/transforms/transforms_test_impl.py
+++ b/test/torchaudio_unittest/prototype/transforms/transforms_test_impl.py
@@ -184,12 +184,12 @@ class TransformsTestImpl(TestBaseMixin):
         snr = torch.rand(1, 1, 1, dtype=self.dtype, device=self.device) * 10
 
         add_noise = T.AddNoise()
-        actual = add_noise(waveform, noise, lengths, snr)
+        actual = add_noise(waveform, noise, snr, lengths)
 
         noise_expanded = noise.expand(*leading_dims, L)
         snr_expanded = snr.expand(*leading_dims)
         lengths_expanded = lengths.expand(*leading_dims)
-        expected = add_noise(waveform, noise_expanded, lengths_expanded, snr_expanded)
+        expected = add_noise(waveform, noise_expanded, snr_expanded, lengths_expanded)
 
         self.assertEqual(expected, actual)
 
@@ -208,7 +208,7 @@ class TransformsTestImpl(TestBaseMixin):
         add_noise = T.AddNoise()
 
         with self.assertRaisesRegex(ValueError, "Input leading dimensions"):
-            add_noise(waveform, noise, lengths, snr)
+            add_noise(waveform, noise, snr, lengths)
 
     def test_AddNoise_length_check(self):
         """Check that add_noise properly rejects inputs that have inconsistent length dimensions."""
@@ -223,7 +223,7 @@ class TransformsTestImpl(TestBaseMixin):
         add_noise = T.AddNoise()
 
         with self.assertRaisesRegex(ValueError, "Length dimensions"):
-            add_noise(waveform, noise, lengths, snr)
+            add_noise(waveform, noise, snr, lengths)
 
     @nested_params(
         [(2, 1, 31)],

--- a/torchaudio/prototype/transforms/_transforms.py
+++ b/torchaudio/prototype/transforms/_transforms.py
@@ -495,21 +495,22 @@ class AddNoise(torch.nn.Module):
     """
 
     def forward(
-        self, waveform: torch.Tensor, noise: torch.Tensor, lengths: torch.Tensor, snr: torch.Tensor
+        self, waveform: torch.Tensor, noise: torch.Tensor, snr: torch.Tensor, lengths: Optional[torch.Tensor] = None
     ) -> torch.Tensor:
         r"""
         Args:
             waveform (torch.Tensor): Input waveform, with shape `(..., L)`.
             noise (torch.Tensor): Noise, with shape `(..., L)` (same shape as ``waveform``).
-            lengths (torch.Tensor): Valid lengths of signals in ``waveform`` and ``noise``, with shape `(...,)`
-                (leading dimensions must match those of ``waveform``).
             snr (torch.Tensor): Signal-to-noise ratios in dB, with shape `(...,)`.
+            lengths (torch.Tensor or None, optional): Valid lengths of signals in ``waveform`` and ``noise``,
+            with shape `(...,)` (leading dimensions must match those of ``waveform``). If ``None``, all
+            elements in ``waveform`` and ``noise`` are treated as valid. (Default: ``None``)
 
         Returns:
             torch.Tensor: Result of scaling and adding ``noise`` to ``waveform``, with shape `(..., L)`
             (same shape as ``waveform``).
         """
-        return add_noise(waveform, noise, lengths, snr)
+        return add_noise(waveform, noise, snr, lengths)
 
 
 class Preemphasis(torch.nn.Module):


### PR DESCRIPTION
For greater flexibility, this PR makes argument `lengths` optional for `add_noise` and `AddNoise`.