### PR TITLE
Fix GPU memory leak on StreamReader

### DIFF
--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_processor.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_processor.cpp
@@ -157,7 +157,7 @@ AVCodecContextPtr get_codec_ctx(
   configure_codec_context(codec_ctx, params, device);
   open_codec(codec_ctx, decoder_option);
   if (codec_ctx->hw_device_ctx) {
-    codec_ctx->hw_frames_ctx = av_buffer_ref(get_hw_frames_ctx(codec_ctx));
+    codec_ctx->hw_frames_ctx = get_hw_frames_ctx(codec_ctx);
   }
   return codec_ctx;
 }


### PR DESCRIPTION
Summary:
Fix the GPU memory leak introduced in https://github.com/pytorch/audio/pull/3183

The HW frames context is owned by AVCodecContext.
The removed `av_buffer_ref` call increased the ferenrence counting unnecessarily,
and prevented AVCodecContext from feeing the resource.

Reviewed By: nateanl

Differential Revision: D44231876

