### PR TITLE
fix supposed typo in speech_recognition_pipeline_tutorial.py

### DIFF
--- a/examples/tutorials/speech_recognition_pipeline_tutorial.py
+++ b/examples/tutorials/speech_recognition_pipeline_tutorial.py
@@ -51,9 +51,9 @@ print(device)
 
 import IPython
 import matplotlib.pyplot as plt
-from torchaudio.utils import _download_asset
+from torchaudio.utils import download_asset
 
-SPEECH_FILE = _download_asset("tutorial-assets/Lab41-SRI-VOiCES-src-sp0307-ch127535-sg0042.wav")
+SPEECH_FILE = download_asset("tutorial-assets/Lab41-SRI-VOiCES-src-sp0307-ch127535-sg0042.wav")
 
 
 ######################################################################


### PR DESCRIPTION
seems as if `_download_asset` is either outdated or a typo. I could execute the script when changing `_download_asset` to `download_asset`

<strong>PLEASE NOTE THAT THE TORCHAUDIO REPOSITORY IS NO LONGER ACTIVELY MONITORED.</strong> You may not get a response. For open discussions, visit https://discuss.pytorch.org/.
