### PR TITLE
Fix stylecheck in io

### DIFF
--- a/torchaudio/io/_compat.py
+++ b/torchaudio/io/_compat.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from typing import BinaryIO, Dict, Optional, Tuple, Union
+from typing import BinaryIO, Optional, Tuple, Union
 
 import torch
 import torchaudio


### PR DESCRIPTION
`Dict` is not used. Fix styecheck by removing the import of `Dict`.