### PR TITLE
[codemod] c10::optional -> std::optional in pytorch/audio/src/libtorchaudio/sox/effects.cpp +20

### DIFF
--- a/src/libtorchaudio/sox/effects.cpp
+++ b/src/libtorchaudio/sox/effects.cpp
@@ -86,9 +86,9 @@ auto apply_effects_tensor(
 auto apply_effects_file(
     const std::string& path,
     const std::vector<std::vector<std::string>>& effects,
-    c10::optional<bool> normalize,
-    c10::optional<bool> channels_first,
-    const c10::optional<std::string>& format)
+    std::optional<bool> normalize,
+    std::optional<bool> channels_first,
+    const std::optional<std::string>& format)
     -> std::tuple<torch::Tensor, int64_t> {
   // Open input file
   SoxFormat sf(sox_open_read(

--- a/src/libtorchaudio/sox/effects.h
+++ b/src/libtorchaudio/sox/effects.h
@@ -19,9 +19,9 @@ auto apply_effects_tensor(
 auto apply_effects_file(
     const std::string& path,
     const std::vector<std::vector<std::string>>& effects,
-    c10::optional<bool> normalize,
-    c10::optional<bool> channels_first,
-    const c10::optional<std::string>& format)
+    std::optional<bool> normalize,
+    std::optional<bool> channels_first,
+    const std::optional<std::string>& format)
     -> std::tuple<torch::Tensor, int64_t>;
 
 } // namespace torchaudio::sox

--- a/src/libtorchaudio/sox/io.cpp
+++ b/src/libtorchaudio/sox/io.cpp
@@ -10,7 +10,7 @@ namespace torchaudio::sox {
 
 std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_file(
     const std::string& path,
-    const c10::optional<std::string>& format) {
+    const std::optional<std::string>& format) {
   SoxFormat sf(sox_open_read(
       path.c_str(),
       /*signal=*/nullptr,
@@ -28,8 +28,8 @@ std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_file(
 }
 
 std::vector<std::vector<std::string>> get_effects(
-    const c10::optional<int64_t>& frame_offset,
-    const c10::optional<int64_t>& num_frames) {
+    const std::optional<int64_t>& frame_offset,
+    const std::optional<int64_t>& num_frames) {
   const auto offset = frame_offset.value_or(0);
   TORCH_CHECK(
       offset >= 0,
@@ -57,11 +57,11 @@ std::vector<std::vector<std::string>> get_effects(
 
 std::tuple<torch::Tensor, int64_t> load_audio_file(
     const std::string& path,
-    const c10::optional<int64_t>& frame_offset,
-    const c10::optional<int64_t>& num_frames,
-    c10::optional<bool> normalize,
-    c10::optional<bool> channels_first,
-    const c10::optional<std::string>& format) {
+    const std::optional<int64_t>& frame_offset,
+    const std::optional<int64_t>& num_frames,
+    std::optional<bool> normalize,
+    std::optional<bool> channels_first,
+    const std::optional<std::string>& format) {
   auto effects = get_effects(frame_offset, num_frames);
   return apply_effects_file(path, effects, normalize, channels_first, format);
 }
@@ -71,10 +71,10 @@ void save_audio_file(
     torch::Tensor tensor,
     int64_t sample_rate,
     bool channels_first,
-    c10::optional<double> compression,
-    c10::optional<std::string> format,
-    c10::optional<std::string> encoding,
-    c10::optional<int64_t> bits_per_sample) {
+    std::optional<double> compression,
+    std::optional<std::string> format,
+    std::optional<std::string> encoding,
+    std::optional<int64_t> bits_per_sample) {
   validate_input_tensor(tensor);
 
   const auto filetype = [&]() {

--- a/src/libtorchaudio/sox/io.h
+++ b/src/libtorchaudio/sox/io.h
@@ -7,31 +7,31 @@
 namespace torchaudio::sox {
 
 auto get_effects(
-    const c10::optional<int64_t>& frame_offset,
-    const c10::optional<int64_t>& num_frames)
+    const std::optional<int64_t>& frame_offset,
+    const std::optional<int64_t>& num_frames)
     -> std::vector<std::vector<std::string>>;
 
 std::tuple<int64_t, int64_t, int64_t, int64_t, std::string> get_info_file(
     const std::string& path,
-    const c10::optional<std::string>& format);
+    const std::optional<std::string>& format);
 
 std::tuple<torch::Tensor, int64_t> load_audio_file(
     const std::string& path,
-    const c10::optional<int64_t>& frame_offset,
-    const c10::optional<int64_t>& num_frames,
-    c10::optional<bool> normalize,
-    c10::optional<bool> channels_first,
-    const c10::optional<std::string>& format);
+    const std::optional<int64_t>& frame_offset,
+    const std::optional<int64_t>& num_frames,
+    std::optional<bool> normalize,
+    std::optional<bool> channels_first,
+    const std::optional<std::string>& format);
 
 void save_audio_file(
     const std::string& path,
     torch::Tensor tensor,
     int64_t sample_rate,
     bool channels_first,
-    c10::optional<double> compression,
-    c10::optional<std::string> format,
-    c10::optional<std::string> encoding,
-    c10::optional<int64_t> bits_per_sample);
+    std::optional<double> compression,
+    std::optional<std::string> format,
+    std::optional<std::string> encoding,
+    std::optional<int64_t> bits_per_sample);
 
 } // namespace torchaudio::sox
 

--- a/src/libtorchaudio/sox/types.cpp
+++ b/src/libtorchaudio/sox/types.cpp
@@ -67,7 +67,7 @@ std::string to_string(Encoding v) {
   }
 }
 
-Encoding get_encoding_from_option(const c10::optional<std::string>& encoding) {
+Encoding get_encoding_from_option(const std::optional<std::string>& encoding) {
   if (!encoding.has_value())
     return Encoding::NOT_PROVIDED;
   std::string v = encoding.value();
@@ -84,7 +84,7 @@ Encoding get_encoding_from_option(const c10::optional<std::string>& encoding) {
   TORCH_CHECK(false, "Internal Error: unexpected encoding value: ", v);
 }
 
-BitDepth get_bit_depth_from_option(const c10::optional<int64_t>& bit_depth) {
+BitDepth get_bit_depth_from_option(const std::optional<int64_t>& bit_depth) {
   if (!bit_depth.has_value())
     return BitDepth::NOT_PROVIDED;
   int64_t v = bit_depth.value();

--- a/src/libtorchaudio/sox/types.h
+++ b/src/libtorchaudio/sox/types.h
@@ -38,7 +38,7 @@ enum class Encoding {
 };
 
 std::string to_string(Encoding v);
-Encoding get_encoding_from_option(const c10::optional<std::string>& encoding);
+Encoding get_encoding_from_option(const std::optional<std::string>& encoding);
 
 enum class BitDepth : unsigned {
   NOT_PROVIDED = 0,
@@ -49,7 +49,7 @@ enum class BitDepth : unsigned {
   B64 = 64,
 };
 
-BitDepth get_bit_depth_from_option(const c10::optional<int64_t>& bit_depth);
+BitDepth get_bit_depth_from_option(const std::optional<int64_t>& bit_depth);
 
 std::string get_encoding(sox_encoding_t encoding);
 

--- a/src/libtorchaudio/sox/utils.cpp
+++ b/src/libtorchaudio/sox/utils.cpp
@@ -289,8 +289,8 @@ std::tuple<sox_encoding_t, unsigned> get_save_encoding_for_wav(
 std::tuple<sox_encoding_t, unsigned> get_save_encoding(
     const std::string& format,
     const caffe2::TypeMeta& dtype,
-    const c10::optional<std::string>& encoding,
-    const c10::optional<int64_t>& bits_per_sample) {
+    const std::optional<std::string>& encoding,
+    const std::optional<int64_t>& bits_per_sample) {
   const Format fmt = get_format_from_string(format);
   const Encoding enc = get_encoding_from_option(encoding);
   const BitDepth bps = get_bit_depth_from_option(bits_per_sample);
@@ -492,9 +492,9 @@ sox_encodinginfo_t get_tensor_encodinginfo(caffe2::TypeMeta dtype) {
 sox_encodinginfo_t get_encodinginfo_for_save(
     const std::string& format,
     const caffe2::TypeMeta& dtype,
-    const c10::optional<double>& compression,
-    const c10::optional<std::string>& encoding,
-    const c10::optional<int64_t>& bits_per_sample) {
+    const std::optional<double>& compression,
+    const std::optional<std::string>& encoding,
+    const std::optional<int64_t>& bits_per_sample) {
   auto enc = get_save_encoding(format, dtype, encoding, bits_per_sample);
   return sox_encodinginfo_t{
       /*encoding=*/std::get<0>(enc),

--- a/src/libtorchaudio/sox/utils.h
+++ b/src/libtorchaudio/sox/utils.h
@@ -104,9 +104,9 @@ sox_encodinginfo_t get_tensor_encodinginfo(const caffe2::TypeMeta dtype);
 sox_encodinginfo_t get_encodinginfo_for_save(
     const std::string& format,
     const caffe2::TypeMeta& dtype,
-    const c10::optional<double>& compression,
-    const c10::optional<std::string>& encoding,
-    const c10::optional<int64_t>& bits_per_sample);
+    const std::optional<double>& compression,
+    const std::optional<std::string>& encoding,
+    const std::optional<int64_t>& bits_per_sample);
 
 } // namespace torchaudio::sox
 #endif

--- a/src/libtorchaudio/utils.cpp
+++ b/src/libtorchaudio/utils.cpp
@@ -23,7 +23,7 @@ bool is_align_available() {
 #endif
 }
 
-c10::optional<int64_t> cuda_version() {
+std::optional<int64_t> cuda_version() {
 #ifdef USE_CUDA
   return CUDA_VERSION;
 #else

--- a/src/libtorchaudio/utils.h
+++ b/src/libtorchaudio/utils.h
@@ -4,5 +4,5 @@
 namespace torchaudio {
 bool is_rir_available();
 bool is_align_available();
-c10::optional<int64_t> cuda_version();
+std::optional<int64_t> cuda_version();
 } // namespace torchaudio

--- a/src/libtorio/ffmpeg/ffmpeg.cpp
+++ b/src/libtorio/ffmpeg/ffmpeg.cpp
@@ -10,7 +10,7 @@ namespace torio::io {
 ////////////////////////////////////////////////////////////////////////////////
 // AVDictionary
 ////////////////////////////////////////////////////////////////////////////////
-AVDictionary* get_option_dict(const c10::optional<OptionDict>& option) {
+AVDictionary* get_option_dict(const std::optional<OptionDict>& option) {
   AVDictionary* opt = nullptr;
   if (option) {
     for (auto const& [key, value] : option.value()) {

--- a/src/libtorio/ffmpeg/ffmpeg.h
+++ b/src/libtorio/ffmpeg/ffmpeg.h
@@ -77,7 +77,7 @@ class Wrapper {
 // IIRC-semantic. Instead we provide helper functions.
 
 // Convert standard dict to FFmpeg native type
-AVDictionary* get_option_dict(const c10::optional<OptionDict>& option);
+AVDictionary* get_option_dict(const std::optional<OptionDict>& option);
 
 // Clean up the dict after use. If there is an unsed key, throw runtime error
 void clean_up_dict(AVDictionary* p);

--- a/src/libtorio/ffmpeg/pybind/pybind.cpp
+++ b/src/libtorio/ffmpeg/pybind/pybind.cpp
@@ -160,8 +160,8 @@ struct StreamingMediaDecoderFileObj : private FileObj,
                                       public StreamingMediaDecoderCustomIO {
   StreamingMediaDecoderFileObj(
       py::object fileobj,
-      const c10::optional<std::string>& format,
-      const c10::optional<std::map<std::string, std::string>>& option,
+      const std::optional<std::string>& format,
+      const std::optional<std::map<std::string, std::string>>& option,
       int buffer_size)
       : FileObj{fileobj, buffer_size},
         StreamingMediaDecoderCustomIO(
@@ -177,7 +177,7 @@ struct StreamingMediaEncoderFileObj : private FileObj,
                                       public StreamingMediaEncoderCustomIO {
   StreamingMediaEncoderFileObj(
       py::object fileobj,
-      const c10::optional<std::string>& format,
+      const std::optional<std::string>& format,
       int buffer_size)
       : FileObj{fileobj, buffer_size},
         StreamingMediaEncoderCustomIO(
@@ -231,8 +231,8 @@ struct StreamingMediaDecoderBytes : private BytesWrapper,
                                     public StreamingMediaDecoderCustomIO {
   StreamingMediaDecoderBytes(
       std::string_view src,
-      const c10::optional<std::string>& format,
-      const c10::optional<std::map<std::string, std::string>>& option,
+      const std::optional<std::string>& format,
+      const std::optional<std::map<std::string, std::string>>& option,
       int64_t buffer_size)
       : BytesWrapper{src},
         StreamingMediaDecoderCustomIO(
@@ -278,10 +278,10 @@ PYBIND11_MODULE(TORIO_FFMPEG_EXT_NAME, m) {
       .def_readwrite("frames", &Chunk::frames)
       .def_readwrite("pts", &Chunk::pts);
   py::class_<CodecConfig>(m, "CodecConfig", py::module_local())
-      .def(py::init<int, int, const c10::optional<int>&, int, int>());
+      .def(py::init<int, int, const std::optional<int>&, int, int>());
   py::class_<StreamingMediaEncoder>(
       m, "StreamingMediaEncoder", py::module_local())
-      .def(py::init<const std::string&, const c10::optional<std::string>&>())
+      .def(py::init<const std::string&, const std::optional<std::string>&>())
       .def("set_metadata", &StreamingMediaEncoder::set_metadata)
       .def("add_audio_stream", &StreamingMediaEncoder::add_audio_stream)
       .def("add_video_stream", &StreamingMediaEncoder::add_video_stream)
@@ -293,7 +293,7 @@ PYBIND11_MODULE(TORIO_FFMPEG_EXT_NAME, m) {
       .def("close", &StreamingMediaEncoder::close);
   py::class_<StreamingMediaEncoderFileObj>(
       m, "StreamingMediaEncoderFileObj", py::module_local())
-      .def(py::init<py::object, const c10::optional<std::string>&, int64_t>())
+      .def(py::init<py::object, const std::optional<std::string>&, int64_t>())
       .def("set_metadata", &StreamingMediaEncoderFileObj::set_metadata)
       .def("add_audio_stream", &StreamingMediaEncoderFileObj::add_audio_stream)
       .def("add_video_stream", &StreamingMediaEncoderFileObj::add_video_stream)
@@ -366,8 +366,8 @@ PYBIND11_MODULE(TORIO_FFMPEG_EXT_NAME, m) {
       m, "StreamingMediaDecoder", py::module_local())
       .def(py::init<
            const std::string&,
-           const c10::optional<std::string>&,
-           const c10::optional<OptionDict>&>())
+           const std::optional<std::string>&,
+           const std::optional<OptionDict>&>())
       .def("num_src_streams", &StreamingMediaDecoder::num_src_streams)
       .def("num_out_streams", &StreamingMediaDecoder::num_out_streams)
       .def(
@@ -385,7 +385,7 @@ PYBIND11_MODULE(TORIO_FFMPEG_EXT_NAME, m) {
       .def("remove_stream", &StreamingMediaDecoder::remove_stream)
       .def(
           "process_packet",
-          py::overload_cast<const c10::optional<double>&, const double>(
+          py::overload_cast<const std::optional<double>&, const double>(
               &StreamingMediaDecoder::process_packet))
       .def("process_all_packets", &StreamingMediaDecoder::process_all_packets)
       .def("fill_buffer", &StreamingMediaDecoder::fill_buffer)
@@ -395,8 +395,8 @@ PYBIND11_MODULE(TORIO_FFMPEG_EXT_NAME, m) {
       m, "StreamingMediaDecoderFileObj", py::module_local())
       .def(py::init<
            py::object,
-           const c10::optional<std::string>&,
-           const c10::optional<OptionDict>&,
+           const std::optional<std::string>&,
+           const std::optional<OptionDict>&,
            int64_t>())
       .def("num_src_streams", &StreamingMediaDecoderFileObj::num_src_streams)
       .def("num_out_streams", &StreamingMediaDecoderFileObj::num_out_streams)
@@ -419,7 +419,7 @@ PYBIND11_MODULE(TORIO_FFMPEG_EXT_NAME, m) {
       .def("remove_stream", &StreamingMediaDecoderFileObj::remove_stream)
       .def(
           "process_packet",
-          py::overload_cast<const c10::optional<double>&, const double>(
+          py::overload_cast<const std::optional<double>&, const double>(
               &StreamingMediaDecoder::process_packet))
       .def(
           "process_all_packets",
@@ -431,8 +431,8 @@ PYBIND11_MODULE(TORIO_FFMPEG_EXT_NAME, m) {
       m, "StreamingMediaDecoderBytes", py::module_local())
       .def(py::init<
            std::string_view,
-           const c10::optional<std::string>&,
-           const c10::optional<OptionDict>&,
+           const std::optional<std::string>&,
+           const std::optional<OptionDict>&,
            int64_t>())
       .def("num_src_streams", &StreamingMediaDecoderBytes::num_src_streams)
       .def("num_out_streams", &StreamingMediaDecoderBytes::num_out_streams)
@@ -455,7 +455,7 @@ PYBIND11_MODULE(TORIO_FFMPEG_EXT_NAME, m) {
       .def("remove_stream", &StreamingMediaDecoderBytes::remove_stream)
       .def(
           "process_packet",
-          py::overload_cast<const c10::optional<double>&, const double>(
+          py::overload_cast<const std::optional<double>&, const double>(
               &StreamingMediaDecoder::process_packet))
       .def(
           "process_all_packets",

--- a/src/libtorio/ffmpeg/stream_reader/buffer/chunked_buffer.cpp
+++ b/src/libtorio/ffmpeg/stream_reader/buffer/chunked_buffer.cpp
@@ -105,7 +105,7 @@ void ChunkedBuffer::push_frame(torch::Tensor frame, int64_t pts_) {
   }
 }
 
-c10::optional<Chunk> ChunkedBuffer::pop_chunk() {
+std::optional<Chunk> ChunkedBuffer::pop_chunk() {
   using namespace torch::indexing;
   if (!num_buffered_frames) {
     return {};

--- a/src/libtorio/ffmpeg/stream_reader/buffer/chunked_buffer.h
+++ b/src/libtorio/ffmpeg/stream_reader/buffer/chunked_buffer.h
@@ -26,7 +26,7 @@ class ChunkedBuffer {
 
   bool is_ready() const;
   void flush();
-  c10::optional<Chunk> pop_chunk();
+  std::optional<Chunk> pop_chunk();
   void push_frame(torch::Tensor frame, int64_t pts_);
 };
 

--- a/src/libtorio/ffmpeg/stream_reader/buffer/unchunked_buffer.cpp
+++ b/src/libtorio/ffmpeg/stream_reader/buffer/unchunked_buffer.cpp
@@ -15,7 +15,7 @@ void UnchunkedBuffer::push_frame(torch::Tensor frame, int64_t pts_) {
   chunks.push_back(frame);
 }
 
-c10::optional<Chunk> UnchunkedBuffer::pop_chunk() {
+std::optional<Chunk> UnchunkedBuffer::pop_chunk() {
   if (chunks.size() == 0) {
     return {};
   }

--- a/src/libtorio/ffmpeg/stream_reader/buffer/unchunked_buffer.h
+++ b/src/libtorio/ffmpeg/stream_reader/buffer/unchunked_buffer.h
@@ -16,7 +16,7 @@ class UnchunkedBuffer {
   explicit UnchunkedBuffer(AVRational time_base);
   bool is_ready() const;
   void push_frame(torch::Tensor frame, int64_t pts_);
-  c10::optional<Chunk> pop_chunk();
+  std::optional<Chunk> pop_chunk();
   void flush();
 };
 

--- a/src/libtorio/ffmpeg/stream_reader/post_process.cpp
+++ b/src/libtorio/ffmpeg/stream_reader/post_process.cpp
@@ -144,7 +144,7 @@ struct ProcessImpl : public IPostDecodeProcess {
     return ret;
   }
 
-  c10::optional<Chunk> pop_chunk() override {
+  std::optional<Chunk> pop_chunk() override {
     return buffer.pop_chunk();
   }
 };

--- a/src/libtorio/ffmpeg/stream_reader/post_process.h
+++ b/src/libtorio/ffmpeg/stream_reader/post_process.h
@@ -8,7 +8,7 @@ struct IPostDecodeProcess {
   virtual ~IPostDecodeProcess() = default;
 
   virtual int process_frame(AVFrame* frame) = 0;
-  virtual c10::optional<Chunk> pop_chunk() = 0;
+  virtual std::optional<Chunk> pop_chunk() = 0;
   virtual bool is_buffer_ready() const = 0;
   virtual const std::string& get_filter_desc() const = 0;
   virtual FilterGraphOutputInfo get_filter_output_info() const = 0;

--- a/src/libtorio/ffmpeg/stream_reader/stream_processor.cpp
+++ b/src/libtorio/ffmpeg/stream_reader/stream_processor.cpp
@@ -8,7 +8,7 @@ namespace torio::io {
 namespace {
 AVCodecContextPtr alloc_codec_context(
     enum AVCodecID codec_id,
-    const c10::optional<std::string>& decoder_name) {
+    const std::optional<std::string>& decoder_name) {
   const AVCodec* codec = [&]() {
     if (decoder_name) {
       const AVCodec* c =
@@ -132,7 +132,7 @@ void configure_codec_context(
 
 void open_codec(
     AVCodecContext* codec_ctx,
-    const c10::optional<OptionDict>& decoder_option) {
+    const std::optional<OptionDict>& decoder_option) {
   AVDictionary* opts = get_option_dict(decoder_option);
 
   // Default to single thread execution.
@@ -158,8 +158,8 @@ bool ends_with(std::string_view str, std::string_view suffix) {
 
 AVCodecContextPtr get_codec_ctx(
     const AVCodecParameters* params,
-    const c10::optional<std::string>& decoder_name,
-    const c10::optional<OptionDict>& decoder_option,
+    const std::optional<std::string>& decoder_name,
+    const std::optional<OptionDict>& decoder_option,
     const torch::Device& device) {
   AVCodecContextPtr codec_ctx =
       alloc_codec_context(params->codec_id, decoder_name);
@@ -266,8 +266,8 @@ void StreamProcessor::set_discard_timestamp(int64_t timestamp) {
 
 void StreamProcessor::set_decoder(
     const AVCodecParameters* codecpar,
-    const c10::optional<std::string>& decoder_name,
-    const c10::optional<OptionDict>& decoder_option,
+    const std::optional<std::string>& decoder_name,
+    const std::optional<OptionDict>& decoder_option,
     const torch::Device& device) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!codec_ctx, "Decoder has already been set.");
   codec_ctx = get_codec_ctx(codecpar, decoder_name, decoder_option, device);
@@ -390,7 +390,7 @@ int StreamProcessor::send_frame(AVFrame* frame_) {
 ////////////////////////////////////////////////////////////////////////////////
 // Retrieval
 ////////////////////////////////////////////////////////////////////////////////
-c10::optional<Chunk> StreamProcessor::pop_chunk(KeyType key) {
+std::optional<Chunk> StreamProcessor::pop_chunk(KeyType key) {
   return post_processes.at(key)->pop_chunk();
 }
 


### PR DESCRIPTION
Summary: `c10::optional` was switched to be `std::optional` after PyTorch moved to C++17. Let's eliminate `c10::optional`, if we can.

Reviewed By: albanD

Differential Revision: D57294298


