### PR TITLE
Adding support Ogg/OPUS to soundfile backend

### DIFF
--- a/torchaudio/backend/soundfile_backend.py
+++ b/torchaudio/backend/soundfile_backend.py
@@ -305,9 +305,14 @@ def _get_subtype(dtype: torch.dtype, format: str, encoding: str, bits_per_sample
             raise ValueError("flac does not support bits_per_sample > 24.")
         return "PCM_S8" if bits_per_sample == 8 else f"PCM_{bits_per_sample}"
     if format in ("ogg", "vorbis"):
-        if encoding or bits_per_sample:
-            raise ValueError("ogg/vorbis does not support encoding/bits_per_sample.")
-        return "VORBIS"
+        if bits_per_sample:
+            raise ValueError("ogg/vorbis/opus does not support bits_per_sample.")
+        if encoding == "":
+            return "VORBIS"
+        if encoding == "opus":
+            return "opus"
+        else:
+            raise ValueError(f"ogg/vorbis/opus does not support {encoding} encoding.")
     if format == "sph":
         return _get_subtype_for_sphere(encoding, bits_per_sample)
     if format in ("nis", "nist"):


### PR DESCRIPTION
SoundFile support OPUS codec, just added a check to the backend.

Now this code works well:

`torchaudio.save('C:\test\test.ogg', audio.unsqueeze(0), sample_rate=48000, format="ogg", encoding="opus")`

After create ogg file, ffmpeg info:

```
Input #0, ogg, from 'C:\test\test.ogg':
  Duration: 00:00:06.46, start: 0.000000, bitrate: 62 kb/s
  Stream #0:0: Audio: opus, 48000 Hz, mono, fltp
```