### PR TITLE
Note references to torchaudio.info

### DIFF
--- a/examples/dnn_beamformer/README.md
+++ b/examples/dnn_beamformer/README.md
@@ -2,7 +2,11 @@
 
 This directory contains sample implementations of training and evaluation pipelines for an DNN Beamforming model.
 
-The `DNNBeamformer` model composes the following componenst:
+> [!NOTE]
+> The code uses the `torchaudio.info` function which was removed from the library in version 2.9. As such, this code will
+> not run as written without modification. It is preserved for reference purposes only.
+
+The `DNNBeamformer` model composes the following components:
 
 + [`torchaudio.transforms.Spectrogram`](https://pytorch.org/audio/stable/generated/torchaudio.transforms.Spectrogram.html#spectrogram) that applies Short-time Fourier Transform (STFT) to the waveform.
 + ConvTasNet without encoder/decoder that predicts T-F masks for speech and noise, respectively.

--- a/examples/hubert/README.md
+++ b/examples/hubert/README.md
@@ -2,6 +2,10 @@
 
 This directory contains sample implementations of pre-training pipeline for [HuBERT: Self-Supervised Speech Representation Learning by Masked Prediction of Hidden Units](https://arxiv.org/abs/2106.07447).
 
+> [!NOTE]
+> The code uses the `torchaudio.info` function which was removed from the library in version 2.9. As such, this code will
+> not run as written without modification. It is preserved for reference purposes only.
+
 ## Pre-training Usage
 
 The Base architecture of HuBERT model requires two iterations of pre-training.


### PR DESCRIPTION
Two of the examples used calls to `torchaudio.info`. This PR notes in the examples that this will not working going forward.