### PR TITLE
Include file path in audio loading error messages

### DIFF
--- a/src/torchaudio/__init__.py
+++ b/src/torchaudio/__init__.py
@@ -83,16 +83,21 @@ def load(
         - Not all audio formats supported by torchaudio backends may be supported
         by TorchCodec.
     """
-    return load_with_torchcodec(
-        uri,
-        frame_offset=frame_offset,
-        num_frames=num_frames,
-        normalize=normalize,
-        channels_first=channels_first,
-        format=format,
-        buffer_size=buffer_size,
-        backend=backend,
-    )
+    try:
+        return load_with_torchcodec(
+            uri,
+            frame_offset=frame_offset,
+            num_frames=num_frames,
+            normalize=normalize,
+            channels_first=channels_first,
+            format=format,
+            buffer_size=buffer_size,
+            backend=backend,
+        )
+    except Exception as e:
+        if str(uri) not in str(e):
+            raise type(e)(f"Failed to load audio from {uri}: {e}") from e
+        raise
 
 
 def save(

--- a/src/torchaudio/_torchcodec.py
+++ b/src/torchaudio/_torchcodec.py
@@ -120,14 +120,14 @@ def load_with_torchcodec(
     # Get sample rate from metadata
     sample_rate = decoder.metadata.sample_rate
     if sample_rate is None:
-        raise RuntimeError("Unable to determine sample rate from audio metadata")
+        raise RuntimeError(f"Unable to determine sample rate from audio metadata for {uri}")
 
     # Decode the entire file first, then subsample manually
     # This is the simplest approach since torchcodec uses time-based indexing
     try:
         audio_samples = decoder.get_all_samples()
     except Exception as e:
-        raise RuntimeError(f"Failed to decode audio samples: {e}") from e
+        raise RuntimeError(f"Failed to decode audio samples from {uri}: {e}") from e
 
     data = audio_samples.data
 


### PR DESCRIPTION
## Summary
- When `torchaudio.load()` fails on a file, the error message now includes the file path/URI that caused the failure
- Updated error messages in `load_with_torchcodec()` for sample rate detection and audio decoding failures to include the URI
- Added a catch-all try/except in `torchaudio.load()` that ensures any unexpected exception also surfaces the file path

Fixes #3810

## Test plan
- [ ] Call `torchaudio.load()` with a non-existent file path and verify the error message includes the file path
- [ ] Call `torchaudio.load()` with a corrupted/invalid audio file and verify the error message includes the file path
- [ ] Call `torchaudio.load()` with a valid audio file and verify it still works correctly
- [ ] Verify that error messages from `load_with_torchcodec()` that already contain the URI are not duplicated