### PR TITLE
Fix incorrect audio trimming with negative index

### DIFF
--- a/src/torchaudio/functional/filtering.py
+++ b/src/torchaudio/functional/filtering.py
@@ -1665,6 +1665,6 @@ def vad(
     if not has_triggered:
         return waveform[..., :0].view(shape[:-1] + torch.Size([0]))
 
-    res = waveform[:, pos - samplesLen_ns + flushedLen_ns :]
+    res = waveform[:, max(pos - samplesLen_ns + flushedLen_ns, 0) :]
     # unpack batch
     return res.view(shape[:-1] + res.shape[-1:])


### PR DESCRIPTION
When `pos - samplesLen_ns + flushedLen_ns < 0`, there should be no trimming at all. Before this fix, the negative index would result in incorrect trimming that wraps around the audio from its end.

Tested by increasing the `pre_trigger_time` argument, which is positively correlated to `samplesLen_ns`. Before the fix, the audio could have been trimmed completely when `pos - samplesLen_ns + flushedLen_ns == -1`. After this fix, it is guaranteed that the audio duration after trimming will not decrease with `pre_trigger_time`, which should be the expected behavior.