### PR TITLE
Remove obsolete MKL constraint, fix MacOS x86 builds

### DIFF
--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -234,7 +234,7 @@ setup_conda_pytorch_constraint() {
     arch_name="$(uname -m)"
     if [[ "${arch_name}" != "arm64" && "${PYTHON_VERSION}" != "3.11" ]]; then
       # Use less than equal to avoid version conflict in python=3.6 environment
-      export CONDA_EXTRA_BUILD_CONSTRAINT="- mkl<=2021.2.0"
+      export CONDA_EXTRA_BUILD_CONSTRAINT="- mkl<=2023.0.0"
     fi
   fi
 }

--- a/packaging/torchaudio/meta.yaml
+++ b/packaging/torchaudio/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - cmake
     - ninja
     - numpy>=1.11 # [py <= 39]
-    - numpy>=1.21.2 # [py >= 310]
+    - numpy>=1.23.1 # [py >= 310]
     - pytorch-mutex 1.0 {{ build_variant }}  # [not osx ]
     {{ environ.get('CONDA_PYTORCH_BUILD_CONSTRAINT', 'pytorch') }}
     {{ environ.get('CONDA_EXTRA_BUILD_CONSTRAINT', '') }}

--- a/packaging/torchaudio/meta.yaml
+++ b/packaging/torchaudio/meta.yaml
@@ -27,7 +27,7 @@ requirements:
   run:
     - python
     - numpy>=1.11 # [py <= 39]
-    - numpy>=1.21.2 # [py >= 310]
+    - numpy>=1.23.1 # [py >= 310]
     - pytorch-mutex 1.0 {{ build_variant }}  # [not osx ]
     {{ environ.get('CONDA_PYTORCH_CONSTRAINT', 'pytorch') }}
     {{ environ.get('CONDA_CUDATOOLKIT_CONSTRAINT', '') }}


### PR DESCRIPTION
Remove obsolete MKL and numpy constraint, fix MacOS x86 builds
Bump Numpy constraint to more recent version