### PR TITLE
Disable HF integration test

### DIFF
--- a/.github/scripts/unittest-linux/install.sh
+++ b/.github/scripts/unittest-linux/install.sh
@@ -71,7 +71,7 @@ fi
 (
     set -x
     conda install -y -c conda-forge ${NUMBA_DEV_CHANNEL} 'librosa==0.10.0' parameterized 'requests>=2.20'
-    pip install kaldi-io SoundFile coverage pytest pytest-cov 'scipy==1.7.3' transformers expecttest unidecode inflect Pillow sentencepiece pytorch-lightning 'protobuf<4.21.0' demucs tinytag pyroomacoustics flashlight-text git+https://github.com/kpu/kenlm
+    pip install kaldi-io SoundFile coverage pytest pytest-cov 'scipy==1.7.3' expecttest unidecode inflect Pillow sentencepiece pytorch-lightning 'protobuf<4.21.0' demucs tinytag pyroomacoustics flashlight-text git+https://github.com/kpu/kenlm
 )
 # Install fairseq
 git clone https://github.com/pytorch/fairseq

--- a/.github/scripts/unittest-windows/install.sh
+++ b/.github/scripts/unittest-windows/install.sh
@@ -82,7 +82,6 @@ esac
         pytest-cov \
         pytorch-lightning \
         'scipy==1.7.3' \
-        transformers \
         unidecode \
         'protobuf<4.21.0' \
         demucs \

--- a/test/torchaudio_unittest/models/wav2vec2/huggingface_intergration_test.py
+++ b/test/torchaudio_unittest/models/wav2vec2/huggingface_intergration_test.py
@@ -1,4 +1,5 @@
 import json
+import unittest
 
 import torch
 from parameterized import parameterized
@@ -87,6 +88,7 @@ WAVLM_CONFIGS = parameterized.expand(
 )
 
 
+@unittest.skip("transformers v4.30 seems to break the weight format. See https://github.com/pytorch/audio/issues/3430")
 @skipIfNoModule("transformers")
 class TestHFIntegration(TorchaudioTestCase):
     """Test the process of importing the models from Hugging Face Transformers


### PR DESCRIPTION
The new version of transformers changed the format of pre-trained weight. Fixing it is low-priority for the maintanance team so we disable the test.

See https://github.com/pytorch/audio/issues/3430