### PR TITLE
[release 2.8] cherry-pick

### DIFF
--- a/src/torchaudio/functional/__init__.py
+++ b/src/torchaudio/functional/__init__.py
@@ -58,7 +58,7 @@ from .functional import (
     preemphasis,
     psd,
     resample,
-    rnnt_loss as _rnnt_loss,
+    rnnt_loss,
     rtf_evd,
     rtf_power,
     sliding_window_cmn,
@@ -67,7 +67,6 @@ from .functional import (
     speed,
 )
 
-rnnt_loss = dropping_support(_rnnt_loss)
 __all__ = [
     "amplitude_to_DB",
     "compute_deltas",

--- a/src/torchaudio/functional/filtering.py
+++ b/src/torchaudio/functional/filtering.py
@@ -6,6 +6,7 @@ import torch
 from torch import Tensor
 
 from torchaudio._extension import _IS_TORCHAUDIO_EXT_AVAILABLE
+from torchaudio._internal.module_utils import dropping_support
 
 
 def _dB2Linear(x: float) -> float:
@@ -324,7 +325,7 @@ def biquad(waveform: Tensor, b0: float, b1: float, b2: float, a0: float, a1: flo
     a1 = torch.as_tensor(a1, dtype=dtype, device=device).view(1)
     a2 = torch.as_tensor(a2, dtype=dtype, device=device).view(1)
 
-    output_waveform = lfilter(
+    output_waveform = _lfilter_deprecated(
         waveform,
         torch.cat([a0, a1, a2]),
         torch.cat([b0, b1, b2]),
@@ -698,8 +699,8 @@ def filtfilt(
         Tensor: Waveform with dimension of either `(..., num_filters, time)` if ``a_coeffs`` and ``b_coeffs``
         are 2D Tensors, or `(..., time)` otherwise.
     """
-    forward_filtered = lfilter(waveform, a_coeffs, b_coeffs, clamp=False, batching=True)
-    backward_filtered = lfilter(
+    forward_filtered = _lfilter_deprecated(waveform, a_coeffs, b_coeffs, clamp=False, batching=True)
+    backward_filtered = _lfilter_deprecated(
         forward_filtered.flip(-1),
         a_coeffs,
         b_coeffs,
@@ -997,7 +998,7 @@ else:
     _lfilter = _lfilter_core
 
 
-def lfilter(waveform: Tensor, a_coeffs: Tensor, b_coeffs: Tensor, clamp: bool = True, batching: bool = True) -> Tensor:
+def _lfilter_deprecated(waveform: Tensor, a_coeffs: Tensor, b_coeffs: Tensor, clamp: bool = True, batching: bool = True) -> Tensor:
     r"""Perform an IIR filter by evaluating difference equation, using differentiable implementation
     developed separately by *Yu et al.* :cite:`ismir_YuF23` and *Forgione et al.* :cite:`forgione2021dynonet`.
     The gradients of ``a_coeffs`` are computed based on a faster algorithm from :cite:`ycy2024diffapf`.
@@ -1066,6 +1067,7 @@ def lfilter(waveform: Tensor, a_coeffs: Tensor, b_coeffs: Tensor, clamp: bool = 
 
     return output
 
+lfilter = dropping_support(_lfilter_deprecated)
 
 def lowpass_biquad(waveform: Tensor, sample_rate: int, cutoff_freq: float, Q: float = 0.707) -> Tensor:
     r"""Design biquad lowpass filter and perform filtering.  Similar to SoX implementation.
@@ -1115,7 +1117,7 @@ else:
     _overdrive_core_loop_cpu = _overdrive_core_loop_generic
 
 
-def overdrive(waveform: Tensor, gain: float = 20, colour: float = 20) -> Tensor:
+def _overdrive_deprecated(waveform: Tensor, gain: float = 20, colour: float = 20) -> Tensor:
     r"""Apply a overdrive effect to the audio. Similar to SoX implementation.
 
     .. devices:: CPU CUDA
@@ -1170,6 +1172,7 @@ def overdrive(waveform: Tensor, gain: float = 20, colour: float = 20) -> Tensor:
 
     return output_waveform.clamp(min=-1, max=1).view(actual_shape)
 
+overdrive = dropping_support(_overdrive_deprecated)
 
 def phaser(
     waveform: Tensor,

--- a/src/torchaudio/functional/functional.py
+++ b/src/torchaudio/functional/functional.py
@@ -9,7 +9,8 @@ from typing import List, Optional, Tuple, Union
 import torch
 import torchaudio
 from torch import Tensor
-from torchaudio._internal.module_utils import deprecated
+from torchaudio._internal.module_utils import deprecated, dropping_support
+
 
 from .filtering import highpass_biquad, treble_biquad
 
@@ -1760,7 +1761,7 @@ def _fix_waveform_shape(
     return waveform_shift
 
 
-def rnnt_loss(
+def _rnnt_loss(
     logits: Tensor,
     targets: Tensor,
     logit_lengths: Tensor,
@@ -1864,6 +1865,9 @@ def psd(
     psd = psd.sum(dim=-3)
     return psd
 
+# Expose both deprecated wrapper as well as original because torchscript breaks on
+# wrapped functions.
+rnnt_loss = dropping_support(_rnnt_loss)
 
 def _compute_mat_trace(input: torch.Tensor, dim1: int = -1, dim2: int = -2) -> torch.Tensor:
     r"""Compute the trace of a Tensor along ``dim1`` and ``dim2`` dimensions.
@@ -2472,7 +2476,7 @@ def preemphasis(waveform, coeff: float = 0.97) -> torch.Tensor:
     return waveform
 
 
-def deemphasis(waveform, coeff: float = 0.97) -> torch.Tensor:
+def _deemphasis(waveform, coeff: float = 0.97) -> torch.Tensor:
     r"""De-emphasizes a waveform along its last dimension.
     Inverse of :meth:`preemphasis`. Concretely, for each signal
     :math:`x` in ``waveform``, computes output :math:`y` as
@@ -2494,8 +2498,9 @@ def deemphasis(waveform, coeff: float = 0.97) -> torch.Tensor:
     """
     a_coeffs = torch.tensor([1.0, -coeff], dtype=waveform.dtype, device=waveform.device)
     b_coeffs = torch.tensor([1.0, 0.0], dtype=waveform.dtype, device=waveform.device)
-    return torchaudio.functional.lfilter(waveform, a_coeffs=a_coeffs, b_coeffs=b_coeffs)
+    return torchaudio.functional.filtering._lfilter_deprecated(waveform, a_coeffs=a_coeffs, b_coeffs=b_coeffs)
 
+deemphasis = dropping_support(_deemphasis)
 
 def frechet_distance(mu_x, sigma_x, mu_y, sigma_y):
     r"""Computes the Fréchet distance between two multivariate normal distributions :cite:`dowson1982frechet`.

--- a/src/torchaudio/models/decoder/__init__.py
+++ b/src/torchaudio/models/decoder/__init__.py
@@ -1,4 +1,5 @@
-from torchaudio._internal.module_utils import dropping_support
+from torchaudio._internal.module_utils import dropping_support, dropping_class_support
+import inspect
 _CTC_DECODERS = [
     "CTCHypothesis",
     "CTCDecoder",
@@ -34,7 +35,11 @@ def __getattr__(name: str):
                 "To use CUCTC decoder, please set BUILD_CUDA_CTC_DECODER=1 when building from source."
             ) from err
 
-        item = dropping_support(getattr(_cuda_ctc_decoder, name))
+        orig_item = getattr(_cuda_ctc_decoder, name)
+        if inspect.isclass(orig_item):
+            item = dropping_class_support(orig_item)
+        else:
+            item = dropping_support(orig_item)
         globals()[name] = item
         return item
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/torchaudio/transforms/_transforms.py
+++ b/src/torchaudio/transforms/_transforms.py
@@ -10,7 +10,7 @@ from torch.nn.modules.lazy import LazyModuleMixin
 from torch.nn.parameter import UninitializedParameter
 
 from torchaudio import functional as F
-from torchaudio.functional.functional import rnnt_loss
+from torchaudio.functional.functional import _rnnt_loss
 from torchaudio.functional.functional import (
     _apply_sinc_resample_kernel,
     _check_convolve_mode,
@@ -1847,7 +1847,7 @@ class RNNTLoss(torch.nn.Module):
             Tensor: Loss with the reduction option applied. If ``reduction`` is  ``"none"``, then size (batch),
             otherwise scalar.
         """
-        return rnnt_loss(
+        return _rnnt_loss(
             logits,
             targets,
             logit_lengths,
@@ -2135,4 +2135,4 @@ class Deemphasis(torch.nn.Module):
         Returns:
             torch.Tensor: De-emphasized waveform, with shape `(..., N)`.
         """
-        return F.deemphasis(waveform, coeff=self.coeff)
+        return F.functional._deemphasis(waveform, coeff=self.coeff)

--- a/test/torchaudio_unittest/common_utils/func_utils.py
+++ b/test/torchaudio_unittest/common_utils/func_utils.py
@@ -6,6 +6,13 @@ import torch
 def torch_script(obj):
     """TorchScript the given function or Module"""
     buffer = io.BytesIO()
+    if hasattr(obj, '__wrapped__'):
+        # This is hack for those functions which are deprecated with decorators
+        # like @deprecated or @dropping_support. Adding the decorators breaks
+        # TorchScript. We need to unwrap the function to get the original one,
+        # which make the tests pass, but that's a lie: the public (deprecated)
+        # function doesn't support torchscript anymore
+        obj = obj.__wrapped__
     torch.jit.save(torch.jit.script(obj), buffer)
     buffer.seek(0)
     return torch.jit.load(buffer)

--- a/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
@@ -285,7 +285,12 @@ class Functional(TempDirMixin, TestBaseMixin):
             device=waveform.device,
             dtype=waveform.dtype,
         )
-        self._assert_consistency(F.lfilter, (waveform, a_coeffs, b_coeffs, True, True))
+        # This is hack for those functions which are deprecated with decorators
+        # like @deprecated or @dropping_support. Adding the decorators breaks
+        # TorchScript. So here we use the private function which make the tests
+        # pass, but that's a lie: the public (deprecated) function doesn't
+        # support torchscript anymore
+        self._assert_consistency(F.filtering._lfilter_deprecated, (waveform, a_coeffs, b_coeffs, True, True))
 
     def test_filtfilt(self):
         waveform = common_utils.get_whitenoise(sample_rate=8000)
@@ -485,7 +490,7 @@ class Functional(TempDirMixin, TestBaseMixin):
         def func(tensor):
             a = torch.tensor([0.7, 0.2, 0.6], device=tensor.device, dtype=tensor.dtype)
             b = torch.tensor([0.4, 0.2, 0.9], device=tensor.device, dtype=tensor.dtype)
-            return F.lfilter(tensor, a, b)
+            return F.filtering._lfilter_deprecated(tensor, a, b)
 
         self._assert_consistency(func, (waveform,))
 
@@ -530,7 +535,12 @@ class Functional(TempDirMixin, TestBaseMixin):
         def func(tensor):
             gain = 30.0
             colour = 50.0
-            return F.overdrive(tensor, gain, colour)
+            # This is hack for those functions which are deprecated with decorators
+            # like @deprecated or @dropping_support. Adding the decorators breaks
+            # TorchScript. So here we use the private function which make the tests
+            # pass, but that's a lie: the public (deprecated) function doesn't
+            # support torchscript anymore
+            return F.filtering._overdrive_deprecated(tensor, gain, colour)
 
         self._assert_consistency(func, (waveform,))
 
@@ -803,7 +813,12 @@ class FunctionalFloat32Only(TestBaseMixin):
             targets = torch.tensor([[1, 2]], device=tensor.device, dtype=torch.int32)
             logit_lengths = torch.tensor([2], device=tensor.device, dtype=torch.int32)
             target_lengths = torch.tensor([2], device=tensor.device, dtype=torch.int32)
-            return rnnt_loss(tensor, targets, logit_lengths, target_lengths)
+            # This is hack for those functions which are deprecated with decorators
+            # like @deprecated or @dropping_support. Adding the decorators breaks
+            # TorchScript. So here we use the private function which make the tests
+            # pass, but that's a lie: the public (deprecated) function doesn't
+            # support torchscript anymore
+            return F.functional._rnnt_loss(tensor, targets, logit_lengths, target_lengths)
 
         logits = torch.tensor(
             [


### PR DESCRIPTION
CP of https://github.com/pytorch/audio/pull/3959, adding more deprecations.