### PR TITLE
Reduce code duplication in VideoOutputStream

### DIFF
--- a/torchaudio/csrc/ffmpeg/stream_writer/video_output_stream.h
+++ b/torchaudio/csrc/ffmpeg/stream_writer/video_output_stream.h
@@ -19,6 +19,8 @@ struct VideoOutputStream : OutputStream {
       const torch::Device& device);
 
   void write_chunk(const torch::Tensor& frames) override;
+  void process_frame();
+
   ~VideoOutputStream() override = default;
 };
 


### PR DESCRIPTION
Summary:
- Introduce process_frame method
- De-dupe validation logic

Differential Revision: D43632390

