### PR TITLE
Enable 3.13t builds on Windows

### DIFF
--- a/cmake/TorchAudioHelper.cmake
+++ b/cmake/TorchAudioHelper.cmake
@@ -57,6 +57,7 @@ if (BUILD_TORCHAUDIO_PYTHON_EXTENSION)
   find_library(TORCH_PYTHON_LIBRARY torch_python PATHS "${TORCH_INSTALL_PREFIX}/lib")
 
   if (WIN32)
+    set (Python3_FIND_ABI "ANY" "ANY" "ANY" "ANY")
     find_package(Python3 ${PYTHON_VERSION} EXACT COMPONENTS Development)
     set(ADDITIONAL_ITEMS Python3::Python)
   endif()


### PR DESCRIPTION
See documentation:
https://cmake.org/cmake/help/latest/module/FindPython3.html 

Successful workflow:
https://github.com/pytorch/test-infra/actions/runs/13381336461/job/37371953479?pr=6

We would need to bump cmake version to 3.31.2 in test-infra.

Please see: https://github.com/pytorch/test-infra/pull/6298
