### PR TITLE
Fix unit test failures because old cuda 10.2 is found

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -53,6 +53,10 @@ printf "Installing PyTorch with %s\n" "${cudatoolkit}"
         conda install ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" $MKL_CONSTRAINT "pytorch-${UPLOAD_CHANNEL}::${pytorch_build}"
     else
         conda install pytorch ${cudatoolkit} ${CONDA_CHANNEL_FLAGS:-} -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia  $MKL_CONSTRAINT
+
+        # make sure local cuda is set to required cuda version and not CUDA version by default
+        rm -f /usr/local/cuda
+        ln -s /usr/local/cuda-${version} /usr/local/cuda
     fi
 )
 


### PR DESCRIPTION
Similar to : https://github.com/pytorch/vision/pull/7332

This resolves unit tests infra issues.
- cu116 images should not be used anymore since they are deprecated. We should use cu117 images