### PR TITLE
Bugfix: Enforcing batch as type Batch for librispeech_conformer_rnnt …

### DIFF
--- a/examples/asr/librispeech_conformer_rnnt/lightning.py
+++ b/examples/asr/librispeech_conformer_rnnt/lightning.py
@@ -99,6 +99,7 @@ class ConformerRNNTModule(LightningModule):
         if batch is None:
             return None
 
+        batch = Batch(batch[0], batch[1], batch[2], batch[3])
         prepended_targets = batch.targets.new_empty([batch.targets.size(0), batch.targets.size(1) + 1])
         prepended_targets[:, 1:] = batch.targets
         prepended_targets[:, 0] = self.blank_idx
@@ -145,6 +146,7 @@ class ConformerRNNTModule(LightningModule):
         Doing so allows us to account for the variability in batch sizes that
         variable-length sequential data yield.
         """
+        batch = Batch(batch[0], batch[1], batch[2], batch[3])
         loss = self._step(batch, batch_idx, "train")
         batch_size = batch.features.size(0)
         batch_sizes = self.all_gather(batch_size)


### PR DESCRIPTION
Hi

I created an issue (#3707) where I detailed a bug with the [librispeech_conformer_rnnt](https://github.com/pytorch/audio/tree/main/examples/asr/librispeech_conformer_rnnt) ASR example. After some digging I found the reason for that error: the variable batch looses the type Batch (named tuple) when a function is called.

On the file [lightning.py](https://github.com/pytorch/audio/blob/main/examples/asr/librispeech_conformer_rnnt/lightning.py) we have:

```python
#
# ...
#

    def _step(self, batch, _, step_type):
        if batch_in is None:
            return None

        prepended_targets = batch.targets.new_empty([batch.targets.size(0), batch.targets.size(1) + 1])

#
# ...
#

    def training_step(self, batch: Batch, batch_idx):
#
# ...
#
        loss = self._step(batch, batch_idx, "train")
        batch_size = batch.features.size(0)
#
# ...
#
```

A simple recast of the tuple solves this. I changed it to:

```python
#
# ...
#

    def _step(self, batch: Batch, _, step_type):
        if batch is None:
            return None

        batch = Batch(batch[0], batch[1], batch[2], batch[3])

        prepended_targets = batch.targets.new_empty([batch.targets.size(0), batch.targets.size(1) + 1])

#
# ...
#
    def training_step(self, batch: Batch, batch_idx):
#
# ...
#
        batch = Batch(batch[0], batch[1], batch[2], batch[3])
        loss = self._step(batch, batch_idx, "train")
        batch_size = batch.features.size(0)
#
# ...
#
```

I don't think this addresses the root cause of the problem but I hope it is a usefull PR to, at least, make the example run.
Thank you for all your work.

(edit: put code inseid a code block)