### PR TITLE
Fix argument comment in pytorch/audio/src/libtorchaudio/rnnt/cpu/compute.cpp +6

### DIFF
--- a/src/libtorchaudio/rnnt/cpu/compute.cpp
+++ b/src/libtorchaudio/rnnt/cpu/compute.cpp
@@ -117,7 +117,7 @@ std::tuple<torch::Tensor, std::optional<torch::Tensor>> compute(
           /*logits=*/logits.data_ptr<float>(),
           /*targets=*/targets.data_ptr<int>(),
           /*logit_lengths=*/logit_lengths.data_ptr<int>(),
-          /*target_lengths=*/target_lengths.data_ptr<int>(),
+          /*tgtLengths=*/target_lengths.data_ptr<int>(),
           /*costs=*/costs.data_ptr<float>(),
           /*gradients=*/gradients->data_ptr<float>());
       break;
@@ -128,7 +128,7 @@ std::tuple<torch::Tensor, std::optional<torch::Tensor>> compute(
           /*logits=*/logits.data_ptr<c10::Half>(),
           /*targets=*/targets.data_ptr<int>(),
           /*logit_lengths=*/logit_lengths.data_ptr<int>(),
-          /*target_lengths=*/target_lengths.data_ptr<int>(),
+          /*tgtLengths=*/target_lengths.data_ptr<int>(),
           /*costs=*/costs.data_ptr<c10::Half>(),
           /*gradients=*/gradients->data_ptr<c10::Half>());
       break;

--- a/src/libtorchaudio/rnnt/cpu/compute_alphas.cpp
+++ b/src/libtorchaudio/rnnt/cpu/compute_alphas.cpp
@@ -56,7 +56,7 @@ torch::Tensor compute_alphas(
       /*logits=*/logits.data_ptr<float>(),
       /*targets=*/targets.data_ptr<int>(),
       /*logit_lengths=*/logit_lengths.data_ptr<int>(),
-      /*target_lengths=*/target_lengths.data_ptr<int>(),
+      /*tgtLengths=*/target_lengths.data_ptr<int>(),
       /*alphas=*/alphas.data_ptr<float>());
   return alphas;
 }

--- a/src/libtorchaudio/rnnt/cpu/compute_betas.cpp
+++ b/src/libtorchaudio/rnnt/cpu/compute_betas.cpp
@@ -60,7 +60,7 @@ torch::Tensor compute_betas(
       /*logits=*/logits.data_ptr<float>(),
       /*targets=*/targets.data_ptr<int>(),
       /*logit_lengths=*/logit_lengths.data_ptr<int>(),
-      /*target_lengths=*/target_lengths.data_ptr<int>(),
+      /*tgtLengths=*/target_lengths.data_ptr<int>(),
       /*costs=*/costs.data_ptr<float>(),
       /*betas=*/betas.data_ptr<float>());
   return betas;


### PR DESCRIPTION
Summary:
Argument comments ensure that the correct values are assigned to the correct arguments.

This diff is a manual fix (assisted by the script in D78190897) of one or more argument comments in pytorch/audio/src/libtorchaudio/rnnt/cpu/compute.cpp. Once existing violations are drawn down we will make mismatches between argument comments and argument names an error.

Reviewed By: dtolnay

Differential Revision: D78191311


