### PR TITLE
Compile CUDA 13 on Nvidia 5090 sm_120

### DIFF
--- a/src/libtorchaudio/forced_align/gpu/compute.cu
+++ b/src/libtorchaudio/forced_align/gpu/compute.cu
@@ -1,3 +1,4 @@
+#include <thrust/functional.h>
 #include <ATen/core/TensorAccessor.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAException.h>
@@ -94,7 +95,7 @@ __global__ void falign_cuda_step_kernel(
     alphas_a[curIdxOffset][i] = result + logProbs_a[batchIndex][t][labelIdx];
     threadMax = max(threadMax, alphas_a[curIdxOffset][i]);
   }
-  scalar_t maxResult = BlockReduce(tempStorage).Reduce(threadMax, cub::Max());
+  scalar_t maxResult = BlockReduce(tempStorage).Reduce(threadMax, thrust::maximum<scalar_t>{});
   if (threadIdx.x == 0) {
     maxValue = maxResult;
   }


### PR DESCRIPTION
CUDA 13 change library and clean code of redundancy. This fix compile on Nvidia 5090 with CUDA 13.0

<strong>PLEASE NOTE THAT THE TORCHAUDIO REPOSITORY IS NO LONGER ACTIVELY MONITORED.</strong> You may not get a response. For open discussions, visit https://discuss.pytorch.org/.
