### PR TITLE
Remove function input parameters from data aug functional tests

### DIFF
--- a/test/torchaudio_unittest/functional/autograd_impl.py
+++ b/test/torchaudio_unittest/functional/autograd_impl.py
@@ -336,7 +336,7 @@ class Autograd(TestBaseMixin):
         self.assert_grad(F.apply_beamforming, (beamform_weights, specgram))
 
     @nested_params(
-        [F.convolve, F.fftconvolve],
+        ["convolve", "fftconvolve"],
         ["full", "valid", "same"],
     )
     def test_convolve(self, fn, mode):
@@ -344,7 +344,7 @@ class Autograd(TestBaseMixin):
         L_x, L_y = 23, 40
         x = torch.rand(*leading_dims, L_x, dtype=self.dtype, device=self.device)
         y = torch.rand(*leading_dims, L_y, dtype=self.dtype, device=self.device)
-        self.assert_grad(fn, (x, y, mode))
+        self.assert_grad(getattr(F, fn), (x, y, mode))
 
     def test_add_noise(self):
         leading_dims = (5, 2, 3)

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -409,7 +409,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         self.assert_batch_consistency(F.apply_beamforming, (beamform_weights, specgram))
 
     @common_utils.nested_params(
-        [F.convolve, F.fftconvolve],
+        ["convolve", "fftconvolve"],
         ["full", "valid", "same"],
     )
     def test_convolve(self, fn, mode):
@@ -418,6 +418,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         x = torch.rand(*leading_dims, L_x, dtype=self.dtype, device=self.device)
         y = torch.rand(*leading_dims, L_y, dtype=self.dtype, device=self.device)
 
+        fn = getattr(F, fn)
         actual = fn(x, y, mode)
         expected = torch.stack(
             [

--- a/test/torchaudio_unittest/prototype/functional/functional_test_impl.py
+++ b/test/torchaudio_unittest/prototype/functional/functional_test_impl.py
@@ -1,9 +1,6 @@
-import math
-
 import torch
 import torchaudio.prototype.functional as F
 from parameterized import param, parameterized
-from torchaudio.functional import lfilter
 from torchaudio_unittest.common_utils import nested_params, TestBaseMixin
 
 from .dsp_utils import freq_ir as freq_ir_np, oscillator_bank as oscillator_bank_np, sinc_ir as sinc_ir_np


### PR DESCRIPTION
Passing functions as test parameters causes issues on some platforms. This PR updates the functional tests to pass functions by name instead.