### PR TITLE
Fix ITokenizer return type annotation

### DIFF
--- a/src/torchaudio/pipelines/_wav2vec2/aligner.py
+++ b/src/torchaudio/pipelines/_wav2vec2/aligner.py
@@ -9,7 +9,7 @@ from torchaudio.functional import TokenSpan
 
 class ITokenizer(ABC):
     @abstractmethod
-    def __call__(self, transcript: List[str]) -> List[List[str]]:
+    def __call__(self, transcript: List[str]) -> List[List[int]]:
         """Tokenize the given transcript (list of word)
 
         .. note::


### PR DESCRIPTION
Fix incorrect return type annotation for `ITokenizer.__call__`.

Resolves #4153