### PR TITLE
Fix incorrect audio trimming with negative index

### DIFF
--- a/src/torchaudio/functional/filtering.py
+++ b/src/torchaudio/functional/filtering.py
@@ -1665,6 +1665,6 @@ def vad(
     if not has_triggered:
         return waveform[..., :0].view(shape[:-1] + torch.Size([0]))
 
-    res = waveform[:, pos - samplesLen_ns + flushedLen_ns :]
+    res = waveform[:, max(pos - samplesLen_ns + flushedLen_ns, 0) :]
     # unpack batch
     return res.view(shape[:-1] + res.shape[-1:])


### PR DESCRIPTION
Summary: When `pos - samplesLen_ns + flushedLen_ns < 0`, there should be no trimming at all. Before this fix, the negative index would result in incorrect trimming that wraps around the audio from its end.

Differential Revision: D67155973


