### PR TITLE
Fix typo in release only chnanges - remove nightly branch for MacOS x86

### DIFF
--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -38,7 +38,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/build_wheels_macos.yml@release/2.1
     with:
       repository: ${{ matrix.repository }}
-      ref: nightly
+      ref: ""
       test-infra-repository: pytorch/test-infra
       test-infra-ref: release/2.1
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}


### PR DESCRIPTION
Fix an issue after https://github.com/pytorch/audio/pull/3583 . Remove reference to nightly branch for macos x86 builds