### PR TITLE
Use non-persistent buffers for recomputable transform state

### DIFF
--- a/src/torchaudio/transforms/_transforms.py
+++ b/src/torchaudio/transforms/_transforms.py
@@ -84,7 +84,7 @@ class Spectrogram(torch.nn.Module):
         self.win_length = win_length if win_length is not None else n_fft
         self.hop_length = hop_length if hop_length is not None else self.win_length // 2
         window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
-        self.register_buffer("window", window)
+        self.register_buffer("window", window, persistent=False)
         self.pad = pad
         self.power = power
         self.normalized = normalized
@@ -178,7 +178,7 @@ class InverseSpectrogram(torch.nn.Module):
         self.win_length = win_length if win_length is not None else n_fft
         self.hop_length = hop_length if hop_length is not None else self.win_length // 2
         window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
-        self.register_buffer("window", window)
+        self.register_buffer("window", window, persistent=False)
         self.pad = pad
         self.normalized = normalized
         self.center = center
@@ -974,7 +974,7 @@ class Resample(torch.nn.Module):
                 beta,
                 dtype=dtype,
             )
-            self.register_buffer("kernel", kernel)
+            self.register_buffer("kernel", kernel, persistent=False)
 
     def forward(self, waveform: Tensor) -> Tensor:
         r"""

--- a/test/torchaudio_unittest/transforms/transforms_test.py
+++ b/test/torchaudio_unittest/transforms/transforms_test.py
@@ -238,17 +238,34 @@ class Tester(common_utils.TorchaudioTestCase):
             sample_rate, upsample_rate, resampling_method="sinc_interp_hann"
         )
         up_sampled = upsample_resample(waveform)
-
-        # we expect the upsampled signal to have twice as many samples
         self.assertTrue(up_sampled.size(-1) == waveform.size(-1) * 2)
 
         downsample_resample = torchaudio.transforms.Resample(
             sample_rate, downsample_rate, resampling_method="sinc_interp_hann"
         )
         down_sampled = downsample_resample(waveform)
-
-        # we expect the downsampled signal to have half as many samples
         self.assertTrue(down_sampled.size(-1) == waveform.size(-1) // 2)
+
+
+    def test_spectrogram_window_not_in_state_dict(self):
+        transform = transforms.Spectrogram()
+        state_dict = transform.state_dict()
+
+        self.assertNotIn("window", state_dict)
+
+
+    def test_inverse_spectrogram_window_not_in_state_dict(self):
+        transform = transforms.InverseSpectrogram(n_fft=400)
+        state_dict = transform.state_dict()
+
+        self.assertNotIn("window", state_dict)
+
+
+    def test_resample_kernel_not_in_state_dict(self):
+        transform = transforms.Resample(orig_freq=16000, new_freq=8000)
+        state_dict = transform.state_dict()
+
+        self.assertNotIn("kernel", state_dict)
 
     def test_compute_deltas(self):
         channel = 13


### PR DESCRIPTION
## Summary
This PR updates recomputable transform buffers to use `register_buffer(..., persistent=False)` so they are not included in the module state dict.

## Motivation
These buffers can be rebuilt from constructor arguments, so persisting them in checkpoints can create unnecessary missing-key issues when loading older checkpoints after adding transforms.

## Changes made
- Updated recomputable buffers to be registered as non-persistent
- Added tests for state-dict behavior for `Spectrogram`, `InverseSpectrogram`, and `Resample`

## Testing
- [x] Ran:
  - `python3 -m pytest test/torchaudio_unittest/transforms/transforms_test.py -k "state_dict or resample"`
  - `python3 -m pytest test/torchaudio_unittest/transforms/transforms_test.py`

Closes #3059