### PR TITLE
Specify CUDA_HOME in CCI GPU Test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -668,7 +668,7 @@ jobs:
     resource_class: gpu.nvidia.medium
     environment:
       <<: *environment
-      CUDA_VERSION: 11.8
+      CUDA_VERSION: 11.7.1
       image_name: pytorch/torchaudio_unittest_base:manylinux-cuda10.2-cudnn8-20210623
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -668,7 +668,7 @@ jobs:
     resource_class: gpu.nvidia.medium
     environment:
       <<: *environment
-      CUDA_VERSION: 11.7
+      CUDA_VERSION: 11.8
       image_name: pytorch/torchaudio_unittest_base:manylinux-cuda10.2-cudnn8-20210623
     steps:
       - checkout

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -52,7 +52,7 @@ printf "Installing PyTorch with %s\n" "${cudatoolkit}"
     if [[ -z "$cudatoolkit" ]]; then
         conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" $MKL_CONSTRAINT "pytorch-${UPLOAD_CHANNEL}::${pytorch_build}"
     else
-        conda install pytorch ${cudatoolkit} ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia  $MKL_CONSTRAINT
+        conda install pytorch ${cudatoolkit} cuda-toolkit ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia  $MKL_CONSTRAINT 
     fi
 )
 

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -52,7 +52,7 @@ printf "Installing PyTorch with %s\n" "${cudatoolkit}"
     if [[ -z "$cudatoolkit" ]]; then
         conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" $MKL_CONSTRAINT "pytorch-${UPLOAD_CHANNEL}::${pytorch_build}"
     else
-        conda install pytorch ${cudatoolkit} cuda-toolkit=${CUDA_VERSION} ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia  $MKL_CONSTRAINT
+        conda install pytorch ${cudatoolkit} cuda-toolkit=${CUDA_VERSION} cuda-compiler=${CUDA_VERSION} ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia  $MKL_CONSTRAINT
     fi
 )
 

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -52,7 +52,7 @@ printf "Installing PyTorch with %s\n" "${cudatoolkit}"
     if [[ -z "$cudatoolkit" ]]; then
         conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" $MKL_CONSTRAINT "pytorch-${UPLOAD_CHANNEL}::${pytorch_build}"
     else
-        conda install pytorch ${cudatoolkit} cuda-toolkit=${CUDA_VERSION} cuda-compiler=${CUDA_VERSION} ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia  $MKL_CONSTRAINT
+        conda install pytorch ${cudatoolkit} cuda-toolkit=${CUDA_VERSION} cuda-nvcc=${CUDA_VERSION} cuda-compiler=${CUDA_VERSION} ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia  $MKL_CONSTRAINT
     fi
 )
 

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -52,13 +52,13 @@ printf "Installing PyTorch with %s\n" "${cudatoolkit}"
     if [[ -z "$cudatoolkit" ]]; then
         conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" $MKL_CONSTRAINT "pytorch-${UPLOAD_CHANNEL}::${pytorch_build}"
     else
-        conda install pytorch ${cudatoolkit} cuda-toolkit ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia  $MKL_CONSTRAINT
+        conda install pytorch ${cudatoolkit} cuda-toolkit=${CUDA_VERSION} ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia  $MKL_CONSTRAINT
     fi
 )
 
 # 2. Install torchaudio
 printf "* Installing torchaudio\n"
-CUDA_HOME=${CONDA_PREFIX} PATH="${CONDA_PREFIX}/bin:${PATH}" python setup.py install
+CUDA_HOME=${CONDA_PREFIX} python setup.py install
 
 # 3. Install Test tools
 printf "* Installing test tools\n"

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -58,7 +58,7 @@ printf "Installing PyTorch with %s\n" "${cudatoolkit}"
 
 # 2. Install torchaudio
 printf "* Installing torchaudio\n"
-python setup.py install
+CUDA_HOME=${CONDA_PREFIX} python setup.py install
 
 # 3. Install Test tools
 printf "* Installing test tools\n"

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -52,7 +52,7 @@ printf "Installing PyTorch with %s\n" "${cudatoolkit}"
     if [[ -z "$cudatoolkit" ]]; then
         conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" $MKL_CONSTRAINT "pytorch-${UPLOAD_CHANNEL}::${pytorch_build}"
     else
-        conda install pytorch ${cudatoolkit} cuda-toolkit=${CUDA_VERSION} cuda-nvcc=${CUDA_VERSION} cuda-compiler=${CUDA_VERSION} cuda-driver-dev=${CUDA_VERSION} ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia  $MKL_CONSTRAINT
+        conda install pytorch ${cudatoolkit} cuda-toolkit ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" -c "nvidia/label/cuda-${CUDA_VERSION}"  $MKL_CONSTRAINT
     fi
 )
 

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -52,13 +52,13 @@ printf "Installing PyTorch with %s\n" "${cudatoolkit}"
     if [[ -z "$cudatoolkit" ]]; then
         conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" $MKL_CONSTRAINT "pytorch-${UPLOAD_CHANNEL}::${pytorch_build}"
     else
-        conda install pytorch ${cudatoolkit} cuda-toolkit ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia  $MKL_CONSTRAINT 
+        conda install pytorch ${cudatoolkit} cuda-toolkit ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia  $MKL_CONSTRAINT
     fi
 )
 
 # 2. Install torchaudio
 printf "* Installing torchaudio\n"
-TORCH_CUDA_ARCH_LIST=71 CUDA_HOME=${CONDA_PREFIX} python setup.py install
+CUDA_HOME=${CONDA_PREFIX} python setup.py install
 
 # 3. Install Test tools
 printf "* Installing test tools\n"

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -58,7 +58,7 @@ printf "Installing PyTorch with %s\n" "${cudatoolkit}"
 
 # 2. Install torchaudio
 printf "* Installing torchaudio\n"
-CUDA_HOME=${CONDA_PREFIX} python setup.py install
+CUDA_HOME=${CONDA_PREFIX} PATH="${CONDA_PREFIX}/bin:${PATH}" python setup.py install
 
 # 3. Install Test tools
 printf "* Installing test tools\n"

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -52,7 +52,7 @@ printf "Installing PyTorch with %s\n" "${cudatoolkit}"
     if [[ -z "$cudatoolkit" ]]; then
         conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" $MKL_CONSTRAINT "pytorch-${UPLOAD_CHANNEL}::${pytorch_build}"
     else
-        conda install pytorch ${cudatoolkit} cuda-toolkit ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" -c "nvidia/label/cuda-${CUDA_VERSION}"  $MKL_CONSTRAINT
+        conda install pytorch ${cudatoolkit} cuda-toolkit cuda-tools ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" -c "nvidia/label/cuda-${CUDA_VERSION}"  $MKL_CONSTRAINT
     fi
 )
 

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -58,7 +58,7 @@ printf "Installing PyTorch with %s\n" "${cudatoolkit}"
 
 # 2. Install torchaudio
 printf "* Installing torchaudio\n"
-CUDA_HOME=${CONDA_PREFIX} python setup.py install
+TORCH_CUDA_ARCH_LIST=71 CUDA_HOME=${CONDA_PREFIX} python setup.py install
 
 # 3. Install Test tools
 printf "* Installing test tools\n"

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -52,7 +52,7 @@ printf "Installing PyTorch with %s\n" "${cudatoolkit}"
     if [[ -z "$cudatoolkit" ]]; then
         conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" $MKL_CONSTRAINT "pytorch-${UPLOAD_CHANNEL}::${pytorch_build}"
     else
-        conda install pytorch ${cudatoolkit} cuda-toolkit=${CUDA_VERSION} cuda-nvcc=${CUDA_VERSION} cuda-compiler=${CUDA_VERSION} ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia  $MKL_CONSTRAINT
+        conda install pytorch ${cudatoolkit} cuda-toolkit=${CUDA_VERSION} cuda-nvcc=${CUDA_VERSION} cuda-compiler=${CUDA_VERSION} cuda-driver-dev=${CUDA_VERSION} ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia  $MKL_CONSTRAINT
     fi
 )
 


### PR DESCRIPTION
In CCI GPU test jobs, CUDA 10.2 is detected.
This commit attempts to fix it.

https://app.circleci.com/pipelines/github/pytorch/audio/15168/workflows/d2f9d011-fce5-4dd1-a18c-96071a562576/jobs/1146522