### PR TITLE
Fix path normalization for StreamWriter-based save operation

### DIFF
--- a/torchaudio/_backend/utils.py
+++ b/torchaudio/_backend/utils.py
@@ -122,7 +122,7 @@ class FFmpegBackend(Backend):
         buffer_size: int = 4096,
     ) -> None:
         save_audio(
-            os.path.normpath(uri),
+            uri,
             src,
             sample_rate,
             channels_first,

--- a/torchaudio/io/_compat.py
+++ b/torchaudio/io/_compat.py
@@ -204,8 +204,11 @@ def save_audio(
     bits_per_sample: Optional[int] = None,
     buffer_size: int = 4096,
 ) -> None:
-    if hasattr(uri, "write") and format is None:
-        raise RuntimeError("'format' is required when saving to file object.")
+    if hasattr(uri, "write"):
+        if format is None:
+            raise RuntimeError("'format' is required when saving to file object.")
+    else:
+        uri = os.path.normpath(uri)
     s = StreamWriter(uri, format=format, buffer_size=buffer_size)
     if format is None:
         tokens = str(uri).split(".")


### PR DESCRIPTION
Follow up of #3243. Save compat module had different semantics than info and load, which requires different way of performing path normalization.