### PR TITLE
Use torchcodec for loading

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Minimum runtime dependencies
 torch
+torchcodec
 
 # Optional runtime dependencies
 kaldi_io

--- a/src/torchaudio/datasets/cmuarctic.py
+++ b/src/torchaudio/datasets/cmuarctic.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Tuple, Union
 
 import torchaudio
+from torchaudio.utils import load_torchcodec
 from torch import Tensor
 from torch.utils.data import Dataset
 from torchaudio._internal import download_url_to_file
@@ -43,7 +44,7 @@ def load_cmuarctic_item(line: str, path: str, folder_audio: str, ext_audio: str)
     file_audio = os.path.join(path, folder_audio, utterance_id + ext_audio)
 
     # Load audio
-    waveform, sample_rate = torchaudio.load(file_audio)
+    waveform, sample_rate = load_torchcodec(file_audio)
 
     return (waveform, sample_rate, transcript, utterance_id.split("_")[1])
 

--- a/src/torchaudio/datasets/commonvoice.py
+++ b/src/torchaudio/datasets/commonvoice.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Tuple, Union
 import torchaudio
 from torch import Tensor
 from torch.utils.data import Dataset
+from torchaudio.utils import load_torchcodec
 
 
 def load_commonvoice_item(
@@ -20,7 +21,7 @@ def load_commonvoice_item(
     filename = os.path.join(path, folder_audio, fileid)
     if not filename.endswith(ext_audio):
         filename += ext_audio
-    waveform, sample_rate = torchaudio.load(filename)
+    waveform, sample_rate = load_torchcodec(filename)
 
     dic = dict(zip(header, line))
 

--- a/src/torchaudio/datasets/dr_vctk.py
+++ b/src/torchaudio/datasets/dr_vctk.py
@@ -6,6 +6,7 @@ from torch import Tensor
 from torch.utils.data import Dataset
 from torchaudio._internal import download_url_to_file
 from torchaudio.datasets.utils import _extract_zip
+from torchaudio.utils import load_torchcodec
 
 
 _URL = "https://datashare.ed.ac.uk/bitstream/handle/10283/3038/DR-VCTK.zip"
@@ -75,8 +76,8 @@ class DR_VCTK(Dataset):
         source, channel_id = self._config[filename]
         file_clean_audio = self._clean_audio_dir / filename
         file_noisy_audio = self._noisy_audio_dir / filename
-        waveform_clean, sample_rate_clean = torchaudio.load(file_clean_audio)
-        waveform_noisy, sample_rate_noisy = torchaudio.load(file_noisy_audio)
+        waveform_clean, sample_rate_clean = load_torchcodec(file_clean_audio)
+        waveform_noisy, sample_rate_noisy = load_torchcodec(file_noisy_audio)
         return (
             waveform_clean,
             sample_rate_clean,

--- a/src/torchaudio/datasets/gtzan.py
+++ b/src/torchaudio/datasets/gtzan.py
@@ -7,6 +7,7 @@ from torch import Tensor
 from torch.utils.data import Dataset
 from torchaudio._internal import download_url_to_file
 from torchaudio.datasets.utils import _extract_tar
+from torchaudio.utils import load_torchcodec
 
 # The following lists prefixed with `filtered_` provide a filtered split
 # that:
@@ -990,7 +991,7 @@ def load_gtzan_item(fileid: str, path: str, ext_audio: str) -> Tuple[Tensor, str
 
     # Read wav
     file_audio = os.path.join(path, label, fileid + ext_audio)
-    waveform, sample_rate = torchaudio.load(file_audio)
+    waveform, sample_rate = load_torchcodec(file_audio)
 
     return waveform, sample_rate, label
 

--- a/src/torchaudio/datasets/librilight_limited.py
+++ b/src/torchaudio/datasets/librilight_limited.py
@@ -8,6 +8,7 @@ from torch.utils.data import Dataset
 from torchaudio._internal import download_url_to_file
 from torchaudio.datasets.librispeech import _get_librispeech_metadata
 from torchaudio.datasets.utils import _extract_tar
+from torchaudio.utils import load_torchcodec
 
 
 _ARCHIVE_NAME = "librispeech_finetuning"
@@ -104,7 +105,7 @@ class LibriLightLimited(Dataset):
         """
         file_path, fileid = self._fileids_paths[n]
         metadata = _get_librispeech_metadata(fileid, self._path, file_path, self._ext_audio, self._ext_txt)
-        waveform, _ = torchaudio.load(os.path.join(self._path, metadata[0]))
+        waveform, _ = load_torchcodec(os.path.join(self._path, metadata[0]))
         return (waveform,) + metadata[1:]
 
     def __len__(self) -> int:

--- a/src/torchaudio/datasets/libritts.py
+++ b/src/torchaudio/datasets/libritts.py
@@ -7,6 +7,7 @@ from torch import Tensor
 from torch.utils.data import Dataset
 from torchaudio._internal import download_url_to_file
 from torchaudio.datasets.utils import _extract_tar
+from torchaudio.utils import load_torchcodec
 
 URL = "train-clean-100"
 FOLDER_IN_ARCHIVE = "LibriTTS"
@@ -41,7 +42,7 @@ def load_libritts_item(
     file_audio = os.path.join(path, speaker_id, chapter_id, file_audio)
 
     # Load audio
-    waveform, sample_rate = torchaudio.load(file_audio)
+    waveform, sample_rate = load_torchcodec(file_audio)
 
     # Load original text
     with open(original_text) as ft:

--- a/src/torchaudio/datasets/ljspeech.py
+++ b/src/torchaudio/datasets/ljspeech.py
@@ -8,7 +8,7 @@ from torch import Tensor
 from torch.utils.data import Dataset
 from torchaudio._internal import download_url_to_file
 from torchaudio.datasets.utils import _extract_tar
-
+from torchaudio.utils import load_torchcodec
 
 _RELEASE_CONFIGS = {
     "release1": {
@@ -94,7 +94,7 @@ class LJSPEECH(Dataset):
         fileid_audio = self._path / (fileid + ".wav")
 
         # Load audio
-        waveform, sample_rate = torchaudio.load(fileid_audio)
+        waveform, sample_rate = load_torchcodec(fileid_audio)
 
         return (
             waveform,

--- a/src/torchaudio/datasets/musdb_hq.py
+++ b/src/torchaudio/datasets/musdb_hq.py
@@ -7,6 +7,7 @@ import torchaudio
 from torch.utils.data import Dataset
 from torchaudio._internal import download_url_to_file
 from torchaudio.datasets.utils import _extract_zip
+from torchaudio.utils import load_torchcodec
 
 _URL = "https://zenodo.org/record/3338373/files/musdb18hq.zip"
 _CHECKSUM = "baac80d0483c61d74b2e5f3be75fa557eec52898339e6aa45c1fa48833c5d21d"
@@ -87,7 +88,7 @@ class MUSDB_HQ(Dataset):
         num_frames = None
         for source in self.sources:
             track = self._get_track(name, source)
-            wav, sr = torchaudio.load(str(track))
+            wav, sr = load_torchcodec(str(track))
             if sr != _SAMPLE_RATE:
                 raise ValueError(f"expected sample rate {_SAMPLE_RATE}, but got {sr}")
             if num_frames is None:

--- a/src/torchaudio/datasets/tedlium.py
+++ b/src/torchaudio/datasets/tedlium.py
@@ -7,6 +7,7 @@ from torch import Tensor
 from torch.utils.data import Dataset
 from torchaudio._internal import download_url_to_file
 from torchaudio.datasets.utils import _extract_tar
+from torchaudio.utils import load_torchcodec
 
 
 _RELEASE_CONFIGS = {
@@ -163,12 +164,7 @@ class TEDLIUM(Dataset):
         Returns:
             [Tensor, int]: Audio tensor representation and sample rate
         """
-        start_time = int(float(start_time) * sample_rate)
-        end_time = int(float(end_time) * sample_rate)
-
-        kwargs = {"frame_offset": start_time, "num_frames": end_time - start_time}
-
-        return torchaudio.load(path, **kwargs)
+        return load_torchcodec(path, start_seconds=float(start_time), stop_seconds=float(end_time))
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, str, int, int, int]:
         """Load the n-th sample from the dataset.

--- a/src/torchaudio/datasets/utils.py
+++ b/src/torchaudio/datasets/utils.py
@@ -3,6 +3,7 @@ import os
 import tarfile
 import zipfile
 from typing import Any, List, Optional
+from torchaudio.utils import load_torchcodec
 
 import torchaudio
 
@@ -48,7 +49,7 @@ def _load_waveform(
     exp_sample_rate: int,
 ):
     path = os.path.join(root, filename)
-    waveform, sample_rate = torchaudio.load(path)
+    waveform, sample_rate = load_torchcodec(path)
     if exp_sample_rate != sample_rate:
         raise ValueError(f"sample rate should be {exp_sample_rate}, but got {sample_rate}")
     return waveform

--- a/src/torchaudio/datasets/vctk.py
+++ b/src/torchaudio/datasets/vctk.py
@@ -6,6 +6,7 @@ from torch import Tensor
 from torch.utils.data import Dataset
 from torchaudio._internal import download_url_to_file
 from torchaudio.datasets.utils import _extract_zip
+from torchaudio.utils import load_torchcodec
 
 URL = "https://datashare.is.ed.ac.uk/bitstream/handle/10283/3443/VCTK-Corpus-0.92.zip"
 _CHECKSUMS = {
@@ -98,7 +99,7 @@ class VCTK_092(Dataset):
             return file_path.readlines()[0]
 
     def _load_audio(self, file_path) -> Tuple[Tensor, int]:
-        return torchaudio.load(file_path)
+        return load_torchcodec(file_path)
 
     def _load_sample(self, speaker_id: str, utterance_id: str, mic_id: str) -> SampleType:
         transcript_path = os.path.join(self._txt_dir, speaker_id, f"{speaker_id}_{utterance_id}.txt")

--- a/src/torchaudio/datasets/yesno.py
+++ b/src/torchaudio/datasets/yesno.py
@@ -7,7 +7,7 @@ from torch import Tensor
 from torch.utils.data import Dataset
 from torchaudio._internal import download_url_to_file
 from torchaudio.datasets.utils import _extract_tar
-
+from torchaudio.utils import load_torchcodec
 
 _RELEASE_CONFIGS = {
     "release1": {
@@ -62,7 +62,7 @@ class YESNO(Dataset):
     def _load_item(self, fileid: str, path: str):
         labels = [int(c) for c in fileid.split("_")]
         file_audio = os.path.join(path, fileid + ".wav")
-        waveform, sample_rate = torchaudio.load(file_audio)
+        waveform, sample_rate = load_torchcodec(file_audio)
         return waveform, sample_rate, labels
 
     def __getitem__(self, n: int) -> Tuple[Tensor, int, List[int]]:

--- a/src/torchaudio/utils/__init__.py
+++ b/src/torchaudio/utils/__init__.py
@@ -3,8 +3,18 @@ from torio.utils import ffmpeg_utils
 from . import sox_utils
 from .download import download_asset
 
+from torchcodec.decoders import AudioDecoder
+
+def load_torchcodec(file, **args):
+    decoder = AudioDecoder(file)
+    if 'start_seconds' in args or 'stop_seconds' in args:
+        samples = decoder.get_samples_played_in_range(**args)
+    else:
+        samples = decoder.get_all_samples()
+    return (samples.data, samples.sample_rate)
 
 __all__ = [
+    "load_torchcodec",
     "download_asset",
     "sox_utils",
     "ffmpeg_utils",


### PR DESCRIPTION
As a first step to removing deprecated functionality, this PR gets the datasets to use `torchcodec` to load their files. 