### PR TITLE
[torchaudio] Use more specific includes than torch/script.h

### DIFF
--- a/torchaudio/csrc/rnnt/gpu/compute.cu
+++ b/torchaudio/csrc/rnnt/gpu/compute.cu
@@ -1,5 +1,5 @@
 #include <c10/cuda/CUDAStream.h>
-#include <torch/script.h>
+#include <torch/types.h>
 #include <torchaudio/csrc/rnnt/gpu/gpu_transducer.h>
 
 namespace torchaudio {

--- a/torchaudio/csrc/rnnt/gpu/compute_alphas.cu
+++ b/torchaudio/csrc/rnnt/gpu/compute_alphas.cu
@@ -1,5 +1,5 @@
 #include <c10/cuda/CUDAStream.h>
-#include <torch/script.h>
+#include <torch/types.h>
 #include <torchaudio/csrc/rnnt/gpu/gpu_transducer.h>
 
 namespace torchaudio {

--- a/torchaudio/csrc/rnnt/gpu/compute_betas.cu
+++ b/torchaudio/csrc/rnnt/gpu/compute_betas.cu
@@ -1,5 +1,5 @@
 #include <c10/cuda/CUDAStream.h>
-#include <torch/script.h>
+#include <torch/types.h>
 #include <torchaudio/csrc/rnnt/gpu/gpu_transducer.h>
 
 namespace torchaudio {


### PR DESCRIPTION
Summary: Fixes build after following diff to use F14 maps in pickler internally.

Differential Revision: D44098387

