### PR TITLE
Split decoder and dst stream configuration logic in StreamReader

### DIFF
--- a/torchaudio/csrc/ffmpeg/pybind/pybind.cpp
+++ b/torchaudio/csrc/ffmpeg/pybind/pybind.cpp
@@ -140,7 +140,11 @@ PYBIND11_MODULE(_torchaudio_ffmpeg, m) {
       .def("process_all_packets", &StreamReader::process_all_packets)
       .def("fill_buffer", &StreamReader::fill_buffer)
       .def("is_buffer_ready", &StreamReader::is_buffer_ready)
-      .def("pop_chunks", &StreamReader::pop_chunks);
+      .def("pop_chunks", &StreamReader::pop_chunks)
+      .def("set_audio_decoder", &StreamReader::set_audio_decoder)
+      .def("add_out_audio_stream", &StreamReader::add_out_audio_stream)
+      .def("set_video_decoder", &StreamReader::set_video_decoder)
+      .def("add_out_video_stream", &StreamReader::add_out_video_stream);
   py::class_<StreamReaderFileObj>(m, "StreamReaderFileObj", py::module_local())
       .def(py::init<
            py::object,
@@ -169,7 +173,11 @@ PYBIND11_MODULE(_torchaudio_ffmpeg, m) {
       .def("process_all_packets", &StreamReaderFileObj::process_all_packets)
       .def("fill_buffer", &StreamReaderFileObj::fill_buffer)
       .def("is_buffer_ready", &StreamReaderFileObj::is_buffer_ready)
-      .def("pop_chunks", &StreamReaderFileObj::pop_chunks);
+      .def("pop_chunks", &StreamReaderFileObj::pop_chunks)
+      .def("set_audio_decoder", &StreamReaderFileObj::set_audio_decoder)
+      .def("add_out_audio_stream", &StreamReaderFileObj::add_out_audio_stream)
+      .def("set_video_decoder", &StreamReaderFileObj::set_video_decoder)
+      .def("add_out_video_stream", &StreamReaderFileObj::add_out_video_stream);
 }
 
 } // namespace

--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_processor.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_processor.h
@@ -101,5 +101,12 @@ class StreamProcessor {
   c10::optional<Chunk> pop_chunk(KeyType key);
 };
 
+std::unique_ptr<StreamProcessor> get_stream_processor(
+    AVStream* stream,
+    int64_t seek_timestamp,
+    const c10::optional<std::string>& decoder,
+    const c10::optional<OptionDict>& decoder_option,
+    const torch::Device& device);
+
 } // namespace io
 } // namespace torchaudio

--- a/torchaudio/io/_stream_reader.py
+++ b/torchaudio/io/_stream_reader.py
@@ -958,3 +958,51 @@ class StreamReader:
             if all(c is None for c in chunks):
                 return
             yield chunks
+
+    def set_audio_decoder(
+        self,
+        stream_index: Optional[int] = None,
+        decoder: Optional[str] = None,
+        decoder_option: Optional[Dict[str, str]] = None,
+    ):
+        i = self.default_audio_stream if stream_index is None else stream_index
+        if i is None:
+            raise RuntimeError("There is no audio stream.")
+        self._be.set_audio_decoder(i, decoder, decoder_option)
+
+    def add_out_audio_stream(
+        self,
+        frames_per_chunk: int,
+        buffer_chunk_size: int = 3,
+        stream_index: Optional[int] = None,
+        filter_desc: Optional[str] = None,
+    ):
+        i = self.default_audio_stream if stream_index is None else stream_index
+        if i is None:
+            raise RuntimeError("There is no audio stream.")
+        self._be.add_out_audio_stream(i, frames_per_chunk, buffer_chunk_size, filter_desc)
+
+    def set_video_decoder(
+        self,
+        stream_index: Optional[int] = None,
+        decoder: Optional[str] = None,
+        decoder_option: Optional[Dict[str, str]] = None,
+        hw_accel: Optional[str] = None,
+    ):
+        i = self.default_video_stream if stream_index is None else stream_index
+        if i is None:
+            raise RuntimeError("There is no video stream.")
+        self._be.set_video_decoder(i, decoder, decoder_option, hw_accel)
+
+    def add_out_video_stream(
+        self,
+        frames_per_chunk: int,
+        buffer_chunk_size: int = 3,
+        stream_index: Optional[int] = None,
+        filter_desc: Optional[str] = None,
+        hw_accel: Optional[str] = None,
+    ):
+        i = self.default_video_stream if stream_index is None else stream_index
+        if i is None:
+            raise RuntimeError("There is no video stream.")
+        self._be.add_out_video_stream(i, frames_per_chunk, buffer_chunk_size, filter_desc, hw_accel)


### PR DESCRIPTION
Summary:
Currently, `StreamReader` expects users to add an output stream using `add_audio_stream`. The function, however, is responsible for configuring both the decoder for the source stream and the transforms to be applied on the decoded frames to produce the output stream. In the scenario where the user adds multiple output streams to a given source stream, this can be confusing, since the user is able to supply decoder options in each invocation, but only those that were provided in the first invocation will be used to configure the decoder.

To better reflect the split between the decoder (source stream) and frame processors (output streams) and to improve usability, this PR introduces separate source stream and destination stream configuration functions. The expectation here is for the user to first configure the source stream and then add destination streams to that source stream.

Differential Revision: D44448429

