### PR TITLE
Remove linux GPU unit test from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -663,44 +663,6 @@ jobs:
       - store_artifacts:
           path: test/htmlcov
 
-  unittest_linux_gpu:
-    <<: *binary_common
-    machine:
-      image: ubuntu-2004-cuda-11.4:202110-01
-    resource_class: gpu.nvidia.medium
-    environment:
-      <<: *environment
-      CUDA_VERSION: 11.7
-      image_name: pytorch/torchaudio_unittest_base:manylinux-cuda10.2-cudnn8-20210623
-    steps:
-      - checkout
-      - attach_workspace:
-          at: third_party
-      - designate_upload_channel
-      - load_conda_channel_flags
-      - run:
-          name: Pull Docker image
-          command: docker pull --quiet "${image_name}"
-      - run:
-          name: Setup
-          command: docker run -t --gpus all -e PYTHON_VERSION -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/setup_env.sh
-      - run:
-          name: Install torchaudio
-          command: docker run -t --gpus all -e UPLOAD_CHANNEL -e CONDA_CHANNEL_FLAGS -e CUDA_VERSION -e USE_FFMPEG=1 -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/install.sh
-      - run:
-          name: Run tests
-          environment:
-              TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_HW_ACCEL: true
-              TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310: true
-              TORCHAUDIO_TEST_ALLOW_SKIP_IF_CUDA_SMALL_MEMORY: true
-              TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_MACOS: true
-          command: |
-            docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "CI=${CI}" -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310 -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_CUDA_SMALL_MEMORY -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_MACOS -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_HW_ACCEL "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
-      - store_test_results:
-          path: test-results
-      - store_artifacts:
-          path: test/htmlcov
-
   unittest_windows_cpu:
     <<: *binary_common
     executor:
@@ -1327,30 +1289,6 @@ workflows:
       - unittest_linux_cpu:
           cuda_version: cpu
           name: unittest_linux_cpu_py3.11
-          python_version: '3.11'
-          requires:
-          - download_third_parties
-      - unittest_linux_gpu:
-          cuda_version: cu117
-          name: unittest_linux_gpu_py3.8
-          python_version: '3.8'
-          requires:
-          - download_third_parties
-      - unittest_linux_gpu:
-          cuda_version: cu117
-          name: unittest_linux_gpu_py3.9
-          python_version: '3.9'
-          requires:
-          - download_third_parties
-      - unittest_linux_gpu:
-          cuda_version: cu117
-          name: unittest_linux_gpu_py3.10
-          python_version: '3.10'
-          requires:
-          - download_third_parties
-      - unittest_linux_gpu:
-          cuda_version: cu117
-          name: unittest_linux_gpu_py3.11
           python_version: '3.11'
           requires:
           - download_third_parties

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -663,44 +663,6 @@ jobs:
       - store_artifacts:
           path: test/htmlcov
 
-  unittest_linux_gpu:
-    <<: *binary_common
-    machine:
-      image: ubuntu-2004-cuda-11.4:202110-01
-    resource_class: gpu.nvidia.medium
-    environment:
-      <<: *environment
-      CUDA_VERSION: 11.7
-      image_name: pytorch/torchaudio_unittest_base:manylinux-cuda10.2-cudnn8-20210623
-    steps:
-      - checkout
-      - attach_workspace:
-          at: third_party
-      - designate_upload_channel
-      - load_conda_channel_flags
-      - run:
-          name: Pull Docker image
-          command: docker pull --quiet "${image_name}"
-      - run:
-          name: Setup
-          command: docker run -t --gpus all -e PYTHON_VERSION -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/setup_env.sh
-      - run:
-          name: Install torchaudio
-          command: docker run -t --gpus all -e UPLOAD_CHANNEL -e CONDA_CHANNEL_FLAGS -e CUDA_VERSION -e USE_FFMPEG=1 -v $PWD:$PWD -w $PWD "${image_name}" .circleci/unittest/linux/scripts/install.sh
-      - run:
-          name: Run tests
-          environment:
-              TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_HW_ACCEL: true
-              TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310: true
-              TORCHAUDIO_TEST_ALLOW_SKIP_IF_CUDA_SMALL_MEMORY: true
-              TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_MACOS: true
-          command: |
-            docker run -t --gpus all -v $PWD:$PWD -w $PWD -e "CI=${CI}" -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310 -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_CUDA_SMALL_MEMORY -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_MACOS -e TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_HW_ACCEL "${image_name}" .circleci/unittest/linux/scripts/run_test.sh
-      - store_test_results:
-          path: test-results
-      - store_artifacts:
-          path: test/htmlcov
-
   unittest_windows_cpu:
     <<: *binary_common
     executor:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -247,7 +247,7 @@ def unittest_workflows(indentation=6):
     jobs += build_download_job(None)
     for os_type in ["linux", "windows", "macos"]:
         for device_type in ["cpu", "gpu"]:
-            if os_type == "macos" and device_type == "gpu":
+            if os_type != "windows" and device_type == "gpu":
                 continue
 
             for i, python_version in enumerate(unittest_python_versions(os_type)):


### PR DESCRIPTION
Linux GPU unit test on CircleCI relies on custom Docker image with CUDA 10.2.

PyTorch 2.0 does not support CUDA 10, so these tests have not run for a while.

We have GPU tests on GHA for Linux, so we can get rid of them.

Windows GPU tests are not ported to GHA yet, but they are still working on CircleCI, so we don't delete them yet.