### PR TITLE
Install conda from miniforge rather than using old conda installation with a slow solver

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -62,6 +62,7 @@ jobs:
         git config --global --add safe.directory /__w/audio/audio
         conda create --quiet -y --prefix ci_env python="${PYTHON_VERSION}"
         conda activate ./ci_env
+        conda install -q -y pip
 
         echo "::endgroup::"
         echo "::group::Install PyTorch"

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -62,7 +62,7 @@ jobs:
         git config --global --add safe.directory /__w/audio/audio
         conda create --quiet -y --prefix ci_env python="${PYTHON_VERSION}"
         conda activate ./ci_env
-        conda install -q -y pip
+        conda install -q -y pip numpy
 
         echo "::endgroup::"
         echo "::group::Install PyTorch"

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -50,6 +50,13 @@ jobs:
           export CHANNEL=nightly
           export BUILD_VERSION="$( cut -f 1 -d a version.txt )".dev"$(date "+%Y%m%d")"
         fi
+        
+        # Install minoconda
+        mkdir -p ~/miniconda3
+        wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh
+        bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
+        rm ~/miniconda3/miniconda.sh
+        source ~/miniconda3/bin/activate
 
         echo "::group::Create conda env"
         # Mark Build Directory Safe

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -75,7 +75,7 @@ jobs:
         echo "::endgroup::"
         echo "::group::Install TorchAudio"
         conda install --quiet --yes cmake>=3.18.0 ninja
-        pip install --progress-bar off -v -e . --no-use-pep517
+        pip install --progress-bar off -v . --no-build-isolation
 
         # TODO: Need to rely on torchcodec instead of building ffmpeg from source.
         echo "::endgroup::"

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -51,12 +51,11 @@ jobs:
           export BUILD_VERSION="$( cut -f 1 -d a version.txt )".dev"$(date "+%Y%m%d")"
         fi
         
-        # Install minoconda
+        # Install miniforge
         mkdir -p ~/miniconda3
-        wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh
-        bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
-        rm ~/miniconda3/miniconda.sh
-        source ~/miniconda3/bin/activate
+        wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+        bash Miniforge3.sh -b -p "${HOME}/conda"
+        source "${HOME}/conda/etc/profile.d/conda.sh"
 
         echo "::group::Create conda env"
         # Mark Build Directory Safe

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -37,6 +37,7 @@ jobs:
 
       script: |
         set -ex
+        
         # Set up Environment Variables
         export PYTHON_VERSION="3.10"
         export CU_VERSION="11.8"
@@ -74,12 +75,12 @@ jobs:
         echo "::endgroup::"
         echo "::group::Install TorchAudio"
         conda install --quiet --yes cmake>=3.18.0 ninja
-        pip3 install --progress-bar off -v -e . --no-use-pep517
+        pip install --progress-bar off -v -e . --no-use-pep517
 
         # TODO: Need to rely on torchcodec instead of building ffmpeg from source.
         echo "::endgroup::"
         echo "::group::Build FFmpeg"
-        .github/scripts/ffmpeg/build_gpu.sh
+        conda install -q -y ffmpeg
 
         echo "::endgroup::"
         echo "::group::Install other dependencies"

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -79,7 +79,7 @@ jobs:
         # TODO: Need to rely on torchcodec instead of building ffmpeg from source.
         echo "::endgroup::"
         echo "::group::Build FFmpeg"
-        conda install -q -y ffmpeg<=7
+        conda install -q -y "ffmpeg<=7"
 
         echo "::endgroup::"
         echo "::group::Install other dependencies"

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -53,7 +53,6 @@ jobs:
         fi
         
         # Install miniforge
-        mkdir -p ~/miniconda3
         wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
         bash Miniforge3.sh -b -p "${HOME}/conda"
         source "${HOME}/conda/etc/profile.d/conda.sh"
@@ -80,7 +79,7 @@ jobs:
         # TODO: Need to rely on torchcodec instead of building ffmpeg from source.
         echo "::endgroup::"
         echo "::group::Build FFmpeg"
-        conda install -q -y ffmpeg
+        conda install -q -y ffmpeg<=7
 
         echo "::endgroup::"
         echo "::group::Install other dependencies"


### PR DESCRIPTION
This PR is in response to #4083. The old version of conda used by pytorch-infra can't resolve the environment well enough to install ffmpeg, so we have to resort to the manual building step given by the ffmpeg github workflow. But @pearu thinks this problem could go away if we just used a more modern conda. This PR is a work in progress- it installs a fresh miniconda and attempts to activate it before building the rest of the docs. 