### PR TITLE
Torchcodec loading

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -68,7 +68,7 @@ jobs:
 
         GPU_ARCH_ID=cu126  # This is hard-coded and must be consistent with gpu-arch-version.
         PYTORCH_WHEEL_INDEX="https://download.pytorch.org/whl/${CHANNEL}/${GPU_ARCH_ID}"
-        pip install --progress-bar=off --pre torch --index-url="${PYTORCH_WHEEL_INDEX}"
+        pip install --progress-bar=off --pre torch torchcodec --index-url="${PYTORCH_WHEEL_INDEX}"
 
         echo "::endgroup::"
         echo "::group::Install TorchAudio"

--- a/src/torchaudio/__init__.py
+++ b/src/torchaudio/__init__.py
@@ -39,12 +39,181 @@ except ImportError:
     pass
 
 
-def load(*args, **kwargs):
-    return load_with_torchcodec(*args, **kwargs)
+def load(
+    uri: Union[BinaryIO, str, os.PathLike],
+    frame_offset: int = 0,
+    num_frames: int = -1,
+    normalize: bool = True,
+    channels_first: bool = True,
+    format: Optional[str] = None,
+    buffer_size: int = 4096,
+    backend: Optional[str] = None,
+) -> Tuple[torch.Tensor, int]:
+    """Load audio data from source using TorchCodec's AudioDecoder.
 
-def save(*args, **kwargs):
-    return save_with_torchcodec(*args, **kwargs)
+    .. note::
 
+        This function supports the same API as :func:`~torchaudio.load`, and
+        relies on TorchCodec's decoding capabilities under the hood. It is
+        provided for convenience, but we do recommend that you port your code to
+        natively use ``torchcodec``'s ``AudioDecoder`` class for better
+        performance:
+        https://docs.pytorch.org/torchcodec/stable/generated/torchcodec.decoders.AudioDecoder.
+        In TorchAudio 2.9, :func:`~torchaudio.load` will be relying on
+        :func:`~torchaudio.load_with_torchcodec`. Note that some parameters of
+        :func:`~torchaudio.load`, like ``normalize``, ``buffer_size``, and
+        ``backend``, are ignored by :func:`~torchaudio.load_with_torchcodec`.
+
+
+    Args:
+        uri (path-like object or file-like object):
+            Source of audio data. The following types are accepted:
+
+            * ``path-like``: File path or URL.
+            * ``file-like``: Object with ``read(size: int) -> bytes`` method.
+
+        frame_offset (int, optional):
+            Number of samples to skip before start reading data.
+        num_frames (int, optional):
+            Maximum number of samples to read. ``-1`` reads all the remaining samples,
+            starting from ``frame_offset``.
+        normalize (bool, optional):
+            TorchCodec always returns normalized float32 samples. This parameter
+            is ignored and a warning is issued if set to False.
+            Default: ``True``.
+        channels_first (bool, optional):
+            When True, the returned Tensor has dimension `[channel, time]`.
+            Otherwise, the returned Tensor's dimension is `[time, channel]`.
+        format (str or None, optional):
+            Format hint for the decoder. May not be supported by all TorchCodec
+            decoders. (Default: ``None``)
+        buffer_size (int, optional):
+            Not used by TorchCodec AudioDecoder. Provided for API compatibility.
+        backend (str or None, optional):
+            Not used by TorchCodec AudioDecoder. Provided for API compatibility.
+
+    Returns:
+        (torch.Tensor, int): Resulting Tensor and sample rate.
+        Always returns float32 tensors. If ``channels_first=True``, shape is
+        `[channel, time]`, otherwise `[time, channel]`.
+
+    Raises:
+        ImportError: If torchcodec is not available.
+        ValueError: If unsupported parameters are used.
+        RuntimeError: If TorchCodec fails to decode the audio.
+
+    Note:
+        - TorchCodec always returns normalized float32 samples, so the ``normalize``
+          parameter has no effect.
+        - The ``buffer_size`` and ``backend`` parameters are ignored.
+        - Not all audio formats supported by torchaudio backends may be supported
+          by TorchCodec.
+    """
+    return load_with_torchcodec(
+        uri,
+        frame_offset=frame_offset,
+        num_frames=num_frames,
+        normalize=normalize,
+        channels_first=channels_first,
+        format=format,
+        buffer_size=buffer_size,
+        backend=backend
+    )
+
+def save(
+    uri: Union[str, os.PathLike],
+    src: torch.Tensor,
+    sample_rate: int,
+    channels_first: bool = True,
+    format: Optional[str] = None,
+    encoding: Optional[str] = None,
+    bits_per_sample: Optional[int] = None,
+    buffer_size: int = 4096,
+    backend: Optional[str] = None,
+    compression: Optional[Union[float, int]] = None,
+) -> None:
+    """Save audio data to file using TorchCodec's AudioEncoder.
+
+    .. note::
+
+        This function supports the same API as :func:`~torchaudio.save`, and
+        relies on TorchCodec's encoding capabilities under the hood. It is
+        provided for convenience, but we do recommend that you port your code to
+        natively use ``torchcodec``'s ``AudioEncoder`` class for better
+        performance:
+        https://docs.pytorch.org/torchcodec/stable/generated/torchcodec.encoders.AudioEncoder.
+        In TorchAudio 2.9, :func:`~torchaudio.save` will be relying on
+        :func:`~torchaudio.save_with_torchcodec`. Note that some parameters of
+        :func:`~torchaudio.save`, like ``format``, ``encoding``,
+        ``bits_per_sample``, ``buffer_size``, and ``backend``, are ignored by
+        are ignored by :func:`~torchaudio.save_with_torchcodec`.
+
+    This function provides a TorchCodec-based alternative to torchaudio.save
+    with the same API. TorchCodec's AudioEncoder provides efficient encoding
+    with FFmpeg under the hood.
+
+    Args:
+        uri (path-like object):
+            Path to save the audio file. The file extension determines the format.
+
+        src (torch.Tensor):
+            Audio data to save. Must be a 1D or 2D tensor with float32 values
+            in the range [-1, 1]. If 2D, shape should be [channel, time] when
+            channels_first=True, or [time, channel] when channels_first=False.
+
+        sample_rate (int):
+            Sample rate of the audio data.
+
+        channels_first (bool, optional):
+            Indicates whether the input tensor has channels as the first dimension.
+            If True, expects [channel, time]. If False, expects [time, channel].
+            Default: True.
+
+        format (str or None, optional):
+            Audio format hint. Not used by TorchCodec (format is determined by
+            file extension). A warning is issued if provided.
+            Default: None.
+
+        encoding (str or None, optional):
+            Audio encoding. Not fully supported by TorchCodec AudioEncoder.
+            A warning is issued if provided. Default: None.
+
+        bits_per_sample (int or None, optional):
+            Bits per sample. Not directly supported by TorchCodec AudioEncoder.
+            A warning is issued if provided. Default: None.
+
+        buffer_size (int, optional):
+            Not used by TorchCodec AudioEncoder. Provided for API compatibility.
+            A warning is issued if not default value. Default: 4096.
+
+        backend (str or None, optional):
+            Not used by TorchCodec AudioEncoder. Provided for API compatibility.
+            A warning is issued if provided. Default: None.
+
+        compression (float, int or None, optional):
+            Compression level or bit rate. Maps to bit_rate parameter in
+            TorchCodec AudioEncoder. Default: None.
+
+    Raises:
+        ImportError: If torchcodec is not available.
+        ValueError: If input parameters are invalid.
+        RuntimeError: If TorchCodec fails to encode the audio.
+
+    Note:
+        - TorchCodec AudioEncoder expects float32 samples in [-1, 1] range.
+        - Some parameters (format, encoding, bits_per_sample, buffer_size, backend)
+          are not used by TorchCodec but are provided for API compatibility.
+        - The output format is determined by the file extension in the uri.
+        - TorchCodec uses FFmpeg under the hood for encoding.
+    """
+    return save_with_torchcodec(uri, src, sample_rate,
+        channels_first=channels_first,
+        format=format,
+        encoding=encoding,
+        bits_per_sample=bits_per_sample,
+        buffer_size=buffer_size,
+        backend=backend,
+        compression=compression)
 
 __all__ = [
     "AudioMetaData",

--- a/src/torchaudio/__init__.py
+++ b/src/torchaudio/__init__.py
@@ -7,8 +7,6 @@ from ._backend import (  # noqa  # usort: skip
     get_audio_backend as _get_audio_backend,
     info as _info,
     list_audio_backends as _list_audio_backends,
-    load,
-    save,
     set_audio_backend as _set_audio_backend,
 )
 from ._torchcodec import load_with_torchcodec, save_with_torchcodec
@@ -39,6 +37,13 @@ try:
     from .version import __version__, git_version  # noqa: F401
 except ImportError:
     pass
+
+
+def load(*args, **kwargs):
+    return load_with_torchcodec(*args, **kwargs)
+
+def save(*args, **kwargs):
+    return save_with_torchcodec(*args, **kwargs)
 
 
 __all__ = [


### PR DESCRIPTION
This PR wraps the `load_with_torchcodec` and `save_with_torchcodec` functions with functions of the name `load` and `save` so that code that depends on the old `load` and `save` functions can continue to work in the future once we remove backend-specific code. 