### PR TITLE
[BC-breaking] Update pre-built ffmpeg4 to 4.4.4

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -16,7 +16,7 @@ Please refer to https://pytorch.org/get-started/locally/ for the details.
    each of which requires a corresponding PyTorch distribution.
 
 .. note::
-   This software was compiled against an unmodified copies of FFmpeg, with the specific rpath removed so as to enable the use of system libraries. The LGPL source can be downloaded from the following locations: `n4.1.8 <https://github.com/FFmpeg/FFmpeg/releases/tag/n4.1.8>`__ (`license <https://github.com/FFmpeg/FFmpeg/blob/n4.1.8/COPYING.LGPLv2.1>`__), `n5.0.3 <https://github.com/FFmpeg/FFmpeg/releases/tag/n5.0.3>`__ (`license <https://github.com/FFmpeg/FFmpeg/blob/n5.0.3/COPYING.LGPLv2.1>`__) and `n6.0 <https://github.com/FFmpeg/FFmpeg/releases/tag/n6.0>`__ (`license <https://github.com/FFmpeg/FFmpeg/blob/n6.0/COPYING.LGPLv2.1>`__).
+   This software was compiled against an unmodified copies of FFmpeg, with the specific rpath removed so as to enable the use of system libraries. The LGPL source can be downloaded from the following locations: `n4.1.8 <https://github.com/FFmpeg/FFmpeg/releases/tag/n4.4.4>`__ (`license <https://github.com/FFmpeg/FFmpeg/blob/n4.4.4/COPYING.LGPLv2.1>`__), `n5.0.3 <https://github.com/FFmpeg/FFmpeg/releases/tag/n5.0.3>`__ (`license <https://github.com/FFmpeg/FFmpeg/blob/n5.0.3/COPYING.LGPLv2.1>`__) and `n6.0 <https://github.com/FFmpeg/FFmpeg/releases/tag/n6.0>`__ (`license <https://github.com/FFmpeg/FFmpeg/blob/n6.0/COPYING.LGPLv2.1>`__).
 
 Dependencies
 ------------
@@ -25,8 +25,12 @@ Dependencies
 
   Please refer to the compatibility matrix bellow for supported PyTorch versions.
 
+.. _optional_dependencies:
+
 Optional Dependencies
 ~~~~~~~~~~~~~~~~~~~~~
+
+.. _ffmpeg:
 
 * `FFmpeg <https://ffmpeg.org>`__
 
@@ -34,8 +38,14 @@ Optional Dependencies
   `I/O functions <./torchaudio.html#i-o>`__.
 
   Starting version 2.1, TorchAudio official binary distributions are compatible with
-  FFmpeg version 6, 5 and 4. At runtime, TorchAudio first looks for FFmpeg 6,
+  FFmpeg version 6, 5 and 4. (>=4.4, <7). At runtime, TorchAudio first looks for FFmpeg 6,
   if not found, then it continues to looks for 5 and move on to 4.
+
+  There are multiple ways to install FFmpeg libraries.
+  Please refer to the official documentation for how to install FFmpeg.
+  If you are using Anaconda Python distribution,
+  ``conda install -c conda-forge 'ffmpeg<7'`` will install
+  compatible FFmpeg libraries.
 
   If you need to specify the version of FFmpeg TorchAudio searches and links, you can
   specify it via the environment variable ``TORCHAUDIO_USE_FFMPEG_VERSION``. For example,
@@ -45,6 +55,11 @@ Optional Dependencies
   If for some reason, this search mechanism is causing an issue, you can disable
   the FFmpeg integration entirely by setting the environment variable
   ``TORCHAUDIO_USE_FFMPEG=0``.
+
+  There are multiple ways to install FFmpeg libraries.
+  If you are using Anaconda Python distribution,
+  ``conda install -c conda-forge 'ffmpeg<7'`` will install
+  compatible FFmpeg libraries.
 
   .. note::
 
@@ -86,6 +101,7 @@ Optional Dependencies
 * `sentencepiece <https://pypi.org/project/sentencepiece/>`__
 
   Required for performing automatic speech recognition with :ref:`Emformer RNN-T<RNNT>`.
+  You can install it by running ``pip install sentencepiece``.
 
 * `deep-phonemizer <https://pypi.org/project/deep-phonemizer/>`__
 

--- a/examples/tutorials/device_asr.py
+++ b/examples/tutorials/device_asr.py
@@ -7,25 +7,22 @@ Device ASR with Emformer RNN-T
 This tutorial shows how to use Emformer RNN-T and streaming API
 to perform speech recognition on a streaming device input, i.e. microphone
 on laptop.
-
-.. note::
-
-   This tutorial requires FFmpeg libraries (>=4.1, <7) and SentencePiece.
-
-   There are multiple ways to install FFmpeg libraries.
-   If you are using Anaconda Python distribution,
-   ``conda install -c conda-forge 'ffmpeg<7'`` will install
-   compatible FFmpeg libraries.
-
-   You can install SentencePiece by running ``pip install sentencepiece``.
-
-.. note::
-
-   This tutorial was tested on MacBook Pro and Dynabook with Windows 10.
-
-   This tutorial does NOT work on Google Colab because the server running
-   this tutorial does not have a microphone that you can talk to.
 """
+
+######################################################################
+#
+# .. note::
+#
+#    This tutorial requires FFmpeg libraries.
+#    Please refer to :ref:`FFmpeg dependency <ffmpeg_dependency>` for
+#    the detail.
+#
+# .. note::
+#
+#    This tutorial was tested on MacBook Pro and Dynabook with Windows 10.
+#
+#    This tutorial does NOT work on Google Colab because the server running
+#    this tutorial does not have a microphone that you can talk to.
 
 ######################################################################
 # 1. Overview

--- a/examples/tutorials/effector_tutorial.py
+++ b/examples/tutorials/effector_tutorial.py
@@ -13,12 +13,9 @@ apply various effects and codecs to waveform tensor.
 #
 # .. note::
 #
-#    This tutorial requires FFmpeg libraries (>=4.1, <7).
-#
-#    There are multiple ways to install FFmpeg libraries.
-#    If you are using Anaconda Python distribution,
-#    ``conda install -c conda-forge 'ffmpeg<7'`` will install
-#    compatible FFmpeg libraries.
+#    This tutorial requires FFmpeg libraries.
+#    Please refer to :ref:`FFmpeg dependency <ffmpeg_dependency>` for
+#    the detail.
 #
 
 ######################################################################
@@ -42,25 +39,15 @@ print(torchaudio.__version__)
 
 ######################################################################
 #
-try:
-    from torchaudio.io import AudioEffector, CodecConfig
-except ImportError as err:
-    raise RuntimeError(
-        "This tutorial requires nightly build of TorchAudio. "
-        "Please install the nightly versions of PyTorch and torchaudio. "
-        "https://pytorch.org/get-started/locally/"
-    ) from err
+from torchaudio.io import AudioEffector, CodecConfig
 
 import matplotlib.pyplot as plt
 from IPython.display import Audio
 
 ######################################################################
 #
-try:
-    for k, v in torchaudio.utils.ffmpeg_utils.get_versions().items():
-        print(k, v)
-except Exception:
-    raise RuntimeError("This tutorial requires FFmpeg libraries 4.2>,<5. " "Please install FFmpeg.")
+for k, v in torchaudio.utils.ffmpeg_utils.get_versions().items():
+    print(k, v)
 
 ######################################################################
 # Usage

--- a/examples/tutorials/online_asr_tutorial.py
+++ b/examples/tutorials/online_asr_tutorial.py
@@ -13,14 +13,11 @@ to perform online speech recognition.
 #
 # .. note::
 #
-#    This tutorial requires FFmpeg libraries (>=4.1, <7) and SentencePiece.
+#    This tutorial requires FFmpeg libraries and SentencePiece.
 #
-#    There are multiple ways to install FFmpeg libraries.
-#    If you are using Anaconda Python distribution,
-#    ``conda install -c conda-forge 'ffmpeg<7'`` will install
-#    compatible FFmpeg libraries.
+#    Please refer to :ref:`Optional Dependencies <optional_dependencies>`
+#    for the detail.
 #
-#    You can install SentencePiece by running ``pip install sentencepiece``.
 
 ######################################################################
 # 1. Overview

--- a/examples/tutorials/streamreader_basic_tutorial.py
+++ b/examples/tutorials/streamreader_basic_tutorial.py
@@ -14,12 +14,9 @@ libavfilter provides.
 #
 # .. note::
 #
-#    This tutorial requires FFmpeg libraries (>=4.1, <7).
-#
-#    There are multiple ways to install FFmpeg libraries.
-#    If you are using Anaconda Python distribution,
-#    ``conda install -c conda-forge 'ffmpeg<7'`` will install
-#    compatible FFmpeg libraries.
+#    This tutorial requires FFmpeg libraries.
+#    Please refer to :ref:`FFmpeg dependency <ffmpeg_dependency>` for
+#    the detail.
 #
 
 ######################################################################

--- a/examples/tutorials/streamwriter_advanced.py
+++ b/examples/tutorials/streamwriter_advanced.py
@@ -23,14 +23,9 @@ play audio and video.
 #
 # .. note::
 #
-#    This tutorial requires FFmpeg libraries (>=4.1, <7).
-#
-#    There are multiple ways to install FFmpeg libraries.
-#    If you are using Anaconda Python distribution,
-#    ``conda install -c conda-forge 'ffmpeg<7'`` will install
-#    compatible FFmpeg libraries.
-#    However, this distribution does not have SDL plugin, so it cannot play
-#    video.
+#    This tutorial requires FFmpeg libraries.
+#    Please refer to :ref:`FFmpeg dependency <ffmpeg_dependency>` for
+#    the detail.
 #
 
 ######################################################################

--- a/examples/tutorials/streamwriter_basic_tutorial.py
+++ b/examples/tutorials/streamwriter_basic_tutorial.py
@@ -13,12 +13,9 @@ encode and save audio/video data into various formats/destinations.
 #
 # .. note::
 #
-#    This tutorial requires FFmpeg libraries (>=4.1, <7).
-#
-#    There are multiple ways to install FFmpeg libraries.
-#    If you are using Anaconda Python distribution,
-#    ``conda install -c conda-forge 'ffmpeg<7'`` will install
-#    compatible FFmpeg libraries.
+#    This tutorial requires FFmpeg libraries.
+#    Please refer to :ref:`FFmpeg dependency <ffmpeg_dependency>` for
+#    the detail.
 #
 
 ######################################################################

--- a/third_party/ffmpeg/multi/CMakeLists.txt
+++ b/third_party/ffmpeg/multi/CMakeLists.txt
@@ -15,8 +15,8 @@ if (APPLE)
   if ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm64")
     FetchContent_Declare(
       f4
-      URL ${base_url}/2023-07-06/macos_arm64/4.1.8.tar.gz
-      URL_HASH SHA256=a44b8152b7f204ce5050fc7f6fd2bbbafe7ae4e45f03e135f3b45dd9a08f404e
+      URL ${base_url}/2023-08-14/macos_arm64/4.4.4.tar.gz
+      URL_HASH SHA256=9a593eb241eb8b23bc557856ee6db5d9aecd2d8895c614a949f3a1ad9799c1a1
       )
     FetchContent_Declare(
       f5
@@ -31,8 +31,8 @@ if (APPLE)
   elseif ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
     FetchContent_Declare(
       f4
-      URL ${base_url}/2023-07-06/macos_x86_64/4.1.8.tar.gz
-      URL_HASH SHA256=392d5af0b24535bfc69d6244e7595e5f07117b93d94505d0a4b34c82ae479f48
+      URL ${base_url}/2023-08-14/macos_x86_64/4.4.4.tar.gz
+      URL_HASH SHA256=0935e359c0864969987d908397f9208d6dc4dc0ef8bfe2ec730bb2c44eae89fc
       )
     FetchContent_Declare(
       f5
@@ -58,8 +58,8 @@ elseif (UNIX)
   if ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
     FetchContent_Declare(
       f4
-      URL ${base_url}/2023-07-06/linux_aarch64/4.1.8.tar.gz
-      URL_HASH SHA256=aae0b713040e30ceebe0d0bc82353d3d9054055c7af8a4f4abc1766015ab7681
+      URL ${base_url}/2023-08-14/linux_aarch64/4.4.4.tar.gz
+      URL_HASH SHA256=6f00437d13a3b3812ebe81c6e6f3a84a58f260d946a1995df87ba09aae234504
       )
     FetchContent_Declare(
       f5
@@ -74,8 +74,8 @@ elseif (UNIX)
   elseif ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
     FetchContent_Declare(
       f4
-      URL ${base_url}/2023-07-06/linux_x86_64/4.1.8.tar.gz
-      URL_HASH SHA256=52e53b8857739bdd54f9d8541e22569b57f6c6f16504ee83963c2ed3e7061a23
+      URL ${base_url}/2023-08-14/linux_x86_64/4.4.4.tar.gz
+      URL_HASH SHA256=9b87eeba9b6975e25f28ba12163bd713228ed84f4c2b3721bc5ebe92055edb51
       )
     FetchContent_Declare(
       f5
@@ -101,8 +101,8 @@ elseif (UNIX)
 elseif(MSVC)
   FetchContent_Declare(
     f4
-    URL ${base_url}/2023-07-06/windows/4.1.8.tar.gz
-    URL_HASH SHA256=c45cd36e0575490f97ace07365bb67c5e1cbe9f3e6a4272d035c19348df96790
+    URL ${base_url}/2023-08-14/windows/4.4.4.tar.gz
+    URL_HASH SHA256=9f9a65cf03a3e164edca601ba18180a504e44e03fae48ce706ca3120b55a4db5
     )
   FetchContent_Declare(
     f5


### PR DESCRIPTION
In https://github.com/pytorch/audio/pull/3460, we switched the build process for FFmpeg extension.
Since it is complicated to install FFmpeg in some environments, at build time, pre-built binaries and its headers 
are downloaded and used as a scaffolding for torchaudio build.

Now even though we did not change any code or FFmpeg version, it turned out that this causes segmentation 
fault on Ubuntu when using system Python and FFmpeg 4.4 installed via aptitude.
While investigating the issue, I swapped the said pre-built FFmpeg scaffolding with FFmpeg 4.4 from aptitude,
and the segmentation fault did not happen. This indicates that it is binary compatibility issue.

Before #3460, each binary build job was building FFmpeg 4.1.8 using the same compiler used to build torchaudio,
but after #3460 the environments to build FFmpeg 4.1.8 and torchaudio are different. My hypothesis is that
this difference is causing some ABI incompatibility when linking against FFmpeg 4.4. (Also, I don't remember well,
but I read somewhere that 4.4 has a different ABI)

Through experiments, it turned out upgrading the pre-built FFmpeg scaffolding to 4.4 resolves this. 
So this commit upgrade the pre-built FFmpeg 4 to 4.4.
The potential (yet unconfirmed) downside is that torchaudio will no longer work with 4.1, 4.2, and 4.3.
Since FFmpeg 4.4 is what Ubuntu 20.04 and 22.04 support by default, and Google Colab is also on 20.04,
I think it is more important to support 4.4.

Therefore we drop the support for 4.1-4.3 from normal build (and official distributions). Those who wish to
use 4.1-4.3 can build torchaudio from source by linking to specific FFmpeg.