### PR TITLE
[Pyspeech] avoid .item call in feature_processing

### DIFF
--- a/src/torchaudio/transforms/_transforms.py
+++ b/src/torchaudio/transforms/_transforms.py
@@ -1185,7 +1185,7 @@ class _AxisMasking(torch.nn.Module):
         self.iid_masks = iid_masks
         self.p = p
 
-    def forward(self, specgram: Tensor, mask_value: float = 0.0) -> Tensor:
+    def forward(self, specgram: Tensor, mask_value: Union[float, torch.Tensor] = 0.0) -> Tensor:
         r"""
         Args:
             specgram (Tensor): Tensor of dimension `(..., freq, time)`.


### PR DESCRIPTION
Summary:
tensor.item() causes CPU_GPU sync and degradates performance.
Avoid using .item() and rewrite mask_along_axis_iid to treat mask_value as a tensor

comparison https://fburl.com/mlhub/37l2ufrp
{F1980844270}

It increases SM U by 1%
{F1980890373}
{F1980890377}

Differential Revision: D79451615
