### PR TITLE
Support specifying a torch range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,12 @@ def _make_version_file(version, sha):
 
 
 def _get_pytorch_version():
-    if "PYTORCH_VERSION" in os.environ:
-        return f"torch=={os.environ['PYTORCH_VERSION']}"
-    return "torch"
+    pytorch_dep = os.getenv("TORCH_PACKAGE_NAME", "torch")
+    if version_pin := os.getenv("PYTORCH_VERSION"):
+        pytorch_dep += "==" + version_pin
+    elif (version_pin_ge := os.getenv("PYTORCH_VERSION_GE")) and (version_pin_lt := os.getenv("PYTORCH_VERSION_LT")):
+        pytorch_dep += f">={version_pin_ge},<{version_pin_lt}"
+    return pytorch_dep
 
 
 class clean(distutils.command.clean.clean):


### PR DESCRIPTION
Motivation: we're using a custom pytorch build and have patch release more recently than upstream. While those updates do not change any abi, we want to allow torchvision/torchaudio to tolerance the changed pytorch version when we update pytorch, otherwise pip will raise a warning.

In this PR, we add two new envionment variable to generate a version range for pytorch.
