### PR TITLE
[CODEDMOD] replace all uses of np.string_ with np.bytes_

### DIFF
--- a/examples/hubert/dataset/hubert_dataset.py
+++ b/examples/hubert/dataset/hubert_dataset.py
@@ -316,7 +316,7 @@ class HuBERTDataSet(Dataset):
         with open(label_dir / f"label_{subset}.pt") as f:
             labels = [line.rstrip() for line in f]
             labels = [labels[i] for i in self.ind_list]
-        return np.asarray(labels, dtype=np.string_)
+        return np.asarray(labels, dtype=np.bytes_)
 
     def __getitem__(self, index):
         waveform = self._load_audio(index)

--- a/examples/self_supervised_learning/data_modules/_utils.py
+++ b/examples/self_supervised_learning/data_modules/_utils.py
@@ -312,7 +312,7 @@ class HuBERTDataSet(Dataset):
         with open(label_dir / f"label_{subset}.pt") as f:
             labels = [line.rstrip() for line in f]
             labels = [labels[i] for i in self.ind_list]
-        return np.asarray(labels, dtype=np.string_)
+        return np.asarray(labels, dtype=np.bytes_)
 
     def __getitem__(self, index):
         waveform = self._load_audio(index)


### PR DESCRIPTION
Summary:
X-link: https://github.com/ctrl-labs/src2/pull/46874

Numpy-2 removed `string_`, with guidance to use `bytes_` instead.
```
fbgs 'np.string_' -ls | xargs perl -pi -e 's,\bnp\.string_\b,np.bytes_,g'
```

Differential Revision: D74099774


