### PR TITLE
Fix I/O test

### DIFF
--- a/test/torchaudio_unittest/io/stream_reader_test.py
+++ b/test/torchaudio_unittest/io/stream_reader_test.py
@@ -259,6 +259,23 @@ class StreamReaderInterfaceTest(_MediaSourceMixin, TempDirMixin, TorchaudioTestC
         s.add_video_stream(-1, filter_desc="fps=10")
         s.add_video_stream(-1, filter_desc="format=rgb24")
         s.add_video_stream(-1, filter_desc="scale=w=160:h=90")
+
+        # Note:
+        # Somehow only FFmpeg 5 reports invalid video frame rate. (24576/0)
+        # FFmpeg 4 and 6 work fine.
+        # Perhaps this is a regression in FFmpeg or it could actually originate
+        # from other libraries.
+        # It consistently fails with FFmpeg installed via conda, so we change
+        # the value based on FFmpeg version.
+        ver = torchaudio.utils.ffmpeg_utils.get_versions()["libavutil"]
+        print(ver)
+        major, minor, _ = ver
+        if major == 57:
+            video_frame_rate = -1
+        else:
+            video_frame_rate = 30000 / 1001
+        print(video_frame_rate)
+
         expected = [
             OutputAudioStream(
                 source_index=4,

--- a/torchaudio/csrc/ffmpeg/pybind/pybind.cpp
+++ b/torchaudio/csrc/ffmpeg/pybind/pybind.cpp
@@ -274,7 +274,6 @@ PYBIND11_MODULE(TORCHAUDIO_FFMPEG_EXT_NAME, m) {
           "frame_rate", [](const OutputStreamInfo& o) -> double {
             if (o.frame_rate.den == 0) {
               TORCH_WARN(
-                  o.frame_rate.den,
                   "Invalid frame rate is found: ",
                   o.frame_rate.num,
                   "/",


### PR DESCRIPTION
Turned out FFmpeg 5 installed via conda reports video frame rate -1. FFmpeg 4 and 6 are fine. This is either a regression in FFmpeg or in the underlying decoding library.

Make the reference value adoptive.