### PR TITLE
Fix breadcrumbs for v2.1

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -201,7 +201,7 @@ else:
 #
 # https://stackoverflow.com/a/33845358/1106930
 #
-html_context = {"version_stable": "2.1.0"}
+html_context = {"version_stable": "2.0.1"}
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -201,7 +201,7 @@ else:
 #
 # https://stackoverflow.com/a/33845358/1106930
 #
-html_context = {"version_stable": "2.0.1"}
+html_context = {"version_stable": "2.1.0"}
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
Change the stable version specified in `docs/source/conf.py` so that breadcrumbs display correctly on TorchAudio documentation pages. I tested on the nightly build using the docs build preview, and tested on the release by building locally on my MBP. See attached screenshots.
![Screenshot 2023-10-05 at 4 47 25 PM](https://github.com/pytorch/audio/assets/1108664/6de86c6f-943c-4c5c-8f90-043ae0c3b894)
![Screenshot 2023-10-05 at 4 45 13 PM](https://github.com/pytorch/audio/assets/1108664/a2dd6c41-925f-41ce-a76e-765d26dfdafc)

