### PR TITLE
[Nova] MacOS Unittests on Nova

### DIFF
--- a/.github/workflows/unittest-macos-cpu.yml
+++ b/.github/workflows/unittest-macos-cpu.yml
@@ -1,0 +1,85 @@
+name: Unit-tests on Macos CPU
+
+on:
+  pull_request:
+  push:
+    branches:
+      - nightly
+      - main
+      - release/*
+  workflow_dispatch:
+
+env:
+  CHANNEL: "nightly"
+
+jobs:
+  tests:
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    with:
+      runner: macos-12
+      repository: pytorch/audio
+      timeout: 120
+      script: |
+        # Mark Build Directory Safe
+        git config --global --add safe.directory /__w/audio/audio
+
+        # Set up Environment Variables
+        export PYTHON_VERSION="3.8"
+        export CU_VERSION=""
+        export CUDATOOLKIT=""
+        export MKL_CONSTRAINT="mkl==2021.2.0"
+
+        # Set CHANNEL
+        if [[(${GITHUB_EVENT_NAME} = 'pull_request' && (${GITHUB_BASE_REF} = 'release'*)) || (${GITHUB_REF} = 'refs/heads/release'*) ]]; then
+          export CHANNEL=test
+        else
+          export CHANNEL=nightly
+        fi
+
+        # Create Conda Env
+        conda create --quiet -y --name ci_env python="${PYTHON_VERSION}"
+        conda activate ci_env
+
+        # Install PyTorch
+        set -euxo pipefail
+        conda install \
+          --yes \
+          --quiet \
+          -c "pytorch-${CHANNEL}" \
+          "$MKL_CONSTRAINT" \
+          "pytorch-${CHANNEL}"::pytorch
+
+        # Install torchaudio
+        conda install --quiet -y 'ffmpeg>=4.1' pkg-config
+        python3 -m pip --quiet install cmake>=3.18.0 ninja
+        USE_FFMPEG=1 python3 -m pip install -v -e . --no-use-pep517
+
+        # Install test tools
+        conda install -y --quiet -c conda-forge -c numba/label/dev 'librosa==0.10.0' parameterized 'requests>=2.20'
+        python3 -m pip install --quiet kaldi-io SoundFile coverage pytest pytest-cov 'scipy==1.7.3' transformers expecttest unidecode inflect Pillow sentencepiece pytorch-lightning 'protobuf<4.21.0' demucs tinytag flashlight-text git+https://github.com/kpu/kenlm/
+        python3 -m pip install --quiet git+https://github.com/pytorch/fairseq.git@e47a4c8
+
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CMD_APPLY_CMVN_SLIDING=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CMD_COMPUTE_FBANK_FEATS=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CMD_COMPUTE_KALDI_PITCH_FEATS=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CMD_COMPUTE_MFCC_FEATS=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CMD_COMPUTE_SPECTROGRAM_FEATS=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CUDA=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_HW_ACCEL=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_QUANTIZATION=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_MOD_sentencepiece=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_AUDIO_OUT_DEVICE=true
+
+        declare -a args=(
+            '-v'
+            '--cov=torchaudio'
+            "--junitxml=${PWD}/test-results/junit.xml"
+            '--durations' '100'
+        )
+
+        cd test
+        python3 -m torch.utils.collect_env
+        env | grep TORCHAUDIO || true
+        pytest "${args[@]}" torchaudio_unittest
+        coverage html

--- a/.github/workflows/unittest-macos-cpu.yml
+++ b/.github/workflows/unittest-macos-cpu.yml
@@ -53,39 +53,3 @@ jobs:
         ./.circleci/unittest/linux/scripts/setup_env.sh
         ./.circleci/unittest/linux/scripts/install.sh
         ./.circleci/unittest/linux/scripts/run_test.sh
-
-        # # Create Conda Env
-        # conda create --quiet -y --name ci_env python="${PYTHON_VERSION}"
-        # conda activate ci_env
-
-        # # Install PyTorch
-        # set -euxo pipefail
-        # conda install \
-        #   --yes \
-        #   --quiet \
-        #   -c "pytorch-${CHANNEL}" \
-        #   "$MKL_CONSTRAINT" \
-        #   "pytorch-${CHANNEL}"::pytorch
-
-        # # Install torchaudio
-        # conda install --quiet -y 'ffmpeg>=4.1' pkg-config
-        # python3 -m pip --quiet install cmake>=3.18.0 ninja
-        # USE_FFMPEG=1 python3 -m pip install -v -e . --no-use-pep517
-
-        # # Install test tools
-        # conda install -y --quiet -c conda-forge -c numba/label/dev 'librosa==0.10.0' parameterized 'requests>=2.20'
-        # python3 -m pip install --quiet kaldi-io SoundFile coverage pytest pytest-cov 'scipy==1.7.3' transformers expecttest unidecode inflect Pillow sentencepiece pytorch-lightning 'protobuf<4.21.0' demucs tinytag flashlight-text git+https://github.com/kpu/kenlm/
-        # python3 -m pip install --quiet git+https://github.com/pytorch/fairseq.git@e47a4c8
-
-        # declare -a args=(
-        #     '-v'
-        #     '--cov=torchaudio'
-        #     "--junitxml=${PWD}/test-results/junit.xml"
-        #     '--durations' '100'
-        # )
-
-        # cd test
-        # python3 -m torch.utils.collect_env
-        # env | grep TORCHAUDIO || true
-        # pytest "${args[@]}" torchaudio_unittest
-        # coverage html

--- a/.github/workflows/unittest-macos-cpu.yml
+++ b/.github/workflows/unittest-macos-cpu.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       runner: macos-12
       repository: pytorch/audio
-      timeout: 120
+      timeout: 180
       script: |
         # Mark Build Directory Safe
         git config --global --add safe.directory /__w/audio/audio

--- a/.github/workflows/unittest-macos-cpu.yml
+++ b/.github/workflows/unittest-macos-cpu.yml
@@ -36,29 +36,6 @@ jobs:
           export CHANNEL=nightly
         fi
 
-        # Create Conda Env
-        conda create --quiet -y --name ci_env python="${PYTHON_VERSION}"
-        conda activate ci_env
-
-        # Install PyTorch
-        set -euxo pipefail
-        conda install \
-          --yes \
-          --quiet \
-          -c "pytorch-${CHANNEL}" \
-          "$MKL_CONSTRAINT" \
-          "pytorch-${CHANNEL}"::pytorch
-
-        # Install torchaudio
-        conda install --quiet -y 'ffmpeg>=4.1' pkg-config
-        python3 -m pip --quiet install cmake>=3.18.0 ninja
-        USE_FFMPEG=1 python3 -m pip install -v -e . --no-use-pep517
-
-        # Install test tools
-        conda install -y --quiet -c conda-forge -c numba/label/dev 'librosa==0.10.0' parameterized 'requests>=2.20'
-        python3 -m pip install --quiet kaldi-io SoundFile coverage pytest pytest-cov 'scipy==1.7.3' transformers expecttest unidecode inflect Pillow sentencepiece pytorch-lightning 'protobuf<4.21.0' demucs tinytag flashlight-text git+https://github.com/kpu/kenlm/
-        python3 -m pip install --quiet git+https://github.com/pytorch/fairseq.git@e47a4c8
-
         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CMD_APPLY_CMVN_SLIDING=true
         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CMD_COMPUTE_FBANK_FEATS=true
         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CMD_COMPUTE_KALDI_PITCH_FEATS=true
@@ -71,15 +48,43 @@ jobs:
         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_MOD_sentencepiece=true
         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_AUDIO_OUT_DEVICE=true
 
-        declare -a args=(
-            '-v'
-            '--cov=torchaudio'
-            "--junitxml=${PWD}/test-results/junit.xml"
-            '--durations' '100'
-        )
+        set -euxo pipefail
+        ./.circleci/unittest/linux/scripts/setup_env.sh
+        ./.circleci/unittest/linux/scripts/install.sh
+        ./.circleci/unittest/linux/scripts/run_test.sh
 
-        cd test
-        python3 -m torch.utils.collect_env
-        env | grep TORCHAUDIO || true
-        pytest "${args[@]}" torchaudio_unittest
-        coverage html
+        # # Create Conda Env
+        # conda create --quiet -y --name ci_env python="${PYTHON_VERSION}"
+        # conda activate ci_env
+
+        # # Install PyTorch
+        # set -euxo pipefail
+        # conda install \
+        #   --yes \
+        #   --quiet \
+        #   -c "pytorch-${CHANNEL}" \
+        #   "$MKL_CONSTRAINT" \
+        #   "pytorch-${CHANNEL}"::pytorch
+
+        # # Install torchaudio
+        # conda install --quiet -y 'ffmpeg>=4.1' pkg-config
+        # python3 -m pip --quiet install cmake>=3.18.0 ninja
+        # USE_FFMPEG=1 python3 -m pip install -v -e . --no-use-pep517
+
+        # # Install test tools
+        # conda install -y --quiet -c conda-forge -c numba/label/dev 'librosa==0.10.0' parameterized 'requests>=2.20'
+        # python3 -m pip install --quiet kaldi-io SoundFile coverage pytest pytest-cov 'scipy==1.7.3' transformers expecttest unidecode inflect Pillow sentencepiece pytorch-lightning 'protobuf<4.21.0' demucs tinytag flashlight-text git+https://github.com/kpu/kenlm/
+        # python3 -m pip install --quiet git+https://github.com/pytorch/fairseq.git@e47a4c8
+
+        # declare -a args=(
+        #     '-v'
+        #     '--cov=torchaudio'
+        #     "--junitxml=${PWD}/test-results/junit.xml"
+        #     '--durations' '100'
+        # )
+
+        # cd test
+        # python3 -m torch.utils.collect_env
+        # env | grep TORCHAUDIO || true
+        # pytest "${args[@]}" torchaudio_unittest
+        # coverage html

--- a/.github/workflows/unittest-macos-cpu.yml
+++ b/.github/workflows/unittest-macos-cpu.yml
@@ -31,9 +31,9 @@ jobs:
 
         # Set CHANNEL
         if [[(${GITHUB_EVENT_NAME} = 'pull_request' && (${GITHUB_BASE_REF} = 'release'*)) || (${GITHUB_REF} = 'refs/heads/release'*) ]]; then
-          export CHANNEL=test
+          export UPLOAD_CHANNEL=test
         else
-          export CHANNEL=nightly
+          export UPLOAD_CHANNEL=nightly
         fi
 
         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CMD_APPLY_CMVN_SLIDING=true

--- a/.github/workflows/unittest-macos-cpu.yml
+++ b/.github/workflows/unittest-macos-cpu.yml
@@ -27,7 +27,8 @@ jobs:
         export PYTHON_VERSION="3.8"
         export CU_VERSION=""
         export CUDATOOLKIT=""
-        export MKL_CONSTRAINT="mkl==2021.2.0"
+        export USE_FFMPEG="1"
+        export USE_OPENMP="0"
 
         # Set CHANNEL
         if [[(${GITHUB_EVENT_NAME} = 'pull_request' && (${GITHUB_BASE_REF} = 'release'*)) || (${GITHUB_REF} = 'refs/heads/release'*) ]]; then

--- a/.github/workflows/unittest-macos-cpu.yml
+++ b/.github/workflows/unittest-macos-cpu.yml
@@ -20,6 +20,7 @@ jobs:
       repository: pytorch/audio
       timeout: 180
       script: |
+        echo '::group::Setup Environment Variables'
         # Mark Build Directory Safe
         git config --global --add safe.directory /__w/audio/audio
 
@@ -48,8 +49,18 @@ jobs:
         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310=true
         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_MOD_sentencepiece=true
         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_AUDIO_OUT_DEVICE=true
+        echo '::endgroup::'
 
         set -euxo pipefail
+
+        echo '::group::Setup Conda Environment'
         ./.circleci/unittest/linux/scripts/setup_env.sh
+        echo '::endgroup::'
+
+        echo '::group::Install PyTorch and Torchaudio'
         ./.circleci/unittest/linux/scripts/install.sh
+        echo '::endgroup::'
+
+        echo '::group::Run Tests'
         ./.circleci/unittest/linux/scripts/run_test.sh
+        echo '::endgroup::'

--- a/test/torchaudio_unittest/common_utils/case_utils.py
+++ b/test/torchaudio_unittest/common_utils/case_utils.py
@@ -67,7 +67,7 @@ class HttpServerMixin(TempDirMixin):
     """
 
     _proc = None
-    _port = 8000
+    _port = 12345
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
As discussed in the [Torchaudio Migration Proposal](https://docs.google.com/document/d/1PF8biwiGzsjzfEBM78mlLiRrkcsGsvuYkeqkI66Ym8A/edit), this PR moves MacOS unittest job to Nova tooling. Note that this does not touch anything within the existing CircleCI job at the moment.

Passing job: https://github.com/pytorch/audio/actions/runs/4932497525/jobs/8815581251?pr=3324