### PR TITLE
Add get_build_config ffmpeg utility function

### DIFF
--- a/torchaudio/csrc/ffmpeg/utils.cpp
+++ b/torchaudio/csrc/ffmpeg/utils.cpp
@@ -92,6 +92,10 @@ std::vector<std::string> get_protocols(bool output) {
   return ret;
 }
 
+std::string get_build_config() {
+  return avcodec_configuration();
+}
+
 TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
   m.def("torchaudio::ffmpeg_get_versions", &get_versions);
   m.def("torchaudio::ffmpeg_get_muxers", []() { return get_muxers(false); });
@@ -99,6 +103,9 @@ TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
       "torchaudio::ffmpeg_get_demuxers", []() { return get_demuxers(false); });
   m.def("torchaudio::ffmpeg_get_input_devices", []() {
     return get_demuxers(true);
+  });
+  m.def("torchaudio::ffmpeg_get_build_config", []() {
+    return get_build_config();
   });
   m.def("torchaudio::ffmpeg_get_output_devices", []() {
     return get_muxers(true);

--- a/torchaudio/utils/ffmpeg_utils.py
+++ b/torchaudio/utils/ffmpeg_utils.py
@@ -235,6 +235,6 @@ def get_build_config() -> str:
 
     Example
         >>> print(get_build_config())
-        --prefix=/Users/runner/miniforge3 --cc=arm64-apple-darwin20.0.0-clang --enable-gpl --enable-hardcoded-tables --enable-libfreetype --enable-libopenh264 --enable-neon --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvtav1 --enable-libxml2 --enable-libvpx --enable-pic --enable-pthreads --enable-shared --disable-static --enable-version3 --enable-zlib --enable-libmp3lame --pkg-config=/Users/runner/miniforge3/conda-bld/ffmpeg_1646229390493/_build_env/bin/pkg-config --enable-cross-compile --arch=arm64 --target-os=darwin --cross-prefix=arm64-apple-darwin20.0.0- --host-cc=/Users/runner/miniforge3/conda-bld/ffmpeg_1646229390493/_build_env/bin/x86_64-apple-darwin13.4.0-clang
+        --prefix=/Users/runner/miniforge3 --cc=arm64-apple-darwin20.0.0-clang --enable-gpl --enable-hardcoded-tables --enable-libfreetype --enable-libopenh264 --enable-neon --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvtav1 --enable-libxml2 --enable-libvpx --enable-pic --enable-pthreads --enable-shared --disable-static --enable-version3 --enable-zlib --enable-libmp3lame --pkg-config=/Users/runner/miniforge3/conda-bld/ffmpeg_1646229390493/_build_env/bin/pkg-config --enable-cross-compile --arch=arm64 --target-os=darwin --cross-prefix=arm64-apple-darwin20.0.0- --host-cc=/Users/runner/miniforge3/conda-bld/ffmpeg_1646229390493/_build_env/bin/x86_64-apple-darwin13.4.0-clang  # noqa
     """
     return torch.ops.torchaudio.ffmpeg_get_build_config()

--- a/torchaudio/utils/ffmpeg_utils.py
+++ b/torchaudio/utils/ffmpeg_utils.py
@@ -225,3 +225,16 @@ def get_output_protocols() -> List[str]:
         ... ['file', 'ftp', 'http', 'https', 'md5', 'pipe', 'prompeg', 'rtmp', 'tee', 'tcp', 'tls', 'udp', 'unix']
     """
     return torch.ops.torchaudio.ffmpeg_get_output_protocols()
+
+
+def get_build_config() -> str:
+    """Get the FFmpeg build configuration
+
+    Returns:
+        str: Build configuration string.
+
+    Example
+        >>> print(get_build_config())
+        --prefix=/Users/runner/miniforge3 --cc=arm64-apple-darwin20.0.0-clang --enable-gpl --enable-hardcoded-tables --enable-libfreetype --enable-libopenh264 --enable-neon --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvtav1 --enable-libxml2 --enable-libvpx --enable-pic --enable-pthreads --enable-shared --disable-static --enable-version3 --enable-zlib --enable-libmp3lame --pkg-config=/Users/runner/miniforge3/conda-bld/ffmpeg_1646229390493/_build_env/bin/pkg-config --enable-cross-compile --arch=arm64 --target-os=darwin --cross-prefix=arm64-apple-darwin20.0.0- --host-cc=/Users/runner/miniforge3/conda-bld/ffmpeg_1646229390493/_build_env/bin/x86_64-apple-darwin13.4.0-clang
+    """
+    return torch.ops.torchaudio.ffmpeg_get_build_config()


### PR DESCRIPTION
We often need to look at which FFmpeg was found and linked when debugging an issue.

Version number is often not enough but there is no easy way to find where the library was found either.

This commit adds utility function that prints the build time configuration.

It helps to distinguish if the linked FFmpeg is the one from binary distribution built in CI or locally built.