### PR TITLE
[typo:priviledge] Fix 'priviledge' -> 'privilege' in comments and documentation

### DIFF
--- a/docs/source/build.jetson.rst
+++ b/docs/source/build.jetson.rst
@@ -59,7 +59,7 @@ To check the version installed you can use the following commands;
 
 Since Tegra GPUs are not supported by ``nvidia-smi`` command, it is recommended to isntall ``jtop``.
 
-Only super-use can install ``jtop``. So make sure to add ``-U``, so that running ``jtop`` won't require super-user priviledge.
+Only super-use can install ``jtop``. So make sure to add ``-U``, so that running ``jtop`` won't require super-user privilege.
 
 3. Install ``pip`` in user env
 ------------------------------

--- a/examples/avsr/data_prep/tools/README.md
+++ b/examples/avsr/data_prep/tools/README.md
@@ -5,7 +5,7 @@ We provide [ibug.face_detection](https://github.com/hhj1897/face_detection) in t
 
 * [Git LFS](https://git-lfs.github.com/), needed for downloading the pretrained weights that are larger than 100 MB.
 
-You could install *`Homebrew`* and then install *`git-lfs`* without sudo priviledges.
+You could install *`Homebrew`* and then install *`git-lfs`* without sudo privileges.
 
 ```Shell
 git clone https://github.com/hhj1897/face_detection.git


### PR DESCRIPTION
Summary:
Fix misspelling of "privilege" (and variants "privileged", "privileges") in comments, documentation, and GraphQL doc strings across fbcode/ and xplat/. All changes are limited to non-functional text — no identifiers, field names, or API-facing strings are affected.

Skipped: pipeline directory path names, hardware register field names in SystemVerilog, WebRTC upstream code, SEGGER SDK constants, GraphQL schema field names (priviledged_users), and language model data.

Differential Revision: D92873251


