### PR TITLE
Migrate the macOS runners label from macos-m1-12 to macos-m1-stable

### DIFF
--- a/.github/workflows/build-conda-m1.yml
+++ b/.github/workflows/build-conda-m1.yml
@@ -45,7 +45,7 @@ jobs:
       test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
-      runner-type: macos-m1-12
+      runner-type: macos-m1-stable
       package-name: ${{ matrix.package-name }}
       trigger-event: ${{ github.event_name }}
     secrets:

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -47,6 +47,6 @@ jobs:
       test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
-      runner-type: macos-m1-12
+      runner-type: macos-m1-stable
       package-name: ${{ matrix.package-name }}
       trigger-event: ${{ github.event_name }}

--- a/.github/workflows/ffmpeg.yml
+++ b/.github/workflows/ffmpeg.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         ffmpeg_version: ["4.4.4", "5.1.4", "6.1.1", "master"]
-        runner: ["macos-m1-12", "macos-12"]
+        runner: ["macos-m1-stable", "macos-12"]
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
       job-name: Build


### PR DESCRIPTION
There is a new label for our macOS runners: "macos-m1-stable". All runners labeled "macos-m1-12" should be switched to "macos-m1-stable". [Here](https://fb.workplace.com/groups/pytorch.dev.perf.infra.teams/permalink/7546708885348237/) you can find more detailed info.