### PR TITLE
Add torchcodec installation instructions

### DIFF
--- a/src/torchaudio/__init__.py
+++ b/src/torchaudio/__init__.py
@@ -36,6 +36,7 @@ def load(
         https://docs.pytorch.org/torchcodec/stable/generated/torchcodec.decoders.AudioDecoder.
         Because of the reliance on Torchcodec, the parameters ``normalize``, ``buffer_size``, and
         ``backend`` are ignored and accepted only for backwards compatibility.
+        To install torchcodec, follow the instructions at https://github.com/pytorch/torchcodec#installing-torchcodec.
 
 
     Args:
@@ -118,6 +119,7 @@ def save(
         Because of the reliance on Torchcodec, the parameters ``format``, ``encoding``,
         ``bits_per_sample``, ``buffer_size``, and ``backend``, are ignored and accepted only for
         backwards compatibility.
+        To install torchcodec, follow the instructions at https://github.com/pytorch/torchcodec#installing-torchcodec.
 
     Args:
         uri (path-like object):

--- a/src/torchaudio/_torchcodec.py
+++ b/src/torchaudio/_torchcodec.py
@@ -30,6 +30,7 @@ def load_with_torchcodec(
         :func:`~torchaudio.load_with_torchcodec`. Note that some parameters of
         :func:`~torchaudio.load`, like ``normalize``, ``buffer_size``, and
         ``backend``, are ignored by :func:`~torchaudio.load_with_torchcodec`.
+        To install torchcodec, follow the instructions at https://github.com/pytorch/torchcodec#installing-torchcodec.
 
 
     Args:
@@ -180,6 +181,7 @@ def save_with_torchcodec(
         :func:`~torchaudio.save`, like ``format``, ``encoding``,
         ``bits_per_sample``, ``buffer_size``, and ``backend``, are ignored by
         are ignored by :func:`~torchaudio.save_with_torchcodec`.
+        To install torchcodec, follow the instructions at https://github.com/pytorch/torchcodec#installing-torchcodec.
 
     This function provides a TorchCodec-based alternative to torchaudio.save
     with the same API. TorchCodec's AudioEncoder provides efficient encoding


### PR DESCRIPTION
To ensure that people know what to do to be able to continue using the load/save functionality, this PR adds a link to the installation instructions for torchcodec. 