### PR TITLE
Fix cuda test failure

### DIFF
--- a/test/torchaudio_unittest/functional/functional_impl.py
+++ b/test/torchaudio_unittest/functional/functional_impl.py
@@ -1234,7 +1234,7 @@ class FunctionalCPUOnly(TestBaseMixin):
         assert len(w) == 1
 
 
-class FunctionalCUDAOnly(Functional):
+class FunctionalCUDAOnly(TestBaseMixin):
     @nested_params(
         [torch.half, torch.float, torch.double],
         [torch.int32, torch.int64],


### PR DESCRIPTION
Fix #3361

When adding FunctionalCUDAOnlyTest, the class should inherit from `TestBaseMixin` instead of `Functional`