### PR TITLE
[TUTORIAL DEPENDENCY REMOVAL] Remove last trace of librosa in tutorials

### DIFF
--- a/examples/tutorials/audio_feature_extractions_tutorial.py
+++ b/examples/tutorials/audio_feature_extractions_tutorial.py
@@ -75,7 +75,8 @@ def plot_spectrogram(specgram, title=None, ylabel="freq_bin", ax=None):
     if title is not None:
         ax.set_title(title)
     ax.set_ylabel(ylabel)
-    ax.imshow(librosa.power_to_db(specgram), origin="lower", aspect="auto", interpolation="nearest")
+    power_to_db = T.AmplitudeToDB("power", 80.0)
+    ax.imshow(power_to_db(specgram), origin="lower", aspect="auto", interpolation="nearest")
 
 
 def plot_fbank(fbank, title=None):


### PR DESCRIPTION
This PR ports the use of librosa for amplitude-to-db calculations to the internal torchaudio functionality, eliminating the last dependency that the tutorials have on librosa. 