### PR TITLE
fix bug: matrix multiplication errors caused by discontinuous memory

### DIFF
--- a/src/torchaudio/compliance/kaldi.py
+++ b/src/torchaudio/compliance/kaldi.py
@@ -627,7 +627,7 @@ def fbank(
     mel_energies = torch.nn.functional.pad(mel_energies, (0, 1), mode="constant", value=0)
 
     # sum with mel fiterbanks over the power spectrum, size (m, num_mel_bins)
-    mel_energies = torch.mm(spectrum, mel_energies.T)
+    mel_energies = torch.mm(spectrum.contiguous(), mel_energies.T.contiguous())
     if use_log_fbank:
         # avoid log of zero (which should be prevented anyway by dithering)
         mel_energies = torch.max(mel_energies, _get_epsilon(device, dtype)).log()


### PR DESCRIPTION
When reading audio files in large quantities with multiple processes, it sometimes leads to discontinuous memory space for the audio. Then, when calling the fbank method, the continuous method is usually not called to make its stored content space continuous. Furthermore, an exception occurred in the torch.mm within the fbank method, ultimately leading to an unexpected segmentation fault.
I ultimately identified this bug and added contigues() to the variables spectrum and mel_deergies. T to avoid this error.
