### PR TITLE
Fix WavLM compute_bias to create tensors on model device

### DIFF
--- a/src/torchaudio/models/wav2vec2/wavlm_attention.py
+++ b/src/torchaudio/models/wav2vec2/wavlm_attention.py
@@ -90,11 +90,11 @@ class WavLMSelfAttention(nn.Module):
         Returns:
             Tensor of shape `(num_heads, query_length, key_length)`, relative positions embeddings
         """
-        context_position = torch.arange(query_length, dtype=torch.long)[:, None]
-        memory_position = torch.arange(key_length, dtype=torch.long)[None, :]
+        device = self.rel_attn_embed.weight.device
+        context_position = torch.arange(query_length, dtype=torch.long, device=device)[:, None]
+        memory_position = torch.arange(key_length, dtype=torch.long, device=device)[None, :]
         relative_position = memory_position - context_position  # Shape (query_length, key_length)
         relative_position_bucket = self._relative_positions_bucket(relative_position, bidirectional=True)
-        relative_position_bucket = relative_position_bucket.to(self.rel_attn_embed.weight.device)
         values = self.rel_attn_embed(relative_position_bucket)  # Shape (query_length, key_length, num_heads)
         values = values.permute([2, 0, 1])
         return values


### PR DESCRIPTION
## Summary

- Fix `WavLMSelfAttention.compute_bias` to create position tensors directly on the model's device instead of CPU

## Problem

`compute_bias()` creates intermediate tensors on CPU via `torch.arange()` without specifying a `device`, then transfers the result to GPU with `.to()`. This causes a severe performance cliff when the model runs on CUDA: for sequences above ~180 frames (~3.6s audio at 16kHz with WavLM's stride), encoding time jumps from ~0.1s to ~2.5s due to implicit CPU-GPU synchronization.

The cliff is sharp and counterintuitive — encoding 3.4s of audio takes 0.12s, but 3.8s of audio takes 2.50s. Above the threshold, time is roughly constant regardless of sequence length (even 15s audio takes ~2.5s), suggesting the overhead comes from synchronization rather than computation.

## Fix

Pass `device=self.rel_attn_embed.weight.device` to `torch.arange()` so all position computation happens on the model's device. This also removes a now-redundant `.to()` call since `_relative_positions_bucket` uses `torch.zeros_like` / `torch.full_like` which inherit the device from their input.

## Benchmark

RTX 4090, WavLM Base+ via Kanade tokenizer (`frothywater/kanade-25hz-clean`), `torch.inference_mode()`, best of 3 runs after 2 warmup runs:

| Audio duration | Before (s) | After (s) | Speedup |
|---|---|---|---|
| 3.4s (170 frames) | 0.118 | 0.028 | 4.2x |
| 3.8s (190 frames) | **2.525** | 0.021 | **120x** |
| 5.0s (250 frames) | **2.312** | 0.021 | **110x** |
| 8.0s (400 frames) | **1.986** | 0.013 | **153x** |
| 10.0s (500 frames) | **2.206** | 0.018 | **123x** |
| 15.0s (750 frames) | **2.174** | 0.015 | **145x** |
