### PR TITLE
Fix AudioEffector for mulaw

### DIFF
--- a/test/torchaudio_unittest/io/effector_test.py
+++ b/test/torchaudio_unittest/io/effector_test.py
@@ -30,14 +30,17 @@ class EffectorTest(TorchaudioTestCase):
             ("ogg", "flac"),  # flac only supports s16 and s32
             ("ogg", "opus"),  # opus only supports 48k Hz
             ("ogg", "vorbis"),  # vorbis only supports stereo
+            # ("ogg", "vorbis", 44100),
+            # this fails with small descrepancy; 441024 vs 441000
+            # TODO: investigate
             ("wav", None),
             ("wav", "pcm_u8"),
             ("mp3", None),
+            ("mulaw", None, 44100),  # mulaw is encoded without header
         ]
     )
-    def test_formats(self, format, encoder):
+    def test_formats(self, format, encoder, sample_rate=8000):
         """Formats (some with restrictions) just work without an issue in effector"""
-        sample_rate = 8000
 
         effector = AudioEffector(format=format, encoder=encoder)
         original = get_sinusoid(n_channels=3, sample_rate=sample_rate, channels_first=False)

--- a/torchaudio/io/_effector.py
+++ b/torchaudio/io/_effector.py
@@ -267,6 +267,10 @@ class AudioEffector:
             muxer = self.format
             encoder = self.encoder
             option = {}
+            # Some formats are headerless, so need to provide these infomation.
+            if self.format == "mulaw":
+                option = {"sample_rate": f"{sample_rate}", "channels": f"{num_channels}"}
+
         else:  # PCM
             muxer = _get_muxer(waveform.dtype)
             encoder = None


### PR DESCRIPTION
When encoding audio with mulaw, the resulting data does not have header, and the StreamReader defaults to 16k Hz, which can strech/shrink the resulting waveform.