### PR TITLE
[STABLE ABI] Port lfilter to stable ABI

### DIFF
--- a/src/libtorchaudio/CMakeLists.txt
+++ b/src/libtorchaudio/CMakeLists.txt
@@ -6,6 +6,7 @@ set(
   lfilter.cpp
   overdrive.cpp
   utils.cpp
+  accessor_tests.cpp
   )
 
 set(

--- a/src/libtorchaudio/accessor.h
+++ b/src/libtorchaudio/accessor.h
@@ -9,6 +9,7 @@ using torch::stable::Tensor;
 template<unsigned int k, typename T, bool IsConst = true>
 class Accessor {
   int64_t strides[k];
+  int64_t sizes[k];
   T *data;
 
 public:
@@ -19,6 +20,7 @@ public:
     data = static_cast<T*>(raw_ptr);
     for (unsigned int i = 0; i < k; i++) {
       strides[i] = tensor.stride(i);
+      sizes[i] = tensor.size(i);
     }
   }
 
@@ -31,6 +33,10 @@ public:
     }
     va_end(args);
     return data[ix];
+  }
+
+  int64_t size(int dim) {
+    return sizes[dim];
   }
 
   template<bool C = IsConst>

--- a/src/libtorchaudio/accessor.h
+++ b/src/libtorchaudio/accessor.h
@@ -15,7 +15,8 @@ public:
   using tensor_type = typename std::conditional<IsConst, const Tensor&, Tensor&>::type;
 
   Accessor(tensor_type tensor) {
-    data = (T*)tensor.template data_ptr();
+    auto raw_ptr = tensor.data_ptr();
+    data = static_cast<T*>(raw_ptr);
     for (unsigned int i = 0; i < k; i++) {
       strides[i] = tensor.stride(i);
     }

--- a/src/libtorchaudio/accessor.h
+++ b/src/libtorchaudio/accessor.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <torch/csrc/stable/tensor.h>
+#include <type_traits>
+#include <cstdarg>
+
+using torch::stable::Tensor;
+
+template<unsigned int k, typename T, bool IsConst = true>
+class Accessor {
+  int64_t strides[k];
+  T *data;
+
+public:
+  using tensor_type = typename std::conditional<IsConst, const Tensor&, Tensor&>::type;
+
+  Accessor(tensor_type tensor) {
+    data = (T*)tensor.template data_ptr();
+    for (unsigned int i = 0; i < k; i++) {
+      strides[i] = tensor.stride(i);
+    }
+  }
+
+  T index(...) {
+    va_list args;
+    va_start(args, k);
+    int64_t ix = 0;
+    for (unsigned int i = 0; i < k; i++) {
+        ix += strides[i] * va_arg(args, int);
+    }
+    va_end(args);
+    return data[ix];
+  }
+
+  template<bool C = IsConst>
+  typename std::enable_if<!C, void>::type set_index(T value, ...) {
+    va_list args;
+    va_start(args, value);
+    int64_t ix = 0;
+    for (unsigned int i = 0; i < k; i++) {
+        ix += strides[i] * va_arg(args, int);
+    }
+    va_end(args);
+    data[ix] = value;
+  }
+};

--- a/src/libtorchaudio/accessor_tests.cpp
+++ b/src/libtorchaudio/accessor_tests.cpp
@@ -1,0 +1,46 @@
+#include <libtorchaudio/accessor.h>
+#include <cstdint>
+#include <torch/torch.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/csrc/stable/library.h>
+
+namespace torchaudio {
+
+namespace accessor_tests {
+
+using namespace std;
+using torch::stable::Tensor;
+
+bool test_accessor(const Tensor tensor) {
+  int64_t* data_ptr = (int64_t*)tensor.data_ptr();
+  auto accessor = Accessor<3, int64_t>(tensor);
+  for (unsigned int i = 0; i < tensor.size(0); i++) {
+    for (unsigned int j = 0; j < tensor.size(1); j++) {
+      for (unsigned int k = 0; k < tensor.size(2); k++) {
+        auto check = *(data_ptr++) ==  accessor.index(i, j, k);
+        if (!check) {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+void boxed_test_accessor(StableIValue* stack, uint64_t num_args, uint64_t num_outputs) {
+  Tensor t1(to<AtenTensorHandle>(stack[0]));
+  auto result = test_accessor(std::move(t1));
+  stack[0] = from(result);
+}
+
+TORCH_LIBRARY_FRAGMENT(torchaudio, m) {
+  m.def(
+      "_test_accessor(Tensor log_probs) -> bool");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(torchaudio, CPU, m) {
+  m.impl("torchaudio::_test_accessor", &boxed_test_accessor);
+}
+
+}
+}

--- a/test/torchaudio_unittest/accessor_test.py
+++ b/test/torchaudio_unittest/accessor_test.py
@@ -1,0 +1,7 @@
+import torch
+from torchaudio._extension import _IS_TORCHAUDIO_EXT_AVAILABLE
+
+if _IS_TORCHAUDIO_EXT_AVAILABLE:
+    def test_accessor():
+        tensor = torch.randint(1000, (5,4,3))
+        assert torch.ops.torchaudio._test_accessor(tensor)


### PR DESCRIPTION
This PR ports lfilter to the stable ABI. The c++ generic interface (for non-cpu and non-cuda devices) is temporarily removed, an will be added back in python for now. The code still uses parallel_for for now. Although the code currently works off of the `stable_accesor` branch (incorporating those commits), it can be rebased to depend only on `main` if necessary.  