### PR TITLE
Fix HW accelerated encoder

### DIFF
--- a/torchaudio/csrc/ffmpeg/stream_writer/video_converter.h
+++ b/torchaudio/csrc/ffmpeg/stream_writer/video_converter.h
@@ -17,15 +17,13 @@ class VideoTensorConverter {
   using InitFunc = std::function<torch::Tensor(const torch::Tensor&)>;
 
  private:
-  enum AVPixelFormat src_fmt;
-  AVCodecContext* codec_ctx;
-  AVFramePtr buffer;
+  AVFrame* buffer;
 
   InitFunc init_func{};
   SlicingTensorConverter::ConvertFunc convert_func{};
 
  public:
-  VideoTensorConverter(enum AVPixelFormat src_fmt, AVCodecContext* codec_ctx);
+  explicit VideoTensorConverter(AVFrame* buffer);
   SlicingTensorConverter convert(const torch::Tensor& frames);
 };
 } // namespace torchaudio::io

--- a/torchaudio/csrc/ffmpeg/stream_writer/video_output_stream.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_writer/video_output_stream.cpp
@@ -33,6 +33,27 @@ FilterGraph get_video_filter(AVPixelFormat src_fmt, AVCodecContext* codec_ctx) {
   return p;
 }
 
+AVFramePtr get_video_frame(AVPixelFormat src_fmt, AVCodecContext* codec_ctx) {
+  AVFramePtr frame{};
+  if (codec_ctx->hw_frames_ctx) {
+    int ret = av_hwframe_get_buffer(codec_ctx->hw_frames_ctx, frame, 0);
+    TORCH_CHECK(ret >= 0, "Failed to fetch CUDA frame: ", av_err2string(ret));
+  } else {
+    frame->format = src_fmt;
+    frame->width = codec_ctx->width;
+    frame->height = codec_ctx->height;
+
+    int ret = av_frame_get_buffer(frame, 0);
+    TORCH_CHECK(
+        ret >= 0,
+        "Error allocating a video buffer (",
+        av_err2string(ret),
+        ").");
+  }
+  frame->pts = 0;
+  return frame;
+}
+
 } // namespace
 
 VideoOutputStream::VideoOutputStream(
@@ -45,7 +66,8 @@ VideoOutputStream::VideoOutputStream(
           format_ctx,
           codec_ctx_,
           get_video_filter(src_fmt, codec_ctx_)),
-      converter(src_fmt, codec_ctx_),
+      buffer(get_video_frame(src_fmt, codec_ctx_)),
+      converter(buffer),
       hw_device_ctx(std::move(hw_device_ctx_)),
       hw_frame_ctx(std::move(hw_frame_ctx_)),
       codec_ctx(std::move(codec_ctx_)) {}

--- a/torchaudio/csrc/ffmpeg/stream_writer/video_output_stream.h
+++ b/torchaudio/csrc/ffmpeg/stream_writer/video_output_stream.h
@@ -5,6 +5,7 @@
 namespace torchaudio::io {
 
 struct VideoOutputStream : OutputStream {
+  AVFramePtr buffer;
   VideoTensorConverter converter;
   AVBufferRefPtr hw_device_ctx;
   AVBufferRefPtr hw_frame_ctx;


### PR DESCRIPTION
Summary:
https://github.com/pytorch/audio/pull/3120 introduced regression in GPU encoder.

This happened because previously source AVPixelFormat (expected channel order of
input tensor) and AVCodecContext (encoding format) in converter (module to copy
input tensor to buffer), even though converter does not need to konw about the
encoding format.

This commit fixes the issue and make sure that converter does not recieve
codec context.

Differential Revision: D43759162

