### PR TITLE
Add compression support to _compat.save_audio function

### DIFF
--- a/torchaudio/_backend/utils.py
+++ b/torchaudio/_backend/utils.py
@@ -126,6 +126,7 @@ class FFmpegBackend(Backend):
             src,
             sample_rate,
             channels_first,
+            -1,
             format,
             encoding,
             bits_per_sample,

--- a/torchaudio/io/_compat.py
+++ b/torchaudio/io/_compat.py
@@ -5,7 +5,7 @@ from typing import BinaryIO, Optional, Tuple, Union
 import torch
 import torchaudio
 from torchaudio.backend.common import AudioMetaData
-from torchaudio.io import StreamWriter
+from torchaudio.io import CodecConfig, StreamWriter
 
 
 # Note: need to comply TorchScript syntax -- need annotation and no f-string nor global
@@ -199,6 +199,7 @@ def save_audio(
     src: torch.Tensor,
     sample_rate: int,
     channels_first: bool = True,
+    compression: int = -1,
     format: Optional[str] = None,
     encoding: Optional[str] = None,
     bits_per_sample: Optional[int] = None,
@@ -223,6 +224,7 @@ def save_audio(
         format=_get_sample_format(src.dtype),
         encoder=_get_encoder(src.dtype, format, encoding, bits_per_sample),
         encoder_format=_get_encoder_format(format, bits_per_sample),
+        codec_config=CodecConfig(compression_level=compression),
     )
     with s.open():
         s.write_audio_chunk(0, src)


### PR DESCRIPTION
So that when updating apply_codec function to use FFmpeg based I/O, it can support compression.

I defer the decision to support compression in torchaudio.save for now.