### PR TITLE
Avoid torch.jit.isinstance to support torch.compile(MFCC(), fullgraph=True)

### DIFF
--- a/src/torchaudio/functional/functional.py
+++ b/src/torchaudio/functional/functional.py
@@ -230,14 +230,14 @@ def inverse_spectrogram(
 
 def _get_spec_norms(normalized: Union[str, bool]):
     frame_length_norm, window_norm = False, False
-    if torch.jit.isinstance(normalized, str):
+    if isinstance(normalized, str):
         if normalized not in ["frame_length", "window"]:
             raise ValueError("Invalid normalized parameter: {}".format(normalized))
         if normalized == "frame_length":
             frame_length_norm = True
         elif normalized == "window":
             window_norm = True
-    elif torch.jit.isinstance(normalized, bool):
+    elif isinstance(normalized, bool):
         if normalized:
             window_norm = True
     else:

--- a/test/torchaudio_unittest/transforms/transforms_test.py
+++ b/test/torchaudio_unittest/transforms/transforms_test.py
@@ -281,6 +281,10 @@ class Tester(common_utils.TorchaudioTestCase):
         assert computed.shape == expected.shape, (computed.shape, expected.shape)
         self.assertEqual(computed, expected, atol=1e-6, rtol=1e-8)
 
+    def test_mfcc_compile_fullgraph(self):
+        # test that MFCC does not use language features not supported by torch.compile
+        torch.compile(MFCC(), fullgraph=True)
+
 
 class SmokeTest(common_utils.TorchaudioTestCase):
     def test_spectrogram(self):


### PR DESCRIPTION
The following code fails on main but works in this PR.

```py
from torchaudio.transforms import MFCC
import torch

mfcc = torch.compile(MFCC(), fullgraph=True)
```

Unfortautnly, the compiled model can still not be used

```py
mfcc(torch.rand(16_000))
```

```
...
torch._dynamo.exc.Unsupported: unsupported operator: aten._fft_r2c.default (see https://docs.google.com/document/d/1GgvOe7C8_NVOMLOCwDaYV1mXXyHMXY7ExoewHqooxrs/edit#heading=h.64r4npvq0w0 for how to fix)

from user code:
...
  File "/Users/twoertwein/miniforge3/lib/python3.11/site-packages/torchaudio/functional/functional.py", line 126, in spectrogram
    spec_f = torch.stft(
```