### PR TITLE
Fix prototype.models documentation

### DIFF
--- a/docs/source/prototype.models.rst
+++ b/docs/source/prototype.models.rst
@@ -27,7 +27,7 @@ For such models, factory functions are provided.
   SquimSubjective
 
 Prototype Factory Functions of Beta Models
-==========================================
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. currentmodule:: torchaudio.models
 


### PR DESCRIPTION
In the nightly documentation, "Prototype Factory Functions of Beta Models" is listed as an individual section, which is not correct.
<img width="310" alt="image" src="https://user-images.githubusercontent.com/8653221/227262349-604b99e8-1b20-4b19-9711-81e7b6cfa62e.png">

After the PR, the section outlook is fixed
<img width="285" alt="image" src="https://user-images.githubusercontent.com/8653221/227262893-b938d81e-6c4b-432a-833c-95981bca5e65.png">


