### PR TITLE
Set TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_FFMPEG to true for CPU unittest job

### DIFF
--- a/.github/workflows/unittest-linux-cpu.yml
+++ b/.github/workflows/unittest-linux-cpu.yml
@@ -56,6 +56,7 @@ jobs:
         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_TEMPORARY_DISABLED=true
         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_SOX_DECODER=true
         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_SOX_ENCODER=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_FFMPEG=true
         echo '::endgroup::'
 
         set -euxo pipefail


### PR DESCRIPTION
…jobs

<strong>PLEASE NOTE THAT THE TORCHAUDIO REPOSITORY IS NO LONGER ACTIVELY MONITORED.</strong> You may not get a response. For open discussions, visit https://discuss.pytorch.org/.
