### PR TITLE
Griffin-Lim phase init (issue 3828)

### DIFF
--- a/src/torchaudio/functional/functional.py
+++ b/src/torchaudio/functional/functional.py
@@ -275,8 +275,10 @@ def griffinlim(
     and *Signal estimation from modified short-time Fourier transform* :cite:`1172092`.
 
     Args:
-        specgram (Tensor): A magnitude-only STFT spectrogram of dimension `(..., freq, frames)`
-            where freq is ``n_fft // 2 + 1``.
+        specgram (Tensor):
+            A STFT spectrogram of dimension `(..., freq, frames)` where freq is ``n_fft // 2 + 1``.
+            If magnitude-only (non-complex dtype), then either random init or zero init.
+            If magnitude and phase (complex dtype), then phase used as init.
         window (Tensor): Window tensor that is applied/multiplied to each frame/window
         n_fft (int): Size of FFT, creates ``n_fft // 2 + 1`` bins
         hop_length (int): Length of hop between STFT windows. (
@@ -306,10 +308,16 @@ def griffinlim(
     specgram = specgram.pow(1 / power)
 
     # initialize the phase
-    if rand_init:
-        angles = torch.rand(specgram.size(), dtype=_get_complex_dtype(specgram.dtype), device=specgram.device)
+    if torch.is_complex(specgram):
+        # Use current phase as init
+        angles = torch.angle(specgram)
+        specgram = torch.abs(specgram)
     else:
-        angles = torch.full(specgram.size(), 1, dtype=_get_complex_dtype(specgram.dtype), device=specgram.device)
+        # Either random phase init or zero phase init
+        if rand_init:
+            angles = torch.rand(specgram.size(), dtype=_get_complex_dtype(specgram.dtype), device=specgram.device)
+        else:
+            angles = torch.full(specgram.size(), 1, dtype=_get_complex_dtype(specgram.dtype), device=specgram.device)
 
     # And initialize the previous iterate to 0
     tprev = torch.tensor(0.0, dtype=specgram.dtype, device=specgram.device)

--- a/src/torchaudio/functional/functional.py
+++ b/src/torchaudio/functional/functional.py
@@ -308,9 +308,12 @@ def griffinlim(
     specgram = specgram.pow(1 / power)
 
     # initialize the phase
-    if torch.is_complex(specgram):
+    if torch.is_complex(specgram) and rand_init:
+        raise ValueError("Cannot choose between given phase init and random phase init. Either give complex spectrogram input or rand_init True with non-complex spectrogram.")
+    elif torch.is_complex(specgram) and not rand_init:
         # Use current phase as init
         angles = torch.angle(specgram)
+        angles = torch.polar(abs=torch.ones_like(angles), angle=angles) # angles should be complex dtype
         specgram = torch.abs(specgram)
     else:
         # Either random phase init or zero phase init

--- a/src/torchaudio/transforms/_transforms.py
+++ b/src/torchaudio/transforms/_transforms.py
@@ -277,8 +277,9 @@ class GriffinLim(torch.nn.Module):
         r"""
         Args:
             specgram (Tensor):
-                A magnitude-only STFT spectrogram of dimension (..., freq, frames)
-                where freq is ``n_fft // 2 + 1``.
+                A STFT spectrogram of dimension (..., freq, frames) where freq is ``n_fft // 2 + 1``.
+                If magnitude-only (non-complex dtype), then either random init or zero init.
+                If magnitude and phase (complex dtype), then phase used as init.
 
         Returns:
             Tensor: waveform of (..., time), where time equals the ``length`` parameter if given.


### PR DESCRIPTION
Proposed solution to issue 3828 "*Ability to provide initial phase to Griffin-Lim*" ([link to issue 3828](https://github.com/pytorch/audio/issues/3828)).
Change: if provided spectrogram is complex (and `rand_init=False`), then its phase is used as initialisation for Griffin-Lim phase estimation algorithm.
I also changed the docs of both `src/torchaudio/transforms/_transforms.py` and `src/torchaudio/functional/functional.py`.

Code used to test proposed solution (messy code): [https://gist.github.com/michiel-j/740f704e50a4f812273fa9c5f88ae982](https://gist.github.com/michiel-j/740f704e50a4f812273fa9c5f88ae982)