### PR TITLE
Fix CUDA 12.5 build

### DIFF
--- a/src/libtorchaudio/cuctc/src/ctc_prefix_decoder_kernel_v2.cu
+++ b/src/libtorchaudio/cuctc/src/ctc_prefix_decoder_kernel_v2.cu
@@ -24,6 +24,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <algorithm>
+#include <float.h>
 #include "ctc_fast_divmod.cuh"
 #include "cub/cub.cuh"
 #include "device_data_wrap.h"


### PR DESCRIPTION
CUDA 12.5 removed the FLT_MAX symbol.
This was previously used without being explicitly imported. FLT_MAX is defined in <float.h>, including this header fixes the issue. 

<strong>PLEASE NOTE THAT THE TORCHAUDIO REPOSITORY IS NO LONGER ACTIVELY MONITORED.</strong> You may not get a response. For open discussions, visit https://discuss.pytorch.org/.

A similar issue has been reported in Kaldi before: https://github.com/kaldi-asr/kaldi/issues/4914