### PR TITLE
[ffmpeg] Print source of StreamReader with error message when decode failed.

### DIFF
--- a/src/torchaudio/_backend/ffmpeg.py
+++ b/src/torchaudio/_backend/ffmpeg.py
@@ -4,6 +4,7 @@ import sys
 from typing import BinaryIO, Optional, Tuple, Union
 
 import torch
+
 import torchaudio
 
 from .backend import Backend
@@ -69,7 +70,7 @@ def _load_audio(
     s.process_all_packets()
     chunk = s.pop_chunks()[0]
     if chunk is None:
-        raise RuntimeError("Failed to decode audio.")
+        raise RuntimeError(f"Failed to decode audio source: {s.src}")
     waveform = chunk._elem
     return waveform.T if channels_first else waveform
 

--- a/src/torchaudio/_backend/ffmpeg.py
+++ b/src/torchaudio/_backend/ffmpeg.py
@@ -4,7 +4,6 @@ import sys
 from typing import BinaryIO, Optional, Tuple, Union
 
 import torch
-
 import torchaudio
 
 from .backend import Backend


### PR DESCRIPTION
Hi!

I think it would be better if we know which file causing error when an decode failed error being raised. Same practice found in [Sox backend](https://github.com/pytorch/audio/blob/fa44bdab1fe49bab58389e7b6a33061ffced9bc7/src/torchaudio/_backend/sox.py#L46).

I got this error and being confuse which file causing error at the first time I prepare the dataset for myself. :smiley: 