### PR TITLE
Fix disabled pr-labels CI workflow

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,4 +1,6 @@
-# name: pr-labels
+name: pr-labels
+
+# This workflow is disabled and kept only for reference.
 
 # on:
 #   push:


### PR DESCRIPTION
As in the title.

We'll enable only the name of the workflow to let the CI workflow to succeed.

<strong>PLEASE NOTE THAT THE TORCHAUDIO REPOSITORY IS NO LONGER ACTIVELY MONITORED.</strong> You may not get a response. For open discussions, visit https://discuss.pytorch.org/.
