### PR TITLE
Tweak `USE_CUDA` detection

### DIFF
--- a/tools/setup_helpers/extension.py
+++ b/tools/setup_helpers/extension.py
@@ -39,7 +39,7 @@ _BUILD_RNNT = _get_build("BUILD_RNNT", True)
 _BUILD_CTC_DECODER = _get_build("BUILD_CTC_DECODER", True)
 _USE_FFMPEG = _get_build("USE_FFMPEG", False)
 _USE_ROCM = _get_build("USE_ROCM", torch.cuda.is_available() and torch.version.hip is not None)
-_USE_CUDA = _get_build("USE_CUDA", torch.cuda.is_available() and torch.version.hip is None)
+_USE_CUDA = _get_build("USE_CUDA", torch.backends.cuda.is_built() and torch.version.hip is None)
 _USE_OPENMP = _get_build("USE_OPENMP", True) and "ATen parallel backend: OpenMP" in torch.__config__.parallel_info()
 _TORCH_CUDA_ARCH_LIST = os.environ.get("TORCH_CUDA_ARCH_LIST", None)
 


### PR DESCRIPTION
We don't need the presence of physical HW to compile with CUDA

Likely one of the causes of  https://github.com/pytorch/audio/issues/2979