### PR TITLE
Update __init__.py - fix for .pyd libraries not loading

### DIFF
--- a/src/torchaudio/_extension/__init__.py
+++ b/src/torchaudio/_extension/__init__.py
@@ -21,7 +21,7 @@ __all__ = [
 ]
 
 
-if os.name == "nt" and (3, 8) <= sys.version_info < (3, 9):
+if os.name == "nt" and (3, 8) <= sys.version_info < (3, 99):
     _init_dll_path()
 
 


### PR DESCRIPTION
In the ComfyUI project ,  and other projects which are dependent on pytorch/audio, there's a failure to load ffmpeg support due to failures when attempting to load libtorio libraries.  Namely any of the following.... 

site-packages\torio\lib\libtorio_ffmpeg4.pyd
site-packages\torio\lib\libtorio_ffmpeg5.pyd
site-packages\torio\lib\libtorio_ffmpeg6.pyd

These fail to load as they can't find the other system shared DLLs required by these .pyd libraries.  Allowing for _init_dll_path() on Python versions above 3.9 allows the .pyd libraries to find their shared libraries and fixes this issue.  

This could be a kludge, but it works.  I'd almost consider getting rid of the upper bounds test, but keeping it seems appropriate.

<strong>PLEASE NOTE THAT THE TORCHAUDIO REPOSITORY IS NO LONGER ACTIVELY MONITORED.</strong> You may not get a response. For open discussions, visit https://discuss.pytorch.org/.    So, yes I may be p***ing into to wind, but I'm making this request for my own tracking,
