### PR TITLE
Fix for breadcrumbs displaying "Old version (stable)" on Nightly build

### DIFF
--- a/docs/source/_templates/breadcrumbs.html
+++ b/docs/source/_templates/breadcrumbs.html
@@ -42,7 +42,7 @@
           <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &gt;</li>
         {% endfor %}
       <li>{{ title }} &gt;</li>
-      {% if 'Nightly' in version %}
+      {% if 'dev' in version %}
       <li>Nightly (unstable)</li>
       {% elif version_stable in version %}
       <li>Current (stable)</li>


### PR DESCRIPTION
Previously, `breadcrumbs.html` identified a nightly build version by the prefix "Nightly" which would normally be prepended to the version in `conf.py`. However, the version string is coming through without the "Nightly" prefix, so this change causes `breadcrumbs.html` to key on the substring "dev" instead.

The reason we aren't getting "Nightly" is apparently because the environment variable BUILD_VERSION is available, so `conf.py` is using the value of that env var instead of the version string imported from the `torchaudio` module itself, which actually appears to be incorrect; see below.

If I install torchaudio using

    conda install torchaudio -c pytorch-nightly

then `torchaudio.__version__` returns the incorrect version string:

    2.0.0.dev20230309