### PR TITLE
Fix windows tests

### DIFF
--- a/test/torchaudio_unittest/backend/dispatcher/ffmpeg/info_test.py
+++ b/test/torchaudio_unittest/backend/dispatcher/ffmpeg/info_test.py
@@ -384,6 +384,7 @@ class Unseekable:
         return self.fileobj.read(n)
 
 
+@skipIfNoExec("sox")
 class TestFileObject(FileObjTestBase, PytorchTestCase):
     _info = partial(get_info_func(), backend="ffmpeg")
 

--- a/test/torchaudio_unittest/backend/dispatcher/ffmpeg/info_test.py
+++ b/test/torchaudio_unittest/backend/dispatcher/ffmpeg/info_test.py
@@ -30,6 +30,7 @@ if _mod_utils.is_module_available("requests"):
     import requests
 
 
+@skipIfNoExec("sox")
 @skipIfNoFFmpeg
 class TestInfo(TempDirMixin, PytorchTestCase):
     _info = partial(get_info_func(), backend="ffmpeg")
@@ -292,6 +293,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
     #     assert info.encoding == "PCM_S"
 
 
+@skipIfNoExec("sox")
 @skipIfNoFFmpeg
 class TestInfoOpus(PytorchTestCase):
     _info = partial(get_info_func(), backend="ffmpeg")
@@ -317,6 +319,7 @@ class TestInfoOpus(PytorchTestCase):
         assert info.encoding == "OPUS"
 
 
+@skipIfNoExec("sox")
 @skipIfNoFFmpeg
 class TestLoadWithoutExtension(PytorchTestCase):
     _info = partial(get_info_func(), backend="ffmpeg")
@@ -574,6 +577,7 @@ class TestFileObjectHttp(HttpServerMixin, FileObjTestBase, PytorchTestCase):
         assert sinfo.encoding == get_encoding(ext, dtype)
 
 
+@skipIfNoExec("sox")
 @skipIfNoFFmpeg
 class TestInfoNoSuchFile(PytorchTestCase):
     _info = partial(get_info_func(), backend="ffmpeg")

--- a/test/torchaudio_unittest/backend/dispatcher/ffmpeg/load_test.py
+++ b/test/torchaudio_unittest/backend/dispatcher/ffmpeg/load_test.py
@@ -307,6 +307,7 @@ class TestLoad(LoadTestBase):
     #     self.assert_format("amr-nb", sample_rate=8000, num_channels=1, bit_depth=32, duration=1)
 
 
+@skipIfNoExec("sox")
 @skipIfNoFFmpeg
 class TestLoadWithoutExtension(PytorchTestCase):
     _load = partial(get_load_func(), backend="ffmpeg")
@@ -587,6 +588,7 @@ class TestFileObjectHttp(HttpServerMixin, PytorchTestCase):
         self.assertEqual(expected, found)
 
 
+@skipIfNoExec("sox")
 @skipIfNoFFmpeg
 class TestLoadNoSuchFile(PytorchTestCase):
     _load = partial(get_load_func(), backend="ffmpeg")

--- a/test/torchaudio_unittest/backend/dispatcher/ffmpeg/save_test.py
+++ b/test/torchaudio_unittest/backend/dispatcher/ffmpeg/save_test.py
@@ -142,6 +142,7 @@ class SaveTestBase(TempDirMixin, TorchaudioTestCase):
         self.assertEqual(found, expected)
 
 
+@skipIfNoExec("sox")
 @skipIfNoExec("ffmpeg")
 @skipIfNoFFmpeg
 class SaveTest(SaveTestBase):
@@ -332,6 +333,7 @@ class SaveTest(SaveTestBase):
         self.assert_save_consistency("wav", encoding="PCM_S", bits_per_sample=16, num_channels=num_channels)
 
 
+@skipIfNoExec("sox")
 @skipIfNoFFmpeg
 class TestSaveParams(TempDirMixin, PytorchTestCase):
     """Test the correctness of optional parameters of `self._save`"""
@@ -378,6 +380,7 @@ class TestSaveParams(TempDirMixin, PytorchTestCase):
         self.assertEqual(data, expected)
 
 
+@skipIfNoExec("sox")
 @skipIfNoFFmpeg
 class TestSaveNonExistingDirectory(PytorchTestCase):
     _save = partial(get_save_func(), backend="ffmpeg")


### PR DESCRIPTION
`sox` is not available on Windows machines. Add skip decorators to the sox related tests to skip running tests on Windows.