### PR TITLE
Introduce packet passthrough feature to streaming api

### DIFF
--- a/torchaudio/csrc/ffmpeg/CMakeLists.txt
+++ b/torchaudio/csrc/ffmpeg/CMakeLists.txt
@@ -13,11 +13,13 @@ set(
   stream_reader/buffer/chunked_buffer.cpp
   stream_reader/buffer/unchunked_buffer.cpp
   stream_reader/conversion.cpp
+  stream_reader/packet_buffer.cpp
   stream_reader/post_process.cpp
   stream_reader/stream_processor.cpp
   stream_reader/stream_reader.cpp
   stream_writer/encode_process.cpp
   stream_writer/encoder.cpp
+  stream_writer/packet_writer.cpp
   stream_writer/stream_writer.cpp
   stream_writer/tensor_converter.cpp
   compat.cpp

--- a/torchaudio/csrc/ffmpeg/ffmpeg.cpp
+++ b/torchaudio/csrc/ffmpeg/ffmpeg.cpp
@@ -158,5 +158,23 @@ AVFilterGraphPtr::AVFilterGraphPtr()
 void AVFilterGraphPtr::reset() {
   ptr.reset(get_filter_graph());
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// AVCodecParameters
+////////////////////////////////////////////////////////////////////////////////
+void AVCodecParametersDeleter::operator()(AVCodecParameters* codecpar) {
+  avcodec_parameters_free(&codecpar);
+}
+
+namespace {
+AVCodecParameters* get_codecpar() {
+  AVCodecParameters* ptr = avcodec_parameters_alloc();
+  TORCH_CHECK(ptr, "Failed to allocate resource.");
+  return ptr;
+}
+} // namespace
+
+AVCodecParametersPtr::AVCodecParametersPtr()
+    : Wrapper<AVCodecParameters, AVCodecParametersDeleter>(get_codecpar()) {}
 } // namespace io
 } // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/ffmpeg.h
+++ b/torchaudio/csrc/ffmpeg/ffmpeg.h
@@ -189,6 +189,24 @@ struct AVFilterGraphPtr : public Wrapper<AVFilterGraph, AVFilterGraphDeleter> {
   AVFilterGraphPtr();
   void reset();
 };
+
+////////////////////////////////////////////////////////////////////////////////
+// AVCodecParameters
+////////////////////////////////////////////////////////////////////////////////
+struct AVCodecParametersDeleter {
+  void operator()(AVCodecParameters* p);
+};
+
+struct AVCodecParametersPtr
+    : public Wrapper<AVCodecParameters, AVCodecParametersDeleter> {
+  AVCodecParametersPtr();
+};
+
+struct StreamParams {
+  AVCodecParametersPtr codec_params;
+  AVRational time_base{};
+  int stream_index{};
+};
 } // namespace io
 } // namespace torchaudio
 

--- a/torchaudio/csrc/ffmpeg/stream_reader/packet_buffer.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/packet_buffer.cpp
@@ -1,0 +1,22 @@
+#include <torchaudio/csrc/ffmpeg/stream_reader/packet_buffer.h>
+
+namespace torchaudio {
+namespace io {
+void PacketBuffer::push_packet(AVPacket* packet) {
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(packet, "Packet is null.");
+  AVPacketPtr pPacket;
+  av_packet_ref(pPacket, packet);
+  packets.push_back(std::move(pPacket));
+}
+std::vector<AVPacketPtr> PacketBuffer::pop_packets() {
+  std::vector<AVPacketPtr> ret{
+      std::make_move_iterator(packets.begin()),
+      std::make_move_iterator(packets.end())};
+  packets.clear();
+  return ret;
+}
+bool PacketBuffer::has_packets() {
+  return packets.size() > 0;
+}
+} // namespace io
+} // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/packet_buffer.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/packet_buffer.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <torchaudio/csrc/ffmpeg/ffmpeg.h>
+
+namespace torchaudio {
+namespace io {
+class PacketBuffer {
+ public:
+  void push_packet(AVPacket* packet);
+  std::vector<AVPacketPtr> pop_packets();
+  bool has_packets();
+
+ private:
+  std::deque<AVPacketPtr> packets;
+};
+} // namespace io
+} // namespace torchaudio

--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <torchaudio/csrc/ffmpeg/ffmpeg.h>
+#include <torchaudio/csrc/ffmpeg/stream_reader/packet_buffer.h>
 #include <torchaudio/csrc/ffmpeg/stream_reader/stream_processor.h>
 #include <torchaudio/csrc/ffmpeg/stream_reader/typedefs.h>
 #include <vector>
@@ -19,6 +20,11 @@ class StreamReader {
   // The first one is processor index,
   // the second is the map key inside of processor.
   std::vector<std::pair<int, int>> stream_indices;
+
+  // For supporting reading raw packets.
+  std::unique_ptr<PacketBuffer> packet_buffer;
+  // Set of source stream indices to read packets for.
+  std::unordered_set<int> packet_stream_indices;
 
   // timestamp to seek to expressed in AV_TIME_BASE
   //
@@ -128,6 +134,14 @@ class StreamReader {
   /// Check if all the buffers of the output streams have enough decoded frames.
   bool is_buffer_ready() const;
 
+  /// @cond
+  /// Get source stream parameters. Necessary on the write side for packet
+  /// passthrough.
+  ///
+  /// @param i Source stream index.
+  StreamParams get_src_stream_params(int i);
+  /// @endcond
+
   ///@}
 
   //////////////////////////////////////////////////////////////////////////////
@@ -215,6 +229,16 @@ class StreamReader {
       const c10::optional<std::string>& decoder = c10::nullopt,
       const c10::optional<OptionDict>& decoder_option = c10::nullopt,
       const c10::optional<std::string>& hw_accel = c10::nullopt);
+
+  /// @cond
+  /// Add a output packet stream.
+  /// Allows for passing packets directly from the source stream, bypassing
+  /// the decode path, to ``StreamWriter`` for remuxing.
+  ///
+  /// @param i The index of the source stream.
+  void add_packet_stream(int i);
+  /// @endcond
+
   /// Remove an output stream.
   ///
   /// @param i The index of the output stream to be removed.
@@ -306,6 +330,10 @@ class StreamReader {
   /// Pop one chunk from each output stream if it is available.
   std::vector<c10::optional<Chunk>> pop_chunks();
 
+  /// @cond
+  /// Pop packets from buffer, if available.
+  std::vector<AVPacketPtr> pop_packets();
+  /// @endcond
   ///@}
 };
 

--- a/torchaudio/csrc/ffmpeg/stream_writer/packet_writer.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_writer/packet_writer.cpp
@@ -1,0 +1,36 @@
+#include <torchaudio/csrc/ffmpeg/stream_writer/packet_writer.h>
+
+namespace torchaudio::io {
+namespace {
+AVStream* add_stream(
+    AVFormatContext* format_ctx,
+    const StreamParams& stream_params) {
+  AVStream* stream = avformat_new_stream(format_ctx, nullptr);
+  int ret =
+      avcodec_parameters_copy(stream->codecpar, stream_params.codec_params);
+  TORCH_CHECK(
+      ret >= 0,
+      "Failed to copy the stream's codec parameters. (",
+      av_err2string(ret),
+      ")");
+  stream->time_base = stream_params.time_base;
+  return stream;
+}
+} // namespace
+PacketWriter::PacketWriter(
+    AVFormatContext* format_ctx_,
+    const StreamParams& stream_params_)
+    : format_ctx(format_ctx_),
+      stream(add_stream(format_ctx_, stream_params_)),
+      original_time_base(stream_params_.time_base) {}
+
+void PacketWriter::write_packet(const AVPacketPtr& packet) {
+  AVPacket dst_packet;
+  int ret = av_packet_ref(&dst_packet, packet);
+  TORCH_CHECK(ret >= 0, "Failed to copy packet.");
+  av_packet_rescale_ts(&dst_packet, original_time_base, stream->time_base);
+  dst_packet.stream_index = stream->index;
+  ret = av_interleaved_write_frame(format_ctx, &dst_packet);
+  TORCH_CHECK(ret >= 0, "Failed to write packet to destination.");
+}
+} // namespace torchaudio::io

--- a/torchaudio/csrc/ffmpeg/stream_writer/packet_writer.h
+++ b/torchaudio/csrc/ffmpeg/stream_writer/packet_writer.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <torchaudio/csrc/ffmpeg/ffmpeg.h>
+
+namespace torchaudio::io {
+class PacketWriter {
+  AVFormatContext* format_ctx;
+  AVStream* stream;
+  AVRational original_time_base;
+
+ public:
+  PacketWriter(
+      AVFormatContext* format_ctx_,
+      const StreamParams& stream_params_);
+  void write_packet(const AVPacketPtr& packet);
+};
+} // namespace torchaudio::io


### PR DESCRIPTION
Summary: Introduces methods to StreamReader and StreamWriter that allow for reading and writing AVPacket instances rather than tensors. Useful for efficiently remuxing data pulled as is from source.

Differential Revision: D44271536

