### PR TITLE
Move I/O logging to C++

### DIFF
--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.cpp
@@ -52,6 +52,7 @@ AVFormatContext* get_input_format_context(
 } // namespace
 
 StreamReader::StreamReader(AVFormatContext* p) : pFormatContext(p) {
+  C10_LOG_API_USAGE_ONCE("torchaudio.io.StreamReader");
   int ret = avformat_find_stream_info(pFormatContext, nullptr);
   TORCH_CHECK(
       ret >= 0, "Failed to find stream information: ", av_err2string(ret));

--- a/torchaudio/csrc/ffmpeg/stream_writer/stream_writer.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_writer/stream_writer.cpp
@@ -40,7 +40,9 @@ AVFormatContext* get_output_format_context(
 }
 } // namespace
 
-StreamWriter::StreamWriter(AVFormatContext* p) : pFormatContext(p) {}
+StreamWriter::StreamWriter(AVFormatContext* p) : pFormatContext(p) {
+  C10_LOG_API_USAGE_ONCE("torchaudio.io.StreamWriter");
+}
 
 StreamWriter::StreamWriter(
     AVIOContext* io_ctx,

--- a/torchaudio/io/_stream_reader.py
+++ b/torchaudio/io/_stream_reader.py
@@ -429,7 +429,6 @@ class StreamReader:
         option: Optional[Dict[str, str]] = None,
         buffer_size: int = 4096,
     ):
-        torch._C._log_api_usage_once("torchaudio.io.StreamReader")
         if isinstance(src, str):
             self._be = torchaudio.lib._torchaudio_ffmpeg.StreamReader(src, format, option)
         elif hasattr(src, "read"):

--- a/torchaudio/io/_stream_writer.py
+++ b/torchaudio/io/_stream_writer.py
@@ -109,7 +109,6 @@ class StreamWriter:
         format: Optional[str] = None,
         buffer_size: int = 4096,
     ):
-        torch._C._log_api_usage_once("torchaudio.io.StreamWriter")
         if isinstance(dst, str):
             self._s = torchaudio.lib._torchaudio_ffmpeg.StreamWriter(dst, format)
         elif hasattr(dst, "write"):


### PR DESCRIPTION
Summary: Moving the I/O usage logging to C++, so that C++ usages are also covered.

Differential Revision: D43686567

