### PR TITLE
Allow overwrite temp data in ffmpeg test

### DIFF
--- a/test/torchaudio_unittest/backend/dispatcher/ffmpeg/save_test.py
+++ b/test/torchaudio_unittest/backend/dispatcher/ffmpeg/save_test.py
@@ -25,7 +25,7 @@ from torchaudio_unittest.common_utils import (
 
 
 def _convert_audio_file(src_path, dst_path, format=None, acodec=None):
-    command = ["ffmpeg", "-i", src_path, "-strict", "-2"]
+    command = ["ffmpeg", "-y", "-i", src_path, "-strict", "-2"]
     if format:
         command += ["-sample_fmt", format]
     if acodec:


### PR DESCRIPTION
When `TORCHAUDIO_TEST_TEMP_DIR` is set, 
all the unit test temporary data are stored in the  given directory.
Running unit tests multiple times reuses the 
directory and the temporary files from the 
previous test runs are found there.

FFmpeg save test writes reference data to the 
temporary directory, but it is not given the 
overwrite flag ("-y"), so it fails in such cases.

This commit fixes that.