### PR TITLE
[ROCm][Windows] Enable build with ROCm on Windows

### DIFF
--- a/cmake/LoadHIP.cmake
+++ b/cmake/LoadHIP.cmake
@@ -1,14 +1,22 @@
 set(PYTORCH_FOUND_HIP FALSE)
 
 if(NOT DEFINED ENV{ROCM_PATH})
-  set(ROCM_PATH /opt/rocm)
+  if(UNIX)
+    set(ROCM_PATH /opt/rocm)
+  else() # Win32
+    set(ROCM_PATH C:/opt/rocm)
+  endif()
 else()
   set(ROCM_PATH $ENV{ROCM_PATH})
 endif()
 
 # HIP_PATH
 if(NOT DEFINED ENV{HIP_PATH})
-  set(HIP_PATH ${ROCM_PATH}/hip)
+  if(UNIX)
+    set(HIP_PATH ${ROCM_PATH}/hip)
+  else() #Win32
+    set(HIP_PATH ${ROCM_PATH})
+  endif()
 else()
   set(HIP_PATH $ENV{HIP_PATH})
 endif()
@@ -129,7 +137,11 @@ else()
 endif()
 
 # Add HIP to the CMAKE Module Path
-set(CMAKE_MODULE_PATH ${HIP_PATH}/cmake ${CMAKE_MODULE_PATH})
+if(UNIX)
+  set(CMAKE_MODULE_PATH ${HIP_PATH}/cmake ${CMAKE_MODULE_PATH})
+else() #Win32
+  set(CMAKE_MODULE_PATH ${HIP_PATH}/lib/cmake/hip ${CMAKE_MODULE_PATH})
+endif()
 
 # Disable Asserts In Code (Can't use asserts on HIP stack.)
 add_definitions(-DNDEBUG)
@@ -139,28 +151,46 @@ macro(find_package_and_print_version PACKAGE_NAME)
   message("${PACKAGE_NAME} VERSION: ${${PACKAGE_NAME}_VERSION}")
 endmacro()
 
-if(UNIX)
-  # Find the HIP Package
-  find_package_and_print_version(HIP 1.0)
+# Find the HIP Package
+find_package_and_print_version(HIP 1.0)
 
-  if(HIP_FOUND)
-    set(PYTORCH_FOUND_HIP TRUE)
+if(HIP_FOUND)
+  set(PYTORCH_FOUND_HIP TRUE)
 
+  if(UNIX)
+    set(ROCM_LIB_NAME "ROCM")
+  else() # Win32
+    set(ROCM_LIB_NAME "HIP")
+  endif()
+  if(UNIX)
     # Find ROCM version for checks
-    file(READ "${ROCM_PATH}/.info/version-dev" ROCM_VERSION_DEV_RAW)
-    string(REGEX MATCH "^([0-9]+)\.([0-9]+)\.([0-9]+)-.*$" ROCM_VERSION_DEV_MATCH ${ROCM_VERSION_DEV_RAW})
-    if(ROCM_VERSION_DEV_MATCH)
-      set(ROCM_VERSION_DEV_MAJOR ${CMAKE_MATCH_1})
-      set(ROCM_VERSION_DEV_MINOR ${CMAKE_MATCH_2})
-      set(ROCM_VERSION_DEV_PATCH ${CMAKE_MATCH_3})
-      set(ROCM_VERSION_DEV "${ROCM_VERSION_DEV_MAJOR}.${ROCM_VERSION_DEV_MINOR}.${ROCM_VERSION_DEV_PATCH}")
-    endif()
+    file(READ "${ROCM_PATH}/.info/version-dev" ${ROCM_LIB_NAME}_VERSION_DEV_RAW)
+  else() #Win32
+    # Find HIP version from hipconfig execution
+    execute_process(
+        COMMAND ${ROCM_PATH}/bin/hipconfig.bat --version
+        OUTPUT_VARIABLE ${ROCM_LIB_NAME}_VERSION_DEV_RAW
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  endif()
+  string(REGEX MATCH "^([0-9]+)\.([0-9]+)\.([0-9]+).*$" ${ROCM_LIB_NAME}_VERSION_DEV_MATCH ${${ROCM_LIB_NAME}_VERSION_DEV_RAW})
+  if(${ROCM_LIB_NAME}_VERSION_DEV_MATCH)
+    set(${ROCM_LIB_NAME}_VERSION_DEV_MAJOR ${CMAKE_MATCH_1})
+    set(${ROCM_LIB_NAME}_VERSION_DEV_MINOR ${CMAKE_MATCH_2})
+    set(${ROCM_LIB_NAME}_VERSION_DEV_PATCH ${CMAKE_MATCH_3})
+    set(${ROCM_LIB_NAME}_VERSION_DEV "${${ROCM_LIB_NAME}_VERSION_DEV_MAJOR}.${${ROCM_LIB_NAME}_VERSION_DEV_MINOR}.${${ROCM_LIB_NAME}_VERSION_DEV_PATCH}")
+  endif()
+  if(UNIX)
     message("\n***** ROCm version from ${ROCM_PATH}/.info/version-dev ****\n")
-    message("ROCM_VERSION_DEV: ${ROCM_VERSION_DEV}")
-    message("ROCM_VERSION_DEV_MAJOR: ${ROCM_VERSION_DEV_MAJOR}")
-    message("ROCM_VERSION_DEV_MINOR: ${ROCM_VERSION_DEV_MINOR}")
-    message("ROCM_VERSION_DEV_PATCH: ${ROCM_VERSION_DEV_PATCH}")
+  else() #Win32
+    message("\n***** HIP version from ${ROCM_PATH}/bin/hipconfig.bat --version ****\n")
+  endif()
+  message("${ROCM_LIB_NAME}_VERSION_DEV: ${${ROCM_LIB_NAME}_VERSION_DEV}")
+  message("${ROCM_LIB_NAME}_VERSION_DEV_MAJOR: ${${ROCM_LIB_NAME}_VERSION_DEV_MAJOR}")
+  message("${ROCM_LIB_NAME}_VERSION_DEV_MINOR: ${${ROCM_LIB_NAME}_VERSION_DEV_MINOR}")
+  message("${ROCM_LIB_NAME}_VERSION_DEV_PATCH: ${${ROCM_LIB_NAME}_VERSION_DEV_PATCH}")
 
+  if(UNIX)
     message("\n***** Library versions from dpkg *****\n")
     execute_process(COMMAND dpkg -l COMMAND grep rocm-dev COMMAND awk "{print $2 \" VERSION: \" $3}")
     execute_process(COMMAND dpkg -l COMMAND grep rocm-libs COMMAND awk "{print $2 \" VERSION: \" $3}")
@@ -169,183 +199,74 @@ if(UNIX)
     execute_process(COMMAND dpkg -l COMMAND grep -w hcc COMMAND awk "{print $2 \" VERSION: \" $3}")
     execute_process(COMMAND dpkg -l COMMAND grep hip_base COMMAND awk "{print $2 \" VERSION: \" $3}")
     execute_process(COMMAND dpkg -l COMMAND grep hip_hcc COMMAND awk "{print $2 \" VERSION: \" $3}")
+  endif()
 
-    message("\n***** Library versions from cmake find_package *****\n")
+  message("\n***** Library versions from cmake find_package *****\n")
 
-    set(CMAKE_HCC_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
-    set(CMAKE_HCC_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
-    ### Remove setting of Flags when FindHIP.CMake PR #558 is accepted.###
+  set(CMAKE_HCC_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+  set(CMAKE_HCC_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
+  ### Remove setting of Flags when FindHIP.CMake PR #558 is accepted.###
 
-    set(hip_DIR ${HIP_PATH}/lib/cmake/hip)
+  set(hip_DIR ${HIP_PATH}/lib/cmake/hip)
+  set(AMDDeviceLibs_DIR ${ROCM_PATH}/lib/cmake/AMDDeviceLibs)
+  set(amd_comgr_DIR ${ROCM_PATH}/lib/cmake/amd_comgr)
+  set(rocrand_DIR ${ROCRAND_PATH}/lib/cmake/rocrand)
+  set(hiprand_DIR ${HIPRAND_PATH}/lib/cmake/hiprand)
+  set(rocblas_DIR ${ROCBLAS_PATH}/lib/cmake/rocblas)
+  set(miopen_DIR ${MIOPEN_PATH}/lib/cmake/miopen)
+  set(rocfft_DIR ${ROCFFT_PATH}/lib/cmake/rocfft)
+  set(hipfft_DIR ${HIPFFT_PATH}/lib/cmake/hipfft)
+  set(hipsparse_DIR ${HIPSPARSE_PATH}/lib/cmake/hipsparse)
+  set(rocprim_DIR ${ROCPRIM_PATH}/lib/cmake/rocprim)
+  set(hipcub_DIR ${HIPCUB_PATH}/lib/cmake/hipcub)
+  set(rocthrust_DIR ${ROCTHRUST_PATH}/lib/cmake/rocthrust)
+
+  find_package_and_print_version(hip REQUIRED)
+  find_package_and_print_version(amd_comgr REQUIRED)
+  find_package_and_print_version(rocrand REQUIRED)
+  find_package_and_print_version(hiprand REQUIRED)
+  find_package_and_print_version(rocblas REQUIRED)
+  find_package_and_print_version(miopen REQUIRED)
+  find_package_and_print_version(rocfft REQUIRED)
+  if(ROCM_VERSION_DEV VERSION_GREATER_EQUAL "4.1.0")
+    find_package_and_print_version(hipfft REQUIRED)
+  endif()
+  find_package_and_print_version(hipsparse REQUIRED)
+  find_package_and_print_version(rocprim REQUIRED)
+  find_package_and_print_version(hipcub REQUIRED)
+  find_package_and_print_version(rocthrust REQUIRED)
+
+  if(HIP_COMPILER STREQUAL clang)
+    set(hip_library_name amdhip64)
+  else()
+    set(hip_library_name hip_hcc)
+  endif()
+  message("HIP library name: ${hip_library_name}")
+
+  # TODO: hip_hcc has an interface include flag "-hc" which is only
+  # recognizable by hcc, but not gcc and clang. Right now in our
+  # setup, hcc is only used for linking, but it should be used to
+  # compile the *_hip.cc files as well.
+  find_library(PYTORCH_HIP_HCC_LIBRARIES ${hip_library_name} HINTS ${HIP_PATH}/lib)
+  # TODO: miopen_LIBRARIES should return fullpath to the library file,
+  # however currently it's just the lib name
+  find_library(PYTORCH_MIOPEN_LIBRARIES ${miopen_LIBRARIES} HINTS ${MIOPEN_PATH}/lib)
+  # hiprtc is part of HIP
+  find_library(ROCM_HIPRTC_LIB ${hip_library_name} HINTS ${HIP_PATH}/lib)
+  
+  if(UNIX)
     set(hsa-runtime64_DIR ${ROCM_PATH}/lib/cmake/hsa-runtime64)
-    set(AMDDeviceLibs_DIR ${ROCM_PATH}/lib/cmake/AMDDeviceLibs)
-    set(amd_comgr_DIR ${ROCM_PATH}/lib/cmake/amd_comgr)
-    set(rocrand_DIR ${ROCRAND_PATH}/lib/cmake/rocrand)
-    set(hiprand_DIR ${HIPRAND_PATH}/lib/cmake/hiprand)
-    set(rocblas_DIR ${ROCBLAS_PATH}/lib/cmake/rocblas)
-    set(miopen_DIR ${MIOPEN_PATH}/lib/cmake/miopen)
-    set(rocfft_DIR ${ROCFFT_PATH}/lib/cmake/rocfft)
-    set(hipfft_DIR ${HIPFFT_PATH}/lib/cmake/hipfft)
-    set(hipsparse_DIR ${HIPSPARSE_PATH}/lib/cmake/hipsparse)
     set(rccl_DIR ${RCCL_PATH}/lib/cmake/rccl)
-    set(rocprim_DIR ${ROCPRIM_PATH}/lib/cmake/rocprim)
-    set(hipcub_DIR ${HIPCUB_PATH}/lib/cmake/hipcub)
-    set(rocthrust_DIR ${ROCTHRUST_PATH}/lib/cmake/rocthrust)
 
-    find_package_and_print_version(hip REQUIRED)
     find_package_and_print_version(hsa-runtime64 REQUIRED)
-    find_package_and_print_version(amd_comgr REQUIRED)
-    find_package_and_print_version(rocrand REQUIRED)
-    find_package_and_print_version(hiprand REQUIRED)
-    find_package_and_print_version(rocblas REQUIRED)
-    find_package_and_print_version(miopen REQUIRED)
-    find_package_and_print_version(rocfft REQUIRED)
-    if(ROCM_VERSION_DEV VERSION_GREATER_EQUAL "4.1.0")
-      find_package_and_print_version(hipfft REQUIRED)
-    endif()
-    find_package_and_print_version(hipsparse REQUIRED)
     find_package_and_print_version(rccl)
-    find_package_and_print_version(rocprim REQUIRED)
-    find_package_and_print_version(hipcub REQUIRED)
-    find_package_and_print_version(rocthrust REQUIRED)
 
-    if(HIP_COMPILER STREQUAL clang)
-      set(hip_library_name amdhip64)
-    else()
-      set(hip_library_name hip_hcc)
-    endif()
-    message("HIP library name: ${hip_library_name}")
-
-    # TODO: hip_hcc has an interface include flag "-hc" which is only
-    # recognizable by hcc, but not gcc and clang. Right now in our
-    # setup, hcc is only used for linking, but it should be used to
-    # compile the *_hip.cc files as well.
-    find_library(PYTORCH_HIP_HCC_LIBRARIES ${hip_library_name} HINTS ${HIP_PATH}/lib)
-    # TODO: miopen_LIBRARIES should return fullpath to the library file,
-    # however currently it's just the lib name
-    find_library(PYTORCH_MIOPEN_LIBRARIES ${miopen_LIBRARIES} HINTS ${MIOPEN_PATH}/lib)
     # TODO: rccl_LIBRARIES should return fullpath to the library file,
     # however currently it's just the lib name
     find_library(PYTORCH_RCCL_LIBRARIES ${rccl_LIBRARIES} HINTS ${RCCL_PATH}/lib)
-    # hiprtc is part of HIP
-    find_library(ROCM_HIPRTC_LIB ${hip_library_name} HINTS ${HIP_PATH}/lib)
     # roctx is part of roctracer
     find_library(ROCM_ROCTX_LIB roctx64 HINTS ${ROCTRACER_PATH}/lib)
     set(roctracer_INCLUDE_DIRS ${ROCTRACER_PATH}/include)
-  endif()
-elseif(WIN32)
-  # Find the HIP Package
-  find_package_and_print_version(hip CONFIG)
+  endif() 
+endif()
 
-  if(hip_FOUND)
-    set(PYTORCH_FOUND_HIP TRUE)
-    set(FOUND_HIP_VERSION_H FALSE)
-
-    set(PROJECT_RANDOM_BINARY_DIR "${PROJECT_BINARY_DIR}")
-    set(file "${PROJECT_BINARY_DIR}/detect_hip_version.cc")
-    # Find HIP version - since we can't use ${ROCM_PATH}/.info/version-dev on Windows for HIP version
-    if(EXISTS ${hip_INCLUDE_DIRS}/hip/hip_version.h)
-      set(FOUND_HIP_VERSION_H TRUE)
-      file(WRITE ${file} ""
-        "#include <hip/hip_version.h>\n"
-        )
-    else()
-      message("********************* hip_version.h couldnt be found ******************\n")
-    endif()
-
-    if(FOUND_HIP_VERSION_H)
-      file(APPEND ${file} ""
-        "#include <cstdio>\n"
-
-        "#ifndef HIP_VERSION_PATCH\n"
-        "#define HIP_VERSION_PATCH 0\n"
-        "#endif\n"
-        "#define STRINGIFYHELPER(x) #x\n"
-        "#define STRINGIFY(x) STRINGIFYHELPER(x)\n"
-        "int main() {\n"
-        "  printf(\"%d.%d.%s\", HIP_VERSION_MAJOR, HIP_VERSION_MINOR, STRINGIFY(HIP_VERSION_PATCH));\n"
-        "  return 0;\n"
-        "}\n"
-        )
-
-      try_run(run_result compile_result ${PROJECT_RANDOM_BINARY_DIR} ${file}
-        CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${HIP_INCLUDE_DIRS}"
-        RUN_OUTPUT_VARIABLE hip_version_from_header
-        COMPILE_OUTPUT_VARIABLE output_var
-        )
-      # We expect the compile to be successful if the include directory exists.
-      if(NOT compile_result)
-        message(FATAL_ERROR "Couldn't determine version from header: " ${output_var})
-      endif()
-      message(STATUS "Header version is: " ${hip_version_from_header})
-      set(HIP_VERSION_DEV_RAW ${hip_version_from_header})
-      message("\n***** HIP version from hip_version.h ****\n")
-    endif()
-
-    string(REGEX MATCH "^([0-9]+)\.([0-9]+)\.([0-9]+).*$" HIP_VERSION_DEV_MATCH ${HIP_VERSION_DEV_RAW})
-    
-    if(HIP_VERSION_DEV_MATCH)
-      set(HIP_VERSION_DEV_MAJOR ${CMAKE_MATCH_1})
-      set(HIP_VERSION_DEV_MINOR ${CMAKE_MATCH_2})
-      set(HIP_VERSION_DEV_PATCH ${CMAKE_MATCH_3})
-      set(HIP_VERSION_DEV "${HIP_VERSION_DEV_MAJOR}.${HIP_VERSION_DEV_MINOR}.${HIP_VERSION_DEV_PATCH}")
-    endif()
-    
-    message("HIP_VERSION_DEV: ${HIP_VERSION_DEV}")
-    message("HIP_VERSION_DEV_MAJOR: ${HIP_VERSION_DEV_MAJOR}")
-    message("HIP_VERSION_DEV_MINOR: ${HIP_VERSION_DEV_MINOR}")
-    message("HIP_VERSION_DEV_PATCH: ${HIP_VERSION_DEV_PATCH}")
-
-    message("\n***** Library versions from cmake find_package *****\n")
-
-    set(CMAKE_HCC_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
-    set(CMAKE_HCC_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
-    ### Remove setting of Flags when FindHIP.CMake PR #558 is accepted.###
-
-    set(hip_DIR ${HIP_PATH}/lib/cmake/hip)
-    set(amd_comgr_DIR ${ROCM_PATH}/lib/cmake/amd_comgr)
-    set(rocrand_DIR ${ROCRAND_PATH}/lib/cmake/rocrand)
-    set(hiprand_DIR ${HIPRAND_PATH}/lib/cmake/hiprand)
-    set(rocblas_DIR ${ROCBLAS_PATH}/lib/cmake/rocblas)
-    set(miopen_DIR ${MIOPEN_PATH}/lib/cmake/miopen)
-    set(rocfft_DIR ${ROCFFT_PATH}/lib/cmake/rocfft)
-    set(hipfft_DIR ${HIPFFT_PATH}/lib/cmake/hipfft)
-    set(hipsparse_DIR ${HIPSPARSE_PATH}/lib/cmake/hipsparse)
-    set(rocprim_DIR ${ROCPRIM_PATH}/lib/cmake/rocprim)
-    set(hipcub_DIR ${HIPCUB_PATH}/lib/cmake/hipcub)
-    set(rocthrust_DIR ${ROCTHRUST_PATH}/lib/cmake/rocthrust)
-
-    find_package_and_print_version(hip REQUIRED)
-    find_package_and_print_version(amd_comgr REQUIRED)
-    find_package_and_print_version(rocrand REQUIRED)
-    find_package_and_print_version(hiprand REQUIRED)
-    find_package_and_print_version(rocblas REQUIRED)
-    find_package_and_print_version(miopen REQUIRED)
-    find_package_and_print_version(rocfft REQUIRED)
-    if(HIP_VERSION_DEV VERSION_GREATER_EQUAL "4.1.0")
-      find_package_and_print_version(hipfft REQUIRED)
-    endif()
-    find_package_and_print_version(hipsparse REQUIRED)
-    find_package_and_print_version(rocprim REQUIRED)
-    find_package_and_print_version(hipcub REQUIRED)
-    find_package_and_print_version(rocthrust REQUIRED)
-
-    if(HIP_COMPILER STREQUAL clang)
-      set(hip_library_name amdhip64)
-    else()
-      set(hip_library_name hip_hcc)
-    endif()
-    message("HIP library name: ${hip_library_name}")
-
-    # TODO: hip_hcc has an interface include flag "-hc" which is only
-    # recognizable by hcc, but not gcc and clang. Right now in our
-    # setup, hcc is only used for linking, but it should be used to
-    # compile the *_hip.cc files as well.
-    find_library(PYTORCH_HIP_HCC_LIBRARIES ${hip_library_name} HINTS ${HIP_PATH}/lib)
-    # TODO: miopen_LIBRARIES should return fullpath to the library file,
-    # however currently it's just the lib name
-    find_library(PYTORCH_MIOPEN_LIBRARIES ${miopen_LIBRARIES} HINTS ${MIOPEN_PATH}/lib)
-    # hiprtc is part of HIP
-    find_library(ROCM_HIPRTC_LIB ${hip_library_name} HINTS ${HIP_PATH}/lib)
-  endif(hip_FOUND)
-endif(UNIX)

--- a/cmake/LoadHIP.cmake
+++ b/cmake/LoadHIP.cmake
@@ -137,11 +137,9 @@ else()
 endif()
 
 # Add HIP to the CMAKE Module Path
-if(UNIX)
-  set(CMAKE_MODULE_PATH ${HIP_PATH}/cmake ${CMAKE_MODULE_PATH})
-else() #Win32
-  set(CMAKE_MODULE_PATH ${HIP_PATH}/lib/cmake/hip ${CMAKE_MODULE_PATH})
-endif()
+# needed because the find_package call to this module uses the Module mode search
+# https://cmake.org/cmake/help/latest/command/find_package.html#search-modes
+set(CMAKE_MODULE_PATH ${HIP_PATH}/lib/cmake/hip ${CMAKE_MODULE_PATH})
 
 # Disable Asserts In Code (Can't use asserts on HIP stack.)
 add_definitions(-DNDEBUG)

--- a/tools/setup_helpers/extension.py
+++ b/tools/setup_helpers/extension.py
@@ -161,9 +161,13 @@ class CMakeBuild(build_ext):
             import sys
 
             python_version = sys.version_info
+
+            cxx_compiler = os.environ.get('CXX', 'cl')
+            c_compiler = os.environ.get('CC', 'cl')
+
             cmake_args += [
-                "-DCMAKE_C_COMPILER=cl",
-                "-DCMAKE_CXX_COMPILER=cl",
+                f"-DCMAKE_C_COMPILER={c_compiler}",
+                f"-DCMAKE_CXX_COMPILER={cxx_compiler}",
                 f"-DPYTHON_VERSION={python_version.major}.{python_version.minor}",
             ]
 


### PR DESCRIPTION
Added changes for Windows in LoadHIP.cmake:

- set default ROCM_PATH and HIP_PATH for Windows case
- update CMAKE_MODULE_PATH with appropriate HIP path - because the find_package call to this module uses the Module mode search
- added code for finding HIP version
- skipped find hsa-runtime64, rccl packages on Windows case
- skipped find rccl, roctx and roctracer libraries on Windows case

CMAKE_C_COMPILER and CMAKE_CXX_COMPILER redefinition on Windows case (if we are building with ROCm on Windows we need to use compiler specified with CXX and CC flags instead of cl)
