### PR TITLE
Turn off failing TestFunctionalCUDAOnlyFloat32::test_lfilter_9th_order_filter_stability test

### DIFF
--- a/test/torchaudio_unittest/functional/functional_cuda_test.py
+++ b/test/torchaudio_unittest/functional/functional_cuda_test.py
@@ -27,6 +27,10 @@ class TestFunctionalCUDAOnlyFloat32(FunctionalCUDAOnly, PytorchTestCase):
     dtype = torch.float32
     device = torch.device("cuda")
 
+    @unittest.expectedFailure
+    def test_lfilter_9th_order_filter_stability(self):
+        super().test_lfilter_9th_order_filter_stability()
+
 
 @skipIfNoCuda
 class TestFunctionalCUDAOnlyFloat64(FunctionalCUDAOnly, PytorchTestCase):

--- a/test/torchaudio_unittest/functional/functional_cuda_test.py
+++ b/test/torchaudio_unittest/functional/functional_cuda_test.py
@@ -28,6 +28,8 @@ class TestFunctionalCUDAOnlyFloat32(FunctionalCUDAOnly, PytorchTestCase):
     device = torch.device("cuda")
 
     @unittest.expectedFailure
+    # TODO: This is the issue associated with the failure.
+    # Follow up required: https://github.com/pytorch/audio/issues/3361
     def test_lfilter_9th_order_filter_stability(self):
         super().test_lfilter_9th_order_filter_stability()
 


### PR DESCRIPTION
Here is the issue: https://github.com/pytorch/audio/issues/3361