### PR TITLE
Add precodition check for contiguous emissions tensor

### DIFF
--- a/torchaudio/models/decoder/_ctc_decoder.py
+++ b/torchaudio/models/decoder/_ctc_decoder.py
@@ -305,6 +305,9 @@ class CTCDecoder:
         if emissions.is_cuda:
             raise RuntimeError("emissions must be a CPU tensor.")
 
+        if not emissions.is_contiguous():
+            raise RuntimeError("emissions must be contiguous.")
+
         if lengths is not None and lengths.is_cuda:
             raise RuntimeError("lengths must be a CPU tensor.")
 


### PR DESCRIPTION
This PR adds a precondition check to the `CTCDecoder` that raises a helpful exception when called on a noncontiguous emissions tensor.

Currently, noncontiguous tensors can be passed into the CTCDecoder, which in turn passes the tensors to the backing Flashlight C++ library and results in undefined behavior, since Flashlight requires the tensors to be laid out in contiguous memory. The following code demonstrates the problem:

```
import torch
from torchaudio.models.decoder import ctc_decoder
 
tokens = ['a', '-', '|']
decoder = ctc_decoder(lexicon=None, tokens=tokens)
 
emissions = torch.rand(len(tokens), 2)  # N x T contiguous
emissions = emissions.t()  # T x N noncontiguous
 
batch = emissions.unsqueeze(0)
result = decoder(batch)  # undefined behavior!!!
```

I stumbled on the issue accidentally when I noticed the decoder wasn't giving the expected results on my input only to realize, finally, that the tensor I had passed in was noncontiguous. In my case, Flashlight was iterating over unrelated segments of memory where it had expected to find a contiguous tensor. A precondition check will hopefully save others from making the same mistake.