### PR TITLE
Package libomp.so with torchaudio wheel for ROCm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,12 @@ def _main():
     with open("README.md") as f:
         long_description = f.read()
 
+    # ROCm build of torchaudio needs libomp.so to be packaged with the wheel
+    # to avoid import-time error due to missing dependency
+    if torch.hip is not None:
+        import shutil
+        shutil.copy("/opt/rocm/llvm/lib/libomp.so", "./torchaudio/lib/")
+
     setup(
         name="torchaudio",
         version=version,
@@ -154,6 +160,7 @@ def _main():
         },
         install_requires=[pytorch_package_dep],
         zip_safe=False,
+        package_data={"torchaudio": ['lib/*.so']},
     )
 
 


### PR DESCRIPTION
**Problem:**
https://github.com/pytorch/audio/pull/2485 introduced a build-time dependency on libomp.so for torchaudio, but when a torchaudio wheel built with that PR is imported in an environment where ROCm is NOT installed, it errors out e.g.:
https://github.com/pytorch/builder/actions/runs/5954772894/job/16152043224
```
  File "/opt/conda/envs/conda-env-5954772894/lib/python3.11/site-packages/torchaudio/__init__.py", line 1, in <module>
    from . import (  # noqa: F401
  File "/opt/conda/envs/conda-env-5954772894/lib/python3.11/site-packages/torchaudio/_extension/__init__.py", line 45, in <module>
    _load_lib("libtorchaudio")
  File "/opt/conda/envs/conda-env-5954772894/lib/python3.11/site-packages/torchaudio/_extension/utils.py", line 64, in _load_lib
    torch.ops.load_library(path)
  File "/opt/conda/envs/conda-env-5954772894/lib/python3.11/site-packages/torch/_ops.py", line 839, in load_library
    ctypes.CDLL(path)
  File "/opt/conda/envs/conda-env-5954772894/lib/python3.11/ctypes/__init__.py", line 376, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: libomp.so: cannot open shared object file: No such file or directory
```

**Proposed solution:**

PART 1:
We need to package the libomp.so library (that comes as part of ROCm installation) with the torchaudio wheel (similar to how we package ROCm libraries with torch wheel). This PR adds the libomp.so to the wheel packaging. 

PART 2:
The above solution will be needed in conjunction with another fix in the wheel building yml file ([this](https://github.com/pytorch/audio/blob/f8067ab4400f2c4690797565bad850add0550752/.github/workflows/build_wheels_linux.yml#L38C11-L38C70) or [this](https://github.com/pytorch/test-infra/blob/65abc6ecc3afe43012e74bc45b824f6cd36c1eff/.github/workflows/build_wheels_linux.yml#L175)?) to set the RUNPATH for `libtorchaudio.so` so that it looks in its current directory (`$ORIGIN`) for any dependencies. This is a technique already used in the PyTorch wheels [here](https://github.com/pytorch/builder/blob/63e0dab0723b6f733b551d2747326630450335e0/manywheel/build_common.sh#L371).

However, I propose just adding `$ORIGIN` to the RUNPATH instead of replacing it, like we do in the PyTorch wheels (for minimal behavior change):
```
export PATCHELF_BIN=/usr/local/bin/patchelf (already available in the manylinux-builder docker image)
CURRENT_RPATH=$($PATCHELF_BIN --print-rpath libtorchaudio.so)
$PATCHELF_BIN --set-rpath '$ORIGIN:'$CURRENT_RPATH libtorchaudio.so
```

This brings the following change in RUNPATH for libtorchaudio.so:
```
<< /opt/rocm/llvm/lib:/opt/conda/envs/py_3.8/lib/python3.8/site-packages/torch/lib:/opt/rocm/hip/lib:/opt/rocm/roctracer/lib:/opt/rocm/lib
====
>> $ORIGIN:/opt/rocm/llvm/lib:/opt/conda/envs/py_3.8/lib/python3.8/site-packages/torch/lib:/opt/rocm/hip/lib:/opt/rocm/roctracer/lib:/opt/rocm/lib
```

ldd shows the expected output:
```
[root@9d581fa3e883 lib]# ldd libtorchaudio.so
./libtorchaudio.so: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by ./libtorchaudio.so)
        libomp.so => /opt/_internal/cpython-3.8.1/lib/python3.8/site-packages/torchaudio/lib/./libomp.so (0x00007fd8f40b7000)
```