### PR TITLE
[Release only changes] Remove python 3.11 from circleci unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1317,12 +1317,6 @@ workflows:
           python_version: '3.10'
           requires:
           - download_third_parties
-      - unittest_linux_cpu:
-          cuda_version: cpu
-          name: unittest_linux_cpu_py3.11
-          python_version: '3.11'
-          requires:
-          - download_third_parties
       - unittest_linux_gpu:
           cuda_version: cu117
           name: unittest_linux_gpu_py3.8
@@ -1339,12 +1333,6 @@ workflows:
           cuda_version: cu117
           name: unittest_linux_gpu_py3.10
           python_version: '3.10'
-          requires:
-          - download_third_parties
-      - unittest_linux_gpu:
-          cuda_version: cu117
-          name: unittest_linux_gpu_py3.11
-          python_version: '3.11'
           requires:
           - download_third_parties
       - unittest_windows_cpu:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -251,6 +251,11 @@ def unittest_workflows(indentation=6):
                 continue
 
             for i, python_version in enumerate(unittest_python_versions(os_type)):
+
+                # Turn off unit tests for 3.11, unit test are not setup properly
+                if python_version == "3.11":
+                    continue
+
                 job = {
                     "name": f"unittest_{os_type}_{device_type}_py{python_version}",
                     "python_version": python_version,


### PR DESCRIPTION
[Release only changes] Remove python 3.11 from circleci unit tests
Similar to: https://github.com/pytorch/vision/commit/dd5e8a48cdfa4bb20d5d382214ca30325c049944