### PR TITLE
Do not build CTC decoder bundle by default

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -58,7 +58,7 @@ printf "Installing PyTorch with %s\n" "${cudatoolkit}"
 
 # 2. Install torchaudio
 printf "* Installing torchaudio\n"
-BUILD_CTC_DECODER=0 python setup.py install
+python setup.py install
 
 # 3. Install Test tools
 printf "* Installing test tools\n"

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -50,7 +50,6 @@ fi
 
 # 2. Install torchaudio
 printf "* Installing torchaudio\n"
-export BUILD_CTC_DECODER=0
 "$root_dir/packaging/vc_env_helper.bat" python setup.py install
 
 # 3. Install Test tools

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -72,7 +72,7 @@ jobs:
         # TODO: Enable NVDec/NVEnc
         conda install --quiet -y 'ffmpeg>=4.1' pkg-config
         pip --quiet install cmake>=3.18.0 ninja
-        BUILD_CTC_DECODER=0 USE_FFMPEG=1 pip install --progress-bar off -v -e . --no-use-pep517
+        USE_FFMPEG=1 pip install --progress-bar off -v -e . --no-use-pep517
 
         # Install runtime dependencies
         pip --quiet install git+https://github.com/kpu/kenlm/ flashlight-text

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         python -m pip install --quiet --upgrade pip
         python -m pip install --quiet --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-        python -m pip install --quiet pytest requests cmake ninja deep-phonemizer sentencepiece
+        python -m pip install --quiet pytest requests cmake ninja deep-phonemizer sentencepiece flashlight-text git+https://github.com/kpu/kenlm
         python setup.py install
       env:
         USE_FFMPEG: true

--- a/.github/workflows/unittest-linux-gpu.yml
+++ b/.github/workflows/unittest-linux-gpu.yml
@@ -57,7 +57,7 @@ jobs:
         # Install torchaudio
         conda install --quiet -y 'ffmpeg>=4.1' pkg-config
         python3 -m pip --quiet install cmake>=3.18.0 ninja
-        BUILD_CTC_DECODER=0 USE_FFMPEG=1 python3 -m pip install -v -e . --no-use-pep517
+        USE_FFMPEG=1 python3 -m pip install -v -e . --no-use-pep517
 
         # Install test tools
         conda install -y --quiet -c conda-forge -c numba/label/dev 'librosa==0.10.0' parameterized 'requests>=2.20'

--- a/tools/setup_helpers/extension.py
+++ b/tools/setup_helpers/extension.py
@@ -37,7 +37,7 @@ _BUILD_SOX = False if platform.system() == "Windows" else _get_build("BUILD_SOX"
 _BUILD_KALDI = False if platform.system() == "Windows" else _get_build("BUILD_KALDI", True)
 _BUILD_RIR = _get_build("BUILD_RIR", True)
 _BUILD_RNNT = _get_build("BUILD_RNNT", True)
-_BUILD_CTC_DECODER = _get_build("BUILD_CTC_DECODER", True)
+_BUILD_CTC_DECODER = _get_build("BUILD_CTC_DECODER", False)
 _USE_FFMPEG = _get_build("USE_FFMPEG", False)
 _USE_ROCM = _get_build("USE_ROCM", torch.backends.cuda.is_built() and torch.version.hip is not None)
 _USE_CUDA = _get_build("USE_CUDA", torch.backends.cuda.is_built() and torch.version.hip is None)


### PR DESCRIPTION
As we migrate to use upstream flashlight-text and KenLM, this PR disable building CTC decoder by default.
This will stop shipping flashlight-text and KenLM bundle in torchaudio binary.

Ref: https://github.com/pytorch/audio/issues/3088

cc @jacobkahn