### PR TITLE
Fix batch consistency test for InverseBarkScale

### DIFF
--- a/test/torchaudio_unittest/prototype/transforms/batch_consistency_test.py
+++ b/test/torchaudio_unittest/prototype/transforms/batch_consistency_test.py
@@ -35,7 +35,7 @@ class BatchConsistencyTest(TorchaudioTestCase):
         n_barks = 32
         n_stft = 5
         bark_spec = torch.randn(3, 2, n_barks, 32) ** 2
-        transform = transforms.InverseMelScale(n_stft, n_barks)
+        transform = T.InverseBarkScale(n_stft, n_barks)
 
         # Because InverseBarkScale runs SGD on randomly initialized values so they do not yield
         # exactly same result. For this reason, tolerance is very relaxed here.


### PR DESCRIPTION
The batch consistency test function should call `InverseBarkScale` instead of `InverseMelScale`.