### PR TITLE
Fix CPU Linux unittest job - part 2

### DIFF
--- a/.github/scripts/unittest-linux/install.sh
+++ b/.github/scripts/unittest-linux/install.sh
@@ -97,6 +97,9 @@ fi
     set -x
     conda install -y -c conda-forge ${NUMBA_DEV_CHANNEL} sox libvorbis librosa parameterized 'requests>=2.20' 'ffmpeg>=6,<7'
     pip install kaldi-io SoundFile coverage pytest pytest-cov scipy expecttest unidecode inflect Pillow sentencepiece pytorch-lightning 'protobuf<4.21.0' demucs tinytag pyroomacoustics flashlight-text git+https://github.com/kpu/kenlm
+
+    # TODO: might be better to fix the single call to `pip install` above
+    pip install "pillow<10.0" "scipy<1.10" "numpy<2.0"
 )
 # Install fairseq
 git clone https://github.com/pytorch/fairseq


### PR DESCRIPTION
We need to pin down numpy, scipy and PIL deps in unittests, otherwise we get cryptic [error](https://github.com/pytorch/audio/actions/runs/15609671867/job/43967331170?pr=3926) during test collection: 

```
 ImportError: cannot import name 'NP_SUPPORTED_MODULES' from 'torch._dynamo.utils'
```

which, by printing this exception from torch core:

https://github.com/pytorch/pytorch/blob/eecaa0bbc6a39c89366f9ec97797479c27f6d760/torch/_dynamo/utils.py#L142-L143

reveals itself as a GLIBCXX error symbol error.


Tests are failing, but at least now they're running.