### PR TITLE
[codemod] facebook-unused-include-check in fbcode/pytorch

### DIFF
--- a/src/libtorchaudio/forced_align/compute.cpp
+++ b/src/libtorchaudio/forced_align/compute.cpp
@@ -1,5 +1,4 @@
 #include <libtorchaudio/forced_align/compute.h>
-#include <torch/script.h>
 
 std::tuple<torch::Tensor, torch::Tensor> forced_align(
     const torch::Tensor& logProbs,

--- a/src/libtorchaudio/rnnt/autograd.cpp
+++ b/src/libtorchaudio/rnnt/autograd.cpp
@@ -1,5 +1,4 @@
 #include <libtorchaudio/rnnt/compute.h>
-#include <torch/script.h>
 
 namespace torchaudio {
 namespace rnnt {

--- a/src/libtorchaudio/rnnt/compute.cpp
+++ b/src/libtorchaudio/rnnt/compute.cpp
@@ -1,5 +1,4 @@
 #include <libtorchaudio/rnnt/compute.h>
-#include <torch/script.h>
 
 std::tuple<torch::Tensor, std::optional<torch::Tensor>> rnnt_loss(
     torch::Tensor& logits,

--- a/src/libtorio/ffmpeg/ffmpeg.cpp
+++ b/src/libtorio/ffmpeg/ffmpeg.cpp
@@ -1,7 +1,6 @@
 #include <c10/util/Exception.h>
 #include <libtorio/ffmpeg/ffmpeg.h>
 #include <sstream>
-#include <stdexcept>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/text/pull/2285

X-link: https://github.com/pytorch/vision/pull/8919

Remove headers flagged by facebook-unused-include-check over fbcode.pytorch.

+ format and autodeps

This is a codemod. It was automatically generated and will be landed once it is approved and tests are passing in sandcastle.
You have been added as a reviewer by Sentinel or Butterfly.

Autodiff project: uip
Autodiff partition: fbcode.pytorch
Autodiff bookmark: ad.uip.fbcode.pytorch

Reviewed By: dtolnay

Differential Revision: D69621180


