### PR TITLE
Revert "Disable asr cuda ctc tutorial (#4006)"

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -70,6 +70,7 @@ model implementations and application components.
 
    tutorials/speech_recognition_pipeline_tutorial
    tutorials/asr_inference_with_ctc_decoder_tutorial
+   tutorials/asr_inference_with_cuda_ctc_decoder_tutorial
    tutorials/forced_alignment_tutorial
    tutorials/forced_alignment_for_multilingual_data_tutorial
    tutorials/tacotron2_pipeline_tutorial

--- a/docs/source/models.decoder.rst
+++ b/docs/source/models.decoder.rst
@@ -20,3 +20,19 @@ CTC Decoder
 .. rubric:: Tutorials using CTC Decoder
 
 .. minigallery:: torchaudio.models.decoder.CTCDecoder
+
+CUDA CTC Decoder
+----------------
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+   :template: autosummary/cuda_ctc_decoder_class.rst
+
+   CUCTCDecoder
+   cuda_ctc_decoder
+
+
+.. rubric:: Tutorials using CUDA CTC Decoder
+
+.. minigallery:: torchaudio.models.decoder.CUCTCDecoder


### PR DESCRIPTION
This commit reverts the removal of the links to the asr cuda ctc tutorial.