### PR TITLE
fix: use persistent=False for recomputable buffers in transforms

### DIFF
--- a/src/torchaudio/transforms/_transforms.py
+++ b/src/torchaudio/transforms/_transforms.py
@@ -84,7 +84,7 @@ class Spectrogram(torch.nn.Module):
         self.win_length = win_length if win_length is not None else n_fft
         self.hop_length = hop_length if hop_length is not None else self.win_length // 2
         window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
-        self.register_buffer("window", window)
+        self.register_buffer("window", window, persistent=False)
         self.pad = pad
         self.power = power
         self.normalized = normalized
@@ -178,7 +178,7 @@ class InverseSpectrogram(torch.nn.Module):
         self.win_length = win_length if win_length is not None else n_fft
         self.hop_length = hop_length if hop_length is not None else self.win_length // 2
         window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
-        self.register_buffer("window", window)
+        self.register_buffer("window", window, persistent=False)
         self.pad = pad
         self.normalized = normalized
         self.center = center
@@ -267,7 +267,7 @@ class GriffinLim(torch.nn.Module):
         self.win_length = win_length if win_length is not None else n_fft
         self.hop_length = hop_length if hop_length is not None else self.win_length // 2
         window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
-        self.register_buffer("window", window)
+        self.register_buffer("window", window, persistent=False)
         self.length = length
         self.power = power
         self.momentum = momentum
@@ -402,7 +402,7 @@ class MelScale(torch.nn.Module):
         fb = F.melscale_fbanks(
             self.n_stft, self.f_min, self.f_max, self.n_mels, self.sample_rate, self.norm, self.mel_scale
         )
-        self.register_buffer("fb", fb)
+        self.register_buffer("fb", fb, persistent=False)
 
     def forward(self, specgram: Tensor) -> Tensor:
         r"""
@@ -486,7 +486,7 @@ class InverseMelScale(torch.nn.Module):
         fb = F.melscale_fbanks(
             self.n_stft, self.f_min, self.f_max, self.n_mels, self.sample_rate, self.norm, self.mel_scale
         )
-        self.register_buffer("fb", fb)
+        self.register_buffer("fb", fb, persistent=False)
 
     def forward(self, melspec: Tensor) -> Tensor:
         r"""
@@ -695,7 +695,7 @@ class MFCC(torch.nn.Module):
         if self.n_mfcc > self.MelSpectrogram.n_mels:
             raise ValueError("Cannot select more MFCC coefficients than # mel bins")
         dct_mat = F.create_dct(self.n_mfcc, self.MelSpectrogram.n_mels, self.norm)
-        self.register_buffer("dct_mat", dct_mat)
+        self.register_buffer("dct_mat", dct_mat, persistent=False)
         self.log_mels = log_mels
 
     def forward(self, waveform: Tensor) -> Tensor:
@@ -798,10 +798,10 @@ class LFCC(torch.nn.Module):
             n_filter=self.n_filter,
             sample_rate=self.sample_rate,
         )
-        self.register_buffer("filter_mat", filter_mat)
+        self.register_buffer("filter_mat", filter_mat, persistent=False)
 
         dct_mat = F.create_dct(self.n_lfcc, self.n_filter, self.norm)
-        self.register_buffer("dct_mat", dct_mat)
+        self.register_buffer("dct_mat", dct_mat, persistent=False)
         self.log_lf = log_lf
 
     def forward(self, waveform: Tensor) -> Tensor:
@@ -974,7 +974,7 @@ class Resample(torch.nn.Module):
                 beta,
                 dtype=dtype,
             )
-            self.register_buffer("kernel", kernel)
+            self.register_buffer("kernel", kernel, persistent=False)
 
     def forward(self, waveform: Tensor) -> Tensor:
         r"""
@@ -1061,7 +1061,7 @@ class TimeStretch(torch.nn.Module):
 
         n_fft = (n_freq - 1) * 2
         hop_length = hop_length if hop_length is not None else n_fft // 2
-        self.register_buffer("phase_advance", torch.linspace(0, math.pi * hop_length, n_freq)[..., None])
+        self.register_buffer("phase_advance", torch.linspace(0, math.pi * hop_length, n_freq)[..., None], persistent=False)
 
     def forward(self, complex_specgrams: Tensor, overriding_rate: Optional[float] = None) -> Tensor:
         r"""
@@ -1663,7 +1663,7 @@ class SpectralCentroid(torch.nn.Module):
         self.win_length = win_length if win_length is not None else n_fft
         self.hop_length = hop_length if hop_length is not None else self.win_length // 2
         window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
-        self.register_buffer("window", window)
+        self.register_buffer("window", window, persistent=False)
         self.pad = pad
 
     def forward(self, waveform: Tensor) -> Tensor:
@@ -1728,7 +1728,7 @@ class PitchShift(LazyModuleMixin, torch.nn.Module):
         self.win_length = win_length if win_length is not None else n_fft
         self.hop_length = hop_length if hop_length is not None else self.win_length // 4
         window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
-        self.register_buffer("window", window)
+        self.register_buffer("window", window, persistent=False)
         rate = 2.0 ** (-float(n_steps) / bins_per_octave)
         self.orig_freq = int(sample_rate / rate)
         self.gcd = math.gcd(int(self.orig_freq), int(sample_rate))


### PR DESCRIPTION
## Summary

Updates all `register_buffer()` calls in `torchaudio/transforms/_transforms.py` 
to use `persistent=False` for buffers that are recomputable from constructor 
arguments.

## Motivation

Fixes #3059

When loading a pre-existing checkpoint into a model containing torchaudio 
transforms, a `missing key` error is raised because recomputable buffers 
(e.g. window functions, mel filterbanks, kernels) are saved in the state dict 
even though they can be reconstructed from the constructor parameters.

## Changes

Added `persistent=False` to the following buffers across transforms:
- `window` — in `Spectrogram`, `InverseSpectrogram`, `GriffinLim`, `ISTFT`, `PitchShift` (5 locations)
- `fb` — in `MelScale`, `InverseMelScale` (2 locations)  
- `dct_mat` — in `MFCC`, `LFCC` (2 locations)
- `filter_mat` — in `LFCC` (1 location)
- `kernel` — in `Resample` (1 location)
- `phase_advance` — in `TimeStretch` (1 location)

## Verification

Before fix:
```python
T.Resample(16000, 8000).state_dict().keys()  # ['kernel']
T.Spectrogram().state_dict().keys()           # ['window']
T.MelSpectrogram().state_dict().keys()        # ['spectrogram.window', 'mel_scale.fb']
```

After fix:
```python
T.Resample(16000, 8000).state_dict().keys()  # []
T.Spectrogram().state_dict().keys()           # []
T.MelSpectrogram().state_dict().keys()        # []
```

cc @mthrok @nateanl