### PR TITLE
Add deprecation warning to decoder

### DIFF
--- a/torchaudio/models/decoder/_ctc_decoder.py
+++ b/torchaudio/models/decoder/_ctc_decoder.py
@@ -9,13 +9,13 @@ import torch
 import torchaudio
 from torchaudio.utils import download_asset
 
-try:
-    # We prioritize the version from upstream flashlight here.
-    # This will allow applications that use the upstream flashlight
-    # alongside torchaudio.
+
+# We prioritize the version from upstream flashlight here.
+# This will allow applications that use the upstream flashlight
+# alongside torchaudio.
+if torchaudio._internal.module_utils.is_module_available("flashlight"):
     from flashlight.lib.text.decoder import (
         CriterionType as _CriterionType,
-        KenLM as _KenLM,
         LexiconDecoder as _LexiconDecoder,
         LexiconDecoderOptions as _LexiconDecoderOptions,
         LexiconFreeDecoder as _LexiconFreeDecoder,
@@ -31,7 +31,14 @@ try:
         Dictionary as _Dictionary,
         load_words as _load_words,
     )
-except Exception:
+    try:
+        from flashlight.lib.text.decoder import KenLM as _KenLM
+    except Exception:
+        _KenLM = None
+else:
+    warnings.warn(
+        "The built-in flashlight integration is deprecated, and will be removed in future release."
+        "Please install flashlight-text. https://pypi.org/project/flashlight-text/")
     torchaudio._extension._load_lib("libflashlight-text")
     from torchaudio.lib.flashlight_lib_text_decoder import (
         CriterionType as _CriterionType,
@@ -427,6 +434,9 @@ def ctc_decoder(
     word_dict = _get_word_dict(lexicon, lm, lm_dict, tokens_dict, unk_word)
 
     if type(lm) == str:
+        if _KenLM is None:
+            raise RuntimeError(
+                "flashlight is installed, but KenLM is not installed. Please install KenLM.")
         lm = _KenLM(lm, word_dict)
     elif lm is None:
         lm = _ZeroLM()

--- a/torchaudio/models/decoder/_ctc_decoder.py
+++ b/torchaudio/models/decoder/_ctc_decoder.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import itertools as it
+
+import warnings
 from abc import abstractmethod
 from collections import namedtuple
 from typing import Dict, List, NamedTuple, Optional, Tuple, Union
@@ -31,6 +33,7 @@ if torchaudio._internal.module_utils.is_module_available("flashlight"):
         Dictionary as _Dictionary,
         load_words as _load_words,
     )
+
     try:
         from flashlight.lib.text.decoder import KenLM as _KenLM
     except Exception:
@@ -38,7 +41,8 @@ if torchaudio._internal.module_utils.is_module_available("flashlight"):
 else:
     warnings.warn(
         "The built-in flashlight integration is deprecated, and will be removed in future release."
-        "Please install flashlight-text. https://pypi.org/project/flashlight-text/")
+        "Please install flashlight-text. https://pypi.org/project/flashlight-text/"
+    )
     torchaudio._extension._load_lib("libflashlight-text")
     from torchaudio.lib.flashlight_lib_text_decoder import (
         CriterionType as _CriterionType,
@@ -435,8 +439,7 @@ def ctc_decoder(
 
     if type(lm) == str:
         if _KenLM is None:
-            raise RuntimeError(
-                "flashlight is installed, but KenLM is not installed. Please install KenLM.")
+            raise RuntimeError("flashlight is installed, but KenLM is not installed. Please install KenLM.")
         lm = _KenLM(lm, word_dict)
     elif lm is None:
         lm = _ZeroLM()


### PR DESCRIPTION
Flashlight Text decoder is now available on PyPI and KenLM support is being added at
https://github.com/flashlight/text/pull/43

Once this work is merged, we can rely on the official distribution of Flashlight Text package, so we are adding deprecation warning.

Once the decoder is fully available, one can install it with

```
pip install flashlight-text
pip install git+https://github.com/kpu/kenlm.git
```