### PR TITLE
Make lengths optional for speed functions and modules

### DIFF
--- a/test/torchaudio_unittest/functional/autograd_impl.py
+++ b/test/torchaudio_unittest/functional/autograd_impl.py
@@ -360,7 +360,7 @@ class Autograd(TestBaseMixin):
         T = 200
         waveform = torch.rand(*leading_dims, T, dtype=self.dtype, device=self.device, requires_grad=True)
         lengths = torch.randint(1, T, leading_dims, dtype=self.dtype, device=self.device)
-        self.assert_grad(F.speed, (waveform, lengths, 1000, 1.1), enable_all_grad=False)
+        self.assert_grad(F.speed, (waveform, 1000, 1.1, lengths), enable_all_grad=False)
 
     def test_preemphasis(self):
         waveform = torch.rand(3, 2, 100, device=self.device, dtype=self.dtype, requires_grad=True)

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -459,12 +459,12 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         unbatched_input = [torch.ones((int(length),)) * 1.0 for length in input_lengths]
         batched_input = torch.nn.utils.rnn.pad_sequence(unbatched_input, batch_first=True)
 
-        output, output_lengths = F.speed(batched_input, input_lengths, orig_freq=orig_freq, factor=factor)
+        output, output_lengths = F.speed(batched_input, orig_freq=orig_freq, factor=factor, lengths=input_lengths)
 
         unbatched_output = []
         unbatched_output_lengths = []
         for idx in range(len(unbatched_input)):
-            w, l = F.speed(unbatched_input[idx], input_lengths[idx], orig_freq=orig_freq, factor=factor)
+            w, l = F.speed(unbatched_input[idx], orig_freq=orig_freq, factor=factor, lengths=input_lengths[idx])
             unbatched_output.append(w)
             unbatched_output_lengths.append(l)
 

--- a/test/torchaudio_unittest/functional/functional_impl.py
+++ b/test/torchaudio_unittest/functional/functional_impl.py
@@ -1042,14 +1042,12 @@ class Functional(TestBaseMixin):
         T = 1000
         waveform = torch.rand(*leading_dims, T)
         lengths = torch.randint(1, 1000, leading_dims)
-        actual_waveform, actual_lengths = F.speed(waveform, lengths, orig_freq=1000, factor=1.0)
+        actual_waveform, actual_lengths = F.speed(waveform, orig_freq=1000, factor=1.0, lengths=lengths)
         self.assertEqual(waveform, actual_waveform)
         self.assertEqual(lengths, actual_lengths)
 
-    @nested_params(
-        [0.8, 1.1, 1.2],
-    )
-    def test_speed_accuracy(self, factor):
+    @nested_params([0.8, 1.1, 1.2], [True, False])
+    def test_speed_accuracy(self, factor, use_lengths):
         """sinusoidal waveform is properly compressed by factor"""
         n_to_trim = 20
 
@@ -1057,10 +1055,18 @@ class Functional(TestBaseMixin):
         freq = 2
         times = torch.arange(0, 5, 1.0 / sample_rate)
         waveform = torch.cos(2 * math.pi * freq * times).unsqueeze(0).to(self.device, self.dtype)
-        lengths = torch.tensor([waveform.size(1)])
 
-        output, output_lengths = F.speed(waveform, lengths, orig_freq=sample_rate, factor=factor)
-        self.assertEqual(output.size(1), output_lengths[0])
+        if use_lengths:
+            lengths = torch.tensor([waveform.size(1)])
+        else:
+            lengths = None
+
+        output, output_lengths = F.speed(waveform, orig_freq=sample_rate, factor=factor, lengths=lengths)
+
+        if use_lengths:
+            self.assertEqual(output.size(1), output_lengths[0])
+        else:
+            self.assertEqual(None, output_lengths)
 
         new_times = torch.arange(0, 5 / factor, 1.0 / sample_rate)
         expected_waveform = torch.cos(2 * math.pi * freq * factor * new_times).unsqueeze(0).to(self.device, self.dtype)

--- a/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
@@ -785,12 +785,16 @@ class Functional(TempDirMixin, TestBaseMixin):
 
         self._assert_consistency(F.add_noise, (waveform, noise, snr, lengths))
 
-    def test_speed(self):
+    @common_utils.nested_params([True, False])
+    def test_speed(self, use_lengths):
         leading_dims = (3, 2)
         T = 200
         waveform = torch.rand(*leading_dims, T, dtype=self.dtype, device=self.device, requires_grad=True)
-        lengths = torch.randint(1, T, leading_dims, dtype=self.dtype, device=self.device)
-        self._assert_consistency(F.speed, (waveform, lengths, 1000, 1.1))
+        if use_lengths:
+            lengths = torch.randint(1, T, leading_dims, dtype=self.dtype, device=self.device)
+        else:
+            lengths = None
+        self._assert_consistency(F.speed, (waveform, 1000, 1.1, lengths))
 
     def test_preemphasis(self):
         waveform = torch.rand(3, 2, 100, device=self.device, dtype=self.dtype)

--- a/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
@@ -207,22 +207,32 @@ class Transforms(TestBaseMixin):
         ts_output = torch_script(convolve)(x, y)
         self.assertEqual(ts_output, output)
 
-    def test_speed(self):
+    @common_utils.nested_params([True, False])
+    def test_speed(self, use_lengths):
         leading_dims = (3, 2)
         time = 200
         waveform = torch.rand(*leading_dims, time, dtype=self.dtype, device=self.device, requires_grad=True)
-        lengths = torch.randint(1, time, leading_dims, dtype=self.dtype, device=self.device)
+
+        if use_lengths:
+            lengths = torch.randint(1, time, leading_dims, dtype=self.dtype, device=self.device)
+        else:
+            lengths = None
 
         speed = T.Speed(1000, 0.9).to(self.device, self.dtype)
         output = speed(waveform, lengths)
         ts_output = torch_script(speed)(waveform, lengths)
         self.assertEqual(ts_output, output)
 
-    def test_speed_perturbation(self):
+    @common_utils.nested_params([True, False])
+    def test_speed_perturbation(self, use_lengths):
         leading_dims = (3, 2)
         time = 200
         waveform = torch.rand(*leading_dims, time, dtype=self.dtype, device=self.device, requires_grad=True)
-        lengths = torch.randint(1, time, leading_dims, dtype=self.dtype, device=self.device)
+
+        if use_lengths:
+            lengths = torch.randint(1, time, leading_dims, dtype=self.dtype, device=self.device)
+        else:
+            lengths = None
 
         speed = T.SpeedPerturbation(1000, [0.9]).to(self.device, self.dtype)
         output = speed(waveform, lengths)


### PR DESCRIPTION
Makes lengths input optional for `torchaudio.functional.speed`, `torchaudio.transforms.Speed`, and `torchaudio.transforms.SpeedPerturbation`.