### PR TITLE
Add guards to prevent ffmpeg failures during dispatcher import

### DIFF
--- a/torchaudio/_backend/utils.py
+++ b/torchaudio/_backend/utils.py
@@ -8,7 +8,9 @@ import torch
 import torchaudio.backend.soundfile_backend as soundfile_backend
 from torchaudio._extension import _FFMPEG_INITIALIZED, _SOX_INITIALIZED
 from torchaudio.backend.common import AudioMetaData
-from torchaudio.io._compat import info_audio, info_audio_fileobj, load_audio, load_audio_fileobj, save_audio
+
+if _FFMPEG_INITIALIZED:
+    from torchaudio.io._compat import info_audio, info_audio_fileobj, load_audio, load_audio_fileobj, save_audio
 
 
 class Backend(ABC):

--- a/torchaudio/backend/__init__.py
+++ b/torchaudio/backend/__init__.py
@@ -1,12 +1,12 @@
 # flake8: noqa
 import torchaudio
 
-from torchaudio._backend.utils import get_info_func, get_load_func, get_save_func
-
 from . import utils
 from .utils import _is_backend_dispatcher_enabled, get_audio_backend, list_audio_backends, set_audio_backend
 
 if _is_backend_dispatcher_enabled():
+    from torchaudio._backend.utils import get_info_func, get_load_func, get_save_func
+
     torchaudio.info = get_info_func()
     torchaudio.load = get_load_func()
     torchaudio.save = get_save_func()


### PR DESCRIPTION
With the introduction of the backend dispatcher, importing torchaudio fails when ffmpeg is not available. This PR adds guards to resolve these failures.