### PR TITLE
remove dep warnings for lfilter and overdrive

### DIFF
--- a/src/torchaudio/functional/filtering.py
+++ b/src/torchaudio/functional/filtering.py
@@ -6,7 +6,6 @@ import torch
 from torch import Tensor
 
 from torchaudio._extension import _IS_TORCHAUDIO_EXT_AVAILABLE
-from torchaudio._internal.module_utils import dropping_support
 
 
 def _dB2Linear(x: float) -> float:
@@ -325,7 +324,7 @@ def biquad(waveform: Tensor, b0: float, b1: float, b2: float, a0: float, a1: flo
     a1 = torch.as_tensor(a1, dtype=dtype, device=device).view(1)
     a2 = torch.as_tensor(a2, dtype=dtype, device=device).view(1)
 
-    output_waveform = _lfilter_deprecated(
+    output_waveform = lfilter(
         waveform,
         torch.cat([a0, a1, a2]),
         torch.cat([b0, b1, b2]),
@@ -699,8 +698,8 @@ def filtfilt(
         Tensor: Waveform with dimension of either `(..., num_filters, time)` if ``a_coeffs`` and ``b_coeffs``
         are 2D Tensors, or `(..., time)` otherwise.
     """
-    forward_filtered = _lfilter_deprecated(waveform, a_coeffs, b_coeffs, clamp=False, batching=True)
-    backward_filtered = _lfilter_deprecated(
+    forward_filtered = lfilter(waveform, a_coeffs, b_coeffs, clamp=False, batching=True)
+    backward_filtered = lfilter(
         forward_filtered.flip(-1),
         a_coeffs,
         b_coeffs,
@@ -998,7 +997,7 @@ else:
     _lfilter = _lfilter_core
 
 
-def _lfilter_deprecated(waveform: Tensor, a_coeffs: Tensor, b_coeffs: Tensor, clamp: bool = True, batching: bool = True) -> Tensor:
+def lfilter(waveform: Tensor, a_coeffs: Tensor, b_coeffs: Tensor, clamp: bool = True, batching: bool = True) -> Tensor:
     r"""Perform an IIR filter by evaluating difference equation, using differentiable implementation
     developed separately by *Yu et al.* :cite:`ismir_YuF23` and *Forgione et al.* :cite:`forgione2021dynonet`.
     The gradients of ``a_coeffs`` are computed based on a faster algorithm from :cite:`ycy2024diffapf`.
@@ -1067,7 +1066,6 @@ def _lfilter_deprecated(waveform: Tensor, a_coeffs: Tensor, b_coeffs: Tensor, cl
 
     return output
 
-lfilter = dropping_support(_lfilter_deprecated)
 
 def lowpass_biquad(waveform: Tensor, sample_rate: int, cutoff_freq: float, Q: float = 0.707) -> Tensor:
     r"""Design biquad lowpass filter and perform filtering.  Similar to SoX implementation.
@@ -1117,7 +1115,7 @@ else:
     _overdrive_core_loop_cpu = _overdrive_core_loop_generic
 
 
-def _overdrive_deprecated(waveform: Tensor, gain: float = 20, colour: float = 20) -> Tensor:
+def overdrive(waveform: Tensor, gain: float = 20, colour: float = 20) -> Tensor:
     r"""Apply a overdrive effect to the audio. Similar to SoX implementation.
 
     .. devices:: CPU CUDA
@@ -1172,7 +1170,6 @@ def _overdrive_deprecated(waveform: Tensor, gain: float = 20, colour: float = 20
 
     return output_waveform.clamp(min=-1, max=1).view(actual_shape)
 
-overdrive = dropping_support(_overdrive_deprecated)
 
 def phaser(
     waveform: Tensor,

--- a/src/torchaudio/functional/functional.py
+++ b/src/torchaudio/functional/functional.py
@@ -2476,7 +2476,7 @@ def preemphasis(waveform, coeff: float = 0.97) -> torch.Tensor:
     return waveform
 
 
-def _deemphasis(waveform, coeff: float = 0.97) -> torch.Tensor:
+def deemphasis(waveform, coeff: float = 0.97) -> torch.Tensor:
     r"""De-emphasizes a waveform along its last dimension.
     Inverse of :meth:`preemphasis`. Concretely, for each signal
     :math:`x` in ``waveform``, computes output :math:`y` as
@@ -2498,9 +2498,8 @@ def _deemphasis(waveform, coeff: float = 0.97) -> torch.Tensor:
     """
     a_coeffs = torch.tensor([1.0, -coeff], dtype=waveform.dtype, device=waveform.device)
     b_coeffs = torch.tensor([1.0, 0.0], dtype=waveform.dtype, device=waveform.device)
-    return torchaudio.functional.filtering._lfilter_deprecated(waveform, a_coeffs=a_coeffs, b_coeffs=b_coeffs)
+    return torchaudio.functional.filtering.lfilter(waveform, a_coeffs=a_coeffs, b_coeffs=b_coeffs)
 
-deemphasis = dropping_support(_deemphasis)
 
 def frechet_distance(mu_x, sigma_x, mu_y, sigma_y):
     r"""Computes the Fréchet distance between two multivariate normal distributions :cite:`dowson1982frechet`.

--- a/src/torchaudio/transforms/_transforms.py
+++ b/src/torchaudio/transforms/_transforms.py
@@ -2135,4 +2135,4 @@ class Deemphasis(torch.nn.Module):
         Returns:
             torch.Tensor: De-emphasized waveform, with shape `(..., N)`.
         """
-        return F.functional._deemphasis(waveform, coeff=self.coeff)
+        return F.functional.deemphasis(waveform, coeff=self.coeff)

--- a/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
@@ -285,12 +285,7 @@ class Functional(TempDirMixin, TestBaseMixin):
             device=waveform.device,
             dtype=waveform.dtype,
         )
-        # This is hack for those functions which are deprecated with decorators
-        # like @deprecated or @dropping_support. Adding the decorators breaks
-        # TorchScript. So here we use the private function which make the tests
-        # pass, but that's a lie: the public (deprecated) function doesn't
-        # support torchscript anymore
-        self._assert_consistency(F.filtering._lfilter_deprecated, (waveform, a_coeffs, b_coeffs, True, True))
+        self._assert_consistency(F.lfilter, (waveform, a_coeffs, b_coeffs, True, True))
 
     def test_filtfilt(self):
         waveform = common_utils.get_whitenoise(sample_rate=8000)
@@ -535,12 +530,7 @@ class Functional(TempDirMixin, TestBaseMixin):
         def func(tensor):
             gain = 30.0
             colour = 50.0
-            # This is hack for those functions which are deprecated with decorators
-            # like @deprecated or @dropping_support. Adding the decorators breaks
-            # TorchScript. So here we use the private function which make the tests
-            # pass, but that's a lie: the public (deprecated) function doesn't
-            # support torchscript anymore
-            return F.filtering._overdrive_deprecated(tensor, gain, colour)
+            return F.overdrive(tensor, gain, colour)
 
         self._assert_consistency(func, (waveform,))
 


### PR DESCRIPTION
Those have python fallbacks, so we don't need to raise a warning.