### PR TITLE
Fix CI tests on gpu machines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -680,7 +680,7 @@ jobs:
               TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310: true
               TORCHAUDIO_TEST_ALLOW_SKIP_IF_CUDA_SMALL_MEMORY: true
           command: |
-            docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "CI=${CI}" -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310 "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
+            docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "CI=${CI}" -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310 -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_CUDA_SMALL_MEMORY "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -678,6 +678,7 @@ jobs:
           name: Run tests
           environment:
               TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310: true
+              TORCHAUDIO_TEST_ALLOW_SKIP_IF_CUDA_SMALL_MEMORY: true
           command: |
             docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "CI=${CI}" -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310 "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
       - store_test_results:
@@ -760,6 +761,7 @@ jobs:
               TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_SOX: true
               TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310: true
               TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_MOD_sentencepiece: true
+              TORCHAUDIO_TEST_ALLOW_SKIP_IF_CUDA_SMALL_MEMORY: true
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -680,7 +680,7 @@ jobs:
               TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310: true
               TORCHAUDIO_TEST_ALLOW_SKIP_IF_CUDA_SMALL_MEMORY: true
           command: |
-            docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "CI=${CI}" -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310 "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
+            docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "CI=${CI}" -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310 -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_CUDA_SMALL_MEMORY "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -678,6 +678,7 @@ jobs:
           name: Run tests
           environment:
               TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310: true
+              TORCHAUDIO_TEST_ALLOW_SKIP_IF_CUDA_SMALL_MEMORY: true
           command: |
             docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "CI=${CI}" -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310 "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
       - store_test_results:
@@ -760,6 +761,7 @@ jobs:
               TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_SOX: true
               TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310: true
               TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_MOD_sentencepiece: true
+              TORCHAUDIO_TEST_ALLOW_SKIP_IF_CUDA_SMALL_MEMORY: true
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/test/torchaudio_unittest/models/wav2vec2/fairseq_integration_test.py
+++ b/test/torchaudio_unittest/models/wav2vec2/fairseq_integration_test.py
@@ -150,8 +150,8 @@ class TestFairseqIntegration(TorchaudioTestCase):
         for i, (ref, _) in enumerate(refs["layer_results"]):
             self.assertEqual(hyp[i], ref.transpose(0, 1))
 
-    @skipIfCudaSmallMemory
     @XLSR_PRETRAINING_CONFIGS
+    @skipIfCudaSmallMemory
     def test_import_xlsr_pretraining_model(self, config, factory_func):
         """XLS-R pretraining models from fairseq can be imported and yields the same results"""
         batch_size, num_frames = 3, 1024
@@ -222,8 +222,8 @@ class TestFairseqIntegration(TorchaudioTestCase):
     def test_wav2vec2_recreate_pretraining_model(self, config, factory_func):
         self._test_recreate_pretraining_model(config, factory_func)
 
-    @skipIfCudaSmallMemory
     @XLSR_PRETRAINING_CONFIGS
+    @skipIfCudaSmallMemory
     def test_xlsr_recreate_pretraining_model(self, config, factory_func):
         self._test_recreate_pretraining_model(config, factory_func)
 

--- a/test/torchaudio_unittest/models/wav2vec2/huggingface_intergration_test.py
+++ b/test/torchaudio_unittest/models/wav2vec2/huggingface_intergration_test.py
@@ -182,8 +182,8 @@ class TestHFIntegration(TorchaudioTestCase):
         imported = import_huggingface_model(original).eval()
         self._test_import_pretrain(original, imported, config)
 
-    @skipIfCudaSmallMemory
     @XLSR_PRETRAIN_CONFIGS
+    @skipIfCudaSmallMemory
     def test_import_xlsr_pretrain(self, config, _):
         """XLS-R models from HF transformers can be imported and yields the same results"""
         original = self._get_model(config).eval()


### PR DESCRIPTION
XLS-R tests are supposed to be skipped on gpu machines, but they are forced to run in [_skipIf](https://github.com/pytorch/audio/blob/main/test/torchaudio_unittest/common_utils/case_utils.py#L143-L145) decorator. This PR skips the XLS-R tests if the machine is CI and CUDA is available.