### PR TITLE
feat: reduce computations in backprop of `lfilter`

### DIFF
--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -634,11 +634,10 @@ booktitle	= {International Conference on Acoustics, Speech and Signal Processing
   publisher={Wiley Online Library}
 }
 
-@inproceedings{ycy2024golf,
-    title     = {Differentiable Time-Varying Linear Prediction in the Context of End-to-End Analysis-by-Synthesis},
-    author    = {Chin-Yun Yu and György Fazekas},
-    year      = {2024},
-    booktitle = {Proc. Interspeech},
-    pages     = {1820--1824},
-    doi       = {10.21437/Interspeech.2024-1187},
+@inproceedings{ycy2024diffapf,
+    title={Differentiable All-pole Filters for Time-varying Audio Systems},
+    author={Chin-Yun Yu and Christopher Mitcheltree and Alistair Carson and Stefan Bilbao and Joshua D. Reiss and György Fazekas},
+    booktitle={International Conference on Digital Audio Effects (DAFx)},
+    year={2024},
+    pages={345--352},
 }

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -633,3 +633,12 @@ booktitle	= {International Conference on Acoustics, Speech and Signal Processing
   year={2021},
   publisher={Wiley Online Library}
 }
+
+@inproceedings{ycy2024golf,
+    title     = {Differentiable Time-Varying Linear Prediction in the Context of End-to-End Analysis-by-Synthesis},
+    author    = {Chin-Yun Yu and György Fazekas},
+    year      = {2024},
+    booktitle = {Proc. Interspeech},
+    pages     = {1820--1824},
+    doi       = {10.21437/Interspeech.2024-1187},
+}

--- a/src/torchaudio/functional/filtering.py
+++ b/src/torchaudio/functional/filtering.py
@@ -1000,7 +1000,7 @@ else:
 def lfilter(waveform: Tensor, a_coeffs: Tensor, b_coeffs: Tensor, clamp: bool = True, batching: bool = True) -> Tensor:
     r"""Perform an IIR filter by evaluating difference equation, using differentiable implementation
     developed independently by *Yu et al.* :cite:`ismir_YuF23` and *Forgione et al.* :cite:`forgione2021dynonet`.
-    The gradients of `a_coeffs` are computed based on a faster algorithm from :cite:`ycy2024golf`.
+    The gradients of ``a_coeffs`` are computed based on a faster algorithm from :cite:`ycy2024golf`.
 
     .. devices:: CPU CUDA
 

--- a/src/torchaudio/functional/filtering.py
+++ b/src/torchaudio/functional/filtering.py
@@ -999,7 +999,7 @@ else:
 
 def lfilter(waveform: Tensor, a_coeffs: Tensor, b_coeffs: Tensor, clamp: bool = True, batching: bool = True) -> Tensor:
     r"""Perform an IIR filter by evaluating difference equation, using differentiable implementation
-    developed independently by *Yu et al.* :cite:`ismir_YuF23` and *Forgione et al.* :cite:`forgione2021dynonet`.
+    developed separately by *Yu et al.* :cite:`ismir_YuF23` and *Forgione et al.* :cite:`forgione2021dynonet`.
     The gradients of ``a_coeffs`` are computed based on a faster algorithm from :cite:`ycy2024diffapf`.
 
     .. devices:: CPU CUDA

--- a/src/torchaudio/functional/filtering.py
+++ b/src/torchaudio/functional/filtering.py
@@ -1000,7 +1000,7 @@ else:
 def lfilter(waveform: Tensor, a_coeffs: Tensor, b_coeffs: Tensor, clamp: bool = True, batching: bool = True) -> Tensor:
     r"""Perform an IIR filter by evaluating difference equation, using differentiable implementation
     developed independently by *Yu et al.* :cite:`ismir_YuF23` and *Forgione et al.* :cite:`forgione2021dynonet`.
-    The gradients of ``a_coeffs`` are computed based on a faster algorithm from :cite:`ycy2024golf`.
+    The gradients of ``a_coeffs`` are computed based on a faster algorithm from :cite:`ycy2024diffapf`.
 
     .. devices:: CPU CUDA
 

--- a/src/torchaudio/functional/filtering.py
+++ b/src/torchaudio/functional/filtering.py
@@ -1000,6 +1000,7 @@ else:
 def lfilter(waveform: Tensor, a_coeffs: Tensor, b_coeffs: Tensor, clamp: bool = True, batching: bool = True) -> Tensor:
     r"""Perform an IIR filter by evaluating difference equation, using differentiable implementation
     developed independently by *Yu et al.* :cite:`ismir_YuF23` and *Forgione et al.* :cite:`forgione2021dynonet`.
+    The gradients of `a_coeffs` are computed based on a faster algorithm from :cite:`ycy2024golf`.
 
     .. devices:: CPU CUDA
 


### PR DESCRIPTION
This PR update the backpropagation computation of `DifferentiableIIR`.
The update is based on my recent work (https://arxiv.org/abs/2406.05128), which uses just one `DifferentiableIIR::apply` instead of two to compute the gradients for both input and `a_coeffs`. The algorithm has been tested in [torchlpc](https://github.com/yoyololicon/torchlpc). 

Below is the benchmark to version 2.4.1 `lfilter`.
The backward computation runs slightly faster especially when using just one thread.

## v2.4.1

```
[-------------- IIR filter -------------]
                  |  forward  |  backward
1 threads: ------------------------------
      [32, 256]   |    404.0  |   1104.5
      [32, 1024]  |    694.3  |   1783.2
      [32, 4096]  |   2637.1  |   6579.2
2 threads: ------------------------------
      [32, 256]   |    381.5  |   1110.2
      [32, 1024]  |    574.7  |   1638.3
      [32, 4096]  |   1729.0  |   5724.7
4 threads: ------------------------------
      [32, 256]   |    362.9  |   1084.0
      [32, 1024]  |    502.0  |   1537.7
      [32, 4096]  |   1485.5  |   5376.4

Times are in microseconds (us).
```

## This version

```
[-------------- IIR filter -------------]
                  |  forward  |  backward
1 threads: ------------------------------
      [32, 256]   |    391.9  |    935.1
      [32, 1024]  |    678.7  |   1499.8
      [32, 4096]  |   2481.2  |   5782.2
2 threads: ------------------------------
      [32, 256]   |    371.5  |    994.5
      [32, 1024]  |    550.3  |   1551.0
      [32, 4096]  |   1655.0  |   5896.0
4 threads: ------------------------------
      [32, 256]   |    349.1  |    981.6
      [32, 1024]  |    484.8  |   1518.2
      [32, 4096]  |   1380.2  |   4969.1

Times are in microseconds (us).
```