### PR TITLE
change video to visual

### DIFF
--- a/examples/avsr/README.md
+++ b/examples/avsr/README.md
@@ -38,7 +38,7 @@ python train.py --exp-dir=[exp_dir] \
 ```
 
 - `exp-dir` and `exp-name`: The directory where the checkpoints will be saved, will be stored at the location `[exp_dir]`/`[exp_name]`.
-- `modality`: Type of the input modality. Valid values are: `video`, `audio`, and `audiovisual`.
+- `modality`: Type of the input modality. Valid values are: `visual`, `audio`, and `audiovisual`.
 - `mode`: Type of the mode. Valid values are: `online` and `offline`.
 - `root-dir`: Path to the root directory where all preprocessed files will be stored.
 - `sp-model-path`: Path to the sentencepiece model. Default: `./spm_unigram_1023.model`, which can be produced using `train_spm.py`.
@@ -55,7 +55,7 @@ python eval.py --modality=[modality] \
                --checkpoint-path=[checkpoint_path]
 ```
 
-- `modality`: Type of the input modality. Valid values are: `video`, `audio`, and `audiovisual`.
+- `modality`: Type of the input modality. Valid values are: `visual`, `audio`, and `audiovisual`.
 - `mode`: Type of the mode. Valid values are: `online` and `offline`.
 - `root-dir`: Path to the root directory where all preprocessed files will be stored.
 - `sp-model-path`: Path to the sentencepiece model. Default: `./spm_unigram_1023.model`.

--- a/examples/avsr/data_prep/data/data_module.py
+++ b/examples/avsr/data_prep/data/data_module.py
@@ -12,7 +12,7 @@ import torchvision
 class AVSRDataLoader:
     def __init__(self, modality, detector="retinaface", resize=None):
         self.modality = modality
-        if modality == "video":
+        if modality == "visual":
             if detector == "retinaface":
                 from detectors.retinaface.detector import LandmarksDetector
                 from detectors.retinaface.video_process import VideoProcess
@@ -31,7 +31,7 @@ class AVSRDataLoader:
             audio, sample_rate = self.load_audio(data_filename)
             audio = self.audio_process(audio, sample_rate)
             return audio
-        if self.modality == "video":
+        if self.modality == "visual":
             video = self.load_video(data_filename)
             landmarks = self.landmarks_detector(video)
             video = self.video_process(video, landmarks)

--- a/examples/avsr/data_prep/preprocess_lrs3.py
+++ b/examples/avsr/data_prep/preprocess_lrs3.py
@@ -65,7 +65,7 @@ seg_duration = args.seg_duration
 dataset = args.dataset
 
 args.data_dir = os.path.normpath(args.data_dir)
-vid_dataloader = AVSRDataLoader(modality="video", detector=args.detector, resize=(96, 96))
+vid_dataloader = AVSRDataLoader(modality="visual", detector=args.detector, resize=(96, 96))
 aud_dataloader = AVSRDataLoader(modality="audio")
 # Step 2, extract mouth patches from segments.
 seg_vid_len = seg_duration * 25

--- a/examples/avsr/train.py
+++ b/examples/avsr/train.py
@@ -59,7 +59,7 @@ def parse_args():
         "--modality",
         type=str,
         help="Modality",
-        choices=['audio','visual','audiovisual'],
+        choices=["audio", "visual", "audiovisual"],
         required=True,
     )
     parser.add_argument(

--- a/examples/avsr/train.py
+++ b/examples/avsr/train.py
@@ -59,6 +59,7 @@ def parse_args():
         "--modality",
         type=str,
         help="Modality",
+        choices=['audio','visual','audiovisual'],
         required=True,
     )
     parser.add_argument(


### PR DESCRIPTION
In some location the input was expected to be video in and other visual.
For example:
https://github.com/pytorch/audio/blob/b7791eabde6fc180e5292e3233ab9baa1522e5b0/examples/avsr/transforms.py#L75

It is now clear in the argparse what options are available and aligned between different modalities

