### PR TITLE
Fix breadcrumbs for v2.1

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -201,7 +201,7 @@ else:
 #
 # https://stackoverflow.com/a/33845358/1106930
 #
-html_context = {"version_stable": "2.0.1"}
+html_context = {"version_stable": "2.1.0"}
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
**[cherry-pick]** Change the stable version specified in `docs/source/conf.py` so that breadcrumbs display correctly on TorchAudio documentation pages.

Differential Revision: D50036850

Pull Request resolved: https://github.com/pytorch/audio/pull/3637