### PR TITLE
Add skip condition to vggish_pipeline_test test 

### DIFF
--- a/test/integration_tests/prototype/vggish_pipeline_test.py
+++ b/test/integration_tests/prototype/vggish_pipeline_test.py
@@ -1,7 +1,8 @@
 import torchaudio
 from torchaudio.prototype.pipelines import VGGISH
+from torchaudio_unittest.common_utils import skipIfNoExec
 
-
+@skipIfNoExec("ffmpeg")
 def test_vggish():
     input_sr = VGGISH.sample_rate
     input_proc = VGGISH.get_input_processor()


### PR DESCRIPTION
Add skip condition to vggish_pipeline_test test similar to https://github.com/pytorch/audio/blob/main/test/torchaudio_unittest/backend/dispatcher/ffmpeg/save_test.py#L166 if ffmpeg executable is not found

Tested on both rocm and nvidia


