### PR TITLE
[Cherry-pick] Fix path-like object support in FFmpeg dispatcher (#3243, #3248)

### DIFF
--- a/test/torchaudio_unittest/backend/dispatcher/ffmpeg/load_test.py
+++ b/test/torchaudio_unittest/backend/dispatcher/ffmpeg/load_test.py
@@ -1,5 +1,6 @@
 import io
 import itertools
+import pathlib
 import tarfile
 from functools import partial
 
@@ -124,6 +125,21 @@ class LoadTestBase(TempDirMixin, PytorchTestCase):
 @skipIfNoFFmpeg
 class TestLoad(LoadTestBase):
     """Test the correctness of `self._load` for various formats"""
+
+    def test_pathlike(self):
+        """FFmpeg dispatcher can load waveform from pathlike object"""
+        sample_rate = 16000
+        dtype = "float32"
+        num_channels = 2
+        duration = 1
+
+        path = self.get_temp_path("data.wav")
+        data = get_wav_data(dtype, num_channels, normalize=False, num_frames=duration * sample_rate)
+        save_wav(path, data, sample_rate)
+
+        waveform, sr = self._load(pathlib.Path(path))
+        self.assertEqual(sr, sample_rate)
+        self.assertEqual(waveform, data)
 
     @parameterized.expand(
         list(

--- a/test/torchaudio_unittest/backend/dispatcher/ffmpeg/save_test.py
+++ b/test/torchaudio_unittest/backend/dispatcher/ffmpeg/save_test.py
@@ -1,5 +1,6 @@
 import io
 import os
+import pathlib
 import subprocess
 import sys
 from functools import partial
@@ -146,6 +147,17 @@ class SaveTestBase(TempDirMixin, TorchaudioTestCase):
 @skipIfNoExec("ffmpeg")
 @skipIfNoFFmpeg
 class SaveTest(SaveTestBase):
+    def test_pathlike(self):
+        """FFmpeg dispatcher can save audio data to pathlike object"""
+        sample_rate = 16000
+        dtype = "float32"
+        num_channels = 2
+        duration = 1
+
+        path = self.get_temp_path("data.wav")
+        data = get_wav_data(dtype, num_channels, normalize=False, num_frames=duration * sample_rate)
+        self._save(pathlib.Path(path), data, sample_rate)
+
     @nested_params(
         ["path", "fileobj", "bytesio"],
         [

--- a/torchaudio/_backend/utils.py
+++ b/torchaudio/_backend/utils.py
@@ -122,7 +122,7 @@ class FFmpegBackend(Backend):
         buffer_size: int = 4096,
     ) -> None:
         save_audio(
-            os.path.normpath(uri),
+            uri,
             src,
             sample_rate,
             channels_first,

--- a/torchaudio/_backend/utils.py
+++ b/torchaudio/_backend/utils.py
@@ -82,7 +82,7 @@ class FFmpegBackend(Backend):
         if hasattr(uri, "read"):
             metadata = info_audio_fileobj(uri, format, buffer_size=buffer_size)
         else:
-            metadata = info_audio(uri, format)
+            metadata = info_audio(os.path.normpath(uri), format)
         metadata.bits_per_sample = _get_bits_per_sample(metadata.encoding, metadata.bits_per_sample)
         metadata.encoding = _map_encoding(metadata.encoding)
         return metadata
@@ -108,7 +108,7 @@ class FFmpegBackend(Backend):
                 buffer_size,
             )
         else:
-            return load_audio(uri, frame_offset, num_frames, normalize, channels_first, format)
+            return load_audio(os.path.normpath(uri), frame_offset, num_frames, normalize, channels_first, format)
 
     @staticmethod
     def save(
@@ -122,7 +122,7 @@ class FFmpegBackend(Backend):
         buffer_size: int = 4096,
     ) -> None:
         save_audio(
-            uri,
+            os.path.normpath(uri),
             src,
             sample_rate,
             channels_first,

--- a/torchaudio/io/_compat.py
+++ b/torchaudio/io/_compat.py
@@ -216,8 +216,11 @@ def save_audio(
     bits_per_sample: Optional[int] = None,
     buffer_size: int = 4096,
 ) -> None:
-    if hasattr(uri, "write") and format is None:
-        raise RuntimeError("'format' is required when saving to file object.")
+    if hasattr(uri, "write"):
+        if format is None:
+            raise RuntimeError("'format' is required when saving to file object.")
+    else:
+        uri = os.path.normpath(uri)
     s = StreamWriter(uri, format=format, buffer_size=buffer_size)
     if format is None:
         tokens = str(uri).split(".")


### PR DESCRIPTION
Summary:
In dispatcher mode, FFmpeg backend does not handle file-like object, and C++ implementation raises an issue.

This commit fixes it by normalizing file-like object to string.

Pull Request resolved: https://github.com/pytorch/audio/pull/3243

Reviewed By: nateanl

Differential Revision: D44719280

Pulled By: mthrok

fbshipit-source-id: 9dae459e2a5fb4992b4ef53fe4829fe8c35b2edd