### PR TITLE
Use null filter in case no filter is used

### DIFF
--- a/torchaudio/csrc/ffmpeg/stream_writer/output_stream.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_writer/output_stream.cpp
@@ -5,7 +5,7 @@ namespace torchaudio::io {
 OutputStream::OutputStream(
     AVFormatContext* format_ctx,
     AVCodecContext* codec_ctx_,
-    std::unique_ptr<FilterGraph>&& filter_)
+    FilterGraph&& filter_)
     : codec_ctx(codec_ctx_),
       encoder(format_ctx, codec_ctx),
       filter(std::move(filter_)),
@@ -13,13 +13,9 @@ OutputStream::OutputStream(
       num_frames(0) {}
 
 void OutputStream::process_frame(AVFrame* src) {
-  if (!filter) {
-    encoder.encode(src);
-    return;
-  }
-  int ret = filter->add_frame(src);
+  int ret = filter.add_frame(src);
   while (ret >= 0) {
-    ret = filter->get_frame(dst_frame);
+    ret = filter.get_frame(dst_frame);
     if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
       if (ret == AVERROR_EOF) {
         encoder.encode(nullptr);

--- a/torchaudio/csrc/ffmpeg/stream_writer/output_stream.h
+++ b/torchaudio/csrc/ffmpeg/stream_writer/output_stream.h
@@ -13,7 +13,7 @@ struct OutputStream {
   // Encoder + Muxer
   Encoder encoder;
   // Filter for additional processing
-  std::unique_ptr<FilterGraph> filter;
+  FilterGraph filter;
   // frame that output from FilterGraph is written
   AVFramePtr dst_frame;
   // The number of samples written so far
@@ -22,7 +22,7 @@ struct OutputStream {
   OutputStream(
       AVFormatContext* format_ctx,
       AVCodecContext* codec_ctx,
-      std::unique_ptr<FilterGraph>&& filter);
+      FilterGraph&& filter);
 
   virtual void write_chunk(const torch::Tensor& input) = 0;
   void process_frame(AVFrame* src);


### PR DESCRIPTION
Summary:
Change the logic around StreamWriter preprocessing.
Currently, no preprocessing is expressed as `nullptr` to `unique_ptr<FilterGraph>`.

This commit changes it to `[a]null` filter, which is just a pass through.
This makes a code a bit simpler, and serves better preparation for adding
filters for CUDA process.

Differential Revision: D43593321

