### PR TITLE
Remove an undefined name

### DIFF
--- a/torchaudio/prototype/models/__init__.py
+++ b/torchaudio/prototype/models/__init__.py
@@ -17,7 +17,6 @@ __all__ = [
     "conformer_rnnt_model",
     "conformer_rnnt_biasing",
     "conformer_rnnt_biasing_base",
-    "conv_tasnet_base",
     "ConvEmformer",
     "conformer_wav2vec2_model",
     "conformer_wav2vec2_base",


### PR DESCRIPTION
In file: __init__.py, the list named `__all__` contains an undefined name which can result in errors when this module is imported. I removed the undefined name (`conv_tasnet_base`) from the list. For more information regarding `__all__`, please read about [importing fields from a package](https://docs.python.org/3/tutorial/modules.html#importing-from-a-package).  

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.