### PR TITLE
Fixes to #3295 Improve RNN-T streaming decoding

### DIFF
--- a/examples/tutorials/online_asr_tutorial.py
+++ b/examples/tutorials/online_asr_tutorial.py
@@ -39,7 +39,6 @@ to perform online speech recognition.
 # --------------
 #
 
-import os
 import torch
 import torchaudio
 

--- a/torchaudio/models/rnnt_decoder.py
+++ b/torchaudio/models/rnnt_decoder.py
@@ -314,7 +314,7 @@ class RNNTBeamSearch(torch.nn.Module):
             state (List[List[torch.Tensor]] or None, optional): list of lists of tensors
                 representing transcription network internal state generated in preceding
                 invocation. (Default: ``None``)
-            hypothesis (Hypothesis or None): hypothesis from preceding invocation to seed
+            hypothesis (List[Hypothesis] or None): hypotheses from preceding invocation to seed
                 search with. (Default: ``None``)
 
         Returns:


### PR DESCRIPTION
Summary: Fixes `RNNTBeamSearch.infer`'s docstring and removes unused import from tutorial.

Differential Revision: D46227174

