### PR TITLE
[2.8 release] Rely on release/2.8 from test-infra

### DIFF
--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -23,12 +23,12 @@ permissions:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@release/2.8
     with:
       package-type: wheel
       os: macos-arm64
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.8
   build:
     needs: generate-matrix
     strategy:
@@ -39,12 +39,12 @@ jobs:
             smoke-test-script: test/smoke_test/smoke_test_no_ffmpeg.py
             package-name: torchaudio
     name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_macos.yml@main
+    uses: pytorch/test-infra/.github/workflows/build_wheels_macos.yml@release/2.8
     with:
       repository: ${{ matrix.repository }}
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.8
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
       runner-type: macos-m1-stable

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -22,7 +22,7 @@ jobs:
     # Do not use matrix here to parameterize Python/CUDA versions.
     # This job is required to pass for each PR.
     # The name of the required job is sensitive to matrix parameter.
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.8
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/build_wheels_aarch64_linux.yml
+++ b/.github/workflows/build_wheels_aarch64_linux.yml
@@ -23,12 +23,12 @@ permissions:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@release/2.8
     with:
       package-type: wheel
       os: linux-aarch64
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.8
       with-cuda: enable
   build:
     needs: generate-matrix
@@ -40,12 +40,12 @@ jobs:
             smoke-test-script: test/smoke_test/smoke_test.py
             package-name: torchaudio
     name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@release/2.8
     with:
       repository: ${{ matrix.repository }}
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.8
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -23,12 +23,12 @@ permissions:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@release/2.8
     with:
       package-type: wheel
       os: linux
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.8
       with-xpu: enable
   build:
     needs: generate-matrix
@@ -40,12 +40,12 @@ jobs:
             smoke-test-script: test/smoke_test/smoke_test_no_ffmpeg.py
             package-name: torchaudio
     name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@release/2.8
     with:
       repository: ${{ matrix.repository }}
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.8
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
       package-name: ${{ matrix.package-name }}

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -19,12 +19,12 @@ permissions:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@release/2.8
     with:
       package-type: wheel
       os: windows
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.8
       with-xpu: enable
   build:
     needs: generate-matrix
@@ -38,12 +38,12 @@ jobs:
             smoke-test-script: test/smoke_test/smoke_test_no_ffmpeg.py
             package-name: torchaudio
     name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_windows.yml@main
+    uses: pytorch/test-infra/.github/workflows/build_wheels_windows.yml@release/2.8
     with:
       repository: ${{ matrix.repository }}
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.8
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       env-script: ${{ matrix.env-script }}
       package-name: ${{ matrix.package-name }}

--- a/.github/workflows/ffmpeg.yml
+++ b/.github/workflows/ffmpeg.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         ffmpeg_version: ["4.4.4", "5.1.4", "6.1.1", "master"]
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.8
     permissions:
       id-token: write
       contents: read
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         ffmpeg_version: ["4.4.4", "5.1.4", "6.1.1", "master"]
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.8
     permissions:
       id-token: write
       contents: read
@@ -69,7 +69,7 @@ jobs:
       matrix:
         ffmpeg_version: ["4.4.4", "5.1.4", "6.1.1", "master"]
         runner: ["macos-m1-stable", "macos-12"]
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.8
     with:
       job-name: Build
       upload-artifact: ffmpeg-lgpl
@@ -91,7 +91,7 @@ jobs:
       fail-fast: false
       matrix:
         ffmpeg_version: ["4.4.4", "5.1.4", "6.1.1", "master"]
-    uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/windows_job.yml@release/2.8
     with:
       job-name: Build
       upload-artifact: ffmpeg-lgpl

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@
 
 # jobs:
 #   python-source-and-configs:
-#     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+#     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.8
 #     permissions:
 #       id-token: write
 #       contents: read

--- a/.github/workflows/unittest-linux-cpu.yml
+++ b/.github/workflows/unittest-linux-cpu.yml
@@ -16,7 +16,7 @@ jobs:
         # TODO all from 3.9 to 3.13
         python_version: ["3.11"]
       fail-fast: false
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.8
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/unittest-linux-gpu.yml
+++ b/.github/workflows/unittest-linux-gpu.yml
@@ -17,7 +17,7 @@
 #         python_version: ["3.9", "3.10"]
 #         cuda_arch_version: ["12.6"]
 #       fail-fast: false
-#     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+#     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.8
 #     permissions:
 #       id-token: write
 #       contents: read

--- a/.github/workflows/unittest-macos-cpu.yml
+++ b/.github/workflows/unittest-macos-cpu.yml
@@ -14,7 +14,7 @@
 
 # jobs:
 #   tests:
-#     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+#     uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.8
 #     with:
 #       runner: macos-12
 #       repository: pytorch/audio

--- a/.github/workflows/unittest-windows-cpu.yml
+++ b/.github/workflows/unittest-windows-cpu.yml
@@ -11,7 +11,7 @@
 
 # jobs:
 #   unittests-windows-cpu:
-#     uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
+#     uses: pytorch/test-infra/.github/workflows/windows_job.yml@release/2.8
 #     with:
 #       repository: pytorch/audio
 #       runner: windows.4xlarge

--- a/.github/workflows/unittest-windows-gpu.yml
+++ b/.github/workflows/unittest-windows-gpu.yml
@@ -11,7 +11,7 @@
 
 # jobs:
 #   unittests-windows-gpu:
-#     uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
+#     uses: pytorch/test-infra/.github/workflows/windows_job.yml@release/2.8
 #     with:
 #       repository: pytorch/audio
 #       runner: windows.g5.4xlarge.nvidia.gpu


### PR DESCRIPTION
<strong>PLEASE NOTE THAT THE TORCHAUDIO REPOSITORY IS NO LONGER ACTIVELY MONITORED.</strong> You may not get a response. For open discussions, visit https://discuss.pytorch.org/.
