### PR TITLE
Move backend initialization to toplevel

### DIFF
--- a/test/torchaudio_unittest/backend/utils_test.py
+++ b/test/torchaudio_unittest/backend/utils_test.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import torchaudio
 from torchaudio_unittest import common_utils
 
@@ -10,13 +8,12 @@ class BackendSwitchMixin:
     backend = None
     backend_module = None
 
-    @patch("torchaudio.backend.utils._is_backend_dispatcher_enabled", lambda: False)
     def test_switch(self):
-        torchaudio.set_audio_backend(self.backend)
+        torchaudio.backend.utils.set_audio_backend(self.backend)
         if self.backend is None:
-            assert torchaudio.get_audio_backend() is None
+            assert torchaudio.backend.utils.get_audio_backend() is None
         else:
-            assert torchaudio.get_audio_backend() == self.backend
+            assert torchaudio.backend.utils.get_audio_backend() == self.backend
         assert torchaudio.load == self.backend_module.load
         assert torchaudio.save == self.backend_module.save
         assert torchaudio.info == self.backend_module.info

--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -12,12 +12,26 @@ from torchaudio import (  # noqa: F401
     utils,
 )
 
-from torchaudio.backend import get_audio_backend, list_audio_backends, set_audio_backend
-
 try:
     from .version import __version__, git_version  # noqa: F401
 except ImportError:
     pass
+
+
+def _is_backend_dispatcher_enabled():
+    import os
+
+    return os.getenv("TORCHAUDIO_USE_BACKEND_DISPATCHER", default="1") == "1"
+
+
+if _is_backend_dispatcher_enabled():
+    from ._backend import _init_backend, get_audio_backend, list_audio_backends, set_audio_backend
+else:
+    from .backend import _init_backend, get_audio_backend, list_audio_backends, set_audio_backend
+
+
+_init_backend()
+
 
 __all__ = [
     "io",

--- a/torchaudio/_backend/__init__.py
+++ b/torchaudio/_backend/__init__.py
@@ -1,6 +1,28 @@
-from .utils import get_info_func, get_load_func, get_save_func
+import warnings
+from typing import List, Optional
+
+import torchaudio
+
+from . import utils
 
 
-info = get_info_func()
-load = get_load_func()
-save = get_save_func()
+# TODO: Once legacy global backend is removed, move this to torchaudio.__init__
+def _init_backend():
+    torchaudio.info = utils.get_info_func()
+    torchaudio.load = utils.get_load_func()
+    torchaudio.save = utils.get_save_func()
+
+
+def list_audio_backends() -> List[str]:
+    return list(utils.get_available_backends().keys())
+
+
+# Temporary until global backend is removed
+def get_audio_backend() -> Optional[str]:
+    warnings.warn("I/O Dispatcher is enabled. There is no global audio backend.", stacklevel=2)
+    return None
+
+
+# Temporary until global backend is removed
+def set_audio_backend(_: Optional[str]):
+    warnings.warn("I/O Dispatcher is enabled. set_audio_backend is a no-op", stacklevel=2)

--- a/torchaudio/backend/__init__.py
+++ b/torchaudio/backend/__init__.py
@@ -1,14 +1,4 @@
-# flake8: noqa
-import torchaudio
+from .utils import _init_backend, get_audio_backend, list_audio_backends, set_audio_backend
 
-from . import utils
-from .utils import _is_backend_dispatcher_enabled, get_audio_backend, list_audio_backends, set_audio_backend
 
-if _is_backend_dispatcher_enabled():
-    from torchaudio._backend.utils import get_info_func, get_load_func, get_save_func
-
-    torchaudio.info = get_info_func()
-    torchaudio.load = get_load_func()
-    torchaudio.save = get_save_func()
-else:
-    utils._init_audio_backend()
+__all__ = ["_init_backend", "get_audio_backend", "list_audio_backends", "set_audio_backend"]

--- a/torchaudio/backend/utils.py
+++ b/torchaudio/backend/utils.py
@@ -1,5 +1,4 @@
 """Defines utilities for switching audio backends"""
-import os
 import warnings
 from typing import List, Optional
 
@@ -15,19 +14,12 @@ __all__ = [
 ]
 
 
-def _is_backend_dispatcher_enabled() -> bool:
-    return os.getenv("TORCHAUDIO_USE_BACKEND_DISPATCHER", default="1") == "1"
-
-
 def list_audio_backends() -> List[str]:
     """List available backends
 
     Returns:
         List[str]: The list of available backends.
     """
-    if _is_backend_dispatcher_enabled():
-        warnings.warn("list_audio_backend's return value is irrelevant when the I/O backend dispatcher is enabled.")
-
     backends = []
     if _mod_utils.is_module_available("soundfile"):
         backends.append("soundfile")
@@ -44,10 +36,6 @@ def set_audio_backend(backend: Optional[str]):
             One of ``"sox_io"`` or ``"soundfile"`` based on availability
             of the system. If ``None`` is provided the  current backend is unassigned.
     """
-    if _is_backend_dispatcher_enabled():
-        warnings.warn("set_audio_backend is a no-op when the I/O backend dispatcher is enabled.")
-        return
-
     if backend is not None and backend not in list_audio_backends():
         raise RuntimeError(f'Backend "{backend}" is not one of ' f"available backends: {list_audio_backends()}.")
 
@@ -64,7 +52,7 @@ def set_audio_backend(backend: Optional[str]):
         setattr(torchaudio, func, getattr(module, func))
 
 
-def _init_audio_backend():
+def _init_backend():
     backends = list_audio_backends()
     if "sox_io" in backends:
         set_audio_backend("sox_io")
@@ -81,9 +69,6 @@ def get_audio_backend() -> Optional[str]:
     Returns:
         Optional[str]: The name of the current backend or ``None`` if no backend is assigned.
     """
-    if _is_backend_dispatcher_enabled():
-        warnings.warn("get_audio_backend's return value is irrelevant when the I/O backend dispatcher is enabled.")
-
     if torchaudio.load == no_backend.load:
         return None
     if torchaudio.load == sox_io_backend.load:


### PR DESCRIPTION
The backend dispatcher is implemented in `torchaudio._backend`, while the legacy backend is implemented in `torchaudio.backend`.

The initialization happen in `torchaudio._backend`.
This commit moves it to `torchaudio.__init__`, so that `backend` and `_backend` is more independent.