### PR TITLE
Set filter graph #threads to 1

### DIFF
--- a/torchaudio/csrc/ffmpeg/filter_graph.cpp
+++ b/torchaudio/csrc/ffmpeg/filter_graph.cpp
@@ -12,6 +12,8 @@ FilterGraph::FilterGraph(AVMediaType media_type) : media_type(media_type) {
     default:
       TORCH_CHECK(false, "Only audio and video type is supported.");
   }
+
+  pFilterGraph->nb_threads = 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
FilterGraph supports multi threading, and by default, the number of threads is determined automatically.

Rather than an automatic behavior, which is unpredictable, it is better to fix the number of threads to 1.

Follow-up: Add an interface to adjust it.

Similar to https://github.com/pytorch/audio/pull/2949.