### PR TITLE
Handle non-UTF-8 metadata in audio file stream info

### DIFF
--- a/src/torchaudio/_torchcodec.py
+++ b/src/torchaudio/_torchcodec.py
@@ -112,13 +112,25 @@ def load_with_torchcodec(
         warnings.warn("The 'format' parameter is not supported by TorchCodec AudioDecoder.", UserWarning, stacklevel=2)
 
     # Create AudioDecoder
+    # Some audio files (e.g. Opus from MLS dataset) contain metadata
+    # with non-UTF-8 bytes, which can cause UnicodeDecodeError during
+    # initialization or when accessing stream metadata.
     try:
         decoder = AudioDecoder(uri)
+    except UnicodeDecodeError as e:
+        raise RuntimeError(
+            f"Failed to create AudioDecoder for {uri}: "
+            f"file metadata contains non-decodable bytes: {e}"
+        ) from e
     except Exception as e:
         raise RuntimeError(f"Failed to create AudioDecoder for {uri}: {e}") from e
 
-    # Get sample rate from metadata
-    sample_rate = decoder.metadata.sample_rate
+    # Get sample rate from metadata.
+    # Guard against UnicodeDecodeError from non-UTF-8 metadata tags.
+    try:
+        sample_rate = decoder.metadata.sample_rate
+    except UnicodeDecodeError:
+        sample_rate = None
     if sample_rate is None:
         raise RuntimeError("Unable to determine sample rate from audio metadata")
 


### PR DESCRIPTION
## Summary

Fixes #3821

Some audio files — particularly Opus files from the MLS dataset — contain
metadata with non-UTF-8 bytes (e.g. Latin-1 encoded artist/title tags with
byte `0xe9`). This causes an unhandled `UnicodeDecodeError` when
`torchaudio.load()` attempts to parse the stream metadata.

This PR adds `try/except UnicodeDecodeError` guards around:

1. **`AudioDecoder(uri)`** construction — catches the error if the decoder
   fails during initialization due to non-decodable metadata bytes, and
   re-raises as a clear `RuntimeError`.
2. **`decoder.metadata.sample_rate`** access — catches the error if metadata
   property access triggers the decode failure, falling back to `None` so the
   existing "unable to determine sample rate" error path is used.

## Test plan

- [ ] Verify that loading a standard WAV/FLAC/MP3 file still works as before
- [ ] Verify that loading an Opus file with ASCII-only metadata works
- [ ] Verify that loading an Opus file with non-UTF-8 metadata bytes (e.g.
      from MLS dataset) no longer raises `UnicodeDecodeError` and instead
      produces a clear `RuntimeError`