### PR TITLE
Add mkl dependency to torchaudio MacOS x86 builds (#3300)

### DIFF
--- a/packaging/torchaudio/meta.yaml
+++ b/packaging/torchaudio/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - ninja
     - numpy>=1.11 # [py <= 39]
     - numpy>=1.21.2 # [py >= 310]
+    - mkl<=2021.4.0 # [osx and x86_64]
     - pytorch-mutex 1.0 {{ build_variant }}  # [not osx ]
     {{ environ.get('CONDA_PYTORCH_BUILD_CONSTRAINT', 'pytorch') }}
     {{ environ.get('CONDA_EXTRA_BUILD_CONSTRAINT', '') }}
@@ -29,6 +30,7 @@ requirements:
     - numpy>=1.11 # [py <= 39]
     - numpy>=1.21.2 # [py >= 310]
     - pytorch-mutex 1.0 {{ build_variant }}  # [not osx ]
+    - mkl<=2021.4.0 # [osx and x86_64]
     {{ environ.get('CONDA_PYTORCH_CONSTRAINT', 'pytorch') }}
     {{ environ.get('CONDA_CUDATOOLKIT_CONSTRAINT', '') }}
 


### PR DESCRIPTION
Summary:
Add mkl dependency to torchaudio MacOS x86 builds

Already tested here: https://github.com/pytorch/audio/actions/runs/4878179835/jobs/8703586137

Pull Request resolved: https://github.com/pytorch/audio/pull/3300

Reviewed By: jeanschmidt, mthrok

Differential Revision: D45566352

Pulled By: atalman

fbshipit-source-id: a0376016506891240b2dd03d4fa4889028bf764b