### PR TITLE
ci: declare contents:read on Lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,9 @@ defaults:
   run:
     shell: bash -l -eo pipefail {0}
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `Lint` workflow runs `pre-commit run --all-files` inside a `conda-incubator/setup-miniconda` env, then `git diff` to surface any pre-commit-applied changes. No GitHub API write, no comment-on-PR step.

This patch pins the workflow to `permissions: contents: read`, matching the per-job permission blocks already declared by the build / unittest / docs workflows in this repo (typically `id-token: write` + `contents: read` for the reusable-test callers).

With explicit scope:

- the workflow token can't be widened by a future change to the repo default
- the SLSA / OpenSSF Scorecard `Token-Permissions` check passes for this file
- any hypothetical compromise of `conda-incubator/setup-miniconda` or `actions/checkout` (cf. tj-actions/changed-files CVE-2025-30066) stays boxed in read-only

`unittest-windows-cpu.yml` and `unittest-windows-gpu.yml` are the other workflows without a permissions block, but they use `actions/cache` and a more involved windows test setup, so I've left them out of this PR to keep the change focused and avoid the cache-write permissions discussion.

No behavioural change.