### PR TITLE
[codemod] c10::optional -> std::optional in pytorch/audio/src/libtorio/ffmpeg/stream_reader/stream_processor.h +20

### DIFF
--- a/src/libtorio/ffmpeg/stream_reader/stream_processor.h
+++ b/src/libtorio/ffmpeg/stream_reader/stream_processor.h
@@ -66,8 +66,8 @@ class StreamProcessor {
 
   void set_decoder(
       const AVCodecParameters* codecpar,
-      const c10::optional<std::string>& decoder_name,
-      const c10::optional<OptionDict>& decoder_option,
+      const std::optional<std::string>& decoder_name,
+      const std::optional<OptionDict>& decoder_option,
       const torch::Device& device);
 
   //////////////////////////////////////////////////////////////////////////////
@@ -100,7 +100,7 @@ class StreamProcessor {
   //////////////////////////////////////////////////////////////////////////////
  public:
   // Get the chunk from the given filter result
-  c10::optional<Chunk> pop_chunk(KeyType key);
+  std::optional<Chunk> pop_chunk(KeyType key);
 };
 
 } // namespace io

--- a/src/libtorio/ffmpeg/stream_reader/stream_reader.cpp
+++ b/src/libtorio/ffmpeg/stream_reader/stream_reader.cpp
@@ -15,8 +15,8 @@ using KeyType = StreamProcessor::KeyType;
 namespace {
 AVFormatContext* get_input_format_context(
     const std::string& src,
-    const c10::optional<std::string>& format,
-    const c10::optional<OptionDict>& option,
+    const std::optional<std::string>& format,
+    const std::optional<OptionDict>& option,
     AVIOContext* io_ctx) {
   AVFormatContext* p = avformat_alloc_context();
   TORCH_CHECK(p, "Failed to allocate AVFormatContext.");
@@ -72,8 +72,8 @@ StreamingMediaDecoder::StreamingMediaDecoder(AVFormatContext* p)
 
 StreamingMediaDecoder::StreamingMediaDecoder(
     AVIOContext* io_ctx,
-    const c10::optional<std::string>& format,
-    const c10::optional<OptionDict>& option)
+    const std::optional<std::string>& format,
+    const std::optional<OptionDict>& option)
     : StreamingMediaDecoder(get_input_format_context(
           "Custom Input Context",
           format,
@@ -82,8 +82,8 @@ StreamingMediaDecoder::StreamingMediaDecoder(
 
 StreamingMediaDecoder::StreamingMediaDecoder(
     const std::string& src,
-    const c10::optional<std::string>& format,
-    const c10::optional<OptionDict>& option)
+    const std::optional<std::string>& format,
+    const std::optional<OptionDict>& option)
     : StreamingMediaDecoder(
           get_input_format_context(src, format, option, nullptr)) {}
 
@@ -308,9 +308,9 @@ void StreamingMediaDecoder::add_audio_stream(
     int64_t i,
     int64_t frames_per_chunk,
     int64_t num_chunks,
-    const c10::optional<std::string>& filter_desc,
-    const c10::optional<std::string>& decoder,
-    const c10::optional<OptionDict>& decoder_option) {
+    const std::optional<std::string>& filter_desc,
+    const std::optional<std::string>& decoder,
+    const std::optional<OptionDict>& decoder_option) {
   add_stream(
       static_cast<int>(i),
       AVMEDIA_TYPE_AUDIO,
@@ -326,10 +326,10 @@ void StreamingMediaDecoder::add_video_stream(
     int64_t i,
     int64_t frames_per_chunk,
     int64_t num_chunks,
-    const c10::optional<std::string>& filter_desc,
-    const c10::optional<std::string>& decoder,
-    const c10::optional<OptionDict>& decoder_option,
-    const c10::optional<std::string>& hw_accel) {
+    const std::optional<std::string>& filter_desc,
+    const std::optional<std::string>& decoder,
+    const std::optional<OptionDict>& decoder_option,
+    const std::optional<std::string>& hw_accel) {
   const torch::Device device = [&]() {
     if (!hw_accel) {
       return torch::Device{c10::DeviceType::CPU};
@@ -371,8 +371,8 @@ void StreamingMediaDecoder::add_stream(
     int frames_per_chunk,
     int num_chunks,
     const std::string& filter_desc,
-    const c10::optional<std::string>& decoder,
-    const c10::optional<OptionDict>& decoder_option,
+    const std::optional<std::string>& decoder,
+    const std::optional<OptionDict>& decoder_option,
     const torch::Device& device) {
   validate_src_stream_type(format_ctx, i, media_type);
 
@@ -517,7 +517,7 @@ void StreamingMediaDecoder::process_all_packets() {
 }
 
 int StreamingMediaDecoder::process_packet(
-    const c10::optional<double>& timeout,
+    const std::optional<double>& timeout,
     const double backoff) {
   int code = [&]() -> int {
     if (timeout.has_value()) {
@@ -531,7 +531,7 @@ int StreamingMediaDecoder::process_packet(
 }
 
 int StreamingMediaDecoder::fill_buffer(
-    const c10::optional<double>& timeout,
+    const std::optional<double>& timeout,
     const double backoff) {
   while (!is_buffer_ready()) {
     int code = process_packet(timeout, backoff);
@@ -556,8 +556,8 @@ int StreamingMediaDecoder::drain() {
   return ret;
 }
 
-std::vector<c10::optional<Chunk>> StreamingMediaDecoder::pop_chunks() {
-  std::vector<c10::optional<Chunk>> ret;
+std::vector<std::optional<Chunk>> StreamingMediaDecoder::pop_chunks() {
+  std::vector<std::optional<Chunk>> ret;
   ret.reserve(static_cast<size_t>(num_out_streams()));
   for (auto& i : stream_indices) {
     ret.emplace_back(processors[i.first]->pop_chunk(i.second));
@@ -602,11 +602,11 @@ CustomInput::CustomInput(
 
 StreamingMediaDecoderCustomIO::StreamingMediaDecoderCustomIO(
     void* opaque,
-    const c10::optional<std::string>& format,
+    const std::optional<std::string>& format,
     int buffer_size,
     int (*read_packet)(void* opaque, uint8_t* buf, int buf_size),
     int64_t (*seek)(void* opaque, int64_t offset, int whence),
-    const c10::optional<OptionDict>& option)
+    const std::optional<OptionDict>& option)
     : CustomInput(opaque, buffer_size, read_packet, seek),
       StreamingMediaDecoder(io_ctx, format, option) {}
 

--- a/src/libtorio/ffmpeg/stream_reader/stream_reader.h
+++ b/src/libtorio/ffmpeg/stream_reader/stream_reader.h
@@ -66,8 +66,8 @@ class StreamingMediaDecoder {
   /// (opening source).
   explicit StreamingMediaDecoder(
       AVIOContext* io_ctx,
-      const c10::optional<std::string>& format = c10::nullopt,
-      const c10::optional<OptionDict>& option = c10::nullopt);
+      const std::optional<std::string>& format = c10::nullopt,
+      const std::optional<OptionDict>& option = c10::nullopt);
 
   /// @endcond
 
@@ -81,8 +81,8 @@ class StreamingMediaDecoder {
   /// (opening source).
   explicit StreamingMediaDecoder(
       const std::string& src,
-      const c10::optional<std::string>& format = c10::nullopt,
-      const c10::optional<OptionDict>& option = c10::nullopt);
+      const std::optional<std::string>& format = c10::nullopt,
+      const std::optional<OptionDict>& option = c10::nullopt);
 
   ///@}
 
@@ -205,9 +205,9 @@ class StreamingMediaDecoder {
       int64_t i,
       int64_t frames_per_chunk,
       int64_t num_chunks,
-      const c10::optional<std::string>& filter_desc = c10::nullopt,
-      const c10::optional<std::string>& decoder = c10::nullopt,
-      const c10::optional<OptionDict>& decoder_option = c10::nullopt);
+      const std::optional<std::string>& filter_desc = c10::nullopt,
+      const std::optional<std::string>& decoder = c10::nullopt,
+      const std::optional<OptionDict>& decoder_option = c10::nullopt);
   /// Define an output video stream.
   ///
   /// @param i,frames_per_chunk,num_chunks,filter_desc,decoder,decoder_option
@@ -226,10 +226,10 @@ class StreamingMediaDecoder {
       int64_t i,
       int64_t frames_per_chunk,
       int64_t num_chunks,
-      const c10::optional<std::string>& filter_desc = c10::nullopt,
-      const c10::optional<std::string>& decoder = c10::nullopt,
-      const c10::optional<OptionDict>& decoder_option = c10::nullopt,
-      const c10::optional<std::string>& hw_accel = c10::nullopt);
+      const std::optional<std::string>& filter_desc = c10::nullopt,
+      const std::optional<std::string>& decoder = c10::nullopt,
+      const std::optional<OptionDict>& decoder_option = c10::nullopt,
+      const std::optional<std::string>& hw_accel = c10::nullopt);
 
   /// @cond
   /// Add a output packet stream.
@@ -255,8 +255,8 @@ class StreamingMediaDecoder {
       int frames_per_chunk,
       int num_chunks,
       const std::string& filter_desc,
-      const c10::optional<std::string>& decoder,
-      const c10::optional<OptionDict>& decoder_option,
+      const std::optional<std::string>& decoder,
+      const std::optional<OptionDict>& decoder_option,
       const torch::Device& device);
 
   //////////////////////////////////////////////////////////////////////////////
@@ -303,7 +303,7 @@ class StreamingMediaDecoder {
   /// @cond
   // High-level method used by Python bindings.
   int process_packet(
-      const c10::optional<double>& timeout,
+      const std::optional<double>& timeout,
       const double backoff);
   /// @endcond
 
@@ -315,7 +315,7 @@ class StreamingMediaDecoder {
   /// @param timeout See `process_packet_block()`
   /// @param backoff See `process_packet_block()`
   int fill_buffer(
-      const c10::optional<double>& timeout = c10::nullopt,
+      const std::optional<double>& timeout = c10::nullopt,
       const double backoff = 10.);
 
   ///@}
@@ -331,7 +331,7 @@ class StreamingMediaDecoder {
   ///@{
 
   /// Pop one chunk from each output stream if it is available.
-  std::vector<c10::optional<Chunk>> pop_chunks();
+  std::vector<std::optional<Chunk>> pop_chunks();
 
   /// @cond
   /// Pop packets from buffer, if available.
@@ -379,11 +379,11 @@ class StreamingMediaDecoderCustomIO : private detail::CustomInput,
   /// @param option Custom option passed when initializing format context.
   StreamingMediaDecoderCustomIO(
       void* opaque,
-      const c10::optional<std::string>& format,
+      const std::optional<std::string>& format,
       int buffer_size,
       int (*read_packet)(void* opaque, uint8_t* buf, int buf_size),
       int64_t (*seek)(void* opaque, int64_t offset, int whence) = nullptr,
-      const c10::optional<OptionDict>& option = c10::nullopt);
+      const std::optional<OptionDict>& option = c10::nullopt);
 };
 
 // For BC

--- a/src/libtorio/ffmpeg/stream_writer/encode_process.cpp
+++ b/src/libtorio/ffmpeg/stream_writer/encode_process.cpp
@@ -22,7 +22,7 @@ EncodeProcess::EncodeProcess(
 
 void EncodeProcess::process(
     const torch::Tensor& tensor,
-    const c10::optional<double>& pts) {
+    const std::optional<double>& pts) {
   if (pts) {
     const double& pts_val = pts.value();
     TORCH_CHECK(
@@ -127,7 +127,7 @@ enum AVPixelFormat get_src_pix_fmt(const std::string& src) {
 ////////////////////////////////////////////////////////////////////////////////
 const AVCodec* get_codec(
     AVCodecID default_codec,
-    const c10::optional<std::string>& encoder) {
+    const std::optional<std::string>& encoder) {
   if (encoder) {
     const AVCodec* c = avcodec_find_encoder_by_name(encoder.value().c_str());
     TORCH_CHECK(c, "Unexpected codec: ", encoder.value());
@@ -151,7 +151,7 @@ AVCodecContextPtr get_codec_ctx(const AVCodec* codec, int flags) {
 
 void open_codec(
     AVCodecContext* codec_ctx,
-    const c10::optional<OptionDict>& option) {
+    const std::optional<OptionDict>& option) {
   AVDictionary* opt = get_option_dict(option);
 
   // Enable experimental feature if required
@@ -224,7 +224,7 @@ std::string get_supported_formats(const AVSampleFormat* sample_fmts) {
 
 AVSampleFormat get_enc_fmt(
     AVSampleFormat src_fmt,
-    const c10::optional<std::string>& encoder_format,
+    const std::optional<std::string>& encoder_format,
     const AVCodec* codec) {
   if (encoder_format) {
     auto& enc_fmt_val = encoder_format.value();
@@ -273,7 +273,7 @@ std::string get_supported_samplerates(const int* supported_samplerates) {
 
 int get_enc_sr(
     int src_sample_rate,
-    const c10::optional<int>& encoder_sample_rate,
+    const std::optional<int>& encoder_sample_rate,
     const AVCodec* codec) {
   // G.722 only supports 16000 Hz, but it does not list the sample rate in
   // supported_samplerates so we hard code it here.
@@ -325,7 +325,7 @@ std::string get_supported_channels(const uint64_t* channel_layouts) {
 
 uint64_t get_channel_layout(
     const uint64_t src_ch_layout,
-    const c10::optional<int> enc_num_channels,
+    const std::optional<int> enc_num_channels,
     const AVCodec* codec) {
   // If the override is presented, and if it is supported by codec, we use it.
   if (enc_num_channels) {
@@ -370,7 +370,7 @@ void configure_audio_codec_ctx(
     AVSampleFormat format,
     int sample_rate,
     uint64_t channel_layout,
-    const c10::optional<CodecConfig>& codec_config) {
+    const std::optional<CodecConfig>& codec_config) {
   codec_ctx->sample_fmt = format;
   codec_ctx->sample_rate = sample_rate;
   codec_ctx->time_base = av_inv_q(av_d2q(sample_rate, 1 << 24));
@@ -421,7 +421,7 @@ std::string get_supported_formats(const AVPixelFormat* pix_fmts) {
 
 AVPixelFormat get_enc_fmt(
     AVPixelFormat src_fmt,
-    const c10::optional<std::string>& encoder_format,
+    const std::optional<std::string>& encoder_format,
     const AVCodec* codec) {
   if (encoder_format) {
     const auto& val = encoder_format.value();
@@ -455,7 +455,7 @@ bool supported_frame_rate(AVRational rate, const AVRational* rates) {
 
 AVRational get_enc_rate(
     AVRational src_rate,
-    const c10::optional<double>& encoder_sample_rate,
+    const std::optional<double>& encoder_sample_rate,
     const AVCodec* codec) {
   if (encoder_sample_rate) {
     const double& enc_rate = encoder_sample_rate.value();
@@ -494,7 +494,7 @@ void configure_video_codec_ctx(
     AVRational frame_rate,
     int width,
     int height,
-    const c10::optional<CodecConfig>& codec_config) {
+    const std::optional<CodecConfig>& codec_config) {
   // TODO: Review other options and make them configurable?
   // https://ffmpeg.org/doxygen/4.1/muxing_8c_source.html#l00147
   //  - bit_rate_tolerance
@@ -596,7 +596,7 @@ FilterGraph get_audio_filter_graph(
     AVSampleFormat src_fmt,
     int src_sample_rate,
     uint64_t src_ch_layout,
-    const c10::optional<std::string>& filter_desc,
+    const std::optional<std::string>& filter_desc,
     AVSampleFormat enc_fmt,
     int enc_sample_rate,
     uint64_t enc_ch_layout,
@@ -639,7 +639,7 @@ FilterGraph get_video_filter_graph(
     AVRational src_rate,
     int src_width,
     int src_height,
-    const c10::optional<std::string>& filter_desc,
+    const std::optional<std::string>& filter_desc,
     AVPixelFormat enc_fmt,
     AVRational enc_rate,
     int enc_width,
@@ -743,13 +743,13 @@ EncodeProcess get_audio_encode_process(
     int src_sample_rate,
     int src_num_channels,
     const std::string& format,
-    const c10::optional<std::string>& encoder,
-    const c10::optional<OptionDict>& encoder_option,
-    const c10::optional<std::string>& encoder_format,
-    const c10::optional<int>& encoder_sample_rate,
-    const c10::optional<int>& encoder_num_channels,
-    const c10::optional<CodecConfig>& codec_config,
-    const c10::optional<std::string>& filter_desc,
+    const std::optional<std::string>& encoder,
+    const std::optional<OptionDict>& encoder_option,
+    const std::optional<std::string>& encoder_format,
+    const std::optional<int>& encoder_sample_rate,
+    const std::optional<int>& encoder_num_channels,
+    const std::optional<CodecConfig>& codec_config,
+    const std::optional<std::string>& filter_desc,
     bool disable_converter) {
   // 1. Check the source format, rate and channels
   TORCH_CHECK(
@@ -854,15 +854,15 @@ EncodeProcess get_video_encode_process(
     int src_width,
     int src_height,
     const std::string& format,
-    const c10::optional<std::string>& encoder,
-    const c10::optional<OptionDict>& encoder_option,
-    const c10::optional<std::string>& encoder_format,
-    const c10::optional<double>& encoder_frame_rate,
-    const c10::optional<int>& encoder_width,
-    const c10::optional<int>& encoder_height,
-    const c10::optional<std::string>& hw_accel,
-    const c10::optional<CodecConfig>& codec_config,
-    const c10::optional<std::string>& filter_desc,
+    const std::optional<std::string>& encoder,
+    const std::optional<OptionDict>& encoder_option,
+    const std::optional<std::string>& encoder_format,
+    const std::optional<double>& encoder_frame_rate,
+    const std::optional<int>& encoder_width,
+    const std::optional<int>& encoder_height,
+    const std::optional<std::string>& hw_accel,
+    const std::optional<CodecConfig>& codec_config,
+    const std::optional<std::string>& filter_desc,
     bool disable_converter) {
   // 1. Checkc the source format, rate and resolution
   TORCH_CHECK(

--- a/src/libtorio/ffmpeg/stream_writer/encode_process.h
+++ b/src/libtorio/ffmpeg/stream_writer/encode_process.h
@@ -26,7 +26,7 @@ class EncodeProcess {
 
   EncodeProcess(EncodeProcess&&) noexcept = default;
 
-  void process(const torch::Tensor& tensor, const c10::optional<double>& pts);
+  void process(const torch::Tensor& tensor, const std::optional<double>& pts);
 
   void process_frame(AVFrame* src);
 
@@ -38,13 +38,13 @@ EncodeProcess get_audio_encode_process(
     int sample_rate,
     int num_channels,
     const std::string& format,
-    const c10::optional<std::string>& encoder,
-    const c10::optional<OptionDict>& encoder_option,
-    const c10::optional<std::string>& encoder_format,
-    const c10::optional<int>& encoder_sample_rate,
-    const c10::optional<int>& encoder_num_channels,
-    const c10::optional<CodecConfig>& codec_config,
-    const c10::optional<std::string>& filter_desc,
+    const std::optional<std::string>& encoder,
+    const std::optional<OptionDict>& encoder_option,
+    const std::optional<std::string>& encoder_format,
+    const std::optional<int>& encoder_sample_rate,
+    const std::optional<int>& encoder_num_channels,
+    const std::optional<CodecConfig>& codec_config,
+    const std::optional<std::string>& filter_desc,
     bool disable_converter = false);
 
 EncodeProcess get_video_encode_process(
@@ -53,15 +53,15 @@ EncodeProcess get_video_encode_process(
     int width,
     int height,
     const std::string& format,
-    const c10::optional<std::string>& encoder,
-    const c10::optional<OptionDict>& encoder_option,
-    const c10::optional<std::string>& encoder_format,
-    const c10::optional<double>& encoder_frame_rate,
-    const c10::optional<int>& encoder_width,
-    const c10::optional<int>& encoder_height,
-    const c10::optional<std::string>& hw_accel,
-    const c10::optional<CodecConfig>& codec_config,
-    const c10::optional<std::string>& filter_desc,
+    const std::optional<std::string>& encoder,
+    const std::optional<OptionDict>& encoder_option,
+    const std::optional<std::string>& encoder_format,
+    const std::optional<double>& encoder_frame_rate,
+    const std::optional<int>& encoder_width,
+    const std::optional<int>& encoder_height,
+    const std::optional<std::string>& hw_accel,
+    const std::optional<CodecConfig>& codec_config,
+    const std::optional<std::string>& filter_desc,
     bool disable_converter = false);
 
 }; // namespace torio::io

--- a/src/libtorio/ffmpeg/stream_writer/stream_writer.cpp
+++ b/src/libtorio/ffmpeg/stream_writer/stream_writer.cpp
@@ -10,7 +10,7 @@ namespace {
 
 AVFormatContext* get_output_format_context(
     const std::string& dst,
-    const c10::optional<std::string>& format,
+    const std::optional<std::string>& format,
     AVIOContext* io_ctx) {
   if (io_ctx) {
     TORCH_CHECK(
@@ -45,26 +45,26 @@ StreamingMediaEncoder::StreamingMediaEncoder(AVFormatContext* p)
 
 StreamingMediaEncoder::StreamingMediaEncoder(
     AVIOContext* io_ctx,
-    const c10::optional<std::string>& format)
+    const std::optional<std::string>& format)
     : StreamingMediaEncoder(
           get_output_format_context("Custom Output Context", format, io_ctx)) {}
 
 StreamingMediaEncoder::StreamingMediaEncoder(
     const std::string& dst,
-    const c10::optional<std::string>& format)
+    const std::optional<std::string>& format)
     : StreamingMediaEncoder(get_output_format_context(dst, format, nullptr)) {}
 
 void StreamingMediaEncoder::add_audio_stream(
     int sample_rate,
     int num_channels,
     const std::string& format,
-    const c10::optional<std::string>& encoder,
-    const c10::optional<OptionDict>& encoder_option,
-    const c10::optional<std::string>& encoder_format,
-    const c10::optional<int>& encoder_sample_rate,
-    const c10::optional<int>& encoder_num_channels,
-    const c10::optional<CodecConfig>& codec_config,
-    const c10::optional<std::string>& filter_desc) {
+    const std::optional<std::string>& encoder,
+    const std::optional<OptionDict>& encoder_option,
+    const std::optional<std::string>& encoder_format,
+    const std::optional<int>& encoder_sample_rate,
+    const std::optional<int>& encoder_num_channels,
+    const std::optional<CodecConfig>& codec_config,
+    const std::optional<std::string>& filter_desc) {
   TORCH_CHECK(!is_open, "Output is already opened. Cannot add a new stream.");
   TORCH_INTERNAL_ASSERT(
       format_ctx->nb_streams == num_output_streams(),
@@ -92,15 +92,15 @@ void StreamingMediaEncoder::add_video_stream(
     int width,
     int height,
     const std::string& format,
-    const c10::optional<std::string>& encoder,
-    const c10::optional<OptionDict>& encoder_option,
-    const c10::optional<std::string>& encoder_format,
-    const c10::optional<double>& encoder_frame_rate,
-    const c10::optional<int>& encoder_width,
-    const c10::optional<int>& encoder_height,
-    const c10::optional<std::string>& hw_accel,
-    const c10::optional<CodecConfig>& codec_config,
-    const c10::optional<std::string>& filter_desc) {
+    const std::optional<std::string>& encoder,
+    const std::optional<OptionDict>& encoder_option,
+    const std::optional<std::string>& encoder_format,
+    const std::optional<double>& encoder_frame_rate,
+    const std::optional<int>& encoder_width,
+    const std::optional<int>& encoder_height,
+    const std::optional<std::string>& hw_accel,
+    const std::optional<CodecConfig>& codec_config,
+    const std::optional<std::string>& filter_desc) {
   TORCH_CHECK(!is_open, "Output is already opened. Cannot add a new stream.");
   TORCH_INTERNAL_ASSERT(
       format_ctx->nb_streams == num_output_streams(),
@@ -139,13 +139,13 @@ void StreamingMediaEncoder::add_audio_frame_stream(
     int sample_rate,
     int num_channels,
     const std::string& format,
-    const c10::optional<std::string>& encoder,
-    const c10::optional<OptionDict>& encoder_option,
-    const c10::optional<std::string>& encoder_format,
-    const c10::optional<int>& encoder_sample_rate,
-    const c10::optional<int>& encoder_num_channels,
-    const c10::optional<CodecConfig>& codec_config,
-    const c10::optional<std::string>& filter_desc) {
+    const std::optional<std::string>& encoder,
+    const std::optional<OptionDict>& encoder_option,
+    const std::optional<std::string>& encoder_format,
+    const std::optional<int>& encoder_sample_rate,
+    const std::optional<int>& encoder_num_channels,
+    const std::optional<CodecConfig>& codec_config,
+    const std::optional<std::string>& filter_desc) {
   TORCH_CHECK(!is_open, "Output is already opened. Cannot add a new stream.");
   TORCH_INTERNAL_ASSERT(
       format_ctx->nb_streams == num_output_streams(),
@@ -174,15 +174,15 @@ void StreamingMediaEncoder::add_video_frame_stream(
     int width,
     int height,
     const std::string& format,
-    const c10::optional<std::string>& encoder,
-    const c10::optional<OptionDict>& encoder_option,
-    const c10::optional<std::string>& encoder_format,
-    const c10::optional<double>& encoder_frame_rate,
-    const c10::optional<int>& encoder_width,
-    const c10::optional<int>& encoder_height,
-    const c10::optional<std::string>& hw_accel,
-    const c10::optional<CodecConfig>& codec_config,
-    const c10::optional<std::string>& filter_desc) {
+    const std::optional<std::string>& encoder,
+    const std::optional<OptionDict>& encoder_option,
+    const std::optional<std::string>& encoder_format,
+    const std::optional<double>& encoder_frame_rate,
+    const std::optional<int>& encoder_width,
+    const std::optional<int>& encoder_height,
+    const std::optional<std::string>& hw_accel,
+    const std::optional<CodecConfig>& codec_config,
+    const std::optional<std::string>& filter_desc) {
   TORCH_CHECK(!is_open, "Output is already opened. Cannot add a new stream.");
   TORCH_INTERNAL_ASSERT(
       format_ctx->nb_streams == num_output_streams(),
@@ -220,7 +220,7 @@ void StreamingMediaEncoder::dump_format(int64_t i) {
   av_dump_format(format_ctx, (int)i, format_ctx->url, 1);
 }
 
-void StreamingMediaEncoder::open(const c10::optional<OptionDict>& option) {
+void StreamingMediaEncoder::open(const std::optional<OptionDict>& option) {
   TORCH_INTERNAL_ASSERT(
       format_ctx->nb_streams == num_output_streams(),
       "The number of encode process and the number of output streams do not match.");
@@ -279,7 +279,7 @@ void StreamingMediaEncoder::close() {
 void StreamingMediaEncoder::write_audio_chunk(
     int i,
     const torch::Tensor& waveform,
-    const c10::optional<double>& pts) {
+    const std::optional<double>& pts) {
   TORCH_CHECK(is_open, "Output is not opened. Did you call `open` method?");
   TORCH_CHECK(
       0 <= i && i < static_cast<int>(format_ctx->nb_streams),
@@ -298,7 +298,7 @@ void StreamingMediaEncoder::write_audio_chunk(
 void StreamingMediaEncoder::write_video_chunk(
     int i,
     const torch::Tensor& frames,
-    const c10::optional<double>& pts) {
+    const std::optional<double>& pts) {
   TORCH_CHECK(is_open, "Output is not opened. Did you call `open` method?");
   TORCH_CHECK(
       0 <= i && i < static_cast<int>(format_ctx->nb_streams),
@@ -379,7 +379,7 @@ CustomOutput::CustomOutput(
 
 StreamingMediaEncoderCustomIO::StreamingMediaEncoderCustomIO(
     void* opaque,
-    const c10::optional<std::string>& format,
+    const std::optional<std::string>& format,
     int buffer_size,
     int (*write_packet)(void* opaque, uint8_t* buf, int buf_size),
     int64_t (*seek)(void* opaque, int64_t offset, int whence))

--- a/src/libtorio/ffmpeg/stream_writer/stream_writer.h
+++ b/src/libtorio/ffmpeg/stream_writer/stream_writer.h
@@ -38,7 +38,7 @@ class StreamingMediaEncoder {
   /// @param format Specify output format.
   explicit StreamingMediaEncoder(
       AVIOContext* io_ctx,
-      const c10::optional<std::string>& format = c10::nullopt);
+      const std::optional<std::string>& format = c10::nullopt);
 
   /// @endcond
 
@@ -50,7 +50,7 @@ class StreamingMediaEncoder {
   /// ``dst``.
   explicit StreamingMediaEncoder(
       const std::string& dst,
-      const c10::optional<std::string>& format = c10::nullopt);
+      const std::optional<std::string>& format = c10::nullopt);
 
   // Non-copyable
   StreamingMediaEncoder(const StreamingMediaEncoder&) = delete;
@@ -113,13 +113,13 @@ class StreamingMediaEncoder {
       int sample_rate,
       int num_channels,
       const std::string& format,
-      const c10::optional<std::string>& encoder = c10::nullopt,
-      const c10::optional<OptionDict>& encoder_option = c10::nullopt,
-      const c10::optional<std::string>& encoder_format = c10::nullopt,
-      const c10::optional<int>& encoder_sample_rate = c10::nullopt,
-      const c10::optional<int>& encoder_num_channels = c10::nullopt,
-      const c10::optional<CodecConfig>& codec_config = c10::nullopt,
-      const c10::optional<std::string>& filter_desc = c10::nullopt);
+      const std::optional<std::string>& encoder = c10::nullopt,
+      const std::optional<OptionDict>& encoder_option = c10::nullopt,
+      const std::optional<std::string>& encoder_format = c10::nullopt,
+      const std::optional<int>& encoder_sample_rate = c10::nullopt,
+      const std::optional<int>& encoder_num_channels = c10::nullopt,
+      const std::optional<CodecConfig>& codec_config = c10::nullopt,
+      const std::optional<std::string>& filter_desc = c10::nullopt);
 
   /// Add an output video stream.
   ///
@@ -161,15 +161,15 @@ class StreamingMediaEncoder {
       int width,
       int height,
       const std::string& format,
-      const c10::optional<std::string>& encoder = c10::nullopt,
-      const c10::optional<OptionDict>& encoder_option = c10::nullopt,
-      const c10::optional<std::string>& encoder_format = c10::nullopt,
-      const c10::optional<double>& encoder_frame_rate = c10::nullopt,
-      const c10::optional<int>& encoder_width = c10::nullopt,
-      const c10::optional<int>& encoder_height = c10::nullopt,
-      const c10::optional<std::string>& hw_accel = c10::nullopt,
-      const c10::optional<CodecConfig>& codec_config = c10::nullopt,
-      const c10::optional<std::string>& filter_desc = c10::nullopt);
+      const std::optional<std::string>& encoder = c10::nullopt,
+      const std::optional<OptionDict>& encoder_option = c10::nullopt,
+      const std::optional<std::string>& encoder_format = c10::nullopt,
+      const std::optional<double>& encoder_frame_rate = c10::nullopt,
+      const std::optional<int>& encoder_width = c10::nullopt,
+      const std::optional<int>& encoder_height = c10::nullopt,
+      const std::optional<std::string>& hw_accel = c10::nullopt,
+      const std::optional<CodecConfig>& codec_config = c10::nullopt,
+      const std::optional<std::string>& filter_desc = c10::nullopt);
   /// @cond
   /// Add output audio frame stream.
   /// Allows for writing frames rather than tensors via `write_frame`.
@@ -179,13 +179,13 @@ class StreamingMediaEncoder {
       int sample_rate,
       int num_channels,
       const std::string& format,
-      const c10::optional<std::string>& encoder = c10::nullopt,
-      const c10::optional<OptionDict>& encoder_option = c10::nullopt,
-      const c10::optional<std::string>& encoder_format = c10::nullopt,
-      const c10::optional<int>& encoder_sample_rate = c10::nullopt,
-      const c10::optional<int>& encoder_num_channels = c10::nullopt,
-      const c10::optional<CodecConfig>& codec_config = c10::nullopt,
-      const c10::optional<std::string>& filter_desc = c10::nullopt);
+      const std::optional<std::string>& encoder = c10::nullopt,
+      const std::optional<OptionDict>& encoder_option = c10::nullopt,
+      const std::optional<std::string>& encoder_format = c10::nullopt,
+      const std::optional<int>& encoder_sample_rate = c10::nullopt,
+      const std::optional<int>& encoder_num_channels = c10::nullopt,
+      const std::optional<CodecConfig>& codec_config = c10::nullopt,
+      const std::optional<std::string>& filter_desc = c10::nullopt);
 
   /// Add output video frame stream.
   /// Allows for writing frames rather than tensors via `write_frame`.
@@ -196,15 +196,15 @@ class StreamingMediaEncoder {
       int width,
       int height,
       const std::string& format,
-      const c10::optional<std::string>& encoder = c10::nullopt,
-      const c10::optional<OptionDict>& encoder_option = c10::nullopt,
-      const c10::optional<std::string>& encoder_format = c10::nullopt,
-      const c10::optional<double>& encoder_frame_rate = c10::nullopt,
-      const c10::optional<int>& encoder_width = c10::nullopt,
-      const c10::optional<int>& encoder_height = c10::nullopt,
-      const c10::optional<std::string>& hw_accel = c10::nullopt,
-      const c10::optional<CodecConfig>& codec_config = c10::nullopt,
-      const c10::optional<std::string>& filter_desc = c10::nullopt);
+      const std::optional<std::string>& encoder = c10::nullopt,
+      const std::optional<OptionDict>& encoder_option = c10::nullopt,
+      const std::optional<std::string>& encoder_format = c10::nullopt,
+      const std::optional<double>& encoder_frame_rate = c10::nullopt,
+      const std::optional<int>& encoder_width = c10::nullopt,
+      const std::optional<int>& encoder_height = c10::nullopt,
+      const std::optional<std::string>& hw_accel = c10::nullopt,
+      const std::optional<CodecConfig>& codec_config = c10::nullopt,
+      const std::optional<std::string>& filter_desc = c10::nullopt);
 
   /// Add packet stream. Intended to be used in conjunction with
   /// ``StreamingMediaDecoder`` to perform packet passthrough.
@@ -226,7 +226,7 @@ class StreamingMediaEncoder {
   /// Open the output file / device and write the header.
   ///
   /// @param opt Private options for protocol, device and muxer.
-  void open(const c10::optional<OptionDict>& opt = c10::nullopt);
+  void open(const std::optional<OptionDict>& opt = c10::nullopt);
   /// Close the output file / device and finalize metadata.
   void close();
 
@@ -248,7 +248,7 @@ class StreamingMediaEncoder {
   void write_audio_chunk(
       int i,
       const torch::Tensor& frames,
-      const c10::optional<double>& pts = c10::nullopt);
+      const std::optional<double>& pts = c10::nullopt);
   /// Write video data
   /// @param i Stream index.
   /// @param frames Video/image tensor. Shape: ``(time, channel, height,
@@ -269,7 +269,7 @@ class StreamingMediaEncoder {
   void write_video_chunk(
       int i,
       const torch::Tensor& frames,
-      const c10::optional<double>& pts = c10::nullopt);
+      const std::optional<double>& pts = c10::nullopt);
   /// @cond
   /// Write frame to stream.
   /// @param i Stream index.
@@ -325,7 +325,7 @@ class StreamingMediaEncoderCustomIO : private detail::CustomOutput,
   /// @param seek Optional seek function that is used to seek the destination.
   StreamingMediaEncoderCustomIO(
       void* opaque,
-      const c10::optional<std::string>& format,
+      const std::optional<std::string>& format,
       int buffer_size,
       int (*write_packet)(void* opaque, uint8_t* buf, int buf_size),
       int64_t (*seek)(void* opaque, int64_t offset, int whence) = nullptr);

--- a/src/libtorio/ffmpeg/stream_writer/types.h
+++ b/src/libtorio/ffmpeg/stream_writer/types.h
@@ -10,7 +10,7 @@ struct CodecConfig {
   // https://trac.ffmpeg.org/wiki/Encode/MP3
   // This should be set like
   // https://github.com/FFmpeg/FFmpeg/blob/n4.3.2/fftools/ffmpeg_opt.c#L1550
-  const c10::optional<int> qscale = -1;
+  const std::optional<int> qscale = -1;
 
   // video
   int gop_size = -1;


### PR DESCRIPTION
Summary: `c10::optional` was switched to be `std::optional` after PyTorch moved to C++17. Let's eliminate `c10::optional`, if we can.

Reviewed By: albanD

Differential Revision: D57294285


