### PR TITLE
Remove generic lfilter loop

### DIFF
--- a/src/libtorchaudio/lfilter.cpp
+++ b/src/libtorchaudio/lfilter.cpp
@@ -73,33 +73,6 @@ void cpu_lfilter_core_loop(
       });
 }
 
-void lfilter_core_generic_loop(
-    const torch::Tensor& input_signal_windows,
-    const torch::Tensor& a_coeff_flipped,
-    torch::Tensor& padded_output_waveform) {
-  int64_t n_samples_input = input_signal_windows.size(2);
-  int64_t n_order = a_coeff_flipped.size(1);
-  auto coeff = a_coeff_flipped.unsqueeze(2);
-  for (int64_t i_sample = 0; i_sample < n_samples_input; i_sample++) {
-    auto windowed_output_signal =
-        padded_output_waveform
-            .index(
-                {torch::indexing::Slice(),
-                 torch::indexing::Slice(),
-                 torch::indexing::Slice(i_sample, i_sample + n_order)})
-            .transpose(0, 1);
-    auto o0 =
-        input_signal_windows.index(
-            {torch::indexing::Slice(), torch::indexing::Slice(), i_sample}) -
-        at::matmul(windowed_output_signal, coeff).squeeze(2).transpose(0, 1);
-    padded_output_waveform.index_put_(
-        {torch::indexing::Slice(),
-         torch::indexing::Slice(),
-         i_sample + n_order - 1},
-        o0);
-  }
-}
-
 } // namespace
 
 TORCH_LIBRARY(torchaudio, m) {
@@ -116,7 +89,3 @@ TORCH_LIBRARY_IMPL(torchaudio, CUDA, m) {
   m.impl("torchaudio::_lfilter_core_loop", &cuda_lfilter_core_loop);
 }
 #endif
-
-TORCH_LIBRARY_IMPL(torchaudio, CompositeExplicitAutograd, m) {
-  m.impl("torchaudio::_lfilter_core_loop", &lfilter_core_generic_loop);
-}


### PR DESCRIPTION
The code for lfilter already has explicit cpu and CUDA. Do we really need a third fallback option? I guess there's an mps device type too. But shouldn't everything else get handled by cpu and cuda? If we removed the fallback, we wouldn't have to worry about porting the transpose, squeeze, and index_put operations to the stable ABI.  

If it's important to keep support for other devices, close this PR.