### PR TITLE
Fix vad to return zero output for zero input

### DIFF
--- a/src/torchaudio/functional/filtering.py
+++ b/src/torchaudio/functional/filtering.py
@@ -1660,6 +1660,9 @@ def vad(
             flushedLen_ns = (measures_len - num_measures_to_flush) * measure_period_ns
             break
     # end for window
+    if not has_triggered:
+        return waveform[..., :0].view(shape[:-1] + torch.Size([0]))
+
     res = waveform[:, pos - samplesLen_ns + flushedLen_ns :]
     # unpack batch
     return res.view(shape[:-1] + res.shape[-1:])

--- a/test/torchaudio_unittest/transforms/sox_compatibility_test.py
+++ b/test/torchaudio_unittest/transforms/sox_compatibility_test.py
@@ -70,6 +70,18 @@ class TestFunctionalFiltering(TempDirMixin, TorchaudioTestCase):
         result = T.Vad(sample_rate)(data)
         self.assert_sox_effect(result, path, ["vad"])
 
+    @parameterized.expand(
+        [
+            (torch.zeros(32000), torch.zeros(0), 16000),
+            (torch.zeros(1, 32000), torch.zeros(1, 0), 32000),
+            (torch.zeros(2, 44100), torch.zeros(2, 0), 32000),
+            (torch.zeros(2, 2, 44100), torch.zeros(2, 2, 0), 32000),
+        ]
+    )
+    def test_vad_on_zero_audio(self, inpt: torch.Tensor, expected_output: torch.Tensor, sample_rate: int):
+        result = T.Vad(sample_rate)(inpt)
+        self.assertEqual(result, expected_output)
+
     def test_vad_warning(self):
         """vad should throw a warning if input dimension is greater than 2"""
         sample_rate = 41100

--- a/test/torchaudio_unittest/transforms/sox_compatibility_test.py
+++ b/test/torchaudio_unittest/transforms/sox_compatibility_test.py
@@ -70,18 +70,6 @@ class TestFunctionalFiltering(TempDirMixin, TorchaudioTestCase):
         result = T.Vad(sample_rate)(data)
         self.assert_sox_effect(result, path, ["vad"])
 
-    @parameterized.expand(
-        [
-            (torch.zeros(32000), torch.zeros(0), 16000),
-            (torch.zeros(1, 32000), torch.zeros(1, 0), 32000),
-            (torch.zeros(2, 44100), torch.zeros(2, 0), 32000),
-            (torch.zeros(2, 2, 44100), torch.zeros(2, 2, 0), 32000),
-        ]
-    )
-    def test_vad_on_zero_audio(self, inpt: torch.Tensor, expected_output: torch.Tensor, sample_rate: int):
-        result = T.Vad(sample_rate)(inpt)
-        self.assertEqual(result, expected_output)
-
     def test_vad_warning(self):
         """vad should throw a warning if input dimension is greater than 2"""
         sample_rate = 41100

--- a/test/torchaudio_unittest/transforms/transforms_test_impl.py
+++ b/test/torchaudio_unittest/transforms/transforms_test_impl.py
@@ -478,3 +478,18 @@ class TransformsTestBase(TestBaseMixin):
             self.assertTrue(diff > 0)
         else:
             self.assertTrue(diff == 0)
+
+    @parameterized.expand(
+        [
+            ((32000,), (0,), 16000),
+            ((1, 32000), (1, 0), 32000),
+            ((2, 44100), (2, 0), 32000),
+            ((2, 2, 44100), (2, 2, 0), 32000),
+        ]
+    )
+    def test_vad_on_zero_audio(self, input_shape, output_shape, sample_rate: int):
+        """VAD should return zero when input is zero Tensor"""
+        inpt = torch.zeros(input_shape, dtype=self.dtype, device=self.device)
+        expected_output = torch.zeros(output_shape, dtype=self.dtype, device=self.device)
+        result = T.Vad(sample_rate)(inpt)
+        self.assertEqual(result, expected_output)


### PR DESCRIPTION
fix #3668 
Return empty result when not `has_triggered`.
Zeroed wav audio added to unit test.