### PR TITLE
Add stereo to mono transform

### DIFF
--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -1618,7 +1618,7 @@ def resample(
 def to_mono(waveform: torch.Tensor, channel_dim: int=-2) -> torch.Tensor:
     r"""
     Args:
-        waveform (Tensor): Tensor of audio of dimension (..., channels, ...).
+        waveform (Tensor): Tensor of the audio signal of dimension (..., channels, ...).
         channel_dim (int, optional): the index of the channel dimension 
             of the input Tensor. (Default: ``-2``)
 

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -1619,6 +1619,7 @@ def to_mono(waveform: torch.Tensor, channel_dim: int=-2) -> torch.Tensor:
     r"""Converts a multi-channel signal into a monoaural signal.
 
     .. devices:: CPU CUDA
+    .. properties:: TorchScript
 
     Args:
         waveform (Tensor): Tensor of the audio signal of dimension (..., channels, ...).
@@ -1630,7 +1631,7 @@ def to_mono(waveform: torch.Tensor, channel_dim: int=-2) -> torch.Tensor:
     """
     is_valid_idx = -len(waveform.shape) <= channel_dim < len(waveform.shape)
     if not is_valid_idx:
-        raise ValueError("Invalid channel index")
+        raise ValueError("Invalid channel dimension index")
 
     if waveform.shape[channel_dim] == 1 or waveform.ndim == 1:
         return waveform

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -1615,19 +1615,21 @@ def resample(
     resampled = _apply_sinc_resample_kernel(waveform, orig_freq, new_freq, gcd, kernel, width)
     return resampled
 
-def to_mono(waveform: torch.Tensor) -> torch.Tensor:
+def to_mono(waveform: torch.Tensor, channel_dim: int=-2) -> torch.Tensor:
     r"""
     Args:
-        waveform (Tensor): Tensor of audio of dimension (..., time)
+        waveform (Tensor): Tensor of audio of dimension (..., channels, ...).
+        channel_dim (int, optional): the index of the channel dimension 
+            of the input Tensor. (Default: ``-2``)
 
     Returns:
-        Tensor: Output signal of dimension (1, time)
+        Tensor: Output signal of dimension ()
     """
 
-    if waveform.shape[0] == 1 or waveform.ndim == 1:
+    if waveform.shape[channel_dim] == 1 or waveform.ndim == 1:
         return waveform
     
-    return torch.mean(waveform, axis=0)
+    return torch.mean(waveform, axis=channel_dim)
 
 @torch.jit.unused
 def edit_distance(seq1: Sequence, seq2: Sequence) -> int:

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -1616,7 +1616,10 @@ def resample(
     return resampled
 
 def to_mono(waveform: torch.Tensor, channel_dim: int=-2) -> torch.Tensor:
-    r"""
+    r"""Converts a multi-channel signal into a monoaural signal.
+
+    .. devices:: CPU CUDA
+
     Args:
         waveform (Tensor): Tensor of the audio signal of dimension (..., channels, ...).
         channel_dim (int, optional): the index of the channel dimension 
@@ -1625,6 +1628,9 @@ def to_mono(waveform: torch.Tensor, channel_dim: int=-2) -> torch.Tensor:
     Returns:
         Tensor: Output signal of dimension ()
     """
+    is_valid_idx = -len(waveform.shape) <= channel_dim < len(waveform.shape)
+    if not is_valid_idx:
+        raise ValueError("Invalid channel index")
 
     if waveform.shape[channel_dim] == 1 or waveform.ndim == 1:
         return waveform

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -1615,6 +1615,19 @@ def resample(
     resampled = _apply_sinc_resample_kernel(waveform, orig_freq, new_freq, gcd, kernel, width)
     return resampled
 
+def to_mono(waveform: torch.Tensor) -> torch.Tensor:
+    r"""
+    Args:
+        waveform (Tensor): Tensor of audio of dimension (..., time)
+
+    Returns:
+        Tensor: Output signal of dimension (1, time)
+    """
+
+    if waveform.shape[0] == 1 or waveform.ndim == 1:
+        return waveform
+    
+    return torch.mean(waveform, axis=0)
 
 @torch.jit.unused
 def edit_distance(seq1: Sequence, seq2: Sequence) -> int:

--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -1009,6 +1009,25 @@ class Resample(torch.nn.Module):
             return waveform
         return _apply_sinc_resample_kernel(waveform, self.orig_freq, self.new_freq, self.gcd, self.kernel, self.width)
 
+class ToMono(torch.nn.Module):
+    r""" Converts a multi-channel signal into a mono 
+
+        .. devices:: CPU CUDA
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+
+    def forward(self, waveform: Tensor) -> Tensor:
+        r"""
+        Args:
+            waveform (Tensor): Tensor of audio of dimension (..., time)
+
+        Returns:
+            Tensor: Output signal of dimension (1, time)
+        """
+        return torch.mean(waveform, axis=0)
 
 class ComputeDeltas(torch.nn.Module):
     r"""Compute delta coefficients of a tensor, usually a spectrogram.

--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -722,7 +722,7 @@ class MFCC(torch.nn.Module):
     def forward(self, waveform: Tensor) -> Tensor:
         r"""
         Args:
-            waveform (Tensor): Tensor of audio of dimension (..., time).
+            waveform (Tensor): Tensor of the audio signal of dimension (..., time).
 
         Returns:
             Tensor: specgram_mel_db of size (..., ``n_mfcc``, time).

--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -1010,24 +1010,32 @@ class Resample(torch.nn.Module):
         return _apply_sinc_resample_kernel(waveform, self.orig_freq, self.new_freq, self.gcd, self.kernel, self.width)
 
 class ToMono(torch.nn.Module):
-    r""" Converts a multi-channel signal into a mono 
+    r""" Converts a multi-channel signal into a mono
 
-        .. devices:: CPU CUDA
+    .. devices:: CPU CUDA
+
+    Args:
+        channel_dim (int, optional): the index of the channel dimension 
+            of the input Tensor. (Default: ``-2``)
     """
 
-    def __init__(self) -> None:
+    def __init__(self, channel_dim: int=-2) -> None:
         super().__init__()
+        self.channel_dim = channel_dim
 
 
     def forward(self, waveform: Tensor) -> Tensor:
         r"""
         Args:
-            waveform (Tensor): Tensor of audio of dimension (..., time)
+            waveform (Tensor): Tensor of audio of dimension (..., channels, ...)
 
         Returns:
-            Tensor: Output signal of dimension (1, time)
+            Tensor: Output signal of dimension ()
         """
-        return torch.mean(waveform, axis=0)
+        if waveform.shape[self.channel_dim] == 1 or waveform.ndim == 1:
+            return waveform
+        
+        return torch.mean(waveform, axis=self.channel_dim)
 
 class ComputeDeltas(torch.nn.Module):
     r"""Compute delta coefficients of a tensor, usually a spectrogram.

--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -1010,7 +1010,7 @@ class Resample(torch.nn.Module):
         return _apply_sinc_resample_kernel(waveform, self.orig_freq, self.new_freq, self.gcd, self.kernel, self.width)
 
 class ToMono(torch.nn.Module):
-    r""" Converts a multi-channel signal into a mono
+    r"""Converts a multi-channel signal into a monoaural signal.
 
     .. devices:: CPU CUDA
 
@@ -1032,6 +1032,10 @@ class ToMono(torch.nn.Module):
         Returns:
             Tensor: Output signal of dimension ()
         """
+        is_valid_idx = -len(waveform.shape) <= self.channel_dim < len(waveform.shape)
+        if not is_valid_idx:
+            raise ValueError("Invalid channel index")
+        
         if waveform.shape[self.channel_dim] == 1 or waveform.ndim == 1:
             return waveform
         

--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -1013,6 +1013,7 @@ class ToMono(torch.nn.Module):
     r"""Converts a multi-channel signal into a monoaural signal.
 
     .. devices:: CPU CUDA
+    .. properties:: TorchScript
 
     Args:
         channel_dim (int, optional): the index of the channel dimension 
@@ -1034,7 +1035,7 @@ class ToMono(torch.nn.Module):
         """
         is_valid_idx = -len(waveform.shape) <= self.channel_dim < len(waveform.shape)
         if not is_valid_idx:
-            raise ValueError("Invalid channel index")
+            raise ValueError("Invalid channel dimension index")
         
         if waveform.shape[self.channel_dim] == 1 or waveform.ndim == 1:
             return waveform


### PR DESCRIPTION
Implements a transformation for converting multi-channel audio to mono audio. The conversion is done by just taking the average of each channel and then dividing it by the number of channels.

- [x]  Added ToMono class to audio/torchaudio/transforms/ _transforms.py. 
- [x]  Added to_mono method in audio/torchaudio/functional/functional.py
- [ ] Indicate dimensions of output tensor.
- [ ] Create tests cases.

Solves Issue: #877 

cc @mthrok 