### PR TITLE
Remove redundant device arg from VideoOutputStream constructor

### DIFF
--- a/torchaudio/csrc/ffmpeg/stream_writer/video_output_stream.h
+++ b/torchaudio/csrc/ffmpeg/stream_writer/video_output_stream.h
@@ -15,8 +15,7 @@ struct VideoOutputStream : OutputStream {
       AVPixelFormat src_fmt,
       AVCodecContextPtr&& codec_ctx,
       AVBufferRefPtr&& hw_device_ctx,
-      AVBufferRefPtr&& hw_frame_ctx,
-      const torch::Device& device);
+      AVBufferRefPtr&& hw_frame_ctx);
 
   void write_chunk(const torch::Tensor& frames) override;
   void process_frame();


### PR DESCRIPTION
Summary:
After careful review, it turned out device arg in VideoOutputStream
constructor and related helper functions can be replaced with
AVCodecContext::pix_fmt == AV_PIX_FMT_CUDA.

Differential Revision: D43677801

