### PR TITLE
Cache HW device context

### DIFF
--- a/torchaudio/csrc/ffmpeg/CMakeLists.txt
+++ b/torchaudio/csrc/ffmpeg/CMakeLists.txt
@@ -9,6 +9,7 @@ set(
   sources
   ffmpeg.cpp
   filter_graph.cpp
+  hw_context.cpp
   stream_reader/buffer/chunked_buffer.cpp
   stream_reader/buffer/unchunked_buffer.cpp
   stream_reader/conversion.cpp

--- a/torchaudio/csrc/ffmpeg/ffmpeg.cpp
+++ b/torchaudio/csrc/ffmpeg/ffmpeg.cpp
@@ -128,8 +128,8 @@ void AutoBufferUnref::operator()(AVBufferRef* p) {
   av_buffer_unref(&p);
 }
 
-AVBufferRefPtr::AVBufferRefPtr()
-    : Wrapper<AVBufferRef, AutoBufferUnref>(nullptr) {}
+AVBufferRefPtr::AVBufferRefPtr(AVBufferRef* p)
+    : Wrapper<AVBufferRef, AutoBufferUnref>(p) {}
 
 void AVBufferRefPtr::reset(AVBufferRef* p) {
   TORCH_CHECK(

--- a/torchaudio/csrc/ffmpeg/ffmpeg.h
+++ b/torchaudio/csrc/ffmpeg/ffmpeg.h
@@ -164,7 +164,7 @@ struct AutoBufferUnref {
 };
 
 struct AVBufferRefPtr : public Wrapper<AVBufferRef, AutoBufferUnref> {
-  AVBufferRefPtr();
+  AVBufferRefPtr(AVBufferRef* p = nullptr);
   void reset(AVBufferRef* p);
 };
 

--- a/torchaudio/csrc/ffmpeg/hw_context.cpp
+++ b/torchaudio/csrc/ffmpeg/hw_context.cpp
@@ -1,0 +1,40 @@
+#include <torchaudio/csrc/ffmpeg/hw_context.h>
+
+namespace torchaudio::io {
+namespace {
+
+static std::mutex MUTEX;
+static std::map<int, AVBufferRefPtr> CUDA_CONTEXT_CACHE;
+
+} // namespace
+
+AVBufferRef* get_cuda_context(int index) {
+  std::lock_guard<std::mutex> lock(MUTEX);
+  if (index == -1) {
+    index = 0;
+  }
+  if (CUDA_CONTEXT_CACHE.count(index) == 0) {
+    AVBufferRef* p = nullptr;
+    int ret = av_hwdevice_ctx_create(
+        &p, AV_HWDEVICE_TYPE_CUDA, std::to_string(index).c_str(), nullptr, 0);
+    TORCH_CHECK(
+        ret >= 0,
+        "Failed to create CUDA device context on device ",
+        index,
+        "(",
+        av_err2string(ret),
+        ")");
+    assert(p);
+    CUDA_CONTEXT_CACHE.emplace(index, p);
+    return p;
+  }
+  AVBufferRefPtr& buffer = CUDA_CONTEXT_CACHE.at(index);
+  return buffer;
+}
+
+void clear_cuda_context_cache() {
+  std::lock_guard<std::mutex> lock(MUTEX);
+  CUDA_CONTEXT_CACHE.clear();
+}
+
+} // namespace torchaudio::io

--- a/torchaudio/csrc/ffmpeg/hw_context.h
+++ b/torchaudio/csrc/ffmpeg/hw_context.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <torchaudio/csrc/ffmpeg/ffmpeg.h>
+
+namespace torchaudio::io {
+
+AVBufferRef* get_cuda_context(int index);
+
+void clear_cuda_context_cache();
+
+} // namespace torchaudio::io

--- a/torchaudio/csrc/ffmpeg/pybind/pybind.cpp
+++ b/torchaudio/csrc/ffmpeg/pybind/pybind.cpp
@@ -1,4 +1,5 @@
 #include <torch/extension.h>
+#include <torchaudio/csrc/ffmpeg/hw_context.h>
 #include <torchaudio/csrc/ffmpeg/pybind/fileobj.h>
 #include <torchaudio/csrc/ffmpeg/stream_reader/stream_reader.h>
 #include <torchaudio/csrc/ffmpeg/stream_writer/stream_writer.h>
@@ -30,6 +31,7 @@ struct StreamWriterFileObj : private FileObj, public StreamWriter {
 };
 
 PYBIND11_MODULE(_torchaudio_ffmpeg, m) {
+  m.def("clear_cuda_context_cache", &clear_cuda_context_cache);
   py::class_<Chunk>(m, "Chunk", py::module_local())
       .def_readwrite("frames", &Chunk::frames)
       .def_readwrite("pts", &Chunk::pts);

--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_processor.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_processor.cpp
@@ -1,3 +1,4 @@
+#include <torchaudio/csrc/ffmpeg/hw_context.h>
 #include <torchaudio/csrc/ffmpeg/stream_reader/stream_processor.h>
 #include <stdexcept>
 
@@ -99,6 +100,7 @@ void configure_codec_context(
     // 2. Set pCodecContext->get_format call back function which
     // will retrieve the HW pixel format from opaque pointer.
     codec_ctx->get_format = get_hw_format;
+    codec_ctx->hw_device_ctx = av_buffer_ref(get_cuda_context(device.index()));
 #endif
   }
 }

--- a/torchaudio/utils/ffmpeg_utils.py
+++ b/torchaudio/utils/ffmpeg_utils.py
@@ -253,3 +253,9 @@ def get_build_config() -> str:
         --prefix=/Users/runner/miniforge3 --cc=arm64-apple-darwin20.0.0-clang --enable-gpl --enable-hardcoded-tables --enable-libfreetype --enable-libopenh264 --enable-neon --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvtav1 --enable-libxml2 --enable-libvpx --enable-pic --enable-pthreads --enable-shared --disable-static --enable-version3 --enable-zlib --enable-libmp3lame --pkg-config=/Users/runner/miniforge3/conda-bld/ffmpeg_1646229390493/_build_env/bin/pkg-config --enable-cross-compile --arch=arm64 --target-os=darwin --cross-prefix=arm64-apple-darwin20.0.0- --host-cc=/Users/runner/miniforge3/conda-bld/ffmpeg_1646229390493/_build_env/bin/x86_64-apple-darwin13.4.0-clang  # noqa
     """
     return torch.ops.torchaudio.ffmpeg_get_build_config()
+
+
+@torchaudio._extension.fail_if_no_ffmpeg
+def clear_cuda_context_cache():
+    """Clear the CUDA context used by CUDA Hardware accelerated video decoding"""
+    torchaudio.lib._torchaudio_ffmpeg.clear_cuda_context_cache()


### PR DESCRIPTION
This commit adds caching mechanism to CUDA device context when using GPU video decoding.

The following table shows the performance improvement from the change when decoding 3 seconds of HEVC video with CUVID on NVIDIA GeForce RTX 3080.

| n |Without Patch | With Patch |
|---|---------------:|------------:|
| 1 | 0.593 | 0.562 |
| 2 | 0.187 | 0.093 |
| 3 | 0.203 | 0.094 |
| 4 | 0.203 | 0.094 |
| 5 | 0.219 | 0.188 | <- Cache cleared
| 6 | 0.203 | 0.094 |
| 7 | 0.203 | 0.094 |
| 8 | 0.203 | 0.094 |

**Note**: The cache was cleared before the 5th iteration

The first time video decoder is used, some other initialization is happening, and it is slower than the other times, but for other cases, caching device context improves the decoding speed.

With 30 seconds of HEVC video, there is 0.13 seconds of improvement.

| n |Without Patch | With Patch |
|---|---------------:|------------:|
| 1 | 1.031 | 0.953 |
| 2 | 0.578 | 0.484 |
| 3 | 0.594 | 0.469 |
| 4 | 0.578 | 0.468 |
| 5 | 0.578 | 0.562 | <- Cache cleared
| 6 | 0.578 | 0.469 |
| 7 | 0.562 | 0.500 |
| 8 | 0.562 | 0.485 |

**Note**: The cache was cleared before the 5th iteration

Memory-wise it caches about 200 MB of GPU memory.


<details><summary>code</summary>

The data is generated with 
- `ffmpeg -f lavfi -i mandelbrot -t 3 -c:v libx265 -pix_fmt yuv420p10le -vtag hvc1 -y test.hevc` and 
- `ffmpeg -f lavfi -i mandelbrot -t 30 -c:v libx265 -pix_fmt yuv420p10le -vtag hvc1 -y test.hevc`


```python
import torch
import torchaudio
from torchaudio.io import StreamReader

import subprocess
import time


def test():
    src = "test.hevc"

    r = StreamReader(src=src)
    r.add_video_stream(
        frames_per_chunk=-1,
        decoder="hevc_cuvid",
        hw_accel="cuda",
    )
    r.process_all_packets()
    r.pop_chunks()


def report(msg):
    print(f"{msg:20s}", end="\t", flush=True)
    subprocess.run(["nvidia-smi", "--query-gpu=memory.used,utilization.memory", "--format=csv,noheader"])


print(torchaudio.__version__)

report("Start up")

_ = torch.empty([1], device=torch.device("cuda"))
torch.cuda.empty_cache()
report("After dummy op")

for i in range(8):
    report(f"Start - {i}:")
    t0 = time.monotonic()
    test()
    elapsed = time.monotonic() - t0
    report(f"Finish - {elapsed:.3f} [sec]:")

    torch.cuda.empty_cache()
    report("Clear torch cuda cache")
    
    
    if i == 3:
        try:
            torchaudio.utils.ffmpeg_utils.clear_cuda_context_cache()
            report("clear hw context cache")
        except:
            pass

try:
    torchaudio.utils.ffmpeg_utils.clear_cuda_context_cache()
    report("clear hw context cache")
except:
    pass
```

</details>

<details><summary>raw data (3sec)</summary>

Upstream main branch
```
2.0.0a0+a6b34a5
Start up                1213 MiB, 21 %
After dummy op          1427 MiB, 21 %
Start - 0:              1427 MiB, 21 %
Finish - 0.593 [sec]:   1737 MiB, 2 %
Clear torch cuda cache  1465 MiB, 2 %
Start - 1:              1465 MiB, 2 %
Finish - 0.187 [sec]:   1737 MiB, 1 %
Clear torch cuda cache  1465 MiB, 2 %
Start - 2:              1465 MiB, 2 %
Finish - 0.203 [sec]:   1737 MiB, 1 %
Clear torch cuda cache  1465 MiB, 1 %
Start - 3:              1465 MiB, 2 %
Finish - 0.203 [sec]:   1737 MiB, 2 %
Clear torch cuda cache  1465 MiB, 2 %
Start - 4:              1465 MiB, 2 %
Finish - 0.219 [sec]:   1737 MiB, 2 %
Clear torch cuda cache  1465 MiB, 2 %
Start - 5:              1465 MiB, 2 %
Finish - 0.203 [sec]:   1737 MiB, 2 %
Clear torch cuda cache  1465 MiB, 2 %
Start - 6:              1465 MiB, 2 %
Finish - 0.203 [sec]:   1737 MiB, 1 %
Clear torch cuda cache  1465 MiB, 2 %
Start - 7:              1465 MiB, 2 %
Finish - 0.203 [sec]:   1737 MiB, 1 %
Clear torch cuda cache  1465 MiB, 1 %
```

This commit
```
2.0.0a0+dea6566
Start up                1213 MiB, 43 %
After dummy op          1427 MiB, 15 %
Start - 0:              1427 MiB, 15 %
Finish - 0.562 [sec]:   1948 MiB, 0 %
Clear torch cuda cache  1676 MiB, 0 %
Start - 1:              1676 MiB, 2 %
Finish - 0.093 [sec]:   1948 MiB, 2 %
Clear torch cuda cache  1676 MiB, 2 %
Start - 2:              1676 MiB, 2 %
Finish - 0.094 [sec]:   1948 MiB, 2 %
Clear torch cuda cache  1676 MiB, 2 %
Start - 3:              1676 MiB, 2 %
Finish - 0.094 [sec]:   1948 MiB, 2 %
Clear torch cuda cache  1676 MiB, 2 %
clear hw context cache  1465 MiB, 2 %
Start - 4:              1465 MiB, 1 %
Finish - 0.188 [sec]:   1948 MiB, 2 %
Clear torch cuda cache  1676 MiB, 2 %
Start - 5:              1676 MiB, 2 %
Finish - 0.094 [sec]:   1948 MiB, 1 %
Clear torch cuda cache  1676 MiB, 1 %
Start - 6:              1676 MiB, 1 %
Finish - 0.094 [sec]:   1948 MiB, 1 %
Clear torch cuda cache  1676 MiB, 1 %
Start - 7:              1676 MiB, 2 %
Finish - 0.094 [sec]:   1948 MiB, 2 %
Clear torch cuda cache  1676 MiB, 2 %
clear hw context cache  1465 MiB, 2 %
```

</details>

<details><summary>raw data (30sec)</summary>

Upstream main branch
```
2.0.0a0+a6b34a5
Start up                1250 MiB, 38 %
After dummy op          1471 MiB, 12 %
Start - 0:              1471 MiB, 12 %
Finish - 1.031 [sec]:   4202 MiB, 7 %
Clear torch cuda cache  1502 MiB, 7 %
Start - 1:              1502 MiB, 7 %
Finish - 0.578 [sec]:   4202 MiB, 8 %
Clear torch cuda cache  1502 MiB, 8 %
Start - 2:              1502 MiB, 8 %
Finish - 0.594 [sec]:   4202 MiB, 7 %
Clear torch cuda cache  1502 MiB, 7 %
Start - 3:              1502 MiB, 7 %
Finish - 0.578 [sec]:   4202 MiB, 7 %
Clear torch cuda cache  1502 MiB, 5 %
Start - 4:              1502 MiB, 5 %
Finish - 0.578 [sec]:   4202 MiB, 7 %
Clear torch cuda cache  1502 MiB, 5 %
Start - 5:              1502 MiB, 5 %
Finish - 0.578 [sec]:   4202 MiB, 7 %
Clear torch cuda cache  1502 MiB, 7 %
Start - 6:              1502 MiB, 3 %
Finish - 0.562 [sec]:   4202 MiB, 8 %
Clear torch cuda cache  1502 MiB, 8 %
Start - 7:              1502 MiB, 8 %
Finish - 0.562 [sec]:   4202 MiB, 7 %
Clear torch cuda cache  1502 MiB, 7 %
```

This commit
```
2.0.0a0+dea6566
Start up                1252 MiB, 37 %
After dummy op          1466 MiB, 28 %
Start - 0:              1466 MiB, 28 %
Finish - 0.953 [sec]:   4415 MiB, 7 %
Clear torch cuda cache  1715 MiB, 6 %
Start - 1:              1715 MiB, 6 %
Finish - 0.484 [sec]:   4415 MiB, 8 %
Clear torch cuda cache  1715 MiB, 8 %
Start - 2:              1715 MiB, 8 %
Finish - 0.469 [sec]:   4415 MiB, 9 %
Clear torch cuda cache  1715 MiB, 9 %
Start - 3:              1715 MiB, 9 %
Finish - 0.468 [sec]:   4415 MiB, 7 %
Clear torch cuda cache  1715 MiB, 7 %
clear hw context cache  1504 MiB, 4 %
Start - 4:              1504 MiB, 4 %
Finish - 0.562 [sec]:   4415 MiB, 7 %
Clear torch cuda cache  1715 MiB, 7 %
Start - 5:              1715 MiB, 4 %
Finish - 0.469 [sec]:   4415 MiB, 7 %
Clear torch cuda cache  1715 MiB, 5 %
Start - 6:              1715 MiB, 5 %
Finish - 0.500 [sec]:   4415 MiB, 8 %
Clear torch cuda cache  1715 MiB, 8 %
Start - 7:              1715 MiB, 8 %
Finish - 0.485 [sec]:   4415 MiB, 7 %
Clear torch cuda cache  1715 MiB, 7 %
clear hw context cache  1504 MiB, 3 %
```

</details>