### PR TITLE
Convert backptr to standard array

### DIFF
--- a/src/libtorchaudio/forced_align/cpu/compute.cpp
+++ b/src/libtorchaudio/forced_align/cpu/compute.cpp
@@ -33,11 +33,14 @@ void forced_align_impl(
     alphas_a[i][1] = kNegInfinity;
   }
 
-  torch::Tensor backPtr = torch::empty({T, S}, torch::kInt8).fill_(-1);
+  auto backPtr_a = new int8_t[T * S];
+  for (int i = 0; i < T * S; i++) {
+    backPtr_a[i] = -1;
+  }
+
   auto logProbs_a = logProbs.accessor<scalar_t, 3>();
   auto targets_a = targets.accessor<target_t, 2>();
   auto paths_a = paths.accessor<target_t, 2>();
-  auto backPtr_a = backPtr.accessor<int8_t, 2>();
   auto R = 0;
   for (auto i = 1; i < L; i++) {
     if (targets_a[batchIndex][i] == targets_a[batchIndex][i - 1]) {
@@ -84,7 +87,7 @@ void forced_align_impl(
     if (start == 0) {
       alphas_a[0][curIdxOffset] =
           alphas_a[0][prevIdxOffset] + logProbs_a[batchIndex][t][blank];
-      backPtr_a[t][0] = 0;
+      backPtr_a[S * t] = 0;
       startloop += 1;
     }
 
@@ -106,13 +109,13 @@ void forced_align_impl(
       scalar_t result = 0.0;
       if (x2 > x1 && x2 > x0) {
         result = x2;
-        backPtr_a[t][i] = 2;
+        backPtr_a[t * S + i] = 2;
       } else if (x1 > x0 && x1 > x2) {
         result = x1;
-        backPtr_a[t][i] = 1;
+        backPtr_a[t * S + i] = 1;
       } else {
         result = x0;
-        backPtr_a[t][i] = 0;
+        backPtr_a[t * S + i] = 0;
       }
       alphas_a[i][curIdxOffset] = result + logProbs_a[batchIndex][t][labelIdx];
     }
@@ -123,7 +126,7 @@ void forced_align_impl(
   for (auto t = T - 1; t > -1; t--) {
     auto lbl_idx = ltrIdx % 2 == 0 ? blank : targets_a[batchIndex][ltrIdx / 2];
     paths_a[batchIndex][t] = lbl_idx;
-    ltrIdx -= backPtr_a[t][ltrIdx];
+    ltrIdx -= backPtr_a[t * S + ltrIdx];
   }
 }
 


### PR DESCRIPTION
Working towards removing the dependence on the `torch` library, this PR changes the `backPtr` tensor in `forced_align` to a standard array. As the dimensions are not known at compile time and we're not using gnu extensions (which would allow for dynamic multidimensional arrays), multidimensional array access is converted to linear indexing. 