### PR TITLE
Support YUV444P in GPU decoder

### DIFF
--- a/torchaudio/csrc/ffmpeg/stream_reader/conversion.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/conversion.h
@@ -102,5 +102,14 @@ class P010CudaConverter : ImageConverterBase {
   torch::Tensor convert(const AVFrame* src);
 };
 
+class YUV444PCudaConverter : ImageConverterBase {
+  const torch::Device device;
+
+ public:
+  YUV444PCudaConverter(int height, int width, const torch::Device& device);
+  void convert(const AVFrame* src, torch::Tensor& dst);
+  torch::Tensor convert(const AVFrame* src);
+};
+
 #endif
 } // namespace torchaudio::io

--- a/torchaudio/csrc/ffmpeg/stream_reader/post_process.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/post_process.cpp
@@ -402,6 +402,11 @@ std::unique_ptr<IPostDecodeProcess> get_unchunked_cuda_video_process(
       return std::make_unique<ProcessImpl<C, B>>(
           std::move(filter), C{i.height, i.width, device}, B{i.time_base});
     }
+    case AV_PIX_FMT_YUV444P: {
+      using C = YUV444PCudaConverter;
+      return std::make_unique<ProcessImpl<C, B>>(
+          std::move(filter), C{i.height, i.width, device}, B{i.time_base});
+    }
     case AV_PIX_FMT_P016: {
       TORCH_CHECK(
           false,
@@ -509,6 +514,13 @@ std::unique_ptr<IPostDecodeProcess> get_chunked_cuda_video_process(
     }
     case AV_PIX_FMT_P010: {
       using C = P010CudaConverter;
+      return std::make_unique<ProcessImpl<C, B>>(
+          std::move(filter),
+          C{i.height, i.width, device},
+          B{i.time_base, frames_per_chunk, num_chunks});
+    }
+    case AV_PIX_FMT_YUV444P: {
+      using C = YUV444PCudaConverter;
       return std::make_unique<ProcessImpl<C, B>>(
           std::move(filter),
           C{i.height, i.width, device},


### PR DESCRIPTION
With the support of CUDA filter in #3183, it is now possible to change the pixel format of CUDA frame.

This commit adds conversion for YUV444P format.