### PR TITLE
Fix ffmpeg dlls not being recognised during buildtime

### DIFF
--- a/src/torchaudio/_extension/__init__.py
+++ b/src/torchaudio/_extension/__init__.py
@@ -21,7 +21,7 @@ __all__ = [
 ]
 
 
-if os.name == "nt" and (3, 8) <= sys.version_info < (3, 9):
+if os.name == "nt" and (3, 8) <= sys.version_info:
     _init_dll_path()
 
 


### PR DESCRIPTION
Enable building torchaudio from source against already existing ffmpeg 