### PR TITLE
[BC-Breaking] Switch to the backend dispatcher

### DIFF
--- a/test/torchaudio_unittest/backend/utils_test.py
+++ b/test/torchaudio_unittest/backend/utils_test.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import torchaudio
 from torchaudio_unittest import common_utils
 
@@ -8,6 +10,7 @@ class BackendSwitchMixin:
     backend = None
     backend_module = None
 
+    @patch("torchaudio.backend.utils._is_backend_dispatcher_enabled", lambda: False)
     def test_switch(self):
         torchaudio.set_audio_backend(self.backend)
         if self.backend is None:

--- a/torchaudio/backend/utils.py
+++ b/torchaudio/backend/utils.py
@@ -16,7 +16,7 @@ __all__ = [
 
 
 def _is_backend_dispatcher_enabled() -> bool:
-    return os.getenv("TORCHAUDIO_USE_BACKEND_DISPATCHER") == "1"
+    return os.getenv("TORCHAUDIO_USE_BACKEND_DISPATCHER", default="1") == "1"
 
 
 def list_audio_backends() -> List[str]:


### PR DESCRIPTION
This commit makes the code defaults to the backend dispatcher by default. Enabling backend dispatcher puts the FFmpeg-based I/O implementation on higher priority (if the corresponding FFmpeg is available), and allows individual function call to specify the backend.

See also https://github.com/pytorch/audio/issues/2950