### PR TITLE
Simplify sox namespace

### DIFF
--- a/torchaudio/csrc/sox/effects.cpp
+++ b/torchaudio/csrc/sox/effects.cpp
@@ -3,11 +3,7 @@
 #include <torchaudio/csrc/sox/effects_chain.h>
 #include <torchaudio/csrc/sox/utils.h>
 
-using namespace torchaudio::sox_utils;
-
-namespace torchaudio {
-namespace sox_effects {
-
+namespace torchaudio::sox {
 namespace {
 
 enum SoxEffectsResourceState { NotInitialized, Initialized, ShutDown };
@@ -58,7 +54,7 @@ auto apply_effects_tensor(
 
   // Create SoxEffectsChain
   const auto dtype = waveform.dtype();
-  torchaudio::sox_effects_chain::SoxEffectsChain chain(
+  SoxEffectsChain chain(
       /*input_encoding=*/get_tensor_encodinginfo(dtype),
       /*output_encoding=*/get_tensor_encodinginfo(dtype));
 
@@ -113,7 +109,7 @@ auto apply_effects_file(
   out_buffer.reserve(sf->signal.length);
 
   // Create and run SoxEffectsChain
-  torchaudio::sox_effects_chain::SoxEffectsChain chain(
+  SoxEffectsChain chain(
       /*input_encoding=*/sf->encoding,
       /*output_encoding=*/get_tensor_encodinginfo(dtype));
 
@@ -138,20 +134,16 @@ auto apply_effects_file(
       tensor, chain.getOutputSampleRate());
 }
 
+namespace {
+
 TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
   m.def(
       "torchaudio::sox_effects_initialize_sox_effects",
-      &torchaudio::sox_effects::initialize_sox_effects);
-  m.def(
-      "torchaudio::sox_effects_shutdown_sox_effects",
-      &torchaudio::sox_effects::shutdown_sox_effects);
-  m.def(
-      "torchaudio::sox_effects_apply_effects_tensor",
-      &torchaudio::sox_effects::apply_effects_tensor);
-  m.def(
-      "torchaudio::sox_effects_apply_effects_file",
-      &torchaudio::sox_effects::apply_effects_file);
+      &initialize_sox_effects);
+  m.def("torchaudio::sox_effects_shutdown_sox_effects", &shutdown_sox_effects);
+  m.def("torchaudio::sox_effects_apply_effects_tensor", &apply_effects_tensor);
+  m.def("torchaudio::sox_effects_apply_effects_file", &apply_effects_file);
 }
 
-} // namespace sox_effects
-} // namespace torchaudio
+} // namespace
+} // namespace torchaudio::sox

--- a/torchaudio/csrc/sox/effects.h
+++ b/torchaudio/csrc/sox/effects.h
@@ -4,8 +4,7 @@
 #include <torch/script.h>
 #include <torchaudio/csrc/sox/utils.h>
 
-namespace torchaudio {
-namespace sox_effects {
+namespace torchaudio::sox {
 
 void initialize_sox_effects();
 
@@ -25,7 +24,6 @@ auto apply_effects_file(
     const c10::optional<std::string>& format)
     -> c10::optional<std::tuple<torch::Tensor, int64_t>>;
 
-} // namespace sox_effects
-} // namespace torchaudio
+} // namespace torchaudio::sox
 
 #endif

--- a/torchaudio/csrc/sox/effects_chain.cpp
+++ b/torchaudio/csrc/sox/effects_chain.cpp
@@ -3,10 +3,8 @@
 #include "c10/util/Exception.h"
 
 using namespace torch::indexing;
-using namespace torchaudio::sox_utils;
 
-namespace torchaudio {
-namespace sox_effects_chain {
+namespace torchaudio::sox {
 
 namespace {
 
@@ -300,5 +298,4 @@ int64_t SoxEffectsChain::getOutputSampleRate() {
   return interm_sig_.rate;
 }
 
-} // namespace sox_effects_chain
-} // namespace torchaudio
+} // namespace torchaudio::sox

--- a/torchaudio/csrc/sox/effects_chain.h
+++ b/torchaudio/csrc/sox/effects_chain.h
@@ -4,8 +4,7 @@
 #include <sox.h>
 #include <torchaudio/csrc/sox/utils.h>
 
-namespace torchaudio {
-namespace sox_effects_chain {
+namespace torchaudio::sox {
 
 // Helper struct to safely close sox_effect_t* pointer returned by
 // sox_create_effect
@@ -57,7 +56,6 @@ class SoxEffectsChain {
   int64_t getOutputSampleRate();
 };
 
-} // namespace sox_effects_chain
-} // namespace torchaudio
+} // namespace torchaudio::sox
 
 #endif

--- a/torchaudio/csrc/sox/io.cpp
+++ b/torchaudio/csrc/sox/io.cpp
@@ -5,10 +5,8 @@
 #include <torchaudio/csrc/sox/utils.h>
 
 using namespace torch::indexing;
-using namespace torchaudio::sox_utils;
 
-namespace torchaudio {
-namespace sox_io {
+namespace torchaudio::sox {
 
 c10::optional<MetaDataTuple> get_info_file(
     const std::string& path,
@@ -68,8 +66,7 @@ c10::optional<std::tuple<torch::Tensor, int64_t>> load_audio_file(
     c10::optional<bool> channels_first,
     const c10::optional<std::string>& format) {
   auto effects = get_effects(frame_offset, num_frames);
-  return torchaudio::sox_effects::apply_effects_file(
-      path, effects, normalize, channels_first, format);
+  return apply_effects_file(path, effects, normalize, channels_first, format);
 }
 
 void save_audio_file(
@@ -123,7 +120,7 @@ void save_audio_file(
       "Error saving audio file: failed to open file ",
       path);
 
-  torchaudio::sox_effects_chain::SoxEffectsChain chain(
+  SoxEffectsChain chain(
       /*input_encoding=*/get_tensor_encodinginfo(tensor.dtype()),
       /*output_encoding=*/sf->encoding);
   chain.addInputTensor(&tensor, sample_rate, channels_first);
@@ -132,14 +129,9 @@ void save_audio_file(
 }
 
 TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
-  m.def("torchaudio::sox_io_get_info", &torchaudio::sox_io::get_info_file);
-  m.def(
-      "torchaudio::sox_io_load_audio_file",
-      &torchaudio::sox_io::load_audio_file);
-  m.def(
-      "torchaudio::sox_io_save_audio_file",
-      &torchaudio::sox_io::save_audio_file);
+  m.def("torchaudio::sox_io_get_info", &get_info_file);
+  m.def("torchaudio::sox_io_load_audio_file", &load_audio_file);
+  m.def("torchaudio::sox_io_save_audio_file", &save_audio_file);
 }
 
-} // namespace sox_io
-} // namespace torchaudio
+} // namespace torchaudio::sox

--- a/torchaudio/csrc/sox/io.h
+++ b/torchaudio/csrc/sox/io.h
@@ -4,8 +4,7 @@
 #include <torch/script.h>
 #include <torchaudio/csrc/sox/utils.h>
 
-namespace torchaudio {
-namespace sox_io {
+namespace torchaudio::sox {
 
 auto get_effects(
     const c10::optional<int64_t>& frame_offset,
@@ -37,7 +36,6 @@ void save_audio_file(
     c10::optional<std::string> encoding,
     c10::optional<int64_t> bits_per_sample);
 
-} // namespace sox_io
-} // namespace torchaudio
+} // namespace torchaudio::sox
 
 #endif

--- a/torchaudio/csrc/sox/pybind/effects.cpp
+++ b/torchaudio/csrc/sox/pybind/effects.cpp
@@ -2,10 +2,7 @@
 #include <torchaudio/csrc/sox/pybind/effects_chain.h>
 #include <torchaudio/csrc/sox/pybind/utils.h>
 
-using namespace torchaudio::sox_utils;
-
-namespace torchaudio {
-namespace sox_effects {
+namespace torchaudio::sox {
 
 // Streaming decoding over file-like object is tricky because libsox operates on
 // FILE pointer. The folloing is what `sox` and `play` commands do
@@ -95,7 +92,7 @@ auto apply_effects_fileobj(
 
   // Create and run SoxEffectsChain
   const auto dtype = get_dtype(sf->encoding.encoding, sf->signal.precision);
-  torchaudio::sox_effects_chain::SoxEffectsChainPyBind chain(
+  SoxEffectsChainPyBind chain(
       /*input_encoding=*/sf->encoding,
       /*output_encoding=*/get_tensor_encodinginfo(dtype));
   chain.addInputFileObj(sf, in_buf, in_buffer_size, &fileobj);
@@ -119,5 +116,4 @@ auto apply_effects_fileobj(
       tensor, static_cast<int64_t>(chain.getOutputSampleRate()));
 }
 
-} // namespace sox_effects
-} // namespace torchaudio
+} // namespace torchaudio::sox

--- a/torchaudio/csrc/sox/pybind/effects.h
+++ b/torchaudio/csrc/sox/pybind/effects.h
@@ -3,8 +3,7 @@
 
 #include <torch/extension.h>
 
-namespace torchaudio {
-namespace sox_effects {
+namespace torchaudio::sox {
 
 auto apply_effects_fileobj(
     py::object fileobj,
@@ -14,7 +13,6 @@ auto apply_effects_fileobj(
     c10::optional<std::string> format)
     -> c10::optional<std::tuple<torch::Tensor, int64_t>>;
 
-} // namespace sox_effects
-} // namespace torchaudio
+} // namespace torchaudio::sox
 
 #endif

--- a/torchaudio/csrc/sox/pybind/effects_chain.cpp
+++ b/torchaudio/csrc/sox/pybind/effects_chain.cpp
@@ -2,11 +2,7 @@
 #include <torchaudio/csrc/sox/pybind/effects_chain.h>
 #include <torchaudio/csrc/sox/pybind/utils.h>
 
-using namespace torchaudio::sox_utils;
-
-namespace torchaudio {
-namespace sox_effects_chain {
-
+namespace torchaudio::sox {
 namespace {
 
 /// helper classes for passing file-like object to SoxEffectChain
@@ -233,5 +229,4 @@ void SoxEffectsChainPyBind::addOutputFileObj(
   }
 }
 
-} // namespace sox_effects_chain
-} // namespace torchaudio
+} // namespace torchaudio::sox

--- a/torchaudio/csrc/sox/pybind/effects_chain.h
+++ b/torchaudio/csrc/sox/pybind/effects_chain.h
@@ -4,8 +4,7 @@
 #include <torch/extension.h>
 #include <torchaudio/csrc/sox/effects_chain.h>
 
-namespace torchaudio {
-namespace sox_effects_chain {
+namespace torchaudio::sox {
 
 class SoxEffectsChainPyBind : public SoxEffectsChain {
   using SoxEffectsChain::SoxEffectsChain;
@@ -24,7 +23,6 @@ class SoxEffectsChainPyBind : public SoxEffectsChain {
       py::object* fileobj);
 };
 
-} // namespace sox_effects_chain
-} // namespace torchaudio
+} // namespace torchaudio::sox
 
 #endif

--- a/torchaudio/csrc/sox/pybind/io.cpp
+++ b/torchaudio/csrc/sox/pybind/io.cpp
@@ -7,10 +7,7 @@
 
 #include <utility>
 
-using namespace torchaudio::sox_utils;
-
-namespace torchaudio {
-namespace sox_io {
+namespace torchaudio::sox {
 
 auto get_info_fileobj(py::object fileobj, c10::optional<std::string> format)
     -> c10::optional<MetaDataTuple> {
@@ -83,7 +80,7 @@ auto load_audio_fileobj(
     c10::optional<std::string> format)
     -> c10::optional<std::tuple<torch::Tensor, int64_t>> {
   auto effects = get_effects(frame_offset, num_frames);
-  return torchaudio::sox_effects::apply_effects_fileobj(
+  return apply_effects_fileobj(
       std::move(fileobj),
       effects,
       normalize,
@@ -177,7 +174,7 @@ void save_audio_fileobj(
         "Error saving audio file: failed to open memory stream.");
   }
 
-  torchaudio::sox_effects_chain::SoxEffectsChainPyBind chain(
+  SoxEffectsChainPyBind chain(
       /*input_encoding=*/get_tensor_encodinginfo(tensor.dtype()),
       /*output_encoding=*/sf->encoding);
   chain.addInputTensor(&tensor, sample_rate, channels_first);
@@ -191,5 +188,4 @@ void save_audio_fileobj(
   fileobj.attr("write")(py::bytes(buffer.ptr, buffer.size));
 }
 
-} // namespace sox_io
-} // namespace torchaudio
+} // namespace torchaudio::sox

--- a/torchaudio/csrc/sox/pybind/io.h
+++ b/torchaudio/csrc/sox/pybind/io.h
@@ -3,8 +3,7 @@
 
 #include <torch/extension.h>
 
-namespace torchaudio {
-namespace sox_io {
+namespace torchaudio::sox {
 
 using MetaDataTuple =
     std::tuple<int64_t, int64_t, int64_t, int64_t, std::string>;
@@ -31,7 +30,6 @@ void save_audio_fileobj(
     c10::optional<std::string> encoding,
     c10::optional<int64_t> bits_per_sample);
 
-} // namespace sox_io
-} // namespace torchaudio
+} // namespace torchaudio::sox
 
 #endif

--- a/torchaudio/csrc/sox/pybind/pybind.cpp
+++ b/torchaudio/csrc/sox/pybind/pybind.cpp
@@ -3,21 +3,22 @@
 #include <torchaudio/csrc/sox/pybind/effects.h>
 #include <torchaudio/csrc/sox/pybind/io.h>
 
+namespace torchaudio::sox {
+namespace {
 PYBIND11_MODULE(_torchaudio_sox, m) {
   m.def(
       "get_info_fileobj",
-      &torchaudio::sox_io::get_info_fileobj,
+      &get_info_fileobj,
       "Get metadata of audio in file object.");
   m.def(
       "load_audio_fileobj",
-      &torchaudio::sox_io::load_audio_fileobj,
+      &load_audio_fileobj,
       "Load audio from file object.");
-  m.def(
-      "save_audio_fileobj",
-      &torchaudio::sox_io::save_audio_fileobj,
-      "Save audio to file obj.");
+  m.def("save_audio_fileobj", &save_audio_fileobj, "Save audio to file obj.");
   m.def(
       "apply_effects_fileobj",
-      &torchaudio::sox_effects::apply_effects_fileobj,
+      &apply_effects_fileobj,
       "Decode audio data from file-like obj and apply effects.");
 }
+} // namespace
+} // namespace torchaudio::sox

--- a/torchaudio/csrc/sox/pybind/utils.cpp
+++ b/torchaudio/csrc/sox/pybind/utils.cpp
@@ -1,7 +1,6 @@
 #include <torchaudio/csrc/sox/pybind/utils.h>
 
-namespace torchaudio {
-namespace sox_utils {
+namespace torchaudio::sox {
 
 auto read_fileobj(py::object* fileobj, const uint64_t size, char* buffer)
     -> uint64_t {
@@ -29,5 +28,4 @@ auto read_fileobj(py::object* fileobj, const uint64_t size, char* buffer)
   return num_read;
 }
 
-} // namespace sox_utils
-} // namespace torchaudio
+} // namespace torchaudio::sox

--- a/torchaudio/csrc/sox/pybind/utils.h
+++ b/torchaudio/csrc/sox/pybind/utils.h
@@ -3,12 +3,10 @@
 
 #include <torch/extension.h>
 
-namespace torchaudio {
-namespace sox_utils {
+namespace torchaudio::sox {
 
 auto read_fileobj(py::object* fileobj, uint64_t size, char* buffer) -> uint64_t;
 
-} // namespace sox_utils
-} // namespace torchaudio
+} // namespace torchaudio::sox
 
 #endif

--- a/torchaudio/csrc/sox/types.cpp
+++ b/torchaudio/csrc/sox/types.cpp
@@ -1,7 +1,6 @@
 #include <torchaudio/csrc/sox/types.h>
 
-namespace torchaudio {
-namespace sox_utils {
+namespace torchaudio::sox {
 
 Format get_format_from_string(const std::string& format) {
   if (format == "wav")
@@ -129,5 +128,4 @@ std::string get_encoding(sox_encoding_t encoding) {
   }
 }
 
-} // namespace sox_utils
-} // namespace torchaudio
+} // namespace torchaudio::sox

--- a/torchaudio/csrc/sox/types.h
+++ b/torchaudio/csrc/sox/types.h
@@ -4,8 +4,7 @@
 #include <sox.h>
 #include <torch/script.h>
 
-namespace torchaudio {
-namespace sox_utils {
+namespace torchaudio::sox {
 
 enum class Format {
   WAV,
@@ -54,7 +53,6 @@ BitDepth get_bit_depth_from_option(const c10::optional<int64_t> bit_depth);
 
 std::string get_encoding(sox_encoding_t encoding);
 
-} // namespace sox_utils
-} // namespace torchaudio
+} // namespace torchaudio::sox
 
 #endif

--- a/torchaudio/csrc/sox/utils.cpp
+++ b/torchaudio/csrc/sox/utils.cpp
@@ -3,8 +3,7 @@
 #include <torchaudio/csrc/sox/types.h>
 #include <torchaudio/csrc/sox/utils.h>
 
-namespace torchaudio {
-namespace sox_utils {
+namespace torchaudio::sox {
 
 void set_seed(const int64_t seed) {
   sox_get_globals()->ranqd1 = static_cast<sox_int32_t>(seed);
@@ -492,30 +491,18 @@ sox_encodinginfo_t get_encodinginfo_for_save(
       /*opposite_endian=*/sox_false};
 }
 
+namespace {
+
 TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
-  m.def("torchaudio::sox_utils_set_seed", &torchaudio::sox_utils::set_seed);
-  m.def(
-      "torchaudio::sox_utils_set_verbosity",
-      &torchaudio::sox_utils::set_verbosity);
-  m.def(
-      "torchaudio::sox_utils_set_use_threads",
-      &torchaudio::sox_utils::set_use_threads);
-  m.def(
-      "torchaudio::sox_utils_set_buffer_size",
-      &torchaudio::sox_utils::set_buffer_size);
-  m.def(
-      "torchaudio::sox_utils_list_effects",
-      &torchaudio::sox_utils::list_effects);
-  m.def(
-      "torchaudio::sox_utils_list_read_formats",
-      &torchaudio::sox_utils::list_read_formats);
-  m.def(
-      "torchaudio::sox_utils_list_write_formats",
-      &torchaudio::sox_utils::list_write_formats);
-  m.def(
-      "torchaudio::sox_utils_get_buffer_size",
-      &torchaudio::sox_utils::get_buffer_size);
+  m.def("torchaudio::sox_utils_set_seed", &set_seed);
+  m.def("torchaudio::sox_utils_set_verbosity", &set_verbosity);
+  m.def("torchaudio::sox_utils_set_use_threads", &set_use_threads);
+  m.def("torchaudio::sox_utils_set_buffer_size", &set_buffer_size);
+  m.def("torchaudio::sox_utils_list_effects", &list_effects);
+  m.def("torchaudio::sox_utils_list_read_formats", &list_read_formats);
+  m.def("torchaudio::sox_utils_list_write_formats", &list_write_formats);
+  m.def("torchaudio::sox_utils_get_buffer_size", &get_buffer_size);
 }
 
-} // namespace sox_utils
-} // namespace torchaudio
+} // namespace
+} // namespace torchaudio::sox

--- a/torchaudio/csrc/sox/utils.h
+++ b/torchaudio/csrc/sox/utils.h
@@ -4,8 +4,7 @@
 #include <sox.h>
 #include <torch/script.h>
 
-namespace torchaudio {
-namespace sox_utils {
+namespace torchaudio::sox {
 
 ////////////////////////////////////////////////////////////////////////////////
 // APIs for Python interaction
@@ -106,6 +105,5 @@ sox_encodinginfo_t get_encodinginfo_for_save(
     const c10::optional<std::string> encoding,
     const c10::optional<int64_t> bits_per_sample);
 
-} // namespace sox_utils
-} // namespace torchaudio
+} // namespace torchaudio::sox
 #endif


### PR DESCRIPTION
Summary: This commit reduces `torchaudio::sox_*` namespace into `torchaudio::sox`.

Differential Revision: D46257367

