### PR TITLE
Declare torch as a runtime dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,12 +86,8 @@ def _main():
     print("-- Git branch:", branch)
     print("-- Git SHA:", sha)
     print("-- Git tag:", tag)
-    # This used to be passed to install_requires
-    # which would cause pinning against a specific torch version in releases.
-    # I don't think we want to pin at all?
-    # TODO: revisit if needed. Maybe it's needed for nightlies. Unsure.
-    # pytorch_package_dep = _get_pytorch_version()
-    # print("-- PyTorch dependency:", pytorch_package_dep)
+    pytorch_package_dep = _get_pytorch_version()
+    print("-- PyTorch dependency:", pytorch_package_dep)
     version = _get_version(sha)
     print("-- Building version", version)
 
@@ -139,7 +135,7 @@ def _main():
             "build_ext": setup_helpers.get_build_ext(),
             "clean": clean,
         },
-        install_requires=[],
+        install_requires=[pytorch_package_dep],
         zip_safe=False,
     )
 


### PR DESCRIPTION
## Summary

torchaudio 2.11.0 ships with `install_requires=[]`, so `pip install torchaudio` no longer pulls `torch`. Since `torchaudio/__init__.py` imports `torch` unconditionally, any clean install into an environment without a separate `pip install torch` fails with:

    ModuleNotFoundError: No module named 'torch'

## Fix

Restore the `_get_pytorch_version()` call that was commented out in #4171. This matches the pattern already used in [pytorch/vision](https://github.com/pytorch/vision/blob/main/setup.py) and [pytorch/text](https://github.com/pytorch/text/blob/main/setup.py):

- **Local / dev builds** (no `PYTORCH_VERSION` env var): `install_requires=["torch"]` — pip pulls the latest torch.
- **Release builds** (`PYTORCH_VERSION` set by the release builder): `install_requires=["torch==X.Y.Z"]` — pinned to the matching torch release, preserving the ABI guarantee historical torchaudio releases shipped with.

The `_get_pytorch_version()` function itself is already defined at line 41 — this just re-enables its use.

## Context

The pre-2.11.0 behavior (`torch==X.Y.Z` pinned in release wheels) was removed in #4171 to avoid version pinning. [@adamjstewart flagged in-thread](https://github.com/pytorch/audio/pull/4171#issuecomment-2715) that listing `torch` unpinned would achieve the stated goal (no version pin) while still keeping pip's resolver correct. This PR takes that further by restoring the env-var-controlled dependency expression, which gives maintainers back the ability to pin in release builds without forcing a pin on local/dev installs.

## Observed externally

The [arm64-python-wheel-tester](https://geoffreyblake.github.io/arm64-python-wheel-tester/) — an aarch64 wheel-install smoke test — has shown torchaudio failing since the 2.11.0 release, because the tester installs each wheel in isolation and `torch` is no longer pulled as a dep.

## Diff

Two chunks: uncomment the `_get_pytorch_version()` call and associated print, and pass the result to `install_requires`. Also removes the now-stale TODO comment.

## Tests

No tests added. The change is to packaging metadata (`setup.py` `install_requires`); exercising it would require a full install-into-clean-env integration test, which is outside the scope of the existing test suite. The fix can be verified by inspecting the resulting wheel's `METADATA` / `requires_dist` after building, or by `pip install torchaudio` into a fresh venv without a separate torch install.