### PR TITLE
Fix style check CI job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,10 @@ jobs:
 
         echo '::group::Setup environment'
         eval "$("$(which conda)" shell.bash hook)"
-        pip install --progress-bar=off pre-commit
+        # libcst does not have 3.11 pre-built binaries yet. Use python 3.10
+        conda create -y --name env python=3.10
+        conda activate env
+        pip3 install --progress-bar=off pre-commit
         echo '::endgroup::'
 
         set +e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,6 @@ line-length = 120
 target-version = ["py38"]
 
 [tool.ufmt]
+excludes = [
+    "examples/tutorials/",
+]


### PR DESCRIPTION
It seems that the default Python version was updated to 3.11.
libcst does not have binary release for 3.11, so the CI attempts to
build from source but it fails because building libcst requires Rust
compiler.

This commit fix the Python version of style check job to 3.10 so that
the issue with Rust compiler is avoided.