### PR TITLE
[codemod] c10::optional -> std::optional in pyspeech/experimental/csrc/decoders/TransducerDecoder.h +20

### DIFF
--- a/docs/source/libtorio.stream_reader.rst
+++ b/docs/source/libtorio.stream_reader.rst
@@ -24,7 +24,7 @@ StreamingMediaDecoder
 
 .. doxygenclass:: torio::io::StreamingMediaDecoder
 
-.. doxygenfunction:: torio::io::StreamingMediaDecoder::StreamingMediaDecoder(const std::string &src, const c10::optional<std::string> &format = {}, const c10::optional<OptionDict> &option = {})
+.. doxygenfunction:: torio::io::StreamingMediaDecoder::StreamingMediaDecoder(const std::string &src, const std::optional<std::string> &format = {}, const c10::optional<OptionDict> &option = {})
 
 StreamingMediaDecoderCustomIO
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/libtorio.stream_writer.rst
+++ b/docs/source/libtorio.stream_writer.rst
@@ -24,7 +24,7 @@ StreamingMediaEncoder
 
 .. doxygenclass:: torio::io::StreamingMediaEncoder
 
-.. doxygenfunction:: torio::io::StreamingMediaEncoder::StreamingMediaEncoder(const std::string &dst, const c10::optional<std::string> &format = {})
+.. doxygenfunction:: torio::io::StreamingMediaEncoder::StreamingMediaEncoder(const std::string &dst, const std::optional<std::string> &format = {})
 
 StreamingMediaEncoderCustomIO
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/libtorchaudio/rnnt/autograd.cpp
+++ b/src/libtorchaudio/rnnt/autograd.cpp
@@ -42,7 +42,7 @@ class RNNTLossFunction : public torch::autograd::Function<RNNTLossFunction> {
   }
 };
 
-std::tuple<torch::Tensor, c10::optional<torch::Tensor>> rnnt_loss_autograd(
+std::tuple<torch::Tensor, std::optional<torch::Tensor>> rnnt_loss_autograd(
     torch::Tensor& logits,
     const torch::Tensor& targets,
     const torch::Tensor& logit_lengths,

--- a/src/libtorchaudio/rnnt/compute.cpp
+++ b/src/libtorchaudio/rnnt/compute.cpp
@@ -1,7 +1,7 @@
 #include <libtorchaudio/rnnt/compute.h>
 #include <torch/script.h>
 
-std::tuple<torch::Tensor, c10::optional<torch::Tensor>> rnnt_loss(
+std::tuple<torch::Tensor, std::optional<torch::Tensor>> rnnt_loss(
     torch::Tensor& logits,
     const torch::Tensor& targets,
     const torch::Tensor& logit_lengths,

--- a/src/libtorchaudio/rnnt/compute.h
+++ b/src/libtorchaudio/rnnt/compute.h
@@ -2,7 +2,7 @@
 
 #include <torch/script.h>
 
-std::tuple<torch::Tensor, c10::optional<torch::Tensor>> rnnt_loss(
+std::tuple<torch::Tensor, std::optional<torch::Tensor>> rnnt_loss(
     torch::Tensor& logits,
     const torch::Tensor& targets,
     const torch::Tensor& logit_lengths,

--- a/src/libtorchaudio/rnnt/cpu/compute.cpp
+++ b/src/libtorchaudio/rnnt/cpu/compute.cpp
@@ -6,7 +6,7 @@ namespace rnnt {
 namespace cpu {
 
 // Entry point into RNNT Loss
-std::tuple<torch::Tensor, c10::optional<torch::Tensor>> compute(
+std::tuple<torch::Tensor, std::optional<torch::Tensor>> compute(
     torch::Tensor& logits,
     const torch::Tensor& targets,
     const torch::Tensor& logit_lengths,
@@ -89,7 +89,7 @@ std::tuple<torch::Tensor, c10::optional<torch::Tensor>> compute(
   torch::Tensor costs = torch::empty(
       options.batchSize_ * options.nHypos_,
       torch::TensorOptions().device(logits.device()).dtype(logits.dtype()));
-  c10::optional<torch::Tensor> gradients = torch::zeros_like(logits);
+  std::optional<torch::Tensor> gradients = torch::zeros_like(logits);
 
   torch::Tensor int_workspace = torch::empty(
       IntWorkspace::ComputeSizeFromOptions(options),

--- a/src/libtorchaudio/rnnt/gpu/compute.cu
+++ b/src/libtorchaudio/rnnt/gpu/compute.cu
@@ -7,7 +7,7 @@ namespace rnnt {
 namespace gpu {
 
 // Entry point into RNNT Loss
-std::tuple<torch::Tensor, c10::optional<torch::Tensor>> compute(
+std::tuple<torch::Tensor, std::optional<torch::Tensor>> compute(
     torch::Tensor& logits,
     const torch::Tensor& targets,
     const torch::Tensor& logit_lengths,
@@ -92,7 +92,7 @@ std::tuple<torch::Tensor, c10::optional<torch::Tensor>> compute(
   torch::Tensor costs = torch::empty(
       options.batchSize_ * options.nHypos_,
       torch::TensorOptions().device(logits.device()).dtype(logits.dtype()));
-  c10::optional<torch::Tensor> gradients = torch::zeros_like(logits);
+  std::optional<torch::Tensor> gradients = torch::zeros_like(logits);
 
   torch::Tensor int_workspace = torch::empty(
       IntWorkspace::ComputeSizeFromOptions(options),


### PR DESCRIPTION
Summary: `c10::optional` was switched to be `std::optional` after PyTorch moved to C++17. Let's eliminate `c10::optional`, if we can.

Reviewed By: albanD

Differential Revision: D57294284


