### PR TITLE
[CODEMOD][pytorch] replace uses of np.ndarray with npt.NDArray (#3845)

### DIFF
--- a/test/torchaudio_unittest/prototype/functional/dsp_utils.py
+++ b/test/torchaudio_unittest/prototype/functional/dsp_utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import numpy.typing as npt
 
 
 def oscillator_bank(
@@ -43,8 +44,8 @@ def freq_ir(magnitudes):
 
 
 def exp_sigmoid(
-    input: np.ndarray, exponent: float = 10.0, max_value: float = 2.0, threshold: float = 1e-7
-) -> np.ndarray:
+    input: npt.NDArray, exponent: float = 10.0, max_value: float = 2.0, threshold: float = 1e-7
+) -> npt.NDArray:
     """Exponential Sigmoid pointwise nonlinearity (Numpy version).
     Implements the equation:
     ``max_value`` * sigmoid(``input``) ** (log(``exponent``)) + ``threshold``


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/opacus/pull/680
X-link: https://github.com/pytorch/captum/pull/1387
X-link: https://github.com/pytorch/botorch/pull/2584

This replaces uses of `numpy.ndarray` in type annotations with `numpy.typing.NDArray`. In Numpy-1.24.0+ `numpy.ndarray` is annotated as generic type. Without template parameters it triggers static analysis errors: 
```counterexample
Generic type `ndarray` expects 2 type parameters.
```
`numpy.typing.NDArray` is an alias that provides default template parameters.

Differential Revision: D64619891


