### PR TITLE
Add IO warning for functionality moved to TorchCodec

### DIFF
--- a/src/torchaudio/__init__.py
+++ b/src/torchaudio/__init__.py
@@ -1,4 +1,4 @@
-from torchaudio._internal.module_utils import dropping_support
+from torchaudio._internal.module_utils import dropping_io_support
 
 # Initialize extension and backend first
 from . import _extension  # noqa  # usort: skip
@@ -12,8 +12,8 @@ from ._backend import (  # noqa  # usort: skip
     set_audio_backend,
 )
 
-load = dropping_support(_load)
-save = dropping_support(_save)
+load = dropping_io_support(_load)
+save = dropping_io_support(_save)
 
 from . import (  # noqa: F401
     compliance,

--- a/src/torchaudio/_internal/module_utils.py
+++ b/src/torchaudio/_internal/module_utils.py
@@ -100,6 +100,10 @@ dropping_support = deprecated(
     "As TorchAudio is no longer being actively developed, this function can no longer be supported."
     "See https://github.com/pytorch/audio/issues/3902 for more details.", version="2.9", remove=True)
 
+dropping_io_support = deprecated(
+    "This functionality has been superseded by `AudioDecoder` from the TorchCodec library."
+    "See https://github.com/pytorch/audio/issues/3902 for more details.", version="2.9", remove=True)
+
 def fail_with_message(message):
     """Generate decorator to give users message about missing TorchAudio extension."""
 

--- a/src/torchaudio/io/__init__.py
+++ b/src/torchaudio/io/__init__.py
@@ -1,14 +1,14 @@
 from torio.io import CodecConfig, StreamingMediaDecoder as StreamReader, StreamingMediaEncoder as StreamWriter
-from torchaudio._internal.module_utils import dropping_support
+from torchaudio._internal.module_utils import dropping_io_support
 
 from ._effector import AudioEffector
 from ._playback import play_audio as _play_audio
 
-CodecConfig.__init__ = dropping_support(CodecConfig.__init__)
-StreamReader.__init__ = dropping_support(StreamReader.__init__)
-StreamWriter.__init__ = dropping_support(StreamWriter.__init__)
-AudioEffector.__init__ = dropping_support(AudioEffector.__init__)
-play_audio = dropping_support(_play_audio)
+CodecConfig.__init__ = dropping_io_support(CodecConfig.__init__)
+StreamReader.__init__ = dropping_io_support(StreamReader.__init__)
+StreamWriter.__init__ = dropping_io_support(StreamWriter.__init__)
+AudioEffector.__init__ = dropping_io_support(AudioEffector.__init__)
+play_audio = dropping_io_support(_play_audio)
 
 
 __all__ = [


### PR DESCRIPTION
<strong>PLEASE NOTE THAT THE TORCHAUDIO REPOSITORY IS NO LONGER ACTIVELY MONITORED.</strong> You may not get a response. For open discussions, visit https://discuss.pytorch.org/.
