### PR TITLE
Remove `dropping_support` decorators.

### DIFF
--- a/src/torchaudio/__init__.py
+++ b/src/torchaudio/__init__.py
@@ -1,4 +1,3 @@
-from torchaudio._internal.module_utils import dropping_io_support, dropping_class_io_support
 from typing import Union, BinaryIO, Optional, Tuple
 import os
 import torch

--- a/src/torchaudio/_internal/module_utils.py
+++ b/src/torchaudio/_internal/module_utils.py
@@ -101,48 +101,6 @@ def deprecated(direction: str, version: Optional[str] = None, remove: bool = Fal
 
     return decorator
 
-DEPRECATION_MSG = (
-    "This deprecation is part of a large refactoring effort to transition TorchAudio into a maintenance phase. "
-    "Please see https://github.com/pytorch/audio/issues/3902 for more information."
-)
-
-IO_DEPRECATION_MSG = (
-    "This deprecation is part of a large refactoring effort to transition TorchAudio into a maintenance phase. "
-    "The decoding and encoding capabilities of PyTorch for both audio and video are being consolidated into TorchCodec. "
-    "Please see https://github.com/pytorch/audio/issues/3902 for more information."
-)
-
-dropping_support = deprecated(DEPRECATION_MSG, version="2.9", remove=True)
-
-def dropping_class_support(c, msg=DEPRECATION_MSG):
-    c.__init__ = wrap_deprecated(c.__init__, f"{c.__module__}.{c.__name__}", msg, version="2.9", remove=True)
-    c.__doc__ = f"""DEPRECATED
-
-.. warning::
-
-    This class is deprecated from version 2.8. It will be removed in the 2.9 release.
-    {msg}
-{c.__doc__}
-"""
-
-    UNSUPPORTED.append(c)
-    return c
-
-def dropping_const_support(c, msg=DEPRECATION_MSG, name=None):
-    c.__doc__ = f"""[DEPRECATED]
-
-.. warning::
-
-    This object is deprecated deprecated from version 2.8. It will be removed in the 2.9 release.
-    {msg}
-{c.__doc__}
-    """
-    return c
-
-dropping_class_io_support = partial(dropping_class_support, msg=IO_DEPRECATION_MSG)
-
-dropping_io_support = deprecated(IO_DEPRECATION_MSG, version="2.9", remove=True)
-
 def fail_with_message(message):
     """Generate decorator to give users message about missing TorchAudio extension."""
 

--- a/src/torchaudio/functional/__init__.py
+++ b/src/torchaudio/functional/__init__.py
@@ -1,6 +1,5 @@
-from torchaudio._internal.module_utils import dropping_support
 
-from ._alignment import forced_align as _forced_align, merge_tokens, TokenSpan
+from ._alignment import forced_align, merge_tokens, TokenSpan
 from .filtering import (
     allpass_biquad,
     band_biquad,
@@ -25,8 +24,6 @@ from .filtering import (
     treble_biquad,
     vad,
 )
-
-forced_align = dropping_support(_forced_align)
 
 from .functional import (
     add_noise,

--- a/src/torchaudio/functional/functional.py
+++ b/src/torchaudio/functional/functional.py
@@ -9,7 +9,7 @@ from typing import List, Optional, Tuple, Union
 import torch
 import torchaudio
 from torch import Tensor
-from torchaudio._internal.module_utils import deprecated, dropping_support
+from torchaudio._internal.module_utils import deprecated
 
 
 from .filtering import highpass_biquad, treble_biquad
@@ -1733,7 +1733,7 @@ class RnntLoss(torch.autograd.Function):
         result = grad * grad_out;
         return (result, None, None, None, None, None, None, None)
 
-def _rnnt_loss(
+def rnnt_loss(
     logits: Tensor,
     targets: Tensor,
     logit_lengths: Tensor,
@@ -1837,9 +1837,6 @@ def psd(
     psd = psd.sum(dim=-3)
     return psd
 
-# Expose both deprecated wrapper as well as original because torchscript breaks on
-# wrapped functions.
-rnnt_loss = dropping_support(_rnnt_loss)
 
 def _compute_mat_trace(input: torch.Tensor, dim1: int = -1, dim2: int = -2) -> torch.Tensor:
     r"""Compute the trace of a Tensor along ``dim1`` and ``dim2`` dimensions.

--- a/src/torchaudio/transforms/__init__.py
+++ b/src/torchaudio/transforms/__init__.py
@@ -1,4 +1,3 @@
-from torchaudio._internal.module_utils import dropping_class_support
 from ._multi_channel import MVDR, PSD, RTFMVDR, SoudenMVDR
 from ._transforms import (
     AddNoise,
@@ -22,7 +21,7 @@ from ._transforms import (
     PitchShift,
     Preemphasis,
     Resample,
-    RNNTLoss as _RNNTLoss,
+    RNNTLoss,
     SlidingWindowCmn,
     SpecAugment,
     SpectralCentroid,
@@ -34,8 +33,6 @@ from ._transforms import (
     Vad,
     Vol,
 )
-
-RNNTLoss = dropping_class_support(_RNNTLoss)
 
 __all__ = [
     "AddNoise",

--- a/src/torchaudio/transforms/_transforms.py
+++ b/src/torchaudio/transforms/_transforms.py
@@ -10,7 +10,7 @@ from torch.nn.modules.lazy import LazyModuleMixin
 from torch.nn.parameter import UninitializedParameter
 
 from torchaudio import functional as F
-from torchaudio.functional.functional import _rnnt_loss
+from torchaudio.functional.functional import rnnt_loss
 from torchaudio.functional.functional import (
     _apply_sinc_resample_kernel,
     _check_convolve_mode,
@@ -1847,7 +1847,7 @@ class RNNTLoss(torch.nn.Module):
             Tensor: Loss with the reduction option applied. If ``reduction`` is  ``"none"``, then size (batch),
             otherwise scalar.
         """
-        return _rnnt_loss(
+        return rnnt_loss(
             logits,
             targets,
             logit_lengths,

--- a/src/torchaudio/utils/download.py
+++ b/src/torchaudio/utils/download.py
@@ -30,8 +30,6 @@ def _get_hash(path, hash, chunk_size=1028):
             data = file.read(chunk_size)
     return m.hexdigest()
 
-from torchaudio._internal.module_utils import dropping_support
-
 def _download_asset(
     key: str,
     hash: str = "",

--- a/test/torchaudio_unittest/common_utils/func_utils.py
+++ b/test/torchaudio_unittest/common_utils/func_utils.py
@@ -8,7 +8,7 @@ def torch_script(obj):
     buffer = io.BytesIO()
     if hasattr(obj, '__wrapped__'):
         # This is hack for those functions which are deprecated with decorators
-        # like @deprecated or @dropping_support. Adding the decorators breaks
+        # like @deprecated. Adding the decorators breaks
         # TorchScript. We need to unwrap the function to get the original one,
         # which make the tests pass, but that's a lie: the public (deprecated)
         # function doesn't support torchscript anymore

--- a/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
+++ b/test/torchaudio_unittest/functional/torchscript_consistency_impl.py
@@ -804,7 +804,7 @@ class FunctionalFloat32Only(TestBaseMixin):
             logit_lengths = torch.tensor([2], device=tensor.device, dtype=torch.int32)
             target_lengths = torch.tensor([2], device=tensor.device, dtype=torch.int32)
             # This is hack for those functions which are deprecated with decorators
-            # like @deprecated or @dropping_support. Adding the decorators breaks
+            # like @deprecated. Adding the decorators breaks
             # TorchScript. So here we use the private function which make the tests
             # pass, but that's a lie: the public (deprecated) function doesn't
             # support torchscript anymore


### PR DESCRIPTION
Now that all functions we deprecated in 2.8 have been removed, there is no need for the `dropping_support` family of decorators. This PR removes them. It also un-deprecates the stable ABI ported functions. Note that this PR depends `no_wrap_ctc_decoder`.