### PR TITLE
Enable Mac OS tests

### DIFF
--- a/.github/workflows/unittest-macos-cpu.yml
+++ b/.github/workflows/unittest-macos-cpu.yml
@@ -1,64 +1,65 @@
-# name: Unit-tests on Macos CPU
+name: Unit-tests on Macos CPU
 
-# on:
-#   pull_request:
-#   push:
-#     branches:
-#       - nightly
-#       - main
-#       - release/*
-#   workflow_dispatch:
+on:
+  pull_request:
+  push:
+    branches:
+      - nightly
+      - main
+      - release/*
+  workflow_dispatch:
 
-# env:
-#   CHANNEL: "nightly"
+env:
+  CHANNEL: "nightly"
 
-# jobs:
-#   tests:
-#     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
-#     with:
-#       runner: macos-12
-#       repository: pytorch/audio
-#       timeout: 180
-#       script: |
-#         echo '::group::Setup Environment Variables'
-#         # Mark Build Directory Safe
-#         git config --global --add safe.directory /__w/audio/audio
+jobs:
+  tests:
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    with:
+      runner: macos-12
+      repository: pytorch/audio
+      timeout: 180
+      script: |
+        echo '::group::Setup Environment Variables'
+        # Mark Build Directory Safe
+        git config --global --add safe.directory /__w/audio/audio
 
-#         # Set up Environment Variables
-#         export PYTHON_VERSION="3.9"
-#         export CU_VERSION=""
-#         export CUDATOOLKIT=""
-#         export USE_OPENMP="0"
+        # Set up Environment Variables
+        export PYTHON_VERSION="3.9"
+        export CU_VERSION=""
+        export CUDATOOLKIT=""
+        export USE_OPENMP="0"
 
-#         # Set CHANNEL
-#         if [[(${GITHUB_EVENT_NAME} = 'pull_request' && (${GITHUB_BASE_REF} = 'release'*)) || (${GITHUB_REF} = 'refs/heads/release'*) ]]; then
-#           export UPLOAD_CHANNEL=test
-#         else
-#           export UPLOAD_CHANNEL=nightly
-#         fi
+        # Set CHANNEL
+        if [[(${GITHUB_EVENT_NAME} = 'pull_request' && (${GITHUB_BASE_REF} = 'release'*)) || (${GITHUB_REF} = 'refs/heads/release'*) ]]; then
+          export UPLOAD_CHANNEL=test
+        else
+          export UPLOAD_CHANNEL=nightly
+        fi
 
-#         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CMD_APPLY_CMVN_SLIDING=true
-#         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CMD_COMPUTE_FBANK_FEATS=true
-#         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CMD_COMPUTE_KALDI_PITCH_FEATS=true
-#         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CMD_COMPUTE_MFCC_FEATS=true
-#         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CMD_COMPUTE_SPECTROGRAM_FEATS=true
-#         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CUDA=true
-#         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_HW_ACCEL=true
-#         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_QUANTIZATION=true
-#         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310=true
-#         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_MOD_sentencepiece=true
-#         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_AUDIO_OUT_DEVICE=true
-#         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_TEMPORARY_DISABLED=true
-#         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_SOX_DECODER=true
-#         export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_SOX_ENCODER=true
-#         echo '::endgroup::'
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CMD_APPLY_CMVN_SLIDING=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CMD_COMPUTE_FBANK_FEATS=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CMD_COMPUTE_KALDI_PITCH_FEATS=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CMD_COMPUTE_MFCC_FEATS=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CMD_COMPUTE_SPECTROGRAM_FEATS=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_CUDA=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_HW_ACCEL=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_QUANTIZATION=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_ON_PYTHON_310=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_MOD_sentencepiece=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_AUDIO_OUT_DEVICE=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_TEMPORARY_DISABLED=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_SOX_DECODER=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_SOX_ENCODER=true
+        export TORCHAUDIO_TEST_ALLOW_SKIP_IF_NO_FFMPEG=true
+        echo '::endgroup::'
 
-#         set -euxo pipefail
+        set -euxo pipefail
 
-#         echo '::group::Install PyTorch and Torchaudio'
-#         ./.github/scripts/unittest-linux/install.sh
-#         echo '::endgroup::'
+        echo '::group::Install PyTorch and Torchaudio'
+        ./.github/scripts/unittest-linux/install.sh
+        echo '::endgroup::'
 
-#         echo '::group::Run Tests'
-#         ./.github/scripts/unittest-linux/run_test.sh
-#         echo '::endgroup::'
+        echo '::group::Run Tests'
+        ./.github/scripts/unittest-linux/run_test.sh
+        echo '::endgroup::'


### PR DESCRIPTION
Mac tests were disabled previously, as dealing with dependencies were causing problems. Now that dependencies have been removed, we should be able to re-enable them. Note that this PR depends on #4057. 