### PR TITLE
Fix tests that failed in Python 3.13 when building the conda-forge package

### DIFF
--- a/examples/asr/emformer_rnnt/librispeech/lightning.py
+++ b/examples/asr/emformer_rnnt/librispeech/lightning.py
@@ -79,20 +79,20 @@ class LibriSpeechRNNTModule(LightningModule):
         self.train_data_pipeline = torch.nn.Sequential(
             FunctionalModule(piecewise_linear_log),
             GlobalStatsNormalization(global_stats_path),
-            FunctionalModule(partial(torch.transpose, dim0=1, dim1=2)),
+            FunctionalModule(staticmethod(partial(torch.transpose, dim0=1, dim1=2))),
             torchaudio.transforms.FrequencyMasking(27),
             torchaudio.transforms.FrequencyMasking(27),
             torchaudio.transforms.TimeMasking(100, p=0.2),
             torchaudio.transforms.TimeMasking(100, p=0.2),
-            FunctionalModule(partial(torch.nn.functional.pad, pad=(0, 4))),
-            FunctionalModule(partial(torch.transpose, dim0=1, dim1=2)),
+            FunctionalModule(staticmethod(partial(torch.nn.functional.pad, pad=(0, 4)))),
+            FunctionalModule(staticmethod(partial(torch.transpose, dim0=1, dim1=2))),
         )
         self.valid_data_pipeline = torch.nn.Sequential(
             FunctionalModule(piecewise_linear_log),
             GlobalStatsNormalization(global_stats_path),
-            FunctionalModule(partial(torch.transpose, dim0=1, dim1=2)),
-            FunctionalModule(partial(torch.nn.functional.pad, pad=(0, 4))),
-            FunctionalModule(partial(torch.transpose, dim0=1, dim1=2)),
+            FunctionalModule(staticmethod(partial(torch.transpose, dim0=1, dim1=2))),
+            FunctionalModule(staticmethod(partial(torch.nn.functional.pad, pad=(0, 4)))),
+            FunctionalModule(staticmethod(partial(torch.transpose, dim0=1, dim1=2))),
         )
 
         self.librispeech_path = librispeech_path

--- a/examples/asr/emformer_rnnt/mustc/lightning.py
+++ b/examples/asr/emformer_rnnt/mustc/lightning.py
@@ -57,20 +57,20 @@ class MuSTCRNNTModule(LightningModule):
         self.train_data_pipeline = torch.nn.Sequential(
             FunctionalModule(piecewise_linear_log),
             GlobalStatsNormalization(global_stats_path),
-            FunctionalModule(partial(torch.transpose, dim0=1, dim1=2)),
+            FunctionalModule(staticmethod(partial(torch.transpose, dim0=1, dim1=2))),
             torchaudio.transforms.FrequencyMasking(27),
             torchaudio.transforms.FrequencyMasking(27),
             torchaudio.transforms.TimeMasking(100, p=0.2),
             torchaudio.transforms.TimeMasking(100, p=0.2),
-            FunctionalModule(partial(torch.nn.functional.pad, pad=(0, 4))),
-            FunctionalModule(partial(torch.transpose, dim0=1, dim1=2)),
+            FunctionalModule(staticmethod(partial(torch.nn.functional.pad, pad=(0, 4)))),
+            FunctionalModule(staticmethod(partial(torch.transpose, dim0=1, dim1=2))),
         )
         self.valid_data_pipeline = torch.nn.Sequential(
             FunctionalModule(piecewise_linear_log),
             GlobalStatsNormalization(global_stats_path),
-            FunctionalModule(partial(torch.transpose, dim0=1, dim1=2)),
-            FunctionalModule(partial(torch.nn.functional.pad, pad=(0, 4))),
-            FunctionalModule(partial(torch.transpose, dim0=1, dim1=2)),
+            FunctionalModule(staticmethod(partial(torch.transpose, dim0=1, dim1=2))),
+            FunctionalModule(staticmethod(partial(torch.nn.functional.pad, pad=(0, 4)))),
+            FunctionalModule(staticmethod(partial(torch.transpose, dim0=1, dim1=2))),
         )
 
         self.mustc_path = mustc_path

--- a/examples/asr/emformer_rnnt/pipeline_demo.py
+++ b/examples/asr/emformer_rnnt/pipeline_demo.py
@@ -29,15 +29,15 @@ class Config:
 
 _CONFIGS = {
     MODEL_TYPE_LIBRISPEECH: Config(
-        partial(torchaudio.datasets.LIBRISPEECH, url="test-clean"),
+        staticmethod(partial(torchaudio.datasets.LIBRISPEECH, url="test-clean")),
         EMFORMER_RNNT_BASE_LIBRISPEECH,
     ),
     MODEL_TYPE_MUSTC: Config(
-        partial(MUSTC, subset="tst-COMMON"),
+        staticmethod(partial(MUSTC, subset="tst-COMMON")),
         EMFORMER_RNNT_BASE_MUSTC,
     ),
     MODEL_TYPE_TEDLIUM3: Config(
-        partial(torchaudio.datasets.TEDLIUM, release="release3", subset="test"),
+        staticmethod(partial(torchaudio.datasets.TEDLIUM, release="release3", subset="test")),
         EMFORMER_RNNT_BASE_TEDLIUM3,
     ),
 }

--- a/examples/asr/emformer_rnnt/tedlium3/lightning.py
+++ b/examples/asr/emformer_rnnt/tedlium3/lightning.py
@@ -87,20 +87,20 @@ class TEDLIUM3RNNTModule(LightningModule):
         self.train_data_pipeline = torch.nn.Sequential(
             FunctionalModule(piecewise_linear_log),
             GlobalStatsNormalization(global_stats_path),
-            FunctionalModule(partial(torch.transpose, dim0=1, dim1=2)),
+            FunctionalModule(staticmethod(partial(torch.transpose, dim0=1, dim1=2))),
             torchaudio.transforms.FrequencyMasking(27),
             torchaudio.transforms.FrequencyMasking(27),
             torchaudio.transforms.TimeMasking(100, p=0.2),
             torchaudio.transforms.TimeMasking(100, p=0.2),
-            FunctionalModule(partial(torch.nn.functional.pad, pad=(0, 4))),
-            FunctionalModule(partial(torch.transpose, dim0=1, dim1=2)),
+            FunctionalModule(staticmethod(partial(torch.nn.functional.pad, pad=(0, 4)))),
+            FunctionalModule(staticmethod(partial(torch.transpose, dim0=1, dim1=2))),
         )
         self.valid_data_pipeline = torch.nn.Sequential(
             FunctionalModule(piecewise_linear_log),
             GlobalStatsNormalization(global_stats_path),
-            FunctionalModule(partial(torch.transpose, dim0=1, dim1=2)),
-            FunctionalModule(partial(torch.nn.functional.pad, pad=(0, 4))),
-            FunctionalModule(partial(torch.transpose, dim0=1, dim1=2)),
+            FunctionalModule(staticmethod(partial(torch.transpose, dim0=1, dim1=2))),
+            FunctionalModule(staticmethod(partial(torch.nn.functional.pad, pad=(0, 4)))),
+            FunctionalModule(staticmethod(partial(torch.transpose, dim0=1, dim1=2))),
         )
 
         self.tedlium_path = tedlium_path

--- a/examples/asr/librispeech_conformer_rnnt/transforms.py
+++ b/examples/asr/librispeech_conformer_rnnt/transforms.py
@@ -71,12 +71,12 @@ class TrainTransform:
         self.train_data_pipeline = torch.nn.Sequential(
             FunctionalModule(_piecewise_linear_log),
             GlobalStatsNormalization(global_stats_path),
-            FunctionalModule(partial(torch.transpose, dim0=1, dim1=2)),
+            FunctionalModule(staticmethod(partial(torch.transpose, dim0=1, dim1=2))),
             torchaudio.transforms.FrequencyMasking(27),
             torchaudio.transforms.FrequencyMasking(27),
             torchaudio.transforms.TimeMasking(100, p=0.2),
             torchaudio.transforms.TimeMasking(100, p=0.2),
-            FunctionalModule(partial(torch.transpose, dim0=1, dim1=2)),
+            FunctionalModule(staticmethod(partial(torch.transpose, dim0=1, dim1=2))),
         )
 
     def __call__(self, samples: List):

--- a/examples/asr/librispeech_conformer_rnnt_biasing/transforms.py
+++ b/examples/asr/librispeech_conformer_rnnt_biasing/transforms.py
@@ -113,12 +113,12 @@ class TrainTransform:
         self.train_data_pipeline = torch.nn.Sequential(
             FunctionalModule(_piecewise_linear_log),
             GlobalStatsNormalization(global_stats_path),
-            FunctionalModule(partial(torch.transpose, dim0=1, dim1=2)),
+            FunctionalModule(staticmethod(partial(torch.transpose, dim0=1, dim1=2))),
             torchaudio.transforms.FrequencyMasking(27),
             torchaudio.transforms.FrequencyMasking(27),
             torchaudio.transforms.TimeMasking(100, p=0.2),
             torchaudio.transforms.TimeMasking(100, p=0.2),
-            FunctionalModule(partial(torch.transpose, dim0=1, dim1=2)),
+            FunctionalModule(staticmethod(partial(torch.transpose, dim0=1, dim1=2))),
         )
         self.blist = blist
         self.droprate = droprate

--- a/examples/pipeline_tacotron2/inference.py
+++ b/examples/pipeline_tacotron2/inference.py
@@ -253,12 +253,14 @@ def main(args):
         raise ValueError("Both --checkpoint-path and --checkpoint-name are specified, " "can only specify one.")
 
     n_symbols = len(get_symbol_list(args.text_preprocessor))
-    text_preprocessor = partial(
-        text_to_sequence,
-        symbol_list=args.text_preprocessor,
-        phonemizer=args.phonemizer,
-        checkpoint=args.phonemizer_checkpoint,
-        cmudict_root=args.cmudict_root,
+    text_preprocessor = staticmethod(
+        partial(
+            text_to_sequence,
+            symbol_list=args.text_preprocessor,
+            phonemizer=args.phonemizer,
+            checkpoint=args.phonemizer_checkpoint,
+            cmudict_root=args.cmudict_root,
+        )
     )
 
     if args.checkpoint_path is not None:

--- a/examples/pipeline_tacotron2/train.py
+++ b/examples/pipeline_tacotron2/train.py
@@ -273,12 +273,14 @@ def log_additional_info(writer, model, loader, epoch):
 
 
 def get_datasets(args):
-    text_preprocessor = partial(
-        text_to_sequence,
-        symbol_list=args.text_preprocessor,
-        phonemizer=args.phonemizer,
-        checkpoint=args.phonemizer_checkpoint,
-        cmudict_root=args.cmudict_root,
+    text_preprocessor = staticmethod(
+        partial(
+            text_to_sequence,
+            symbol_list=args.text_preprocessor,
+            phonemizer=args.phonemizer,
+            checkpoint=args.phonemizer_checkpoint,
+            cmudict_root=args.cmudict_root,
+        )
     )
 
     transforms = torch.nn.Sequential(
@@ -391,7 +393,7 @@ def train(rank, world_size, args):
         "shuffle": False,
         "pin_memory": True,
         "drop_last": False,
-        "collate_fn": partial(text_mel_collate_fn, n_frames_per_step=args.n_frames_per_step),
+        "collate_fn": staticmethod(partial(text_mel_collate_fn, n_frames_per_step=args.n_frames_per_step)),
     }
 
     train_loader = DataLoader(trainset, sampler=train_sampler, **loader_params)

--- a/examples/self_supervised_learning/train_hubert.py
+++ b/examples/self_supervised_learning/train_hubert.py
@@ -115,11 +115,13 @@ def run_train(args):
             f"Found {args.model_name}."
         )
     model = getattr(torchaudio.models, args.model_name)()
-    loss_fn = partial(
-        hubert_loss,
-        masked_weight=args.masked_weight,
-        unmasked_weight=args.unmasked_weight,
-        feature_weight=args.feature_weight,
+    loss_fn = staticmethod(
+        partial(
+            hubert_loss,
+            masked_weight=args.masked_weight,
+            unmasked_weight=args.unmasked_weight,
+            feature_weight=args.feature_weight,
+        )
     )
     optimizer = torch.optim.AdamW(
         model.parameters(),

--- a/examples/source_separation/utils/dataset/utils.py
+++ b/examples/source_separation/utils/dataset/utils.py
@@ -84,6 +84,6 @@ def get_collate_fn(dataset_type, mode, sample_rate=None, duration=4):
         if mode == "train":
             if sample_rate is None:
                 raise ValueError("sample_rate is not given.")
-            return partial(collate_fn_wsj0mix_train, sample_rate=sample_rate, duration=duration)
-        return partial(collate_fn_wsj0mix_test, sample_rate=sample_rate)
+            return staticmethod(partial(collate_fn_wsj0mix_train, sample_rate=sample_rate, duration=duration))
+        return staticmethod(partial(collate_fn_wsj0mix_test, sample_rate=sample_rate))
     raise ValueError(f"Unexpected dataset: {dataset_type}")

--- a/src/torchaudio/datasets/cmuarctic.py
+++ b/src/torchaudio/datasets/cmuarctic.py
@@ -1,4 +1,3 @@
-import csv
 import os
 from pathlib import Path
 from typing import Tuple, Union
@@ -129,8 +128,7 @@ class CMUARCTIC(Dataset):
         self._text = os.path.join(self._path, self._folder_text, self._file_text)
 
         with open(self._text, "r") as text:
-            walker = csv.reader(text, delimiter="\n")
-            self._walker = list(walker)
+            self._walker = [[line.strip()] for line in text if line.strip()]
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, str]:
         """Load the n-th sample from the dataset.

--- a/src/torchaudio/pipelines/_source_separation_pipeline.py
+++ b/src/torchaudio/pipelines/_source_separation_pipeline.py
@@ -61,7 +61,7 @@ class SourceSeparationBundle:
 
 CONVTASNET_BASE_LIBRI2MIX = SourceSeparationBundle(
     _model_path="models/conv_tasnet_base_libri2mix.pt",
-    _model_factory_func=partial(conv_tasnet_base, num_sources=2),
+    _model_factory_func=staticmethod(partial(conv_tasnet_base, num_sources=2)),
     _sample_rate=8000,
 )
 CONVTASNET_BASE_LIBRI2MIX.__doc__ = """Pre-trained Source Separation pipeline with *ConvTasNet*
@@ -78,7 +78,7 @@ Please refer to :class:`SourceSeparationBundle` for usage instructions.
 
 HDEMUCS_HIGH_MUSDB_PLUS = SourceSeparationBundle(
     _model_path="models/hdemucs_high_trained.pt",
-    _model_factory_func=partial(hdemucs_high, sources=["drums", "bass", "other", "vocals"]),
+    _model_factory_func=staticmethod(partial(hdemucs_high, sources=["drums", "bass", "other", "vocals"])),
     _sample_rate=44100,
 )
 HDEMUCS_HIGH_MUSDB_PLUS.__doc__ = """Pre-trained music source separation pipeline with
@@ -96,7 +96,7 @@ Please refer to :class:`SourceSeparationBundle` for usage instructions.
 
 HDEMUCS_HIGH_MUSDB = SourceSeparationBundle(
     _model_path="models/hdemucs_high_musdbhq_only.pt",
-    _model_factory_func=partial(hdemucs_high, sources=["drums", "bass", "other", "vocals"]),
+    _model_factory_func=staticmethod(partial(hdemucs_high, sources=["drums", "bass", "other", "vocals"])),
     _sample_rate=44100,
 )
 HDEMUCS_HIGH_MUSDB.__doc__ = """Pre-trained music source separation pipeline with

--- a/src/torchaudio/pipelines/rnnt_pipeline.py
+++ b/src/torchaudio/pipelines/rnnt_pipeline.py
@@ -356,7 +356,7 @@ class RNNTBundle:
 
 EMFORMER_RNNT_BASE_LIBRISPEECH = RNNTBundle(
     _rnnt_path="models/emformer_rnnt_base_librispeech.pt",
-    _rnnt_factory_func=partial(emformer_rnnt_base, num_symbols=4097),
+    _rnnt_factory_func=staticmethod(partial(emformer_rnnt_base, num_symbols=4097)),
     _global_stats_path="pipeline-assets/global_stats_rnnt_librispeech.json",
     _sp_model_path="pipeline-assets/spm_bpe_4096_librispeech.model",
     _right_padding=4,

--- a/src/torchaudio/prototype/pipelines/rnnt_pipeline.py
+++ b/src/torchaudio/prototype/pipelines/rnnt_pipeline.py
@@ -6,7 +6,7 @@ from torchaudio.pipelines import RNNTBundle
 
 EMFORMER_RNNT_BASE_MUSTC = RNNTBundle(
     _rnnt_path="models/emformer_rnnt_base_mustc.pt",
-    _rnnt_factory_func=partial(emformer_rnnt_base, num_symbols=501),
+    _rnnt_factory_func=staticmethod(partial(emformer_rnnt_base, num_symbols=501)),
     _global_stats_path="pipeline-assets/global_stats_rnnt_mustc.json",
     _sp_model_path="pipeline-assets/spm_bpe_500_mustc.model",
     _right_padding=4,
@@ -33,7 +33,7 @@ Please refer to :py:class:`torchaudio.pipelines.RNNTBundle` for usage instructio
 
 EMFORMER_RNNT_BASE_TEDLIUM3 = RNNTBundle(
     _rnnt_path="models/emformer_rnnt_base_tedlium3.pt",
-    _rnnt_factory_func=partial(emformer_rnnt_base, num_symbols=501),
+    _rnnt_factory_func=staticmethod(partial(emformer_rnnt_base, num_symbols=501)),
     _global_stats_path="pipeline-assets/global_stats_rnnt_tedlium3.json",
     _sp_model_path="pipeline-assets/spm_bpe_500_tedlium3.model",
     _right_padding=4,

--- a/test/torchaudio_unittest/backend/dispatcher/ffmpeg/info_test.py
+++ b/test/torchaudio_unittest/backend/dispatcher/ffmpeg/info_test.py
@@ -34,7 +34,7 @@ if _mod_utils.is_module_available("requests"):
 @skipIfNoExec("sox")
 @skipIfNoFFmpeg
 class TestInfo(TempDirMixin, PytorchTestCase):
-    _info = partial(get_info_func(), backend="ffmpeg")
+    _info = staticmethod(partial(get_info_func(), backend="ffmpeg"))
 
     def test_pathlike(self):
         """FFmpeg dispatcher can query audio data from pathlike object"""
@@ -315,7 +315,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
 @skipIfNoExec("sox")
 @skipIfNoFFmpeg
 class TestInfoOpus(PytorchTestCase):
-    _info = partial(get_info_func(), backend="ffmpeg")
+    _info = staticmethod(partial(get_info_func(), backend="ffmpeg"))
 
     @parameterized.expand(
         list(
@@ -341,7 +341,7 @@ class TestInfoOpus(PytorchTestCase):
 @skipIfNoExec("sox")
 @skipIfNoFFmpeg
 class TestLoadWithoutExtension(PytorchTestCase):
-    _info = partial(get_info_func(), backend="ffmpeg")
+    _info = staticmethod(partial(get_info_func(), backend="ffmpeg"))
 
     def test_mp3(self):
         """MP3 file without extension can be loaded
@@ -405,7 +405,7 @@ class Unseekable:
 
 @skipIfNoExec("sox")
 class TestFileObject(FileObjTestBase, PytorchTestCase):
-    _info = partial(get_info_func(), backend="ffmpeg")
+    _info = staticmethod(partial(get_info_func(), backend="ffmpeg"))
 
     def _query_fileobj(self, ext, dtype, sample_rate, num_channels, num_frames, *, comments=None):
         path = self._gen_file(ext, dtype, sample_rate, num_channels, num_frames, comments=comments)
@@ -557,7 +557,7 @@ class TestFileObject(FileObjTestBase, PytorchTestCase):
 @skipIfNoExec("sox")
 @skipIfNoModule("requests")
 class TestFileObjectHttp(HttpServerMixin, FileObjTestBase, PytorchTestCase):
-    _info = partial(get_info_func(), backend="ffmpeg")
+    _info = staticmethod(partial(get_info_func(), backend="ffmpeg"))
 
     def _query_http(self, ext, dtype, sample_rate, num_channels, num_frames):
         audio_path = self._gen_file(ext, dtype, sample_rate, num_channels, num_frames)
@@ -600,7 +600,7 @@ class TestFileObjectHttp(HttpServerMixin, FileObjTestBase, PytorchTestCase):
 @skipIfNoExec("sox")
 @skipIfNoFFmpeg
 class TestInfoNoSuchFile(PytorchTestCase):
-    _info = partial(get_info_func(), backend="ffmpeg")
+    _info = staticmethod(partial(get_info_func(), backend="ffmpeg"))
 
     def test_info_fail(self):
         """

--- a/test/torchaudio_unittest/backend/dispatcher/ffmpeg/load_test.py
+++ b/test/torchaudio_unittest/backend/dispatcher/ffmpeg/load_test.py
@@ -33,7 +33,7 @@ if _mod_utils.is_module_available("requests"):
 
 
 class LoadTestBase(TempDirMixin, PytorchTestCase):
-    _load = partial(get_load_func(), backend="ffmpeg")
+    _load = staticmethod(partial(get_load_func(), backend="ffmpeg"))
 
     def assert_format(
         self,
@@ -324,7 +324,7 @@ class TestLoad(LoadTestBase):
 @skipIfNoExec("sox")
 @skipIfNoFFmpeg
 class TestLoadWithoutExtension(PytorchTestCase):
-    _load = partial(get_load_func(), backend="ffmpeg")
+    _load = staticmethod(partial(get_load_func(), backend="ffmpeg"))
 
     def test_mp3(self):
         """MP3 file without extension can be loaded
@@ -364,7 +364,7 @@ class TestFileObject(TempDirMixin, PytorchTestCase):
     because `load` function is rigrously tested for file path inputs to match libsox's result,
     """
 
-    _load = partial(get_load_func(), backend="ffmpeg")
+    _load = staticmethod(partial(get_load_func(), backend="ffmpeg"))
 
     @parameterized.expand(
         [
@@ -541,7 +541,7 @@ class Unseekable:
 @skipIfNoExec("sox")
 @skipIfNoModule("requests")
 class TestFileObjectHttp(HttpServerMixin, PytorchTestCase):
-    _load = partial(get_load_func(), backend="ffmpeg")
+    _load = staticmethod(partial(get_load_func(), backend="ffmpeg"))
 
     @parameterized.expand(
         [
@@ -606,7 +606,7 @@ class TestFileObjectHttp(HttpServerMixin, PytorchTestCase):
 @skipIfNoExec("sox")
 @skipIfNoFFmpeg
 class TestLoadNoSuchFile(PytorchTestCase):
-    _load = partial(get_load_func(), backend="ffmpeg")
+    _load = staticmethod(partial(get_load_func(), backend="ffmpeg"))
 
     def test_load_fail(self):
         """

--- a/test/torchaudio_unittest/backend/dispatcher/ffmpeg/save_test.py
+++ b/test/torchaudio_unittest/backend/dispatcher/ffmpeg/save_test.py
@@ -41,7 +41,7 @@ def _convert_audio_file(src_path, dst_path, muxer=None, encoder=None, sample_fmt
 
 
 class SaveTestBase(TempDirMixin, TorchaudioTestCase):
-    _save = partial(get_save_func(), backend="ffmpeg")
+    _save = staticmethod(partial(get_save_func(), backend="ffmpeg"))
 
     def assert_save_consistency(
         self,
@@ -398,7 +398,7 @@ class SaveTest(SaveTestBase):
 class TestSaveParams(TempDirMixin, PytorchTestCase):
     """Test the correctness of optional parameters of `self._save`"""
 
-    _save = partial(get_save_func(), backend="ffmpeg")
+    _save = staticmethod(partial(get_save_func(), backend="ffmpeg"))
 
     @parameterized.expand([(True,), (False,)], name_func=name_func)
     def test_save_channels_first(self, channels_first):
@@ -444,7 +444,7 @@ class TestSaveParams(TempDirMixin, PytorchTestCase):
 @skipIfNoExec("sox")
 @skipIfNoFFmpeg
 class TestSaveNonExistingDirectory(PytorchTestCase):
-    _save = partial(get_save_func(), backend="ffmpeg")
+    _save = staticmethod(partial(get_save_func(), backend="ffmpeg"))
 
     def test_save_fail(self):
         """

--- a/test/torchaudio_unittest/backend/dispatcher/soundfile/info_test.py
+++ b/test/torchaudio_unittest/backend/dispatcher/soundfile/info_test.py
@@ -24,7 +24,7 @@ if _mod_utils.is_module_available("soundfile"):
 
 @skipIfNoModule("soundfile")
 class TestInfo(TempDirMixin, PytorchTestCase):
-    _info = partial(get_info_func(), backend="soundfile")
+    _info = staticmethod(partial(get_info_func(), backend="soundfile"))
 
     @parameterize(
         ["float32", "int32", "int16", "uint8"],
@@ -127,7 +127,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
 
 @skipIfNoModule("soundfile")
 class TestFileObject(TempDirMixin, PytorchTestCase):
-    _info = partial(get_info_func(), backend="soundfile")
+    _info = staticmethod(partial(get_info_func(), backend="soundfile"))
 
     def _test_fileobj(self, ext, subtype, bits_per_sample):
         """Query audio via file-like object works"""

--- a/test/torchaudio_unittest/backend/dispatcher/soundfile/load_test.py
+++ b/test/torchaudio_unittest/backend/dispatcher/soundfile/load_test.py
@@ -97,7 +97,7 @@ class SoundFileMock:
 
 
 class MockedLoadTest(PytorchTestCase):
-    _load = partial(get_load_func(), backend="soundfile")
+    _load = staticmethod(partial(get_load_func(), backend="soundfile"))
 
     def assert_dtype(self, ext, dtype, sample_rate, num_channels, normalize, channels_first):
         """When format is WAV or NIST, normalize=False will return the native dtype Tensor, otherwise float32"""
@@ -143,7 +143,7 @@ class MockedLoadTest(PytorchTestCase):
 
 
 class LoadTestBase(TempDirMixin, PytorchTestCase):
-    _load = partial(get_load_func(), backend="soundfile")
+    _load = staticmethod(partial(get_load_func(), backend="soundfile"))
 
     def assert_wav(
         self,
@@ -272,7 +272,7 @@ class TestLoad(LoadTestBase):
 class TestLoadFormat(TempDirMixin, PytorchTestCase):
     """Given `format` parameter, `so.load` can load files without extension"""
 
-    _load = partial(get_load_func(), backend="soundfile")
+    _load = staticmethod(partial(get_load_func(), backend="soundfile"))
     original = None
     path = None
 
@@ -314,7 +314,7 @@ class TestLoadFormat(TempDirMixin, PytorchTestCase):
 
 @skipIfNoModule("soundfile")
 class TestFileObject(TempDirMixin, PytorchTestCase):
-    _load = partial(get_load_func(), backend="soundfile")
+    _load = staticmethod(partial(get_load_func(), backend="soundfile"))
 
     def _test_fileobj(self, ext):
         """Loading audio via file-like object works"""

--- a/test/torchaudio_unittest/backend/dispatcher/soundfile/save_test.py
+++ b/test/torchaudio_unittest/backend/dispatcher/soundfile/save_test.py
@@ -21,7 +21,7 @@ if _mod_utils.is_module_available("soundfile"):
 
 
 class MockedSaveTest(PytorchTestCase):
-    _save = partial(get_save_func(), backend="soundfile")
+    _save = staticmethod(partial(get_save_func(), backend="soundfile"))
 
     @nested_params(
         ["float32", "int32", "int16", "uint8"],
@@ -168,7 +168,7 @@ class MockedSaveTest(PytorchTestCase):
 
 @skipIfNoModule("soundfile")
 class SaveTestBase(TempDirMixin, PytorchTestCase):
-    _save = partial(get_save_func(), backend="soundfile")
+    _save = staticmethod(partial(get_save_func(), backend="soundfile"))
 
     def assert_wav(self, dtype, sample_rate, num_channels, num_frames):
         """`self._save` can save wav format."""
@@ -264,7 +264,7 @@ class TestSave(SaveTestBase):
 class TestSaveParams(TempDirMixin, PytorchTestCase):
     """Test the correctness of optional parameters of `self._save`"""
 
-    _save = partial(get_save_func(), backend="soundfile")
+    _save = staticmethod(partial(get_save_func(), backend="soundfile"))
 
     @parameterize([True, False])
     def test_channels_first(self, channels_first):
@@ -279,7 +279,7 @@ class TestSaveParams(TempDirMixin, PytorchTestCase):
 
 @skipIfNoModule("soundfile")
 class TestFileObject(TempDirMixin, PytorchTestCase):
-    _save = partial(get_save_func(), backend="soundfile")
+    _save = staticmethod(partial(get_save_func(), backend="soundfile"))
 
     def _test_fileobj(self, ext):
         """Saving audio to file-like object works"""

--- a/test/torchaudio_unittest/backend/dispatcher/sox/info_test.py
+++ b/test/torchaudio_unittest/backend/dispatcher/sox/info_test.py
@@ -31,7 +31,7 @@ if _mod_utils.is_module_available("requests"):
 @skipIfNoExec("sox")
 @skipIfNoSox
 class TestInfo(TempDirMixin, PytorchTestCase):
-    _info = partial(get_info_func(), backend="sox")
+    _info = staticmethod(partial(get_info_func(), backend="sox"))
 
     @parameterized.expand(
         list(
@@ -262,7 +262,7 @@ class TestInfo(TempDirMixin, PytorchTestCase):
 @disabledInCI
 @skipIfNoSoxDecoder("opus")
 class TestInfoOpus(PytorchTestCase):
-    _info = partial(get_info_func(), backend="sox")
+    _info = staticmethod(partial(get_info_func(), backend="sox"))
 
     @parameterized.expand(
         list(
@@ -321,7 +321,7 @@ class Unseekable:
 @skipIfNoSox
 @skipIfNoExec("sox")
 class TestFileObject(FileObjTestBase, PytorchTestCase):
-    _info = partial(get_info_func(), backend="sox")
+    _info = staticmethod(partial(get_info_func(), backend="sox"))
 
     def _query_fileobj(self, ext, dtype, sample_rate, num_channels, num_frames, *, comments=None):
         path = self._gen_file(ext, dtype, sample_rate, num_channels, num_frames, comments=comments)
@@ -353,7 +353,7 @@ class TestFileObject(FileObjTestBase, PytorchTestCase):
 @skipIfNoExec("sox")
 @skipIfNoModule("requests")
 class TestFileObjectHttp(HttpServerMixin, FileObjTestBase, PytorchTestCase):
-    _info = partial(get_info_func(), backend="sox")
+    _info = staticmethod(partial(get_info_func(), backend="sox"))
 
     def _query_http(self, ext, dtype, sample_rate, num_channels, num_frames):
         audio_path = self._gen_file(ext, dtype, sample_rate, num_channels, num_frames)
@@ -387,7 +387,7 @@ class TestFileObjectHttp(HttpServerMixin, FileObjTestBase, PytorchTestCase):
 
 @skipIfNoSox
 class TestInfoNoSuchFile(PytorchTestCase):
-    _info = partial(get_info_func(), backend="sox")
+    _info = staticmethod(partial(get_info_func(), backend="sox"))
 
     def test_info_fail(self):
         """

--- a/test/torchaudio_unittest/backend/dispatcher/sox/load_test.py
+++ b/test/torchaudio_unittest/backend/dispatcher/sox/load_test.py
@@ -22,7 +22,7 @@ from .common import name_func
 
 
 class LoadTestBase(TempDirMixin, PytorchTestCase):
-    _load = partial(get_load_func(), backend="sox")
+    _load = staticmethod(partial(get_load_func(), backend="sox"))
 
     def assert_format(
         self,
@@ -293,7 +293,7 @@ class TestLoad(LoadTestBase):
 class TestLoadParams(TempDirMixin, PytorchTestCase):
     """Test the correctness of frame parameters of `sox_io_backend.load`"""
 
-    _load = partial(get_load_func(), backend="sox")
+    _load = staticmethod(partial(get_load_func(), backend="sox"))
 
     def _test(self, func, frame_offset, num_frames, channels_first, normalize):
         original = get_wav_data("int16", num_channels=2, normalize=False)
@@ -329,7 +329,7 @@ class TestFileObject(TempDirMixin, PytorchTestCase):
     because `load` function is rigrously tested for file path inputs to match libsox's result,
     """
 
-    _load = partial(get_load_func(), backend="sox")
+    _load = staticmethod(partial(get_load_func(), backend="sox"))
 
     @parameterized.expand(
         [
@@ -360,7 +360,7 @@ class TestFileObject(TempDirMixin, PytorchTestCase):
 
 @skipIfNoSox
 class TestLoadNoSuchFile(PytorchTestCase):
-    _load = partial(get_load_func(), backend="sox")
+    _load = staticmethod(partial(get_load_func(), backend="sox"))
 
     def test_load_fail(self):
         """

--- a/test/torchaudio_unittest/backend/dispatcher/sox/roundtrip_test.py
+++ b/test/torchaudio_unittest/backend/dispatcher/sox/roundtrip_test.py
@@ -13,8 +13,8 @@ from .common import get_enc_params, name_func
 class TestRoundTripIO(TempDirMixin, PytorchTestCase):
     """save/load round trip should not degrade data for lossless formats"""
 
-    _load = partial(get_load_func(), backend="sox")
-    _save = partial(get_save_func(), backend="sox")
+    _load = staticmethod(partial(get_load_func(), backend="sox"))
+    _save = staticmethod(partial(get_save_func(), backend="sox"))
 
     @parameterized.expand(
         list(

--- a/test/torchaudio_unittest/backend/dispatcher/sox/save_test.py
+++ b/test/torchaudio_unittest/backend/dispatcher/sox/save_test.py
@@ -34,7 +34,7 @@ def _get_sox_encoding(encoding):
 
 
 class SaveTestBase(TempDirMixin, TorchaudioTestCase):
-    _save = partial(get_save_func(), backend="sox")
+    _save = staticmethod(partial(get_save_func(), backend="sox"))
 
     def assert_save_consistency(
         self,
@@ -361,7 +361,7 @@ class SaveTest(SaveTestBase):
 class TestSaveParams(TempDirMixin, PytorchTestCase):
     """Test the correctness of optional parameters of `self._save`"""
 
-    _save = partial(get_save_func(), backend="sox")
+    _save = staticmethod(partial(get_save_func(), backend="sox"))
 
     @parameterized.expand([(True,), (False,)], name_func=name_func)
     def test_save_channels_first(self, channels_first):
@@ -405,7 +405,7 @@ class TestSaveParams(TempDirMixin, PytorchTestCase):
 
 @skipIfNoSox
 class TestSaveNonExistingDirectory(PytorchTestCase):
-    _save = partial(get_save_func(), backend="sox")
+    _save = staticmethod(partial(get_save_func(), backend="sox"))
 
     def test_save_fail(self):
         """

--- a/test/torchaudio_unittest/backend/dispatcher/sox/smoke_test.py
+++ b/test/torchaudio_unittest/backend/dispatcher/sox/smoke_test.py
@@ -19,9 +19,9 @@ class SmokeTest(TempDirMixin, TorchaudioTestCase):
     however without such tools, the correctness of each function cannot be verified.
     """
 
-    _info = partial(get_info_func(), backend="sox")
-    _load = partial(get_load_func(), backend="sox")
-    _save = partial(get_save_func(), backend="sox")
+    _info = staticmethod(partial(get_info_func(), backend="sox"))
+    _load = staticmethod(partial(get_load_func(), backend="sox"))
+    _save = staticmethod(partial(get_save_func(), backend="sox"))
 
     def run_smoke_test(self, ext, sample_rate, num_channels, *, dtype="float32"):
         duration = 1

--- a/test/torchaudio_unittest/example/emformer_rnnt/test_librispeech_lightning.py
+++ b/test/torchaudio_unittest/example/emformer_rnnt/test_librispeech_lightning.py
@@ -34,7 +34,7 @@ class MockLIBRISPEECH:
 @contextmanager
 def get_lightning_module():
     with patch(
-        "sentencepiece.SentencePieceProcessor", new=partial(MockSentencePieceProcessor, num_symbols=4096)
+        "sentencepiece.SentencePieceProcessor", new=staticmethod(partial(MockSentencePieceProcessor, num_symbols=4096))
     ), patch("asr.emformer_rnnt.librispeech.lightning.GlobalStatsNormalization", new=torch.nn.Identity), patch(
         "torchaudio.datasets.LIBRISPEECH", new=MockLIBRISPEECH
     ), patch(

--- a/test/torchaudio_unittest/example/emformer_rnnt/test_mustc_lightning.py
+++ b/test/torchaudio_unittest/example/emformer_rnnt/test_mustc_lightning.py
@@ -29,7 +29,9 @@ class MockMUSTC:
 
 @contextmanager
 def get_lightning_module():
-    with patch("sentencepiece.SentencePieceProcessor", new=partial(MockSentencePieceProcessor, num_symbols=500)), patch(
+    with patch(
+        "sentencepiece.SentencePieceProcessor", new=staticmethod(partial(MockSentencePieceProcessor, num_symbols=500))
+    ), patch(
         "asr.emformer_rnnt.mustc.lightning.GlobalStatsNormalization", new=torch.nn.Identity
     ), patch("asr.emformer_rnnt.mustc.lightning.MUSTC", new=MockMUSTC), patch(
         "asr.emformer_rnnt.mustc.lightning.CustomDataset", new=MockCustomDataset

--- a/test/torchaudio_unittest/example/emformer_rnnt/test_tedlium3_lightning.py
+++ b/test/torchaudio_unittest/example/emformer_rnnt/test_tedlium3_lightning.py
@@ -33,7 +33,9 @@ class MockTEDLIUM:
 
 @contextmanager
 def get_lightning_module():
-    with patch("sentencepiece.SentencePieceProcessor", new=partial(MockSentencePieceProcessor, num_symbols=500)), patch(
+    with patch(
+        "sentencepiece.SentencePieceProcessor", new=staticmethod(partial(MockSentencePieceProcessor, num_symbols=500))
+    ), patch(
         "asr.emformer_rnnt.tedlium3.lightning.GlobalStatsNormalization", new=torch.nn.Identity
     ), patch("torchaudio.datasets.TEDLIUM", new=MockTEDLIUM), patch(
         "asr.emformer_rnnt.tedlium3.lightning.CustomDataset", new=MockCustomDataset

--- a/test/torchaudio_unittest/functional/autograd_impl.py
+++ b/test/torchaudio_unittest/functional/autograd_impl.py
@@ -65,7 +65,7 @@ class Autograd(TestBaseMixin):
         x = get_whitenoise(sample_rate=22050, duration=0.01, n_channels=3)
         a = torch.tensor([[0.7, 0.2, 0.6], [0.8, 0.2, 0.9]])
         b = torch.tensor([[0.4, 0.2, 0.9], [0.7, 0.2, 0.6]])
-        self.assert_grad(partial(F.lfilter, batching=False), (x, a, b))
+        self.assert_grad(staticmethod(partial(F.lfilter, batching=False)), (x, a, b))
 
     def test_lfilter_batching(self):
         x = get_whitenoise(sample_rate=22050, duration=0.01, n_channels=2)

--- a/test/torchaudio_unittest/functional/batch_consistency_test.py
+++ b/test/torchaudio_unittest/functional/batch_consistency_test.py
@@ -62,7 +62,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
             "length": length,
             "rand_init": False,
         }
-        func = partial(F.griffinlim, **kwargs)
+        func = staticmethod(partial(F.griffinlim, **kwargs))
         self.assert_batch_consistency(func, inputs=(batch,), atol=1e-4)
 
     @parameterized.expand(
@@ -89,7 +89,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         kwargs = {
             "sample_rate": sample_rate,
         }
-        func = partial(F.detect_pitch_frequency, **kwargs)
+        func = staticmethod(partial(F.detect_pitch_frequency, **kwargs))
         self.assert_batch_consistency(func, inputs=(waveforms,))
 
     @parameterized.expand(
@@ -111,7 +111,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
             "db_multiplier": db_mult,
             "top_db": top_db,
         }
-        func = partial(F.amplitude_to_DB, **kwargs)
+        func = staticmethod(partial(F.amplitude_to_DB, **kwargs))
         # Test with & without a `top_db` clamp
         self.assert_batch_consistency(func, inputs=(spec,))
 
@@ -141,7 +141,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
             "db_multiplier": db_mult,
             "top_db": top_db,
         }
-        func = partial(F.amplitude_to_DB, **kwargs)
+        func = staticmethod(partial(F.amplitude_to_DB, **kwargs))
         self.assert_batch_consistency(func, inputs=(spec,))
 
     def test_amplitude_to_DB_not_channelwise_clamps(self):
@@ -170,7 +170,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         kwargs = {
             "enhancement_amount": 80.0,
         }
-        func = partial(F.contrast, **kwargs)
+        func = staticmethod(partial(F.contrast, **kwargs))
         self.assert_batch_consistency(func, inputs=(waveforms,))
 
     def test_dcshift(self):
@@ -179,7 +179,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
             "shift": 0.5,
             "limiter_gain": 0.05,
         }
-        func = partial(F.dcshift, **kwargs)
+        func = staticmethod(partial(F.dcshift, **kwargs))
         self.assert_batch_consistency(func, inputs=(waveforms,))
 
     def test_overdrive(self):
@@ -188,7 +188,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
             "gain": 45,
             "colour": 30,
         }
-        func = partial(F.overdrive, **kwargs)
+        func = staticmethod(partial(F.overdrive, **kwargs))
         self.assert_batch_consistency(func, inputs=(waveforms,))
 
     def test_phaser(self):
@@ -201,7 +201,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         kwargs = {
             "sample_rate": sample_rate,
         }
-        func = partial(F.phaser, **kwargs)
+        func = staticmethod(partial(F.phaser, **kwargs))
         self.assert_batch_consistency(func, inputs=(batch,))
 
     def test_flanger(self):
@@ -210,7 +210,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         kwargs = {
             "sample_rate": sample_rate,
         }
-        func = partial(F.flanger, **kwargs)
+        func = staticmethod(partial(F.flanger, **kwargs))
         self.assert_batch_consistency(func, inputs=(waveforms,))
 
     @parameterized.expand(
@@ -228,7 +228,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
             "center": center,
             "norm_vars": norm_vars,
         }
-        func = partial(F.sliding_window_cmn, **kwargs)
+        func = staticmethod(partial(F.sliding_window_cmn, **kwargs))
         self.assert_batch_consistency(func, inputs=(spectrogram,))
 
     @parameterized.expand([("sinc_interp_hann"), ("sinc_interp_kaiser")])
@@ -246,7 +246,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
             "new_freq": new_sr,
             "resampling_method": resampling_method,
         }
-        func = partial(F.resample, **kwargs)
+        func = staticmethod(partial(F.resample, **kwargs))
 
         self.assert_batch_consistency(
             func,
@@ -301,7 +301,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         kwargs = {
             "reference_channel": 0,
         }
-        func = partial(F.mvdr_weights_souden, **kwargs)
+        func = staticmethod(partial(F.mvdr_weights_souden, **kwargs))
         self.assert_batch_consistency(func, (psd_noise, psd_speech))
 
     def test_mvdr_weights_souden_with_tensor(self):
@@ -323,7 +323,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         kwargs = {
             "reference_channel": 0,
         }
-        func = partial(F.mvdr_weights_rtf, **kwargs)
+        func = staticmethod(partial(F.mvdr_weights_rtf, **kwargs))
         self.assert_batch_consistency(func, (rtf, psd_noise))
 
     def test_mvdr_weights_rtf_with_tensor(self):
@@ -360,7 +360,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
             "reference_channel": 0,
             "n_iter": n_iter,
         }
-        func = partial(F.rtf_power, **kwargs)
+        func = staticmethod(partial(F.rtf_power, **kwargs))
         self.assert_batch_consistency(func, (psd_speech, psd_noise))
 
     @parameterized.expand(
@@ -380,7 +380,7 @@ class TestFunctional(common_utils.TorchaudioTestCase):
         kwargs = {
             "n_iter": n_iter,
         }
-        func = partial(F.rtf_power, **kwargs)
+        func = staticmethod(partial(F.rtf_power, **kwargs))
         self.assert_batch_consistency(func, (psd_speech, psd_noise, reference_channel))
 
     def test_apply_beamforming(self):


### PR DESCRIPTION
The following tests failed in Python 3.13 when building the conda-forge package (conda-forge/torchaudio-feedstock#30):

```
FAILED test/torchaudio_unittest/backend/dispatcher/soundfile/info_test.py::TestInfo::test_unknown_subtype_warning - assert 2 == 1
 +  where 2 = len([<warnings.WarningMessage object at 0x1712d0cb0>, <warnings.WarningMessage object at 0x1712d0d40>])
```
This was caused by `FutureWarning: functools.partial will be a method descriptor in future Python versions; wrap it in staticmethod() if you want to preserve the old behavior` in Python 3.13.

```
FAILED test/torchaudio_unittest/datasets/cmuarctic_test.py::TestCMUARCTIC::test_cmuarctic_path - ValueError: bad delimiter value
FAILED test/torchaudio_unittest/datasets/cmuarctic_test.py::TestCMUARCTIC::test_cmuarctic_str - ValueError: bad delimiter value
```
These were caused by `csv.reader(text, delimiter="\n")` in `torchaudio/datasets/cmuarctic.py`, which is not allowed in Python 3.13.
