### PR TITLE
[rocm] Fix current torch.linalg.lstsq limitation in InverseMelScale module

### DIFF
--- a/src/torchaudio/transforms/_transforms.py
+++ b/src/torchaudio/transforms/_transforms.py
@@ -17,6 +17,7 @@ from torchaudio.functional.functional import (
     _get_sinc_resample_kernel,
     _stretch_waveform,
 )
+from torch.utils.cpp_extension import ROCM_HOME
 
 __all__ = []
 
@@ -495,7 +496,11 @@ class InverseMelScale(torch.nn.Module):
         if self.n_mels != n_mels:
             raise ValueError("Expected an input with {} mel bins. Found: {}".format(self.n_mels, n_mels))
 
-        specgram = torch.relu(torch.linalg.lstsq(self.fb.transpose(-1, -2)[None], melspec, driver=self.driver).solution)
+        if ROCM_HOME is not None:
+            solution = torch.linalg.pinv(self.fb.transpose(-1, -2)[None]) @ melspec
+        else:
+            solution = torch.linalg.lstsq(self.fb.transpose(-1, -2)[None], melspec, driver=self.driver).solution
+        specgram = torch.relu(solution)
 
         # unpack batch
         specgram = specgram.view(shape[:-2] + (freq, time))


### PR DESCRIPTION
This PR fixes the following error:
`RuntimeError: torch.linalg.lstsq: only overdetermined systems (input.size(-2) >= input.size(-1)) are allowed on CUDA. Please rebuild with cuSOLVER`

Checking the pytorch code https://github.com/ROCm/pytorch/blob/main/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp, it calls magma. According to magma documentation, least squares method - magma_sgels_gpu supports only overdetermined systems https://icl.utk.edu/projectsfiles/magma/doxygen/group__magma__gels.html

The proposed temporary solution uses https://docs.pytorch.org/docs/stable/generated/torch.linalg.pinv.html as a replacement for linear least squares. This change can be reverted once torch.linalg.lstsq uses hipSolver for underconstrained systems.

Tested on rocm with 
`pytest test/torchaudio_unittest/transforms/transforms_cuda_test.py -k test_inverse_melscale`
