### PR TITLE
[STABLE ABI] Eliminate torch/extension.h dependency

### DIFF
--- a/src/libtorchaudio/pybind/pybind.cpp
+++ b/src/libtorchaudio/pybind/pybind.cpp
@@ -1,5 +1,6 @@
 #include <libtorchaudio/utils.h>
-#include <torch/extension.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 namespace torchaudio {
 namespace {


### PR DESCRIPTION
As in the title.

<strong>PLEASE NOTE THAT THE TORCHAUDIO REPOSITORY IS NO LONGER ACTIVELY MONITORED.</strong> You may not get a response. For open discussions, visit https://discuss.pytorch.org/.
