### PR TITLE
Fix WAVLM_LARGE bundle

### DIFF
--- a/src/torchaudio/pipelines/_wav2vec2/impl.py
+++ b/src/torchaudio/pipelines/_wav2vec2/impl.py
@@ -1350,7 +1350,7 @@ WAVLM_LARGE = Wav2Vec2Bundle(
         "encoder_ff_interm_features": 4096,
         "encoder_ff_interm_dropout": 0.0,
         "encoder_dropout": 0.1,
-        "encoder_layer_norm_first": False,
+        "encoder_layer_norm_first": True,
         "encoder_layer_drop": 0.05,
         "aux_num_out": None,
     },


### PR DESCRIPTION
Address #3347 
The `encoder_layer_norm_first` should be set to `True` for the Large model of WavLM.