### PR TITLE
Avoid crash when __doc__ is optimized away to None (-OO)

### DIFF
--- a/src/torio/io/_streaming_media_decoder.py
+++ b/src/torio/io/_streaming_media_decoder.py
@@ -338,7 +338,8 @@ class ChunkTensor(ChunkTensorBase):
 
 def _format_doc(**kwargs):
     def decorator(obj):
-        obj.__doc__ = obj.__doc__.format(**kwargs)
+        if obj.__doc__ is not None:
+            obj.__doc__ = obj.__doc__.format(**kwargs)
         return obj
 
     return decorator

--- a/src/torio/io/_streaming_media_encoder.py
+++ b/src/torio/io/_streaming_media_encoder.py
@@ -48,7 +48,8 @@ def _convert_config(cfg: CodecConfig):
 
 def _format_doc(**kwargs):
     def decorator(obj):
-        obj.__doc__ = obj.__doc__.format(**kwargs)
+        if obj.__doc__ is not None:
+            obj.__doc__ = obj.__doc__.format(**kwargs)
         return obj
 
     return decorator


### PR DESCRIPTION
When the `python -OO` flag is used, doc strings are no longer stored, and __doc__ always returns None.

This makes the library fail at import time for a rather dubious reason.

It would be good to have this fixed.