### PR TITLE
Add default use_tmp_hub_dir value for integration tests

### DIFF
--- a/test/integration_tests/conftest.py
+++ b/test/integration_tests/conftest.py
@@ -102,7 +102,7 @@ def pytest_addoption(parser):
 
 @pytest.fixture(autouse=True)
 def temp_hub_dir(tmp_path, pytestconfig):
-    if not pytestconfig.getoption("use_tmp_hub_dir"):
+    if not pytestconfig.getoption("use_tmp_hub_dir", default=False):
         yield
     else:
         org_dir = torch.hub.get_dir()


### PR DESCRIPTION
Summary: In the event that `use_tmp_hub_dir` isn't specified as an option, pytest shouldn't fail. To resolve such failures, this PR modifies function `temp_hub_dir` to fall back on a default value of `False` for `use_tmp_hub_dir`.

Differential Revision: D48318947

