### PR TITLE
Replace torchaudio::ffmpeg with torchaudio::io

### DIFF
--- a/torchaudio/csrc/ffmpeg/ffmpeg.cpp
+++ b/torchaudio/csrc/ffmpeg/ffmpeg.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 ////////////////////////////////////////////////////////////////////////////////
 // AVDictionary
@@ -158,5 +158,5 @@ AVFilterGraphPtr::AVFilterGraphPtr()
 void AVFilterGraphPtr::reset() {
   ptr.reset(get_filter_graph());
 }
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/ffmpeg.h
+++ b/torchaudio/csrc/ffmpeg/ffmpeg.h
@@ -23,7 +23,7 @@ extern "C" {
 }
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 using OptionDict = c10::Dict<std::string, std::string>;
 
@@ -187,5 +187,5 @@ struct AVFilterGraphPtr : public Wrapper<AVFilterGraph, AVFilterGraphDeleter> {
   AVFilterGraphPtr();
   void reset();
 };
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/filter_graph.cpp
+++ b/torchaudio/csrc/ffmpeg/filter_graph.cpp
@@ -2,7 +2,7 @@
 #include <stdexcept>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 FilterGraph::FilterGraph(AVMediaType media_type) : media_type(media_type) {
   switch (media_type) {
@@ -200,5 +200,5 @@ int FilterGraph::get_frame(AVFrame* pOutputFrame) {
   return av_buffersink_get_frame(buffersink_ctx, pOutputFrame);
 }
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/filter_graph.h
+++ b/torchaudio/csrc/ffmpeg/filter_graph.h
@@ -2,7 +2,7 @@
 
 #include <torchaudio/csrc/ffmpeg/ffmpeg.h>
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 class FilterGraph {
   AVMediaType media_type;
@@ -64,5 +64,5 @@ class FilterGraph {
   int get_frame(AVFrame* pOutputFrame);
 };
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/pybind/pybind.cpp
+++ b/torchaudio/csrc/ffmpeg/pybind/pybind.cpp
@@ -4,7 +4,7 @@
 #include <torchaudio/csrc/ffmpeg/pybind/stream_writer.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 namespace {
 
 PYBIND11_MODULE(_torchaudio_ffmpeg, m) {
@@ -49,5 +49,5 @@ PYBIND11_MODULE(_torchaudio_ffmpeg, m) {
 }
 
 } // namespace
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/pybind/stream_reader.cpp
+++ b/torchaudio/csrc/ffmpeg/pybind/stream_reader.cpp
@@ -2,7 +2,7 @@
 #include <torchaudio/csrc/ffmpeg/pybind/typedefs.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 namespace {
 SrcInfoPyBind convert_pybind(SrcStreamInfo ssi) {
   return SrcInfoPyBind(std::forward_as_tuple(
@@ -72,5 +72,5 @@ void StreamReaderFileObj::add_video_stream(
       hw_accel);
 }
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/pybind/stream_reader.h
+++ b/torchaudio/csrc/ffmpeg/pybind/stream_reader.h
@@ -3,7 +3,7 @@
 #include <torchaudio/csrc/ffmpeg/stream_reader/stream_reader_wrapper.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 // The reason we inherit FileObj instead of making it an attribute
 // is so that FileObj is instantiated first.
@@ -37,5 +37,5 @@ class StreamReaderFileObj : protected FileObj, public StreamReaderBinding {
       const c10::optional<std::string>& hw_accel);
 };
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/pybind/stream_writer.cpp
+++ b/torchaudio/csrc/ffmpeg/pybind/stream_writer.cpp
@@ -1,7 +1,7 @@
 #include <torchaudio/csrc/ffmpeg/pybind/stream_writer.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 StreamWriterFileObj::StreamWriterFileObj(
     py::object fileobj_,
@@ -51,5 +51,5 @@ void StreamWriterFileObj::add_video_stream(
       hw_accel);
 }
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/pybind/stream_writer.h
+++ b/torchaudio/csrc/ffmpeg/pybind/stream_writer.h
@@ -3,7 +3,7 @@
 #include <torchaudio/csrc/ffmpeg/stream_writer/stream_writer.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 class StreamWriterFileObj : private FileObj, public StreamWriter {
  public:
@@ -31,5 +31,5 @@ class StreamWriterFileObj : private FileObj, public StreamWriter {
       const c10::optional<std::string>& hw_accel);
 };
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/pybind/typedefs.cpp
+++ b/torchaudio/csrc/ffmpeg/pybind/typedefs.cpp
@@ -1,7 +1,7 @@
 #include <torchaudio/csrc/ffmpeg/pybind/typedefs.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 namespace {
 
 static int read_function(void* opaque, uint8_t* buf, int buf_size) {
@@ -112,5 +112,5 @@ OptionMap dict2map(const OptionDict& src) {
   return ret;
 }
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/pybind/typedefs.h
+++ b/torchaudio/csrc/ffmpeg/pybind/typedefs.h
@@ -3,7 +3,7 @@
 #include <torchaudio/csrc/ffmpeg/ffmpeg.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 struct FileObj {
   py::object fileobj;
@@ -20,5 +20,5 @@ c10::optional<OptionDict> map2dict(const c10::optional<OptionMap>& src);
 
 OptionMap dict2map(const OptionDict& src);
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/buffer.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/buffer.h
@@ -4,7 +4,7 @@
 #include <torchaudio/csrc/ffmpeg/stream_reader/typedefs.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 //////////////////////////////////////////////////////////////////////////////
 // Buffer Interface
@@ -29,5 +29,5 @@ class Buffer {
   virtual void flush() = 0;
 };
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/buffer/chunked_buffer.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/buffer/chunked_buffer.cpp
@@ -2,7 +2,7 @@
 #include <torchaudio/csrc/ffmpeg/stream_reader/buffer/common.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 namespace detail {
 
 ChunkedBuffer::ChunkedBuffer(
@@ -152,5 +152,5 @@ void ChunkedBuffer::flush() {
 }
 
 } // namespace detail
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/buffer/chunked_buffer.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/buffer/chunked_buffer.h
@@ -3,7 +3,7 @@
 #include <torchaudio/csrc/ffmpeg/stream_reader/buffer.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 namespace detail {
 
 //////////////////////////////////////////////////////////////////////////////
@@ -63,5 +63,5 @@ class ChunkedVideoBuffer : public ChunkedBuffer {
 };
 
 } // namespace detail
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/buffer/common.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/buffer/common.cpp
@@ -7,7 +7,7 @@
 #endif
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 namespace detail {
 
 torch::Tensor convert_audio(AVFrame* pFrame) {
@@ -380,5 +380,5 @@ torch::Tensor convert_image(AVFrame* frame, const torch::Device& device) {
 }
 
 } // namespace detail
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/buffer/common.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/buffer/common.h
@@ -3,7 +3,7 @@
 #include <torchaudio/csrc/ffmpeg/ffmpeg.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 namespace detail {
 
 //////////////////////////////////////////////////////////////////////////////
@@ -14,5 +14,5 @@ torch::Tensor convert_audio(AVFrame* frame);
 torch::Tensor convert_image(AVFrame* frame, const torch::Device& device);
 
 } // namespace detail
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/buffer/unchunked_buffer.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/buffer/unchunked_buffer.cpp
@@ -2,7 +2,7 @@
 #include <torchaudio/csrc/ffmpeg/stream_reader/buffer/unchunked_buffer.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 namespace detail {
 
 UnchunkedVideoBuffer::UnchunkedVideoBuffer(const torch::Device& device)
@@ -43,5 +43,5 @@ void UnchunkedBuffer::flush() {
 }
 
 } // namespace detail
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/buffer/unchunked_buffer.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/buffer/unchunked_buffer.h
@@ -5,7 +5,7 @@
 #include <deque>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 namespace detail {
 
 //////////////////////////////////////////////////////////////////////////////
@@ -42,5 +42,5 @@ class UnchunkedVideoBuffer : public UnchunkedBuffer {
 };
 
 } // namespace detail
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/decoder.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/decoder.cpp
@@ -1,7 +1,7 @@
 #include <torchaudio/csrc/ffmpeg/stream_reader/decoder.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 ////////////////////////////////////////////////////////////////////////////////
 // Decoder
@@ -131,5 +131,5 @@ void Decoder::flush_buffer() {
   avcodec_flush_buffers(pCodecContext);
 }
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/decoder.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/decoder.h
@@ -3,7 +3,7 @@
 #include <torchaudio/csrc/ffmpeg/ffmpeg.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 class Decoder {
   AVCodecContextPtr pCodecContext;
@@ -34,5 +34,5 @@ class Decoder {
   void flush_buffer();
 };
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/sink.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/sink.cpp
@@ -4,7 +4,7 @@
 #include <stdexcept>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 namespace {
 std::unique_ptr<Buffer> get_buffer(
@@ -130,5 +130,5 @@ void Sink::flush() {
   buffer->flush();
 }
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/sink.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/sink.h
@@ -5,7 +5,7 @@
 #include <torchaudio/csrc/ffmpeg/stream_reader/buffer.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 class Sink {
   AVFramePtr frame;
@@ -35,5 +35,5 @@ class Sink {
   void flush();
 };
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_processor.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_processor.cpp
@@ -2,7 +2,7 @@
 #include <stdexcept>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 using KeyType = StreamProcessor::KeyType;
 
@@ -155,5 +155,5 @@ c10::optional<Chunk> StreamProcessor::pop_chunk(KeyType key) {
   return sinks.at(key).buffer->pop_chunk();
 }
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_processor.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_processor.h
@@ -8,7 +8,7 @@
 #include <map>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 class StreamProcessor {
  public:
@@ -99,5 +99,5 @@ class StreamProcessor {
   c10::optional<Chunk> pop_chunk(KeyType key);
 };
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.cpp
@@ -6,7 +6,7 @@
 #include <thread>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 using KeyType = StreamProcessor::KeyType;
 
@@ -445,5 +445,5 @@ std::vector<c10::optional<Chunk>> StreamReader::pop_chunks() {
   return ret;
 }
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.h
@@ -6,7 +6,7 @@
 #include <vector>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 ///
 /// Fetch and decode audio/video streams chunk by chunk.
@@ -293,5 +293,5 @@ class StreamReader {
   ///@}
 };
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_reader_binding.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_reader_binding.cpp
@@ -3,7 +3,7 @@
 #include <stdexcept>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 namespace {
 
@@ -92,5 +92,5 @@ TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
 }
 
 } // namespace
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_reader_tensor_binding.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_reader_tensor_binding.cpp
@@ -1,7 +1,7 @@
 #include <torchaudio/csrc/ffmpeg/stream_reader/stream_reader_wrapper.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 namespace {
 
 //////////////////////////////////////////////////////////////////////////////
@@ -190,5 +190,5 @@ TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
       .def("pop_chunks", [](S s) { return s->pop_chunks(); });
 }
 } // namespace
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_reader_wrapper.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_reader_wrapper.cpp
@@ -1,7 +1,7 @@
 #include <torchaudio/csrc/ffmpeg/stream_reader/stream_reader_wrapper.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 namespace {
 
 SrcInfo convert(SrcStreamInfo ssi) {
@@ -93,5 +93,5 @@ std::vector<c10::optional<ChunkData>> StreamReaderBinding::pop_chunks() {
   return ret;
 }
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_reader_wrapper.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_reader_wrapper.h
@@ -3,7 +3,7 @@
 #include <torchaudio/csrc/ffmpeg/stream_reader/stream_reader.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 // Because TorchScript requires c10::Dict type to pass dict,
 // while PyBind11 requires std::map type to pass dict,
@@ -86,5 +86,5 @@ struct StreamReaderBinding : public StreamReader,
   std::vector<c10::optional<ChunkData>> pop_chunks();
 };
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/typedefs.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/typedefs.h
@@ -4,7 +4,7 @@
 #include <iostream>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 struct SrcStreamInfo {
   /// @name COMMON MEMBERS
@@ -119,5 +119,5 @@ struct Chunk {
   double pts;
 };
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_writer/stream_writer.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_writer/stream_writer.cpp
@@ -5,7 +5,7 @@
 #endif
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 namespace {
 
 AVFormatContext* get_output_format_context(
@@ -1107,5 +1107,5 @@ void StreamWriter::flush_stream(OutputStream& os) {
     encode_frame(nullptr, os.codec_ctx, os.stream);
   }
 }
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_writer/stream_writer.h
+++ b/torchaudio/csrc/ffmpeg/stream_writer/stream_writer.h
@@ -5,7 +5,7 @@
 #include <torchaudio/csrc/ffmpeg/filter_graph.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 
 struct OutputStream {
   AVStream* stream;
@@ -208,5 +208,5 @@ class StreamWriter {
   void flush_stream(OutputStream& os);
 };
 
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_writer/stream_writer_binding.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_writer/stream_writer_binding.cpp
@@ -2,7 +2,7 @@
 #include <torchaudio/csrc/ffmpeg/stream_writer/stream_writer.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 namespace {
 
 class StreamWriterBinding : public StreamWriter,
@@ -82,5 +82,5 @@ TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
 }
 
 } // namespace
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/utils.cpp
+++ b/torchaudio/csrc/ffmpeg/utils.cpp
@@ -2,7 +2,7 @@
 #include <torchaudio/csrc/ffmpeg/ffmpeg.h>
 
 namespace torchaudio {
-namespace ffmpeg {
+namespace io {
 namespace {
 
 c10::Dict<std::string, std::tuple<int64_t, int64_t, int64_t>> get_versions() {
@@ -124,5 +124,5 @@ TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
 }
 
 } // namespace
-} // namespace ffmpeg
+} // namespace io
 } // namespace torchaudio


### PR DESCRIPTION
Summary: Namespace clean up before publishing the torchaudio C++ API as prototype.

Differential Revision: D42699903

