### PR TITLE
Simplify HW decoder initialization

### DIFF
--- a/torchaudio/csrc/ffmpeg/stream_writer/video_output_stream.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_writer/video_output_stream.cpp
@@ -59,17 +59,13 @@ AVFramePtr get_video_frame(AVPixelFormat src_fmt, AVCodecContext* codec_ctx) {
 VideoOutputStream::VideoOutputStream(
     AVFormatContext* format_ctx,
     AVPixelFormat src_fmt,
-    AVCodecContextPtr&& codec_ctx_,
-    AVBufferRefPtr&& hw_device_ctx_,
-    AVBufferRefPtr&& hw_frame_ctx_)
+    AVCodecContextPtr&& codec_ctx_)
     : OutputStream(
           format_ctx,
           codec_ctx_,
           get_video_filter(src_fmt, codec_ctx_)),
       buffer(get_video_frame(src_fmt, codec_ctx_)),
       converter(buffer),
-      hw_device_ctx(std::move(hw_device_ctx_)),
-      hw_frame_ctx(std::move(hw_frame_ctx_)),
       codec_ctx(std::move(codec_ctx_)) {}
 
 void VideoOutputStream::write_chunk(const torch::Tensor& frames) {

--- a/torchaudio/csrc/ffmpeg/stream_writer/video_output_stream.h
+++ b/torchaudio/csrc/ffmpeg/stream_writer/video_output_stream.h
@@ -7,16 +7,12 @@ namespace torchaudio::io {
 struct VideoOutputStream : OutputStream {
   AVFramePtr buffer;
   VideoTensorConverter converter;
-  AVBufferRefPtr hw_device_ctx;
-  AVBufferRefPtr hw_frame_ctx;
   AVCodecContextPtr codec_ctx;
 
   VideoOutputStream(
       AVFormatContext* format_ctx,
       AVPixelFormat src_fmt,
-      AVCodecContextPtr&& codec_ctx,
-      AVBufferRefPtr&& hw_device_ctx,
-      AVBufferRefPtr&& hw_frame_ctx);
+      AVCodecContextPtr&& codec_ctx);
 
   void write_chunk(const torch::Tensor& frames) override;
 


### PR DESCRIPTION
Summary:
hw_device and hw_frame assigned to an AVCodecContext object
are owned by libavformat, and there is no need to keep the
reference around.

Also, instead of manually setting the hw_frame, we rely on
the encoder to perform the frame management.

Differential Revision: D43738009

