### PR TITLE
The state-of-the-art rnnt recipe

### DIFF
--- a/examples/asr/librispeech_conformer_rnnt/README.md
+++ b/examples/asr/librispeech_conformer_rnnt/README.md
@@ -12,7 +12,7 @@ To build TorchAudio from source, refer to the [contributing guidelines](https://
 
 ### Install additional dependencies
 ```bash
-pip install pytorch-lightning sentencepiece
+pip install pytorch-lightning sentencepiece tensorboard
 ```
 
 ## Usage
@@ -27,7 +27,7 @@ pip install pytorch-lightning sentencepiece
 
 Sample SLURM command:
 ```
-srun --cpus-per-task=12 --gpus-per-node=8 -N 4 --ntasks-per-node=8 python train.py --exp_dir ./experiments --librispeech_path ./librispeech/ --global_stats_path ./global_stats.json --sp_model_path ./spm_unigram_1023.model --epochs 160
+srun --cpus-per-task=12 --gpus-per-node=8 -N 4 --ntasks-per-node=8 python train.py --exp-dir ./experiments --librispeech-path ./librispeech/ --global-stats-path ./global_stats.json --sp-model-path ./spm_unigram_1023.model --epochs 160
 ```
 
 ### Evaluation
@@ -36,7 +36,7 @@ srun --cpus-per-task=12 --gpus-per-node=8 -N 4 --ntasks-per-node=8 python train.
 
 Sample SLURM command:
 ```
-srun python eval.py --checkpoint_path ./experiments/checkpoints/epoch=159.ckpt --librispeech_path ./librispeech/ --sp_model_path ./spm_unigram_1023.model --use_cuda
+srun python eval.py --checkpoint-path ./experiments/checkpoints/epoch=159.ckpt --librispeech-path ./librispeech/ --sp-model-path ./spm_unigram_1023.model --use-cuda
 ```
 
 The table below contains WER results for various splits.

--- a/examples/asr/librispeech_conformer_rnnt/additive_noise.py
+++ b/examples/asr/librispeech_conformer_rnnt/additive_noise.py
@@ -1,0 +1,74 @@
+import torch
+import random
+import torchaudio.functional as F
+
+
+class AddNoise(torch.nn.Module):
+    def __init__(
+        self,
+        noise_dataset,
+        sampling_rate = 16000,
+        snr = (10, 20),
+        p = 0.5,
+        seed: int = 42,
+    ):
+        # `noise_dataset` is a pytorch dataset that contains noise samples
+        # `p` is the probability of adding any noise
+
+        super().__init__()
+        self.noise_dataset = noise_dataset
+        self.noise_count = len(noise_dataset)
+        self.sampling_rate = sampling_rate
+        self.snr = snr
+        self.p = p
+        self.seed = seed
+        self.rng = random.Random(seed)
+        self.noise_batch = None
+        self.position = 0
+
+
+    def fetch_noise_batch(self, total_length):
+        # This will fetch noise until the number of sample points is equal or more than the speech samples
+
+        wav_list = []
+        while total_length > 0:
+            idx = self.rng.randint(0, self.noise_count - 1)  # (both included)
+            wav, sr, filename = self.noise_dataset[idx]
+            assert sr == self.sampling_rate
+            wav_list.append(wav)
+            total_length -= wav.size(-1)
+        self.noise_batch = torch.cat(wav_list, dim=-1)
+        self.position = self.rng.randint(0, self.noise_batch.size(-1) - 1)
+        return self.noise_batch
+
+
+    def get_my_noise(self, length):
+        noise_list = []
+        while length > 0:
+            noise = self.noise_batch[:, self.position:self.position+length]
+            noise_list.append(noise)
+            length -= noise.size(-1)
+            self.position += length
+            if self.position > self.noise_batch.size(-1):
+                self.position = 0
+        return torch.cat(noise_list, dim=-1)
+
+
+    def forward(self, sample: torch.Tensor) -> torch.Tensor:
+        # You might need to resample the input or noise such that their 
+        # sample rates are matched.
+        # We don't need to do this here for Librispeech, because
+        # Librispeech and Musan are both 16kHz.
+
+        # Reference: https://github.com/lhotse-speech/lhotse/blob/master/lhotse/cut/set.py#L1798
+
+        if sample.ndim == 1:
+            sample = sample.unsqueeze(0)
+
+        if self.rng.uniform(0.0, 1.0) > self.p:
+            return sample[0], sample.size(-1)
+
+        snr = self.rng.uniform(*self.snr) if isinstance(self.snr, (list, tuple)) else self.snr
+        noise = self.get_my_noise(sample.size(-1))
+        noisy_sample = F.add_noise(sample, noise, torch.tensor([snr]))
+        return noisy_sample[0], noisy_sample.size(-1)

--- a/examples/asr/librispeech_conformer_rnnt/lightning.py
+++ b/examples/asr/librispeech_conformer_rnnt/lightning.py
@@ -8,7 +8,7 @@ import torch
 import torchaudio
 from pytorch_lightning import LightningModule
 from torchaudio.models import Hypothesis, RNNTBeamSearch
-from torchaudio.prototype.models import conformer_rnnt_base
+from torchaudio.prototype.models import conformer_rnnt_base, conformer_rnnt_model
 
 
 logger = logging.getLogger()
@@ -75,6 +75,28 @@ def post_process_hypos(
     return nbest_batch
 
 
+def conformer_rnnt_torchaudio2_1_paper():
+    return conformer_rnnt_model(
+        input_dim=80,
+        encoding_dim=512,
+        time_reduction_stride=4,
+        conformer_input_dim=512,
+        conformer_ffn_dim=2048,
+        conformer_num_layers=12,
+        conformer_num_heads=8,
+        conformer_depthwise_conv_kernel_size=31,
+        conformer_dropout=0.1,
+        num_symbols=1024,
+        symbol_embedding_dim=1024,
+        num_lstm_layers=2,
+        lstm_hidden_dim=512,
+        lstm_layer_norm=True,
+        lstm_layer_norm_epsilon=1e-5,
+        lstm_dropout=0.3,
+        joiner_activation="tanh",
+    )
+
+
 class ConformerRNNTModule(LightningModule):
     def __init__(self, sp_model):
         super().__init__()
@@ -90,7 +112,8 @@ class ConformerRNNTModule(LightningModule):
 
         # ``conformer_rnnt_base`` hardcodes a specific Conformer RNN-T configuration.
         # For greater customizability, please refer to ``conformer_rnnt_model``.
-        self.model = conformer_rnnt_base()
+        # self.model = conformer_rnnt_base()
+        self.model = conformer_rnnt_torchaudio2_1_paper()
         self.loss = torchaudio.transforms.RNNTLoss(reduction="sum")
         self.optimizer = torch.optim.Adam(self.model.parameters(), lr=8e-4, betas=(0.9, 0.98), eps=1e-9, weight_decay=1e-3)
         self.warmup_lr_scheduler = WarmupLR(self.optimizer, 40, 120, 0.96)

--- a/examples/asr/librispeech_conformer_rnnt/lightning.py
+++ b/examples/asr/librispeech_conformer_rnnt/lightning.py
@@ -92,7 +92,7 @@ class ConformerRNNTModule(LightningModule):
         # For greater customizability, please refer to ``conformer_rnnt_model``.
         self.model = conformer_rnnt_base()
         self.loss = torchaudio.transforms.RNNTLoss(reduction="sum")
-        self.optimizer = torch.optim.Adam(self.model.parameters(), lr=8e-4, betas=(0.9, 0.98), eps=1e-9)
+        self.optimizer = torch.optim.Adam(self.model.parameters(), lr=8e-4, betas=(0.9, 0.98), eps=1e-9, weight_decay=1e-3)
         self.warmup_lr_scheduler = WarmupLR(self.optimizer, 40, 120, 0.96)
 
     def _step(self, batch, _, step_type):

--- a/examples/asr/librispeech_conformer_rnnt/lightning.py
+++ b/examples/asr/librispeech_conformer_rnnt/lightning.py
@@ -94,6 +94,7 @@ def conformer_rnnt_torchaudio2_1_paper():
         lstm_layer_norm_epsilon=1e-5,
         lstm_dropout=0.3,
         joiner_activation="tanh",
+        subsampling_type="conv",
     )
 
 

--- a/examples/asr/librispeech_conformer_rnnt/train.py
+++ b/examples/asr/librispeech_conformer_rnnt/train.py
@@ -49,7 +49,12 @@ def run_train(args):
 
     sp_model = spm.SentencePieceProcessor(model_file=str(args.sp_model_path))
     model = ConformerRNNTModule(sp_model)
-    data_module = get_data_module(str(args.librispeech_path), str(args.global_stats_path), str(args.sp_model_path))
+    data_module = get_data_module(
+        args.librispeech_path,
+        args.global_stats_path,
+        str(args.sp_model_path),
+        args.musan_path,
+    )
     trainer.fit(model, data_module, ckpt_path=args.checkpoint_path)
 
 
@@ -78,6 +83,13 @@ def cli_main():
         type=pathlib.Path,
         help="Path to LibriSpeech datasets.",
         required=True,
+    )
+    parser.add_argument(
+        "--musan-path",
+        type=pathlib.Path,
+        help="Path to MUSAN dataset for addtive noise.",
+        default=None,
+        required=False,
     )
     parser.add_argument(
         "--sp-model-path",

--- a/examples/asr/librispeech_conformer_rnnt/train.py
+++ b/examples/asr/librispeech_conformer_rnnt/train.py
@@ -6,7 +6,7 @@ import sentencepiece as spm
 from lightning import ConformerRNNTModule
 from pytorch_lightning import seed_everything, Trainer
 from pytorch_lightning.callbacks import LearningRateMonitor, ModelCheckpoint
-from pytorch_lightning.plugins import DDPPlugin
+from pytorch_lightning.strategies import DDPStrategy
 from transforms import get_data_module
 
 
@@ -39,9 +39,9 @@ def run_train(args):
         default_root_dir=args.exp_dir,
         max_epochs=args.epochs,
         num_nodes=args.nodes,
-        gpus=args.gpus,
+        devices=args.gpus,
         accelerator="gpu",
-        strategy=DDPPlugin(find_unused_parameters=False),
+        strategy=DDPStrategy(find_unused_parameters=False),
         callbacks=callbacks,
         reload_dataloaders_every_n_epochs=1,
         gradient_clip_val=10.0,

--- a/examples/asr/librispeech_conformer_rnnt/transforms.py
+++ b/examples/asr/librispeech_conformer_rnnt/transforms.py
@@ -124,4 +124,5 @@ def get_data_module(librispeech_path, global_stats_path, sp_model_path):
         train_transform=train_transform,
         val_transform=val_transform,
         test_transform=test_transform,
+        max_tokens=1200,
     )

--- a/examples/asr/librispeech_conformer_rnnt/transforms.py
+++ b/examples/asr/librispeech_conformer_rnnt/transforms.py
@@ -9,12 +9,17 @@ import torchaudio
 from data_module import LibriSpeechDataModule
 from lightning import Batch
 
+import torchaudio.transforms as T
+from additive_noise import AddNoise
+from torchaudio.prototype.datasets import Musan
+
 
 _decibel = 2 * 20 * math.log10(torch.iinfo(torch.int16).max)
 _gain = pow(10, 0.05 * _decibel)
 
 _spectrogram_transform = torchaudio.transforms.MelSpectrogram(sample_rate=16000, n_fft=400, n_mels=80, hop_length=160)
 _speed_perturb_transform = torchaudio.transforms.SpeedPerturbation(orig_freq=16000, factors=[0.9, 1.0, 1.1])
+_additive_noise_transform = None
 
 
 def _piecewise_linear_log(x):
@@ -58,9 +63,14 @@ def _extract_labels(sp_model, samples: List):
     return targets, lengths
 
 
-def _extract_features(data_pipeline, samples: List, speed_perturbation=False):
+def _extract_features(data_pipeline, samples: List, speed_perturbation=False, musan_noise=False):
     if speed_perturbation:
         samples = [_speed_perturb_transform(sample[0].squeeze()) for sample in samples]
+
+    if musan_noise:
+        total_length = sum([sample[0].size(-1) for sample in samples])
+        _additive_noise_transform.fetch_noise_batch(total_length)
+        samples = [_additive_noise_transform(sample[0].squeeze()) for sample in samples]
 
     mel_features = [_spectrogram_transform(sample[0].squeeze()).transpose(1, 0) for sample in samples]
     features = torch.nn.utils.rnn.pad_sequence(mel_features, batch_first=True)
@@ -92,7 +102,12 @@ class TrainTransform:
         )
 
     def __call__(self, samples: List):
-        features, feature_lengths = _extract_features(self.train_data_pipeline, samples)
+        features, feature_lengths = _extract_features(
+            self.train_data_pipeline,
+            samples,
+            speed_perturbation=True,
+            musan_noise=(_additive_noise_transform is not None),
+        )
         targets, target_lengths = _extract_labels(self.sp_model, samples)
         return Batch(features, feature_lengths, targets, target_lengths)
 
@@ -119,7 +134,13 @@ class TestTransform:
         return self.val_transforms([sample]), [sample]
 
 
-def get_data_module(librispeech_path, global_stats_path, sp_model_path):
+def get_data_module(librispeech_path, global_stats_path, sp_model_path, musan_path=None):
+    if musan_path is not None:
+        subsets = ["noise", "music"]  # we might not need to add the "speech" part in MUSAN
+        musan = Musan(musan_path, subsets)
+        global _additive_noise_transform
+        _additive_noise_transform = AddNoise(musan, snr=[15, 30], p=0.5)
+
     train_transform = TrainTransform(global_stats_path=global_stats_path, sp_model_path=sp_model_path)
     val_transform = ValTransform(global_stats_path=global_stats_path, sp_model_path=sp_model_path)
     test_transform = TestTransform(global_stats_path=global_stats_path, sp_model_path=sp_model_path)

--- a/examples/asr/librispeech_conformer_rnnt/transforms.py
+++ b/examples/asr/librispeech_conformer_rnnt/transforms.py
@@ -76,6 +76,14 @@ class TrainTransform:
             torchaudio.transforms.FrequencyMasking(27),
             torchaudio.transforms.TimeMasking(100, p=0.2),
             torchaudio.transforms.TimeMasking(100, p=0.2),
+            torchaudio.transforms.TimeMasking(100, p=0.2),
+            torchaudio.transforms.TimeMasking(100, p=0.2),
+            torchaudio.transforms.TimeMasking(100, p=0.2),
+            torchaudio.transforms.TimeMasking(100, p=0.2),
+            torchaudio.transforms.TimeMasking(100, p=0.2),
+            torchaudio.transforms.TimeMasking(100, p=0.2),
+            torchaudio.transforms.TimeMasking(100, p=0.2),
+            torchaudio.transforms.TimeMasking(100, p=0.2),
             FunctionalModule(partial(torch.transpose, dim0=1, dim1=2)),
         )
 

--- a/torchaudio/prototype/datasets/musan.py
+++ b/torchaudio/prototype/datasets/musan.py
@@ -18,12 +18,17 @@ class Musan(Dataset):
         subset (str): Subset of the dataset to use. Options: [``"music"``, ``"noise"``, ``"speech"``].
     """
 
-    def __init__(self, root: Union[str, Path], subset: str):
-        if subset not in _SUBSETS:
-            raise ValueError(f"Invalid subset '{subset}' given. Please provide one of {_SUBSETS}")
+    def __init__(self, root: Union[str, Path], subsets: Union[str, list]):
+        if type(subsets) is str:
+            subsets = [subsets]
 
-        subset_path = Path(root) / subset
-        self._walker = [str(p) for p in subset_path.glob("*/*.*")]
+        self._walker = []
+        for subset in subsets:
+            if subset not in _SUBSETS:
+                raise ValueError(f"Invalid subset '{subset}' given. Please provide one of {_SUBSETS}")
+
+            subset_path = Path(root) / subset
+            self._walker += [str(p) for p in subset_path.glob("*/*.*")]
 
     def get_metadata(self, n: int) -> Tuple[str, int, str]:
         r"""Get metadata for the n-th sample in the dataset. Returns filepath instead of waveform,


### PR DESCRIPTION
This PR contains updates for the RNN-T recipe that produces the state-of-the-art performance:
Librispeech WER: `test-clean/test-other  2.54/5.59`

If we merge this PR into master, we need to update the README.md in `librispeech_conformer_rnnt` folder.