### PR TITLE
Merge pop_chunks methods

### DIFF
--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.cpp
@@ -383,21 +383,9 @@ int StreamReader::drain() {
   return ret;
 }
 
-std::vector<c10::optional<torch::Tensor>> StreamReader::pop_chunks() {
-  std::vector<c10::optional<torch::Tensor>> ret;
-  for (auto& c : pop_chunks_with_metadata()) {
-    if (c) {
-      ret.emplace_back(c->frames);
-    } else {
-      ret.emplace_back();
-    }
-  }
-  return ret;
-}
-
-std::vector<c10::optional<Chunk>> StreamReader::pop_chunks_with_metadata() {
+std::vector<c10::optional<Chunk>> StreamReader::pop_chunks() {
   std::vector<c10::optional<Chunk>> ret;
-  ret.reserve(num_out_streams());
+  ret.reserve(static_cast<size_t>(num_out_streams()));
   for (auto& i : stream_indices) {
     ret.emplace_back(processors[i.first]->pop_chunk(i.second));
   }

--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.h
@@ -260,13 +260,9 @@ class StreamReader {
   ///@{
 
   /// Pop one chunk from each output stream if it is available.
-  std::vector<c10::optional<torch::Tensor>> pop_chunks();
+  std::vector<c10::optional<Chunk>> pop_chunks();
 
   ///@}
-
-  /// Pop one chunk from each output stream if it is available.
-  /// TODO: merge this to pop_chunks
-  std::vector<c10::optional<Chunk>> pop_chunks_with_metadata();
 };
 
 } // namespace ffmpeg

--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_reader_wrapper.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_reader_wrapper.cpp
@@ -106,7 +106,7 @@ int64_t StreamReaderBinding::fill_buffer(
 std::vector<c10::optional<ChunkData>> StreamReaderBinding::pop_chunks() {
   std::vector<c10::optional<ChunkData>> ret;
   ret.reserve(static_cast<size_t>(num_out_streams()));
-  for (auto& c : StreamReader::pop_chunks_with_metadata()) {
+  for (auto& c : StreamReader::pop_chunks()) {
     if (c) {
       ret.emplace_back(std::forward_as_tuple(c->frames, c->pts));
     } else {


### PR DESCRIPTION
Summary:
This commit merges `pop_chunks` and `pop_chunks_with_metadata`.

In #2975 (D42526945 (https://github.com/pytorch/audio/commit/0dd59e0dda22eabf54fc95ad8050094df239bd39)), we updated StreamReader so that it returns PTS.
In that PR, we introduced `pop_chunks_with_metadata` method, so that
the original `pop_chunks` method returns the same type and we could
focus on the PTS logic in the code review.

The commit is landed, now we merge the two methods, so that the original
`pop_chunks` returns Tensor frames and metadata (PTS).

Differential Revision: D42662321

