### PR TITLE
Ffmpeg generalize cmake

### DIFF
--- a/third_party/ffmpeg/single/CMakeLists.txt
+++ b/third_party/ffmpeg/single/CMakeLists.txt
@@ -20,12 +20,12 @@ if(MULTIARCH_TRIPLET)
 endif()
 
 add_library(ffmpeg INTERFACE)
-target_include_directories(ffmpeg INTERFACE "${include_dir}")
+target_include_directories(ffmpeg INTERFACE ${include_dir})
 
 function (_find_ffmpeg_lib component)
   find_path("${component}_header"
     NAMES "lib${component}/${component}.h"
-    PATHS "${include_dir}"
+    PATHS ${include_dir}
     DOC "The include directory for ${component}"
     REQUIRED)
   find_library("lib${component}"


### PR DESCRIPTION
Closes #4032 . 

With the understanding that torchaudio is undergoing a transition into maintenance mode, the following PR is meant to facilitate the current usage of building audio with FFMPEG enabled on Fedora and multiarchitecture debian systems. Hopefully, this generalization will facilitate the maintainability of the repository. 

<strong>PLEASE NOTE THAT THE TORCHAUDIO REPOSITORY IS NO LONGER ACTIVELY MONITORED.</strong> You may not get a response. For open discussions, visit https://discuss.pytorch.org/.
