### PR TITLE
Improve the performance of CUDA HEVC decoding

### DIFF
--- a/torchaudio/csrc/ffmpeg/stream_reader/conversion.h
+++ b/torchaudio/csrc/ffmpeg/stream_reader/conversion.h
@@ -94,7 +94,7 @@ class NV12CudaConverter : ImageConverterBase {
 };
 
 class P010CudaConverter : ImageConverterBase {
-  torch::Tensor tmp_uv;
+  torch::Device device;
 
  public:
   P010CudaConverter(int height, int width, const torch::Device& device);


### PR DESCRIPTION
* Use `from_blob` for intermediate UV tensor, which avoids copy.
* Replace `index_put_` with `slice` and `copy_`.
    This does not contribute to the performance, but make the source tidier.

It improves the performance of HEVC decoding about 30% on CUDA 11.7.

| | main | PR |
|-|-|-|
|1280x720 (test1.hevc bellow)|0.672|0.453|
|320x240 (test2.hevc bellow)|0.469|0.328| 

[seconds]

UPDATE:

Turned out that use of `from_blob` somehow causes illegal memory access when performing GPU decoding on a different file consecutively.  The following code hangs or fails on at the beginning of the decoding the second file. Causing Y plane `cudaMemcpy2D` to report 700 (`cudaErrorIllegalAddress`)

<details><summary>code</summary>


    import torch
    import torchaudio
    from torchaudio.io import StreamReader


    def test(src):
        video = StreamReader(src)
        video.add_video_stream(3, decoder="hevc_cuvid", hw_accel="cuda:0")

       t0 = time.monotonic()
       for i, (frame, ) in enumerate(video.stream()):
            pass
        t1 = time.monotonic()

        print(t1 - t0)


    srcs = [
        "test1.hevc",
        "test1.hevc",
    ]

    for src in srcs:
        print(f"Testing {src}")
        for _ in range(5):
            test(src)
</details>

where the data are generated with;

```
ffmpeg -f lavfi -i testsrc=duration=30:size=1280x720:rate=30 -c:v libx265 -pix_fmt yuv420p10le -vtag hvc1 -y test1.hevc
ffmpeg -f lavfi -i testsrc=duration=30:size=320x240:rate=30 -c:v libx265 -pix_fmt yuv420p10le -vtag hvc1 -y test2.hevc
```

The most likely cause is that `index_put_` followed by `from_blob` is aysnc operation, and it does not finish before the execution flow goes out of the block. Setting `CUDA_LAUNCH_BLOCKING=1` or adding `torch::cuda::synchronize();` after `index_put_` resolves this, but the improvement is small. Perhaps we can set the custom `CuStream` when creating the CUDA decoder, and keep the stream alive so that the `index_put_` operation ends. 
(nvdec decoder sets stream as following so it seems possible to pass custom cuda stream)

https://github.com/FFmpeg/FFmpeg/blob/d4c48ee7f398c58f22844513a898cf2792961c99/libavcodec/nvdec.c#L187-L214