### PR TITLE
Fix the redundant installation instructions.

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -56,11 +56,6 @@ Optional Dependencies
   the FFmpeg integration entirely by setting the environment variable
   ``TORIO_USE_FFMPEG=0``.
 
-  There are multiple ways to install FFmpeg libraries.
-  If you are using Anaconda Python distribution,
-  ``conda install -c conda-forge 'ffmpeg<7'`` will install
-  compatible FFmpeg libraries.
-
   .. note::
 
      When searching for FFmpeg installation, TorchAudio looks for library files


### PR DESCRIPTION
The instructions are redundant with https://github.com/pytorch/audio/blob/7f6209b44a1b838e9f33fdd382a3c4ae14e8297f/docs/source/installation.rst?plain=1#L44-L48