### PR TITLE
Update CUDA version in GH workflows to 2.9.

### DIFF
--- a/.github/scripts/unittest-windows/setup_env.sh
+++ b/.github/scripts/unittest-windows/setup_env.sh
@@ -36,4 +36,4 @@ fi
 conda activate "${env_dir}"
 
 # 3. Install minimal build tools
-conda install -y -c conda-forge cmake ninja "ffmpeg<8"
+conda install -y -c conda-forge cmake ninja "ffmpeg<9"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,15 +14,15 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11"]
-        cuda-version: ["12.6"]
-        ffmpeg-version: ["7"]
+        cuda-version: ["12.9"]
+        ffmpeg-version: ["8"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
       id-token: write
       contents: read
     with:
-      runner: linux.4xlarge.nvidia.gpu
+      runner: linux.g5.4xlarge.nvidia.gpu
       repository: pytorch/audio
       upload-artifact: docs
       gpu-arch-type: cuda

--- a/.github/workflows/unittest-linux-gpu.yml
+++ b/.github/workflows/unittest-linux-gpu.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11"]
-        cuda-version: ["12.6"]
+        cuda-version: ["12.9"]
         ffmpeg-version: ["7"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main


### PR DESCRIPTION
As in the title.

To resolve an issue where
```
python -m pip install --pre torch torchcodec --index-url=https://download.pytorch.org/whl/nightly/cu126
```
leads to
```
Additionally, some packages in these conflicts have no matching distributions available for your environment:
    nvidia-nvshmem-cu12
```
See https://github.com/pytorch/audio/actions/runs/19634194213/job/56220847951 , for instance.

<strong>PLEASE NOTE THAT THE TORCHAUDIO REPOSITORY IS NO LONGER ACTIVELY MONITORED.</strong> You may not get a response. For open discussions, visit https://discuss.pytorch.org/.
