### PR TITLE
Decouple StreamProcessor construction and decoder configuration

### DIFF
--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_processor.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_processor.h
@@ -16,9 +16,9 @@ class StreamProcessor {
  private:
   // Stream time base which is not stored in AVCodecContextPtr
   AVRational stream_time_base;
-  AVCodecContextPtr codec_ctx;
 
   // Components for decoding source media
+  AVCodecContextPtr codec_ctx{nullptr};
   AVFramePtr frame;
 
   KeyType current_key = 0;
@@ -32,12 +32,7 @@ class StreamProcessor {
   int64_t discard_before_pts = 0;
 
  public:
-  StreamProcessor(
-      const AVRational& time_base,
-      const AVCodecParameters* codecpar,
-      const c10::optional<std::string>& decoder_name,
-      const c10::optional<OptionDict>& decoder_option,
-      const torch::Device& device);
+  explicit StreamProcessor(const AVRational& time_base);
   ~StreamProcessor() = default;
   // Non-copyable
   StreamProcessor(const StreamProcessor&) = delete;
@@ -69,6 +64,12 @@ class StreamProcessor {
   // The input timestamp must be expressed in AV_TIME_BASE unit.
   void set_discard_timestamp(int64_t timestamp);
 
+  void set_decoder(
+      const AVCodecParameters* codecpar,
+      const c10::optional<std::string>& decoder_name,
+      const c10::optional<OptionDict>& decoder_option,
+      const torch::Device& device);
+
   //////////////////////////////////////////////////////////////////////////////
   // Query methods
   //////////////////////////////////////////////////////////////////////////////
@@ -76,6 +77,7 @@ class StreamProcessor {
   [[nodiscard]] FilterGraphOutputInfo get_filter_output_info(KeyType key) const;
 
   bool is_buffer_ready() const;
+  [[nodiscard]] bool is_decoder_set() const;
 
   //////////////////////////////////////////////////////////////////////////////
   // The streaming process

--- a/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_reader/stream_reader.cpp
@@ -345,19 +345,18 @@ void StreamReader::add_stream(
       "Failed to detect the source stream format.");
 
   if (!processors[i]) {
-    processors[i] = std::make_unique<StreamProcessor>(
-        stream->time_base, stream->codecpar, decoder, decoder_option, device);
+    processors[i] = std::make_unique<StreamProcessor>(stream->time_base);
     processors[i]->set_discard_timestamp(seek_timestamp);
-  } else {
-    if (decoder) {
-      // TODO: Validate that the decoder is consistent as the one used to define
-      // previous output streams.
-      // i.e. the following is not permitted.
-      // reader.add_video_stream(..., decoder="h264")
-      // reader.add_video_stream(..., decoder="x264")
-      // reader.add_video_stream(..., decoder="h264_cuvid")
-    }
   }
+  if (!processors[i]->is_decoder_set()) {
+    processors[i]->set_decoder(
+        stream->codecpar, decoder, decoder_option, device);
+  } else {
+    TORCH_CHECK(
+        !decoder && (!decoder_option || decoder_option.value().size() == 0),
+        "Decoder options were provided, but the decoder has already been initialized.")
+  }
+
   stream->discard = AVDISCARD_DEFAULT;
 
   auto frame_rate = [&]() -> AVRational {


### PR DESCRIPTION
Summary: Each `StreamProcessor` is responsible for processing a source stream. In the case where we support packet passthrough, `StreamProcessor`'s choice of decoder is irrelevant as no decoding is performed. Currently, however, `StreamProcessor` requires decoder params and fixes a decoder at construction time. To accommodate this future packet passthrough use case, this PR decouples the construction of `StreamProcessor` from the configuration of the decoder that it uses.

Differential Revision: D44554934

