### PR TITLE
Enable bandit CI workflow

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -1,5 +1,4 @@
-GitHub Actions Bandit Workflow
-
+# GitHub Actions Bandit Workflow
 name: Bandit
 
 on:


### PR DESCRIPTION
As in the title.

Notice that third_party/ currently contains only ffmpeg that we'll plan to remove in favor of installing it via conda.

<strong>PLEASE NOTE THAT THE TORCHAUDIO REPOSITORY IS NO LONGER ACTIVELY MONITORED.</strong> You may not get a response. For open discussions, visit https://discuss.pytorch.org/.
