### PR TITLE
Adding device argument in Resample class

### DIFF
--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -956,6 +956,7 @@ class Resample(torch.nn.Module):
             cached as ``torch.float64``. If you use resample with lower precision, then instead of providing this
             providing this argument, please use ``Resample.to(dtype)``, so that the kernel generation is still
             carried out on ``torch.float64``.
+        device (torch.device): The location to allocate for PyTorch tensors. (Default: ``cpu``)
 
     Example
         >>> waveform, sample_rate = torchaudio.load("test.wav", normalize=True)
@@ -973,6 +974,7 @@ class Resample(torch.nn.Module):
         beta: Optional[float] = None,
         *,
         dtype: Optional[torch.dtype] = None,
+        device: Optional[torch.device] = torch.device("cpu"),
     ) -> None:
         super().__init__()
 
@@ -994,6 +996,7 @@ class Resample(torch.nn.Module):
                 self.resampling_method,
                 beta,
                 dtype=dtype,
+                device=device
             )
             self.register_buffer("kernel", kernel)
 

--- a/torchaudio/transforms/_transforms.py
+++ b/torchaudio/transforms/_transforms.py
@@ -996,7 +996,7 @@ class Resample(torch.nn.Module):
                 self.resampling_method,
                 beta,
                 dtype=dtype,
-                device=device
+                device=device,
             )
             self.register_buffer("kernel", kernel)
 
@@ -1207,7 +1207,6 @@ class _AxisMasking(torch.nn.Module):
     __constants__ = ["mask_param", "axis", "iid_masks", "p"]
 
     def __init__(self, mask_param: int, axis: int, iid_masks: bool, p: float = 1.0) -> None:
-
         super(_AxisMasking, self).__init__()
         self.mask_param = mask_param
         self.axis = axis


### PR DESCRIPTION
The `torchaudio.transforms.Resample` class specifies that it is CUDA compatible, but it is not. See the following small example:

    import torch
    from torchaudio.transforms import Resample

    Fs_source = 22050
    Fs_target = 16000
    device = 'cuda'

    x = 2 * torch.pi * 440 * torch.arange(Fs_source, device=device) / Fs_source

    resample = Resample(Fs_source, Fs_target)
    x_new = resample(x)
    # RuntimeError: Input type (torch.cuda.FloatTensor) and weight type (torch.FloatTensor) should be the same

To fix this error, I introduced a `device` argument to the init function of the class.