### PR TITLE
Expose AudioMetadata

### DIFF
--- a/docs/source/backend.rst
+++ b/docs/source/backend.rst
@@ -38,7 +38,7 @@ Structures used to report the metadata of audio files.
 AudioMetaData
 -------------
 
-.. autoclass:: torchaudio.backend.common.AudioMetaData
+.. autoclass:: torchaudio.AudioMetaData
 
 .. py:module:: torchaudio.backend.sox_io_backend
 

--- a/torchaudio/__init__.py
+++ b/torchaudio/__init__.py
@@ -1,4 +1,4 @@
-from torchaudio import (  # noqa: F401
+from . import (  # noqa: F401
     _extension,
     compliance,
     datasets,
@@ -11,6 +11,8 @@ from torchaudio import (  # noqa: F401
     transforms,
     utils,
 )
+from .backend.common import AudioMetaData
+
 
 try:
     from .version import __version__, git_version  # noqa: F401
@@ -34,6 +36,7 @@ _init_backend()
 
 
 __all__ = [
+    "AudioMetaData",
     "io",
     "compliance",
     "datasets",

--- a/torchaudio/backend/common.py
+++ b/torchaudio/backend/common.py
@@ -1,8 +1,7 @@
 class AudioMetaData:
-    """Return type of ``torchaudio.info`` function.
+    """AudioMetaData()
 
-    This class is used by :py:mod:`"sox_io" backend<torchaudio.backends.sox_io_backend>` and
-    :py:mod:`"soundfile" backend<torchaudio.backends.soundfile_backend>`.
+    Return type of ``torchaudio.info`` function.
 
     :ivar int sample_rate: Sample rate
     :ivar int num_frames: The number of frames


### PR DESCRIPTION
`torchaudio.info` returns `AudioMetaData`. It should be exposed as public API, without referring `backend` submodule.