### PR TITLE
Use cuda 11.8 for circleci tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,7 @@ jobs:
       name: windows-gpu
     environment:
       <<: *environment
-      CUDA_VERSION: "11.7"
+      CUDA_VERSION: "11.8"
     steps:
       - checkout
       - designate_upload_channel

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -319,7 +319,7 @@ jobs:
       name: windows-gpu
     environment:
       <<: *environment
-      CUDA_VERSION: "11.7"
+      CUDA_VERSION: "11.8"
     steps:
       - checkout
       - designate_upload_channel


### PR DESCRIPTION
Use cuda 11.8 for circleci tests.
11.7 was deprecated