### PR TITLE
[Cherry-pick 2.0.1] Properly set #samples passed to encoder (#3204)

### DIFF
--- a/torchaudio/csrc/ffmpeg/stream_writer/stream_writer.cpp
+++ b/torchaudio/csrc/ffmpeg/stream_writer/stream_writer.cpp
@@ -409,6 +409,9 @@ std::unique_ptr<FilterGraph> _get_audio_filter(
     AVCodecContextPtr& ctx) {
   std::stringstream desc;
   desc << "aformat=" << av_get_sample_fmt_name(ctx->sample_fmt);
+  if (ctx->frame_size) {
+    desc << ",asetnsamples=n=" << ctx->frame_size << ":p=0";
+  }
 
   auto p = std::make_unique<FilterGraph>(AVMEDIA_TYPE_AUDIO);
   p->add_audio_src(fmt, ctx->time_base, ctx->sample_rate, ctx->channel_layout);


### PR DESCRIPTION
Summary:
Some audio encoders expect specific, exact number of samples described as in `AVCodecContext.frame_size`.

The `AVFrame.nb_samples` is set for the frames passed to `AVFilterGraph`, but frames coming out of the graph do not necessarily have the same numbr of frames.

This causes issues with encoding OPUS (among others).

This commit fixes it by inserting `asetnsamples` to filter graph if a fixed number of samples is requested.

Note:
It turned out that FFmpeg 4.1 has issue with OPUS encoding. It does not properly discard some sample. We should probably move the minimum required FFmpeg to 4.2, but I am not sure if we can enforce it via ABI. Work around will be to issue an warning if encoding OPUS with 4.1. (follow-up)

Pull Request resolved: https://github.com/pytorch/audio/pull/3204

Reviewed By: nateanl

Differential Revision: D44374668

Pulled By: mthrok

fbshipit-source-id: 10ef5333dc0677dfb83c8e40b78edd8ded1b21dc