### PR TITLE
Fix signature mismatch on _fail_info_fileobj

### DIFF
--- a/torchaudio/backend/sox_io_backend.py
+++ b/torchaudio/backend/sox_io_backend.py
@@ -13,7 +13,7 @@ def _fail_info(filepath: str, format: Optional[str]) -> AudioMetaData:
     raise RuntimeError("Failed to fetch metadata from {}".format(filepath))
 
 
-def _fail_info_fileobj(fileobj, format: Optional[str]) -> AudioMetaData:
+def _fail_info_fileobj(fileobj, format: Optional[str], buffer_size: int) -> AudioMetaData:
     raise RuntimeError("Failed to fetch metadata from {}".format(fileobj))
 
 


### PR DESCRIPTION
If FFmpeg is not available, sox_io cannot fallback to it. In such case, we use a fallback function, just to raise an error with easy-to-understand message.

Turned out that the number of arguments this function receives is wrong.

This commit fixes it.