### PR TITLE
Add switch to disable sox integration and ffmpeg integration at runtime

### DIFF
--- a/.github/workflows/unittest-windows-cpu.yml
+++ b/.github/workflows/unittest-windows-cpu.yml
@@ -45,6 +45,7 @@ jobs:
         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_MOD_sentencepiece=true
         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_AUDIO_OUT_DEVICE=true
         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_MACOS=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_TEMPORARY_DISABLED=true
 
         .github/scripts/unittest-windows/setup_env.sh
         .github/scripts/unittest-windows/install.sh


### PR DESCRIPTION
Since libsox and ffmpeg extensions now depend on external libraries, their initialization processes might cause unrecoverable issue, such as segfault.

This commit adds environment variable to disable them so that importing torchaudio won't attempt to load these libraries.