### PR TITLE
Remove deprecation of CUTC decoder

### DIFF
--- a/src/torchaudio/models/decoder/__init__.py
+++ b/src/torchaudio/models/decoder/__init__.py
@@ -1,4 +1,3 @@
-from torchaudio._internal.module_utils import dropping_support, dropping_class_support
 import inspect
 _CTC_DECODERS = [
     "CTCHypothesis",
@@ -35,11 +34,7 @@ def __getattr__(name: str):
                 "To use CUCTC decoder, please set BUILD_CUDA_CTC_DECODER=1 when building from source."
             ) from err
 
-        orig_item = getattr(_cuda_ctc_decoder, name)
-        if inspect.isclass(orig_item):
-            item = dropping_class_support(orig_item)
-        else:
-            item = dropping_support(orig_item)
+        item = getattr(_cuda_ctc_decoder, name)
         globals()[name] = item
         return item
     raise AttributeError(f"module {__name__} has no attribute {name}")


### PR DESCRIPTION
We deprecated the CUTC decoder for the 2.8 release as we thought we might need to remove all C++ extensions from the package. However, realizing now that this does not need to be the case, we should un-deprecate the functionality. 