### PR TITLE
Update `torchaudio` doc and tutorial

### DIFF
--- a/docs/source/torchaudio.rst
+++ b/docs/source/torchaudio.rst
@@ -1,11 +1,60 @@
 torchaudio
 ==========
 
-.. note::
-   Release 2.1 will revise ``torchaudio.info``, ``torchaudio.load``, and ``torchaudio.save`` to allow for backend selection via function parameter rather than ``torchaudio.set_audio_backend``, with FFmpeg being the default backend.
-   The new API can be enabled in the current release by setting environment variable ``TORCHAUDIO_USE_BACKEND_DISPATCHER=1``.
-   See :ref:`future_api` for details on the new API.
+I/O
+---
 
+``torchaudio`` top-level module provides the following functions that make
+it easy to handle audio data.
+
+- :py:func:`torchaudio.info`
+- :py:func:`torchaudio.load`
+- :py:func:`torchaudio.save`
+
+Under the hood, these functions are implemented using various decoding/encoding
+libraries. There are currently three variants.
+
+- ``FFmpeg``
+- ``libsox``
+- ``SoundFile``
+
+``libsox`` backend is the first backend implemented in TorchAudio, and it
+works on Linux and macOS.
+``SoundFile`` backend was added to extend audio I/O support to Windows.
+It also works on Linux and macOS.
+``FFmpeg`` backend is the latest addition and it supports wide range of audio, video
+formats and protocols.
+It works on Linux, macOS and Windows.
+
+.. _dispatcher_migration:
+
+Introduction of Dispatcher
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Conventionally, torchaudio has had its IO backend set globally at runtime based on availability.
+However, this approach does not allow applications to use different
+backends, and it is not well-suited for large codebases.
+
+For these reasons, we are introducing a dispatcher, a new mechanism to allow users to
+choose a backend for each function call, and migrating the I/O functions.
+This incurs multiple changes, some of which involve backward-compatibility-breaking changes, and require
+users to change their function call.
+
+The (planned) changes are as follows. For up-to-date information,
+please refer to https://github.com/pytorch/audio/issues/2950
+
+* In 2.0, audio I/O backend dispatcher was introduced.
+  Users can opt-in to using dispatcher by setting the environment variable
+  ``TORCHAUDIO_USE_BACKEND_DISPATCHER=1``
+* In 2.1, the disptcher becomes the default mechanism for I/O.
+  Those who need to keep using the previous mechanism (global backend) can do
+  so by setting ``TORCHAUDIO_USE_BACKEND_DISPATCHER=0``.
+
+Furthermore, we are removing file-like object support from libsox backend, as this
+is better supported by FFmpeg backend and makes the build process simpler.
+Therefore, beginning with 2.1, FFmpeg and Soundfile are the sole backends that support file-like objects.
+
+The changes in 2.1 will mark the :ref:`backend utilities <backend_utils>` deprecated.
 
 Current API
 -----------
@@ -18,13 +67,23 @@ Audio I/O functions are implemented in :ref:`torchaudio.backend<backend>` module
 
 Please refer to :ref:`backend` for the detail, and the :doc:`Audio I/O tutorial <../tutorials/audio_io_tutorial>` for the usage.
 
+
+torchaudio.info
+~~~~~~~~~~~~~~~
+
 .. function:: torchaudio.info(filepath: str, ...)
 
    Fetch meta data of an audio file. Refer to :ref:`backend` for the detail.
 
+torchaudio.load
+~~~~~~~~~~~~~~~
+
 .. function:: torchaudio.load(filepath: str, ...)
 
    Load audio file into torch.Tensor object. Refer to :ref:`backend` for the detail.
+
+torchaudio.save
+~~~~~~~~~~~~~~~
 
 .. function:: torchaudio.save(filepath: str, src: torch.Tensor, sample_rate: int, ...)
 
@@ -32,8 +91,13 @@ Please refer to :ref:`backend` for the detail, and the :doc:`Audio I/O tutorial 
 
 .. currentmodule:: torchaudio
 
+.. _backend_utils:
+
 Backend Utilities
 ~~~~~~~~~~~~~~~~~
+
+The following functions are effective only when backend dispatcher is disabled.
+They are effectively deprecated.
 
 .. autofunction:: list_audio_backends
 
@@ -41,11 +105,23 @@ Backend Utilities
 
 .. autofunction:: set_audio_backend
 
-
 .. _future_api:
 
 Future API
 ----------
+
+Dispatcher
+~~~~~~~~~~
+
+The dispatcher tries to use the I/O backend in the following order of precedence
+
+1. FFmpeg
+2. libsox
+3. soundfile
+
+One can pass ``backend`` argument to I/O functions to override this.
+
+See :ref:`future_api` for details on the new API.
 
 In the next release, each of ``torchaudio.info``, ``torchaudio.load``, and ``torchaudio.save`` will allow for selecting a backend to use via parameter ``backend``.
 The functions will support using any of FFmpeg, SoX, and SoundFile, provided that the corresponding library is installed.
@@ -57,11 +133,20 @@ These functions can be enabled in the current release by setting environment var
 
 .. currentmodule:: torchaudio._backend
 
+torchaudio.info
+~~~~~~~~~~~~~~~
+
 .. autofunction:: info
    :noindex:
 
+torchaudio.load
+~~~~~~~~~~~~~~~
+
 .. autofunction:: load
    :noindex:
+
+torchaudio.save
+~~~~~~~~~~~~~~~
 
 .. autofunction:: save
    :noindex:


### PR DESCRIPTION
This commit is preparation for landing dispatcher switch in #3241 

Making FFmpeg backend default causes some issues on tutorials, so this commit disable it.
The IO tutorial will be updated after #3241 is landed to accommodate the change.

Since it is necessary to mention the changes related to migration in the IO tutorial,
I also update the IO documentation to include migration work so that  it's easy to redirect.