### PR TITLE
Linux CPU job should respect set Python version

### DIFF
--- a/.github/scripts/unittest-linux/install.sh
+++ b/.github/scripts/unittest-linux/install.sh
@@ -19,6 +19,9 @@ case "$(uname -s)" in
         eval "$("/opt/conda/bin/conda" shell.bash hook)"
 esac
 
+conda create -n ci python=${PYTHON_VERSION}
+conda activate ci
+
 # 1. Install PyTorch
 if [ -z "${CUDA_VERSION:-}" ] ; then
     if [ "${os}" == MacOSX ] ; then

--- a/.github/scripts/unittest-linux/install.sh
+++ b/.github/scripts/unittest-linux/install.sh
@@ -19,7 +19,7 @@ case "$(uname -s)" in
         eval "$("/opt/conda/bin/conda" shell.bash hook)"
 esac
 
-conda create -n ci python=${PYTHON_VERSION}
+conda create -n ci -y python="${PYTHON_VERSION}"
 conda activate ci
 
 # 1. Install PyTorch

--- a/.github/scripts/unittest-linux/install.sh
+++ b/.github/scripts/unittest-linux/install.sh
@@ -13,7 +13,9 @@ set -e
 
 case "$(uname -s)" in
     Darwin*)
-        os=MacOSX;;
+        os=MacOSX
+        eval "$($(which conda) shell.bash hook)"
+        ;;
     *)
         os=Linux
         eval "$("/opt/conda/bin/conda" shell.bash hook)"

--- a/.github/scripts/unittest-linux/run_test.sh
+++ b/.github/scripts/unittest-linux/run_test.sh
@@ -4,6 +4,8 @@ set -e
 
 eval "$(/opt/conda/bin/conda shell.bash hook)"
 
+conda activate ci
+
 python -m torch.utils.collect_env
 env | grep TORCHAUDIO || true
 

--- a/.github/scripts/unittest-linux/run_test.sh
+++ b/.github/scripts/unittest-linux/run_test.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-eval "$(/opt/conda/bin/conda shell.bash hook)"
+eval "$($(which conda) shell.bash hook)"
 
 conda activate ci
 


### PR DESCRIPTION
Reintroduce a conda environment within which we will do all deps installation, audio builds, and tests runs. This conda environment will use the python version set by the GHA job - previously this just defaulted to using the system 3.10 python which was default inside the container.