### PR TITLE
Fix Linux aarch64 nightly builds. Set with-cuda: enabled

### DIFF
--- a/.github/workflows/build_wheels_aarch64_linux.yml
+++ b/.github/workflows/build_wheels_aarch64_linux.yml
@@ -29,7 +29,7 @@ jobs:
       os: linux-aarch64
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
-      with-cuda: disable
+      with-cuda: enable
   build:
     needs: generate-matrix
     strategy:


### PR DESCRIPTION
Follow up after https://github.com/pytorch/test-infra/pull/6584

with-cuda on these jobs need to be enabled. I believe when CUDA aarch64 jobs where introduced the flag was not flipped however we have not noticed it since there was a bug in test infra generating the aarch64 builds. The PR: https://github.com/pytorch/test-infra/pull/6584 resolved this bug. As a followup we need to set the flag with-cuda: enabled.