### PR TITLE
fix OOB in cuda_ctc_decoder (#3754)

### DIFF
--- a/src/libtorchaudio/cuctc/src/ctc_prefix_decoder_kernel_v2.cu
+++ b/src/libtorchaudio/cuctc/src/ctc_prefix_decoder_kernel_v2.cu
@@ -294,8 +294,7 @@ __global__ __launch_bounds__(BLOCK_SIZE) void first_matrix__bitonic_topk_kernel(
   queue.done();
   float* block_topk_key =
       reinterpret_cast<float*>(smem_buf_bytes + smem_result_byte_offset);
-  int* block_topk_value =
-      reinterpret_cast<int*>(block_topk_key + sizeof(float) * beam);
+  int* block_topk_value = reinterpret_cast<int*>(block_topk_key + beam);
 
   queue.store(block_topk_key, block_topk_value);
   for (int idx = tx; idx < beam; idx += BLOCK_SIZE) {

--- a/test/torchaudio_unittest/models/decoder/cuda_ctc_decoder_test.py
+++ b/test/torchaudio_unittest/models/decoder/cuda_ctc_decoder_test.py
@@ -13,7 +13,7 @@ NUM_TOKENS = 7
 @skipIfNoCuda
 @skipIfNoCuCtcDecoder
 class CUCTCDecoderTest(TempDirMixin, TorchaudioTestCase):
-    def _get_decoder(self, tokens=None, **kwargs):
+    def _get_decoder(self, tokens=None, beam_size=5, **kwargs):
         from torchaudio.models.decoder import cuda_ctc_decoder
 
         if tokens is None:
@@ -21,12 +21,12 @@ class CUCTCDecoderTest(TempDirMixin, TorchaudioTestCase):
 
         return cuda_ctc_decoder(
             tokens=tokens,
-            beam_size=5,
+            beam_size=beam_size,
             **kwargs,
         )
 
-    def _get_emissions(self):
-        B, T, N = 4, 15, NUM_TOKENS
+    def _get_emissions(self, num_tokens=NUM_TOKENS):
+        B, T, N = 4, 15, num_tokens
 
         emissions = torch.rand(B, T, N).cuda()
         emissions = torch.nn.functional.log_softmax(emissions, -1)
@@ -45,5 +45,14 @@ class CUCTCDecoderTest(TempDirMixin, TorchaudioTestCase):
         log_probs = self._get_emissions()
         encoder_out_lens = torch.tensor([15, 14, 13, 12], dtype=torch.int32).cuda()
         decoder = self._get_decoder()
+        results = decoder(log_probs, encoder_out_lens)
+        self.assertEqual(len(results), log_probs.shape[0])
+
+    def test_large_beam_size(self):
+        # Regression test for https://github.com/pytorch/audio/issues/3754
+        tokens = ["-"] + [str(i) for i in range(128)]
+        decoder = self._get_decoder(tokens=tokens, beam_size=128)
+        log_probs = self._get_emissions(num_tokens=len(tokens))
+        encoder_out_lens = torch.tensor([15, 14, 13, 12], dtype=torch.int32).cuda()
         results = decoder(log_probs, encoder_out_lens)
         self.assertEqual(len(results), log_probs.shape[0])


### PR DESCRIPTION
`first_matrix__bitonic_topk_kernel` placed its top-k values array with:

> int* block_topk_value = reinterpret_cast<int*>(block_topk_key + sizeof(float) * beam);

This is a classic pitfall with pointers arithmetic: `block_topk_key` is a `float*`, so `+ sizeof(float) * beam` advances `sizeof(float) * beam` (= 4\*4\*beam bytes) instead of `beam` "elements" (= 4\*beam bytes). Therefore, the value is written and read 8\*beam..12\*beam bytes past the end of the kernel's allocated smem.

On Hopper/Blackwell, the issue is systematic at the first synchronize after the kernel (probably because of tighter shared-memory bounds on newer architectures?). On Ampere/Ada, the issue only becomes apparent at higher beam sizes because it makes the overrun large enough.

Advance by `beam` elements instead of `sizeof(float)*beam` elements. Add a regression test that decodes with beam_size=128, so that the overrun is large enough to fault on any GPU.

Fixes #3754.

---

For future reference: `compute-sanitizer --tool memcheck` on the unpatched decoder yields the exact OOB line (at the `queue.store`):

```
========= Invalid __shared__ write of size 4 bytes
=========     at first_matrix__bitonic_topk_kernel<(int)256, (int)16>(...)+0x... in ctc_prefix_decoder_kernel_v2.cu:299
=========     by thread (0,0,0) in block (0,0,0)
=========     Access to 0x8a0 is out of bounds
========= ERROR SUMMARY: 41 errors
```

Also, linters are usually able to catch such pointer arithmetic bugs statically.

---

<strong>PLEASE NOTE THAT THE TORCHAUDIO REPOSITORY IS NO LONGER ACTIVELY MONITORED.</strong> You may not get a response. For open discussions, visit https://discuss.pytorch.org/.
