### PR TITLE
Follow-up fix policy set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,9 @@ if(NOT CMAKE_VERSION VERSION_LESS 3.15.0)
 endif()
 
 # Suppress warning about ExternalProject_Add timestamp
-cmake_policy(SET CMP0135 NEW)
+if(NOT CMAKE_VERSION VERSION_LESS 3.24.0)
+  cmake_policy(SET CMP0135 OLD)
+endif()
 
 project(torchaudio)
 


### PR DESCRIPTION
Commit b4c66d1 broke all the CIs.
The new policy changes the timestamp of configuration files of third party libraries,
which triggers re-configuration which requires extra tools.

This commit fixes it by reverting the old behavior.
Also this adds guard for older cmake versions.