### PR TITLE
Annotate kaldi.vtln_warp_mel_freq low_freq as float for TorchScript

### DIFF
--- a/src/torchaudio/compliance/kaldi.py
+++ b/src/torchaudio/compliance/kaldi.py
@@ -409,7 +409,7 @@ def vtln_warp_freq(
 def vtln_warp_mel_freq(
     vtln_low_cutoff: float,
     vtln_high_cutoff: float,
-    low_freq,
+    low_freq: float,
     high_freq: float,
     vtln_warp_factor: float,
     mel_freq: Tensor,


### PR DESCRIPTION
## Summary

`torchaudio.compliance.kaldi.vtln_warp_mel_freq` accepted `low_freq` without a type annotation, while every other parameter in the signature (`vtln_low_cutoff`, `vtln_high_cutoff`, `high_freq`, `vtln_warp_factor`, `mel_freq`) was annotated. Without the hint, `torch.jit.script` infers `Tensor` and refuses to lower the function, blocking TorchScript export of any model that exercises this path.

The sibling `vtln_warp_freq` function (line 337) already annotates `low_freq: float`, so this matches existing convention.

## Change

One-token addition of `: float` to the `low_freq` parameter.

```diff
 def vtln_warp_mel_freq(
     vtln_low_cutoff: float,
     vtln_high_cutoff: float,
-    low_freq,
+    low_freq: float,
     high_freq: float,
     vtln_warp_factor: float,
     mel_freq: Tensor,
 ) -> Tensor:
```

The existing docstring already documents the parameter as `low_freq (float)`, so behaviour and documentation are unchanged. Runtime behaviour is unchanged; this is purely a TorchScript compatibility fix.

Fixes #3729