### PR TITLE
Add xpu linux wheel build into torchaudio build matrix

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -29,6 +29,7 @@ jobs:
       os: linux
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
+      with-xpu: enable
   build:
     needs: generate-matrix
     strategy:


### PR DESCRIPTION
Add xpu linux wheel build for torchaudio to complete xpu nightly wheels build after PR https://github.com/pytorch/test-infra/pull/5489 landed. Works for https://github.com/pytorch/pytorch/issues/114850
