### PR TITLE
Refactor audio conversion

### DIFF
--- a/torchaudio/csrc/ffmpeg/stream_writer/audio_converter.h
+++ b/torchaudio/csrc/ffmpeg/stream_writer/audio_converter.h
@@ -11,17 +11,12 @@ namespace torchaudio::io {
 // conversion process (InitFunc and ConvertFunc) based on the input sample
 // format information, and own them.
 class AudioTensorConverter {
-  enum AVSampleFormat src_fmt;
-  AVCodecContext* codec_ctx;
-  AVFramePtr buffer;
+  AVFrame* buffer;
   const int64_t buffer_size;
   SlicingTensorConverter::ConvertFunc convert_func;
 
  public:
-  AudioTensorConverter(
-      enum AVSampleFormat src_fmt,
-      AVCodecContext* codec_ctx,
-      int default_frame_size = 10000);
+  AudioTensorConverter(AVFrame* buffer, const int64_t buffer_size);
   SlicingTensorConverter convert(const torch::Tensor& frames);
 };
 } // namespace torchaudio::io

--- a/torchaudio/csrc/ffmpeg/stream_writer/audio_output_stream.h
+++ b/torchaudio/csrc/ffmpeg/stream_writer/audio_output_stream.h
@@ -5,8 +5,8 @@
 namespace torchaudio::io {
 
 struct AudioOutputStream : OutputStream {
+  AVFramePtr buffer;
   AudioTensorConverter converter;
-  int64_t frame_capacity;
   AVCodecContextPtr codec_ctx;
 
   AudioOutputStream(


### PR DESCRIPTION
Summary:
Similar to https://github.com/pytorch/audio/pull/3140,
only provide objects which are semantically related to the
operation performed by AudioConverter.

Reviewed By: xiaohui-zhang

Differential Revision: D43781012

