### PR TITLE
Skip playback tests on linux gpu machine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -690,6 +690,7 @@ jobs:
           environment:
               TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310: true
               TORCHAUDIO_TEST_ALLOW_SKIP_IF_CUDA_SMALL_MEMORY: true
+              TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_MACOS: true
           command: |
             docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "CI=${CI}" -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310 -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_CUDA_SMALL_MEMORY "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
       - store_test_results:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -690,6 +690,7 @@ jobs:
           environment:
               TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310: true
               TORCHAUDIO_TEST_ALLOW_SKIP_IF_CUDA_SMALL_MEMORY: true
+              TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_MACOS: true
           command: |
             docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "CI=${CI}" -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310 -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_CUDA_SMALL_MEMORY "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
       - store_test_results:


### PR DESCRIPTION
`playback` function was added in #3026, the function only supports MacOS, hence the tests should be skipped on other OS. The PR skips the tests on linux gpu machines on Circle CI.