### PR TITLE
Fix doc deloyment condition

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -79,7 +79,7 @@ jobs:
         mv docs/build/html /artifacts/
 
   commit:
-    if: github.repository == 'pytorch/audio'
+    if: ${{ (github.repository == 'pytorch/audio') && ((github.event_name == 'push') && (github.ref_name == 'nightly')) }}
     permissions:
       # Required for `git push`
       # Note:
@@ -97,11 +97,10 @@ jobs:
       with:
         name: docs
     - name: Update nightly doc
-      # TODO: add tag-based process (need to handle the main directory name)
-      if: github.ref_name == 'nightly'
       run: |
         set -x
 
+        # TODO: add tag-based process (need to handle the main directory name)
         rm -rf main
         mv html main
 


### PR DESCRIPTION
Follow-up of #3292

Doc deployment is gated by branch_name == nightly, but nightly branch fires push and PR events and there will be two deployment jobs.

This commit specify push event.