### PR TITLE
Remove Unused Variable indexScores from fbcode/pytorch/audio/src/libtorchaudio/forced_align/gpu/compute.cu

### DIFF
--- a/src/libtorchaudio/forced_align/gpu/compute.cu
+++ b/src/libtorchaudio/forced_align/gpu/compute.cu
@@ -234,12 +234,10 @@ void forced_align_impl(
       alphasCpu_a[curIdxOffset][S - 1] > alphasCpu_a[curIdxOffset][S - 2]
       ? S - 1
       : S - 2;
-  int indexScores = 0;
   for (int t = T - 1; t >= 0; --t) {
     auto lbl_idx =
         ltrIdx % 2 == 0 ? blank : targetsCpu_a[batchIndex][ltrIdx / 2];
     paths_a[batchIndex][t] = lbl_idx;
-    ++indexScores;
     ltrIdx -= backPtrCpu_a[t][ltrIdx];
   }
 }


### PR DESCRIPTION
Summary:
From canary diff: D74892205
```
[2025-05-19T14:52:37.259-07:00] Stderr:
fbcode/pytorch/audio/src/libtorchaudio/forced_align/gpu/compute.cu:237:5: error: variable 'indexScores' set but not used [-Werror,-Wunused-but-set-variable]
  237 | int indexScores = 0;
      |     ^
1 error generated.
```
Eliminate the unused variable indexScores in fbcode/pytorch/audio/src/libtorchaudio/forced_align/gpu/compute.cu to resolve the -Wunused-but-set-variable warning.

Differential Revision: D75027221


