### PR TITLE
[Cherry-pick release/2.0] Fix doc build (#3125)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -872,7 +872,7 @@ jobs:
           environment:
             BUILD_GALLERY: 1
             TORCH_SHOW_CPP_STACKTRACES: 1
-          no_output_timeout: 30m
+          no_output_timeout: 60m
       - persist_to_workspace:
           root: ./
           paths:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -872,7 +872,7 @@ jobs:
           environment:
             BUILD_GALLERY: 1
             TORCH_SHOW_CPP_STACKTRACES: 1
-          no_output_timeout: 30m
+          no_output_timeout: 60m
       - persist_to_workspace:
           root: ./
           paths:

--- a/docs/source/hw_acceleration_tutorial.ipynb
+++ b/docs/source/hw_acceleration_tutorial.ipynb
@@ -16,7 +16,7 @@
         "\n",
         "Using them in TorchAduio requires FFmpeg built with NVENC/NVDEC support. Google Colab has such FFmpeg pre-installed, so you can [run this tutorial on Google Colab](https://colab.research.google.com/drive/1DDah_IaGULEO66CfQWltRqaVheBkiXdN#sandboxMode=true).\n",
         "\n",
-        "If you want to enable GPU decoding/encoding, please refer to [Enabling GPU video decoder/encoder](./build.ffmpeg.html)."
+        "If you want to enable GPU decoding/encoding, please refer to [Enabling GPU video decoder/encoder](https://pytorch.org/audio/main/build.ffmpeg.html)."
       ]
     },
     {
@@ -64,8 +64,9 @@
         }
       ],
       "source": [
-        "!pip uninstall -y -q torch torchaudio torchvision torchtext\n",
-        "!pip install --progress-bar off --pre torch torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu117 2> /dev/null"
+        "%%bash\n",
+        "pip uninstall -y -q torch torchaudio torchvision torchtext\n",
+        "pip install --progress-bar off --pre torch torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu117 2> /dev/null"
       ]
     },
     {
@@ -115,7 +116,8 @@
         }
       ],
       "source": [
-        "!pip3 install --progress-bar off boto3 2> /dev/null"
+        "%%bash\n",
+        "pip3 install --progress-bar off boto3 2> /dev/null"
       ]
     },
     {
@@ -126,7 +128,8 @@
       },
       "outputs": [],
       "source": [
-        "!wget -q -O input.mp4 \"https://download.pytorch.org/torchaudio/tutorial-assets/stream-api/NASAs_Most_Scientifically_Complex_Space_Observatory_Requires_Precision-MP4_small.mp4\""
+        "%%bash\n",
+        "wget -q -O input.mp4 \"https://download.pytorch.org/torchaudio/tutorial-assets/stream-api/NASAs_Most_Scientifically_Complex_Space_Observatory_Requires_Precision-MP4_small.mp4\""
       ]
     },
     {
@@ -177,7 +180,8 @@
         }
       ],
       "source": [
-        "!nvidia-smi"
+        "%%bash\n",
+        "nvidia-smi"
       ]
     },
     {
@@ -219,7 +223,8 @@
         }
       ],
       "source": [
-        "!ffmpeg -hide_banner -decoders | grep -i cuvid"
+        "%%bash\n",
+        "ffmpeg -hide_banner -decoders | grep -i cuvid"
       ]
     },
     {
@@ -246,7 +251,8 @@
         }
       ],
       "source": [
-        "!ffmpeg -hide_banner -encoders | grep -i nvenc"
+        "%%bash\n",
+        "ffmpeg -hide_banner -encoders | grep -i nvenc"
       ]
     },
     {
@@ -311,7 +317,8 @@
         }
       ],
       "source": [
-        "!ffmpeg -hide_banner -y -vsync 0 -hwaccel cuvid -hwaccel_output_format cuda -c:v h264_cuvid -resize 360x240 -i \"https://download.pytorch.org/torchaudio/tutorial-assets/stream-api/NASAs_Most_Scientifically_Complex_Space_Observatory_Requires_Precision-MP4_small.mp4\" -c:a copy -c:v h264_nvenc -b:v 5M test.mp4"
+        "%%bash\n",
+        "ffmpeg -hide_banner -y -vsync 0 -hwaccel cuvid -hwaccel_output_format cuda -c:v h264_cuvid -resize 360x240 -i \"https://download.pytorch.org/torchaudio/tutorial-assets/stream-api/NASAs_Most_Scientifically_Complex_Space_Observatory_Requires_Precision-MP4_small.mp4\" -c:a copy -c:v h264_nvenc -b:v 5M test.mp4"
       ]
     },
     {

--- a/examples/tutorials/streamwriter_advanced.py
+++ b/examples/tutorials/streamwriter_advanced.py
@@ -246,7 +246,7 @@ with s.open():
 #        <source src="https://download.pytorch.org/torchaudio/tutorial-assets/torchaudio-sdl-demo.mp4">
 #    </video>
 #
-# [`code <https://download.pytorch.org/torchaudio/tutorial-assets/sdl.py>`_]
+# [`code <https://download.pytorch.org/torchaudio/tutorial-assets/sdl.py>`__]
 #
 
 ######################################################################
@@ -292,7 +292,7 @@ with s.open():
 #        <source src="https://download.pytorch.org/torchaudio/tutorial-assets/torchaudio-rtmp-demo.mp4">
 #    </video>
 #
-# [`code <https://download.pytorch.org/torchaudio/tutorial-assets/rtmp.py>`_]
+# [`code <https://download.pytorch.org/torchaudio/tutorial-assets/rtmp.py>`__]
 #
 
 
@@ -324,7 +324,7 @@ with s.open():
 #        <source src="https://download.pytorch.org/torchaudio/tutorial-assets/torchaudio-udp-demo.mp4">
 #    </video>
 #
-# [`code <https://download.pytorch.org/torchaudio/tutorial-assets/udp.py>`_]
+# [`code <https://download.pytorch.org/torchaudio/tutorial-assets/udp.py>`__]
 #
 
 ######################################################################


### PR DESCRIPTION
Summary:
Fix build_doc job

https://app.circleci.com/pipelines/github/pytorch/audio/15217/workflows/ce50b317-a59e-4741-b8d2-59129420deb8

- build.ffmpeg.html might not exist when IPython notebook is processed. Changing to main doc URL.
- Fix bash cell syntax in HW tutorial
- Fix C++ doc
- Fix duplicated target name in streamwriter tutorial

Pull Request resolved: https://github.com/pytorch/audio/pull/3125

Reviewed By: xiaohui-zhang

Differential Revision: D43724078

Pulled By: mthrok

fbshipit-source-id: ea7d46ec5e377cf2fbd7c3798df57da73750ac5c