### PR TITLE
Migrate torch.norm to torch.linalg.vector_norm

### DIFF
--- a/examples/libtorchaudio/augmentation/create_jittable_pipeline.py
+++ b/examples/libtorchaudio/augmentation/create_jittable_pipeline.py
@@ -35,7 +35,7 @@ class Pipeline(torch.nn.Module):
         rir, _ = torchaudio.sox_effects.apply_effects_tensor(
             self.rir, self.rir_sample_rate, effects=[["rate", str(sample_rate)]]
         )
-        rir = rir / torch.norm(rir, p=2)
+        rir = rir / torch.linalg.vector_norm(rir, ord=2)
         rir = torch.flip(rir, [1])
 
         # 4. Apply RIR filter

--- a/examples/tutorials/audio_data_augmentation_tutorial.py
+++ b/examples/tutorials/audio_data_augmentation_tutorial.py
@@ -170,7 +170,7 @@ Audio(rir_raw, rate=sample_rate)
 #
 
 rir = rir_raw[:, int(sample_rate * 1.01) : int(sample_rate * 1.3)]
-rir = rir / torch.norm(rir, p=2)
+rir = rir / torch.linalg.vector_norm(rir, ord=2)
 
 plot_waveform(rir, sample_rate, title="Room Impulse Response")
 

--- a/test/torchaudio_unittest/transforms/transforms_test_impl.py
+++ b/test/torchaudio_unittest/transforms/transforms_test_impl.py
@@ -472,8 +472,9 @@ class TransformsTestBase(TestBaseMixin):
             self.assertFalse(False in torch.eq(f_axis_mean[f_axis_mean != 0], 1))
 
         # Test if iid_masks gives different masking results for different spectrograms across the 0th dimension.
-        print(torch.norm(spec_masked[0] - spec_masked[1]).item())
+        diff = torch.linalg.vector_norm(spec_masked[0] - spec_masked[1]).item()
+        print(diff)
         if iid_masks is True:
-            self.assertTrue(torch.norm(spec_masked[0] - spec_masked[1]).item() > 0)
+            self.assertTrue(diff > 0)
         else:
-            self.assertTrue(torch.norm(spec_masked[0] - spec_masked[1]).item() == 0)
+            self.assertTrue(diff == 0)

--- a/torchaudio/functional/functional.py
+++ b/torchaudio/functional/functional.py
@@ -1046,8 +1046,8 @@ def _compute_nccf(waveform: Tensor, sample_rate: int, frame_time: float, freq_lo
 
         output_frames = (
             (s1 * s2).sum(-1)
-            / (EPSILON + torch.norm(s1, p=2, dim=-1)).pow(2)
-            / (EPSILON + torch.norm(s2, p=2, dim=-1)).pow(2)
+            / (EPSILON + torch.linalg.vector_norm(s1, ord=2, dim=-1)).pow(2)
+            / (EPSILON + torch.linalg.vector_norm(s2, ord=2, dim=-1)).pow(2)
         )
 
         output_lag.append(output_frames.unsqueeze(-1))


### PR DESCRIPTION
torch.norm is now deprecated.
The usages in torchaudio seems to be vector norm, so replacing them with torch.linalg.vector_norm

Resolves https://github.com/pytorch/audio/issues/3484