### PR TITLE
Fix document for forced_align method

### DIFF
--- a/src/libtorchaudio/forced_align/cpu/compute.cpp
+++ b/src/libtorchaudio/forced_align/cpu/compute.cpp
@@ -42,9 +42,9 @@ void forced_align_impl(
   }
   TORCH_CHECK(
       T >= L + R,
-      "targets length is too long for CTC. Found targets length: ",
+      "targets length is too long for CTC. Found log_probs length: ",
       T,
-      ", log_probs length: ",
+      ", targets length: ",
       L,
       ", and number of repeats: ",
       R);

--- a/src/libtorchaudio/forced_align/gpu/compute.cu
+++ b/src/libtorchaudio/forced_align/gpu/compute.cu
@@ -160,9 +160,9 @@ void forced_align_impl(
   }
   TORCH_CHECK(
       T >= L + R,
-      "targets length is too long for CTC. Found targets length: ",
+      "targets length is too long for CTC. Found log_probs length: ",
       T,
-      ", log_probs length: ",
+      ", targets length: ",
       L,
       ", and number of repeats: ",
       R);


### PR DESCRIPTION
This PR addresses https://github.com/pytorch/audio/issues/3747. The lengths of `targets` and `log_probs` should be reversed.