### PR TITLE
Cherry-pick 2.1.1: Support compression level in i/o dispatcher backend

### DIFF
--- a/test/torchaudio_unittest/backend/dispatcher/dispatcher_test.py
+++ b/test/torchaudio_unittest/backend/dispatcher/dispatcher_test.py
@@ -105,7 +105,7 @@ class DispatcherTest(PytorchTestCase):
             f"torchaudio._backend.utils.{expected_backend.__name__}.save"
         ) as mock_save:
             get_save_func()(filename, src, sample_rate, format=format)
-            mock_save.assert_called_once_with(filename, src, sample_rate, True, format, None, None, 4096)
+            mock_save.assert_called_once_with(filename, src, sample_rate, True, format, None, None, 4096, None)
 
     @parameterized.expand(
         [
@@ -126,4 +126,4 @@ class DispatcherTest(PytorchTestCase):
             f"torchaudio._backend.utils.{expected_backend.__name__}.save"
         ) as mock_save:
             get_save_func()(f, src, sample_rate, format=format, buffer_size=buffer_size)
-            mock_save.assert_called_once_with(f, src, sample_rate, True, format, None, None, buffer_size)
+            mock_save.assert_called_once_with(f, src, sample_rate, True, format, None, None, buffer_size, None)

--- a/torchaudio/_backend/backend.py
+++ b/torchaudio/_backend/backend.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from typing import BinaryIO, Optional, Tuple, Union
 
 from torch import Tensor
+from torchaudio.io import CodecConfig
 
 from .common import AudioMetaData
 
@@ -37,6 +38,7 @@ class Backend(ABC):
         encoding: Optional[str] = None,
         bits_per_sample: Optional[int] = None,
         buffer_size: int = 4096,
+        compression: Optional[Union[CodecConfig, float, int]] = None,
     ) -> None:
         raise NotImplementedError
 

--- a/torchaudio/_backend/ffmpeg.py
+++ b/torchaudio/_backend/ffmpeg.py
@@ -253,6 +253,7 @@ def save_audio(
     encoding: Optional[str] = None,
     bits_per_sample: Optional[int] = None,
     buffer_size: int = 4096,
+    compression: Optional[torchaudio.io.CodecConfig] = None,
 ) -> None:
     ext = None
     if hasattr(uri, "write"):
@@ -275,6 +276,7 @@ def save_audio(
         format=_get_sample_format(src.dtype),
         encoder=encoder,
         encoder_format=enc_fmt,
+        codec_config=compression,
     )
     with s.open():
         s.write_audio_chunk(0, src)
@@ -343,7 +345,13 @@ class FFmpegBackend(Backend):
         encoding: Optional[str] = None,
         bits_per_sample: Optional[int] = None,
         buffer_size: int = 4096,
+        compression: Optional[Union[torchaudio.io.CodecConfig, float, int]] = None,
     ) -> None:
+        if not isinstance(compression, (torchaudio.io.CodecConfig, type(None))):
+            raise ValueError(
+                "FFmpeg backend expects non-`None` value for argument `compression` to be of ",
+                f"type `torchaudio.io.CodecConfig`, but received value of type {type(compression)}",
+            )
         save_audio(
             uri,
             src,
@@ -353,6 +361,7 @@ class FFmpegBackend(Backend):
             encoding,
             bits_per_sample,
             buffer_size,
+            compression,
         )
 
     @staticmethod

--- a/torchaudio/_backend/soundfile.py
+++ b/torchaudio/_backend/soundfile.py
@@ -2,6 +2,7 @@ import os
 from typing import BinaryIO, Optional, Tuple, Union
 
 import torch
+from torchaudio.io import CodecConfig
 
 from . import soundfile_backend
 from .backend import Backend
@@ -35,7 +36,11 @@ class SoundfileBackend(Backend):
         encoding: Optional[str] = None,
         bits_per_sample: Optional[int] = None,
         buffer_size: int = 4096,
+        compression: Optional[Union[CodecConfig, float, int]] = None,
     ) -> None:
+        if compression:
+            raise ValueError("soundfile backend does not support argument `compression`.")
+
         soundfile_backend.save(
             uri, src, sample_rate, channels_first, format=format, encoding=encoding, bits_per_sample=bits_per_sample
         )

--- a/torchaudio/_backend/sox.py
+++ b/torchaudio/_backend/sox.py
@@ -2,6 +2,7 @@ import os
 from typing import BinaryIO, Optional, Tuple, Union
 
 import torch
+from torchaudio.io import CodecConfig
 
 from .backend import Backend
 from .common import AudioMetaData
@@ -55,7 +56,13 @@ class SoXBackend(Backend):
         encoding: Optional[str] = None,
         bits_per_sample: Optional[int] = None,
         buffer_size: int = 4096,
+        compression: Optional[Union[CodecConfig, float, int]] = None,
     ) -> None:
+        if not isinstance(compression, (float, int, type(None))):
+            raise ValueError(
+                "SoX backend expects non-`None` value for argument `compression` to be of ",
+                f"type `float` or `int`, but received value of type {type(compression)}",
+            )
         if hasattr(uri, "write"):
             raise ValueError(
                 "SoX backend does not support writing to file-like objects. ",
@@ -67,7 +74,7 @@ class SoXBackend(Backend):
                 src,
                 sample_rate,
                 channels_first,
-                None,
+                compression,
                 format,
                 encoding,
                 bits_per_sample,

--- a/torchaudio/_backend/utils.py
+++ b/torchaudio/_backend/utils.py
@@ -5,6 +5,7 @@ from typing import BinaryIO, Dict, Optional, Tuple, Type, Union
 import torch
 
 from torchaudio._extension import _FFMPEG_EXT, _SOX_INITIALIZED
+from torchaudio.io import CodecConfig
 
 from . import soundfile_backend
 
@@ -229,6 +230,7 @@ def get_save_func():
         bits_per_sample: Optional[int] = None,
         buffer_size: int = 4096,
         backend: Optional[str] = None,
+        compression: Optional[Union[CodecConfig, float, int]] = None,
     ):
         """Save audio data to file.
 
@@ -283,8 +285,32 @@ def get_save_func():
 
                 .. seealso::
                    :ref:`backend`
+
+            compression (CodecConfig, float, int, or None, optional):
+                Compression configuration to apply.
+
+                If the selected backend is FFmpeg, an instance of :py:class:`CodecConfig` must be provided.
+
+                Otherwise, if the selected backend is SoX, a float or int value corresponding to option ``-C`` of the
+                ``sox`` command line interface must be provided. For instance:
+
+                ``"mp3"``
+                    Either bitrate (in ``kbps``) with quality factor, such as ``128.2``, or
+                    VBR encoding with quality factor such as ``-4.2``. Default: ``-4.5``.
+
+                ``"flac"``
+                    Whole number from ``0`` to ``8``. ``8`` is default and highest compression.
+
+                ``"ogg"``, ``"vorbis"``
+                    Number from ``-1`` to ``10``; ``-1`` is the highest compression
+                    and lowest quality. Default: ``3``.
+
+                Refer to http://sox.sourceforge.net/soxformat.html for more details.
+
         """
         backend = dispatcher(uri, format, backend)
-        return backend.save(uri, src, sample_rate, channels_first, format, encoding, bits_per_sample, buffer_size)
+        return backend.save(
+            uri, src, sample_rate, channels_first, format, encoding, bits_per_sample, buffer_size, compression
+        )
 
     return save


### PR DESCRIPTION
Differential Revision: D50367721

Pull Request resolved: https://github.com/pytorch/audio/pull/3662