### PR TITLE
Simplify the logic to initialize FFmpeg

### DIFF
--- a/src/libtorchaudio/pybind/pybind.cpp
+++ b/src/libtorchaudio/pybind/pybind.cpp
@@ -8,7 +8,6 @@ PYBIND11_MODULE(_torchaudio, m) {
   m.def("is_rir_available", &is_rir_available, "");
   m.def("is_align_available", &is_align_available, "");
   m.def("cuda_version", &cuda_version, "");
-  m.def("find_avutil", &find_avutil, "");
 }
 
 } // namespace

--- a/src/libtorchaudio/utils.cpp
+++ b/src/libtorchaudio/utils.cpp
@@ -31,10 +31,4 @@ c10::optional<int64_t> cuda_version() {
 #endif
 }
 
-int find_avutil(const char* name) {
-  auto lib = at::DynamicLibrary{name};
-  auto avutil_version = (unsigned (*)())(lib.sym("avutil_version"));
-  return static_cast<int>(avutil_version() >> 16);
-}
-
 } // namespace torchaudio

--- a/src/libtorchaudio/utils.h
+++ b/src/libtorchaudio/utils.h
@@ -5,5 +5,4 @@ namespace torchaudio {
 bool is_rir_available();
 bool is_align_available();
 c10::optional<int64_t> cuda_version();
-int find_avutil(const char* name);
 } // namespace torchaudio

--- a/src/torchaudio/_backend/utils.py
+++ b/src/torchaudio/_backend/utils.py
@@ -4,7 +4,7 @@ from typing import BinaryIO, Dict, Optional, Tuple, Type, Union
 
 import torch
 
-from torchaudio._extension import _FFMPEG_EXT, _SOX_INITIALIZED
+from torchaudio._extension import _SOX_INITIALIZED, lazy_import_ffmpeg_ext
 
 from . import soundfile_backend
 
@@ -18,7 +18,7 @@ from .sox import SoXBackend
 @lru_cache(None)
 def get_available_backends() -> Dict[str, Type[Backend]]:
     backend_specs: Dict[str, Type[Backend]] = {}
-    if _FFMPEG_EXT is not None:
+    if lazy_import_ffmpeg_ext().is_available():
         backend_specs["ffmpeg"] = FFmpegBackend
     if _SOX_INITIALIZED:
         backend_specs["sox"] = SoXBackend

--- a/src/torchaudio/io/_playback.py
+++ b/src/torchaudio/io/_playback.py
@@ -15,7 +15,6 @@ dict_format = {
 }
 
 
-@torchaudio._extension.fail_if_no_ffmpeg
 def play_audio(
     waveform: torch.Tensor,
     sample_rate: Optional[float],
@@ -57,7 +56,9 @@ def play_audio(
     time, num_channels = waveform.size()
     if num_channels > 2:
         warnings.warn(
-            f"Expected up to 2 channels, got {num_channels} channels instead. Only the first 2 channels will be played."
+            f"Expected up to 2 channels, got {num_channels} channels instead. "
+            "Only the first 2 channels will be played.",
+            stacklevel=2,
         )
 
     # Write to speaker device

--- a/src/torchaudio/io/_stream_reader.py
+++ b/src/torchaudio/io/_stream_reader.py
@@ -9,11 +9,7 @@ import torch
 import torchaudio
 from torch.utils._pytree import tree_map
 
-if torchaudio._extension._FFMPEG_EXT is not None:
-    _StreamReader = torchaudio._extension._FFMPEG_EXT.StreamReader
-    _StreamReaderBytes = torchaudio._extension._FFMPEG_EXT.StreamReaderBytes
-    _StreamReaderFileObj = torchaudio._extension._FFMPEG_EXT.StreamReaderFileObj
-
+ffmpeg_ext = torchaudio._extension.lazy_import_ffmpeg_ext()
 
 __all__ = [
     "StreamReader",
@@ -442,7 +438,6 @@ InputStreamTypes = TypeVar("InputStream", bound=SourceStream)
 OutputStreamTypes = TypeVar("OutputStream", bound=OutputStream)
 
 
-@torchaudio._extension.fail_if_no_ffmpeg
 class StreamReader:
     """Fetch and decode audio/video streams chunk by chunk.
 
@@ -524,11 +519,11 @@ class StreamReader:
     ):
         self.src = src
         if isinstance(src, bytes):
-            self._be = _StreamReaderBytes(src, format, option, buffer_size)
+            self._be = ffmpeg_ext.StreamReaderBytes(src, format, option, buffer_size)
         elif hasattr(src, "read"):
-            self._be = _StreamReaderFileObj(src, format, option, buffer_size)
+            self._be = ffmpeg_ext.StreamReaderFileObj(src, format, option, buffer_size)
         else:
-            self._be = _StreamReader(os.path.normpath(src), format, option)
+            self._be = ffmpeg_ext.StreamReader(os.path.normpath(src), format, option)
 
         i = self._be.find_best_audio_stream()
         self._default_audio_stream = None if i < 0 else i

--- a/src/torchaudio/utils/ffmpeg_utils.py
+++ b/src/torchaudio/utils/ffmpeg_utils.py
@@ -6,8 +6,9 @@ from typing import Dict, List, Tuple
 
 import torchaudio
 
+ffmpeg_ext = torchaudio._extension.lazy_import_ffmpeg_ext()
 
-@torchaudio._extension.fail_if_no_ffmpeg
+
 def get_versions() -> Dict[str, Tuple[int]]:
     """Get the versions of FFmpeg libraries
 
@@ -15,19 +16,17 @@ def get_versions() -> Dict[str, Tuple[int]]:
         dict: mapping from library names to version string,
             i.e. `"libavutil": (56, 22, 100)`.
     """
-    return torchaudio._extension._FFMPEG_EXT.get_versions()
+    return ffmpeg_ext.get_versions()
 
 
-@torchaudio._extension.fail_if_no_ffmpeg
 def get_log_level() -> int:
     """Get the log level of FFmpeg.
 
     See :py:func:`set_log_level` for the detailo.
     """
-    return torchaudio._extension._FFMPEG_EXT.get_log_level()
+    return ffmpeg_ext.get_log_level()
 
 
-@torchaudio._extension.fail_if_no_ffmpeg
 def set_log_level(level: int):
     """Set the log level of FFmpeg (libavformat etc)
 
@@ -61,10 +60,9 @@ def set_log_level(level: int):
                   Extremely verbose debugging, useful for libav* development.
 
     """
-    torchaudio._extension._FFMPEG_EXT.set_log_level(level)
+    ffmpeg_ext.set_log_level(level)
 
 
-@torchaudio._extension.fail_if_no_ffmpeg
 def get_demuxers() -> Dict[str, str]:
     """Get the available demuxers.
 
@@ -79,10 +77,9 @@ def get_demuxers() -> Dict[str, str]:
         ... aax: CRI AAX
         ... ac3: raw AC-3
     """
-    return torchaudio._extension._FFMPEG_EXT.get_demuxers()
+    return ffmpeg_ext.get_demuxers()
 
 
-@torchaudio._extension.fail_if_no_ffmpeg
 def get_muxers() -> Dict[str, str]:
     """Get the available muxers.
 
@@ -98,10 +95,9 @@ def get_muxers() -> Dict[str, str]:
         ... adx: CRI ADX
         ... aiff: Audio IFF
     """
-    return torchaudio._extension._FFMPEG_EXT.get_muxers()
+    return ffmpeg_ext.get_muxers()
 
 
-@torchaudio._extension.fail_if_no_ffmpeg
 def get_audio_decoders() -> Dict[str, str]:
     """Get the available audio decoders.
 
@@ -117,10 +113,9 @@ def get_audio_decoders() -> Dict[str, str]:
         ... adx: CRI ADX
         ... aiff: Audio IFF
     """
-    return torchaudio._extension._FFMPEG_EXT.get_audio_decoders()
+    return ffmpeg_ext.get_audio_decoders()
 
 
-@torchaudio._extension.fail_if_no_ffmpeg
 def get_audio_encoders() -> Dict[str, str]:
     """Get the available audio encoders.
 
@@ -137,10 +132,9 @@ def get_audio_encoders() -> Dict[str, str]:
         ... ac3_fixed: ATSC A/52A (AC-3)
         ... alac: ALAC (Apple Lossless Audio Codec)
     """
-    return torchaudio._extension._FFMPEG_EXT.get_audio_encoders()
+    return ffmpeg_ext.get_audio_encoders()
 
 
-@torchaudio._extension.fail_if_no_ffmpeg
 def get_video_decoders() -> Dict[str, str]:
     """Get the available video decoders.
 
@@ -157,10 +151,9 @@ def get_video_decoders() -> Dict[str, str]:
         ... amv: AMV Video
         ... anm: Deluxe Paint Animation
     """
-    return torchaudio._extension._FFMPEG_EXT.get_video_decoders()
+    return ffmpeg_ext.get_video_decoders()
 
 
-@torchaudio._extension.fail_if_no_ffmpeg
 def get_video_encoders() -> Dict[str, str]:
     """Get the available video encoders.
 
@@ -178,10 +171,9 @@ def get_video_encoders() -> Dict[str, str]:
         ... asv1: ASUS V1
         ... asv2: ASUS V2
     """
-    return torchaudio._extension._FFMPEG_EXT.get_video_encoders()
+    return ffmpeg_ext.get_video_encoders()
 
 
-@torchaudio._extension.fail_if_no_ffmpeg
 def get_input_devices() -> Dict[str, str]:
     """Get the available input devices.
 
@@ -194,10 +186,9 @@ def get_input_devices() -> Dict[str, str]:
         ... avfoundation: AVFoundation input device
         ... lavfi: Libavfilter virtual input device
     """
-    return torchaudio._extension._FFMPEG_EXT.get_input_devices()
+    return ffmpeg_ext.get_input_devices()
 
 
-@torchaudio._extension.fail_if_no_ffmpeg
 def get_output_devices() -> Dict[str, str]:
     """Get the available output devices.
 
@@ -209,10 +200,9 @@ def get_output_devices() -> Dict[str, str]:
         >>>     print(f"{k}: {v}")
         ... audiotoolbox: AudioToolbox output device
     """
-    return torchaudio._extension._FFMPEG_EXT.get_output_devices()
+    return ffmpeg_ext.get_output_devices()
 
 
-@torchaudio._extension.fail_if_no_ffmpeg
 def get_input_protocols() -> List[str]:
     """Get the supported input protocols.
 
@@ -223,10 +213,9 @@ def get_input_protocols() -> List[str]:
         >>> print(get_input_protocols())
         ... ['file', 'ftp', 'hls', 'http','https', 'pipe', 'rtmp', 'tcp', 'tls', 'udp', 'unix']
     """
-    return torchaudio._extension._FFMPEG_EXT.get_input_protocols()
+    return ffmpeg_ext.get_input_protocols()
 
 
-@torchaudio._extension.fail_if_no_ffmpeg
 def get_output_protocols() -> List[str]:
     """Get the supported output protocols.
 
@@ -237,10 +226,9 @@ def get_output_protocols() -> List[str]:
         >>> print(get_output_protocols())
         ... ['file', 'ftp', 'http', 'https', 'md5', 'pipe', 'prompeg', 'rtmp', 'tee', 'tcp', 'tls', 'udp', 'unix']
     """
-    return torchaudio._extension._FFMPEG_EXT.get_output_protocols()
+    return ffmpeg_ext.get_output_protocols()
 
 
-@torchaudio._extension.fail_if_no_ffmpeg
 def get_build_config() -> str:
     """Get the FFmpeg build configuration
 
@@ -251,10 +239,9 @@ def get_build_config() -> str:
         >>> print(get_build_config())
         --prefix=/Users/runner/miniforge3 --cc=arm64-apple-darwin20.0.0-clang --enable-gpl --enable-hardcoded-tables --enable-libfreetype --enable-libopenh264 --enable-neon --enable-libx264 --enable-libx265 --enable-libaom --enable-libsvtav1 --enable-libxml2 --enable-libvpx --enable-pic --enable-pthreads --enable-shared --disable-static --enable-version3 --enable-zlib --enable-libmp3lame --pkg-config=/Users/runner/miniforge3/conda-bld/ffmpeg_1646229390493/_build_env/bin/pkg-config --enable-cross-compile --arch=arm64 --target-os=darwin --cross-prefix=arm64-apple-darwin20.0.0- --host-cc=/Users/runner/miniforge3/conda-bld/ffmpeg_1646229390493/_build_env/bin/x86_64-apple-darwin13.4.0-clang  # noqa
     """
-    return torchaudio._extension._FFMPEG_EXT.get_build_config()
+    return ffmpeg_ext.get_build_config()
 
 
-@torchaudio._extension.fail_if_no_ffmpeg
 def clear_cuda_context_cache():
     """Clear the CUDA context used by CUDA Hardware accelerated video decoding"""
-    torchaudio._extension._FFMPEG_EXT.clear_cuda_context_cache()
+    ffmpeg_ext.clear_cuda_context_cache()

--- a/test/torchaudio_unittest/common_utils/__init__.py
+++ b/test/torchaudio_unittest/common_utils/__init__.py
@@ -3,7 +3,6 @@ from .backend_utils import set_audio_backend
 from .case_utils import (
     disabledInCI,
     HttpServerMixin,
-    is_ffmpeg_available,
     PytorchTestCase,
     skipIfCudaSmallMemory,
     skipIfNoAudioDevice,
@@ -44,7 +43,6 @@ __all__ = [
     "TestBaseMixin",
     "PytorchTestCase",
     "TorchaudioTestCase",
-    "is_ffmpeg_available",
     "skipIfNoAudioDevice",
     "skipIfNoCtcDecoder",
     "skipIfNoCuCtcDecoder",

--- a/test/torchaudio_unittest/common_utils/case_utils.py
+++ b/test/torchaudio_unittest/common_utils/case_utils.py
@@ -111,10 +111,7 @@ class TorchaudioTestCase(TestBaseMixin, PytorchTestCase):
     pass
 
 
-def is_ffmpeg_available():
-    return torchaudio._extension._FFMPEG_EXT is not None
-
-
+_IS_FFMPEG_AVAILABLE = torchaudio._extension.lazy_import_ffmpeg_ext().is_available()
 _IS_CTC_DECODER_AVAILABLE = None
 _IS_CUDA_CTC_DECODER_AVAILABLE = None
 
@@ -260,7 +257,7 @@ skipIfNoQengine = _skipIf(
     key="NO_QUANTIZATION",
 )
 skipIfNoFFmpeg = _skipIf(
-    not is_ffmpeg_available(),
+    not _IS_FFMPEG_AVAILABLE,
     reason="ffmpeg features are not available.",
     key="NO_FFMPEG",
 )
@@ -273,7 +270,7 @@ skipIfPy310 = _skipIf(
     key="ON_PYTHON_310",
 )
 skipIfNoAudioDevice = _skipIf(
-    not torchaudio.utils.ffmpeg_utils.get_output_devices(),
+    not (_IS_FFMPEG_AVAILABLE and torchaudio.utils.ffmpeg_utils.get_output_devices()),
     reason="No output audio device is available.",
     key="NO_AUDIO_OUT_DEVICE",
 )
@@ -291,7 +288,7 @@ disabledInCI = _skipIf(
 
 def skipIfNoHWAccel(name):
     key = "NO_HW_ACCEL"
-    if not is_ffmpeg_available():
+    if not _IS_FFMPEG_AVAILABLE:
         return _skipIf(True, reason="ffmpeg features are not available.", key=key)
     if not torch.cuda.is_available():
         return _skipIf(True, reason="CUDA is not available.", key=key)

--- a/test/torchaudio_unittest/io/stream_reader_test.py
+++ b/test/torchaudio_unittest/io/stream_reader_test.py
@@ -3,13 +3,22 @@ import io
 import torch
 import torchaudio
 from parameterized import parameterized, parameterized_class
+
+from torchaudio.io import StreamReader, StreamWriter
+from torchaudio.io._stream_reader import (
+    ChunkTensor,
+    OutputAudioStream,
+    OutputVideoStream,
+    SourceAudioStream,
+    SourceStream,
+    SourceVideoStream,
+)
 from torchaudio_unittest.common_utils import (
     disabledInCI,
     get_asset_path,
     get_image,
     get_sinusoid,
     get_wav_data,
-    is_ffmpeg_available,
     nested_params,
     rgb_to_gray,
     rgb_to_yuv_ccir,
@@ -20,18 +29,6 @@ from torchaudio_unittest.common_utils import (
     TempDirMixin,
     TorchaudioTestCase,
 )
-
-
-if is_ffmpeg_available():
-    from torchaudio.io import StreamReader, StreamWriter
-    from torchaudio.io._stream_reader import (
-        ChunkTensor,
-        OutputAudioStream,
-        OutputVideoStream,
-        SourceAudioStream,
-        SourceStream,
-        SourceVideoStream,
-    )
 
 
 @skipIfNoFFmpeg

--- a/test/torchaudio_unittest/io/stream_writer_test.py
+++ b/test/torchaudio_unittest/io/stream_writer_test.py
@@ -5,10 +5,11 @@ import torch
 import torchaudio
 
 from parameterized import parameterized, parameterized_class
+
+from torchaudio.io import CodecConfig, StreamReader, StreamWriter
 from torchaudio_unittest.common_utils import (
     get_asset_path,
     get_sinusoid,
-    is_ffmpeg_available,
     nested_params,
     rgb_to_yuv_ccir,
     skipIfNoFFmpeg,
@@ -18,9 +19,6 @@ from torchaudio_unittest.common_utils import (
 )
 
 from .common import lt42
-
-if is_ffmpeg_available():
-    from torchaudio.io import CodecConfig, StreamReader, StreamWriter
 
 
 def get_audio_chunk(fmt, sample_rate, num_channels):


### PR DESCRIPTION
Summary:
Update the logic to initialize FFmpeg extension so that it's not initialized until the user code accesses any attribute.

- Utilizes lazy module mechanism.
- Get rid of decorators for failure message (simply rely on the lazy initialization mechanism)

Now that all the attributes in `torchaudio.io` are importable without side-effect.

Differential Revision: D50193749


