### PR TITLE
Deprecate sox initialization/shutdown public API functions

### DIFF
--- a/docs/source/sox_effects.rst
+++ b/docs/source/sox_effects.rst
@@ -26,6 +26,4 @@ Utilities
    :toctree: generated
    :nosignatures:
 
-   init_sox_effects
-   shutdown_sox_effects
    effect_names

--- a/torchaudio/sox_effects/sox_effects.py
+++ b/torchaudio/sox_effects/sox_effects.py
@@ -3,9 +3,11 @@ from typing import List, Optional, Tuple
 
 import torch
 import torchaudio
+from torchaudio._internal.module_utils import deprecated
 from torchaudio.utils.sox_utils import list_effects
 
 
+@deprecated("Please remove the call. This function is called automatically.")
 def init_sox_effects():
     """Initialize resources required to use sox effects.
 
@@ -20,6 +22,7 @@ def init_sox_effects():
     pass
 
 
+@deprecated("Please remove the call. This function is called automatically.")
 def shutdown_sox_effects():
     """Clean up resources required to use sox effects.
 


### PR DESCRIPTION
These functions are called part of sox initialization, thus it is no longer needed.