### PR TITLE
Fix invalid TimeStretch example in transforms doc

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -36,7 +36,7 @@ Transforms are implemented using :class:`torch.nn.Module`. Common ways to build 
            self.spec = Spectrogram(n_fft=n_fft, power=2)
 
            self.spec_aug = torch.nn.Sequential(
-               TimeStretch(stretch_factor, fixed_rate=True),
+               TimeStretch(n_freq=n_fft // 2 + 1, fixed_rate=stretch_factor),
                FrequencyMasking(freq_mask_param=80),
                TimeMasking(time_mask_param=80),
            )


### PR DESCRIPTION
## Summary

`docs/source/transforms.rst` showed the `TimeStretch` transform being constructed as:

```python
TimeStretch(stretch_factor, fixed_rate=True)
```

This is incorrect for two reasons:

1. `TimeStretch.__init__` has no positional `stretch_factor` parameter. Its signature is `TimeStretch(hop_length=None, n_freq=201, fixed_rate=None)`, so `stretch_factor` would silently bind to `hop_length`.
2. `fixed_rate` is typed as `Optional[float]` (the rate to stretch by), not a boolean.

This PR replaces the example with a runnable form that matches the actual signature, using `n_freq` derived the same way as the `MelScale` call directly below it (`n_fft // 2 + 1`), and passing the existing `stretch_factor` argument as `fixed_rate`:

```python
TimeStretch(n_freq=n_fft // 2 + 1, fixed_rate=stretch_factor)
```

Fixes #3438.

## Test plan

- [x] Confirmed `TimeStretch` signature in `src/torchaudio/transforms/_transforms.py`: `__init__(self, hop_length=None, n_freq=201, fixed_rate=None)`.
- [x] Docs-only change; no code paths affected.