### PR TITLE
Fixes examples/source_separation for WSJ0_2mix dataset

### DIFF
--- a/examples/source_separation/eval.py
+++ b/examples/source_separation/eval.py
@@ -31,7 +31,7 @@ def _eval(model, data_loader, device):
 
 def cli_main():
     parser = ArgumentParser()
-    parser.add_argument("--dataset", default="librimix", type=str, choices=["wsj0-mix", "librimix"])
+    parser.add_argument("--dataset", default="librimix", type=str, choices=["wsj0mix", "librimix"])
     parser.add_argument(
         "--root-dir",
         type=Path,
@@ -79,7 +79,7 @@ def cli_main():
 
     _, _, eval_loader = _get_dataloader(
         args.dataset,
-        args.data_dir,
+        args.root_dir,
         args.num_speakers,
         args.sample_rate,
         1,  # batch size is set to 1 to avoid masking

--- a/examples/source_separation/lightning_train.py
+++ b/examples/source_separation/lightning_train.py
@@ -308,7 +308,7 @@ def _get_dataloader(
 def cli_main():
     parser = ArgumentParser()
     parser.add_argument("--batch-size", default=6, type=int)
-    parser.add_argument("--dataset", default="librimix", type=str, choices=["wsj0-mix", "librimix"])
+    parser.add_argument("--dataset", default="librimix", type=str, choices=["wsj0mix", "librimix"])
     parser.add_argument(
         "--root-dir",
         type=Path,
@@ -412,9 +412,10 @@ def cli_main():
     trainer = Trainer(
         default_root_dir=args.exp_dir,
         max_epochs=args.epochs,
-        gpus=args.num_gpu,
         num_nodes=args.num_node,
+        accelerator="gpu",
         strategy="ddp_find_unused_parameters_false",
+        devices=args.num_gpu,
         limit_train_batches=1.0,  # Useful for fast experiment
         gradient_clip_val=5.0,
         callbacks=callbacks,


### PR DESCRIPTION
The `examples/source_separation` scripts use inconsistent keyword to indicate the WSJ0_2mix dataset. This PR does the following.

1. Use `wsj0mix` consistently as keyword indicating the WSJ0_2mix dataset
2. Corrects `args.data_dir` to `args.root_dir` in eval.py
3. Modify the parameters of `pytorch_lightning.Trainer` according to latest version (use `accelerator="gpu"` and `devices=args.num_devices`, instead of just `gpus=args.num_devices`)