### PR TITLE
Improve RNN-T streaming decoding

### DIFF
--- a/examples/asr/emformer_rnnt/pipeline_demo.py
+++ b/examples/asr/emformer_rnnt/pipeline_demo.py
@@ -65,9 +65,9 @@ def run_eval_streaming(args):
             with torch.no_grad():
                 features, length = streaming_feature_extractor(segment)
                 hypos, state = decoder.infer(features, length, 10, state=state, hypothesis=hypothesis)
-            hypothesis = hypos[0]
-            transcript = token_processor(hypothesis[0], lstrip=False)
-            print(transcript, end="", flush=True)
+            hypothesis = hypos
+            transcript = token_processor(hypos[0][0], lstrip=True)
+            print(transcript, end="\r", flush=True)
         print()
 
         # Non-streaming decode.

--- a/examples/tutorials/online_asr_tutorial.py
+++ b/examples/tutorials/online_asr_tutorial.py
@@ -39,6 +39,7 @@ to perform online speech recognition.
 # --------------
 #
 
+import os
 import torch
 import torchaudio
 
@@ -222,9 +223,9 @@ def run_inference(num_iter=100):
         segment = cacher(chunk[:, 0])
         features, length = feature_extractor(segment)
         hypos, state = decoder.infer(features, length, 10, state=state, hypothesis=hypothesis)
-        hypothesis = hypos[0]
-        transcript = token_processor(hypothesis[0], lstrip=False)
-        print(transcript, end="", flush=True)
+        hypothesis = hypos
+        transcript = token_processor(hypos[0][0], lstrip=False)
+        print(transcript, end="\r", flush=True)
 
         chunks.append(chunk)
         feats.append(features)

--- a/test/torchaudio_unittest/models/rnnt_decoder/rnnt_decoder_test_impl.py
+++ b/test/torchaudio_unittest/models/rnnt_decoder/rnnt_decoder_test_impl.py
@@ -99,7 +99,7 @@ class RNNTBeamSearchTestImpl(TestBaseMixin):
             self.assertEqual(res, scripted_res)
 
             state = res[1]
-            hypo = res[0][0]
+            hypo = res[0]
 
             scripted_state = scripted_res[1]
-            scripted_hypo = scripted_res[0][0]
+            scripted_hypo = scripted_res[0]


### PR DESCRIPTION
This commit fixes the following issues affecting streaming decoding quality
1. The `init_b` hypothesis is only regenerated from blank token if no initial hypotheses are provided.
2. Allows the decoder to receive top-K hypothesis to continue decoding from, instead of using just the top hypothesis at each decoding step.  This dramatically affects decoding quality especially for speech with long pauses and disfluencies.
3. Some minor errors regarding shape checking for length.

This also means that the resulting output is the entire transcript up until that time step, instead of just the incremental change in transcript.



