### PR TITLE
[STABLE ABI] Use const/mutable_data_ptr templates instead of reinterpret_cast

### DIFF
--- a/src/libtorchaudio/lfilter.cpp
+++ b/src/libtorchaudio/lfilter.cpp
@@ -24,12 +24,10 @@ void host_lfilter_core_loop(
   int64_t n_samples_input = input_signal_windows.size(2);
   int64_t n_samples_output = padded_output_waveform.size(2);
   int64_t n_order = a_coeff_flipped.size(1);
-  scalar_t* output_data =
-      reinterpret_cast<scalar_t*>(padded_output_waveform.data_ptr());
-  const scalar_t* input_data =
-      reinterpret_cast<scalar_t*>(input_signal_windows.data_ptr());
+  scalar_t* output_data = padded_output_waveform.mutable_data_ptr<scalar_t>();
+  const scalar_t* input_data = input_signal_windows.const_data_ptr<scalar_t>();
   const scalar_t* a_coeff_flipped_data =
-      reinterpret_cast<scalar_t*>(a_coeff_flipped.data_ptr());
+      a_coeff_flipped.const_data_ptr<scalar_t>();
 
   torch::stable::parallel_for(
       0, n_channel * n_batch, 1, [&](int64_t begin, int64_t end) {

--- a/src/libtorchaudio/rnnt/gpu/compute.cu
+++ b/src/libtorchaudio/rnnt/gpu/compute.cu
@@ -106,9 +106,9 @@ std::tuple<Tensor, Tensor> compute(
 
   Workspace<float> workspace(
       /*options=*/options,
-      /*dtype_data=*/reinterpret_cast<float*>(float_workspace.data_ptr()),
+      /*dtype_data=*/float_workspace.mutable_data_ptr<float>(),
       /*dtype_size=*/float_workspace.numel(),
-      /*int_data=*/reinterpret_cast<int*>(int_workspace.data_ptr()),
+      /*int_data=*/int_workspace.mutable_data_ptr<int>(),
       /*int_size=*/int_workspace.numel());
 
   THO_DISPATCH_V2(
@@ -117,12 +117,12 @@ std::tuple<Tensor, Tensor> compute(
       AT_WRAP([&] {
         (Compute</*DTYPE=*/scalar_t, /*CAST_DTYPE=*/float>(
             /*workspace=*/workspace,
-            /*logits=*/reinterpret_cast<scalar_t*>(logits.data_ptr()),
-            /*targets=*/reinterpret_cast<int*>(targets.data_ptr()),
-            /*srcLengths=*/reinterpret_cast<int*>(logit_lengths.data_ptr()),
-            /*tgtLengths=*/reinterpret_cast<int*>(target_lengths.data_ptr()),
-            /*costs=*/reinterpret_cast<scalar_t*>(costs.data_ptr()),
-            /*gradients=*/reinterpret_cast<scalar_t*>(gradients.data_ptr())));
+            /*logits=*/logits.const_data_ptr<scalar_t>(),
+            /*targets=*/targets.const_data_ptr<int>(),
+            /*srcLengths=*/logit_lengths.const_data_ptr<int>(),
+            /*tgtLengths=*/target_lengths.const_data_ptr<int>(),
+            /*costs=*/costs.mutable_data_ptr<scalar_t>(),
+            /*gradients=*/gradients.mutable_data_ptr<scalar_t>()));
       }),
       ScalarType::Float,
       ScalarType::Half);


### PR DESCRIPTION
As in the title. The const/mutable_data_ptr templates are safer to use as these implement type check before casting.

<strong>PLEASE NOTE THAT THE TORCHAUDIO REPOSITORY IS NO LONGER ACTIVELY MONITORED.</strong> You may not get a response. For open discussions, visit https://discuss.pytorch.org/.
