### PR TITLE
Fix #3059

### DIFF
--- a/audio-clone/src/torchaudio/transforms/_transforms.py
+++ b/audio-clone/src/torchaudio/transforms/_transforms.py
@@ -1,0 +1,80 @@
+        self.win_length = win_length if win_length is not None else n_fft
+        self.hop_length = hop_length if hop_length is not None else self.win_length // 4
+        window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
+        self.register_buffer("window", window, persistent=False)
+        rate = 2.0 ** (-float(n_steps) / bins_per_octave)
+        self.orig_freq = int(sample_rate / rate)
+        self.gcd = math.gcd(int(self.orig_freq), int(sample_rate))
+        self.win_length = win_length if win_length is not None else n_fft
+        self.hop_length = hop_length if hop_length is not None else self.win_length // 2
+        window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
+        self.register_buffer("window", window, persistent=False)
+        self.pad = pad
+
+    def forward(self, waveform: Tensor) -> Tensor:
+
+        n_fft = (n_freq - 1) * 2
+        hop_length = hop_length if hop_length is not None else n_fft // 2
+        self.register_buffer("phase_advance", torch.linspace(0, math.pi * hop_length, n_freq)[..., None], persistent=False)
+
+    def forward(self, complex_specgrams: Tensor, overriding_rate: Optional[float] = None) -> Tensor:
+        r"""
+                beta,
+                dtype=dtype,
+            )
+            self.register_buffer("kernel", kernel, persistent=False)
+
+    def forward(self, waveform: Tensor) -> Tensor:
+        r"""
+            n_filter=self.n_filter,
+            sample_rate=self.sample_rate,
+        )
+        self.register_buffer("filter_mat", filter_mat, persistent=False)
+
+        dct_mat = F.create_dct(self.n_lfcc, self.n_filter, self.norm)
+        self.register_buffer("dct_mat", dct_mat, persistent=False)
+        self.log_lf = log_lf
+
+    def forward(self, waveform: Tensor) -> Tensor:
+        if self.n_mfcc > self.MelSpectrogram.n_mels:
+            raise ValueError("Cannot select more MFCC coefficients than # mel bins")
+        dct_mat = F.create_dct(self.n_mfcc, self.MelSpectrogram.n_mels, self.norm)
+        self.register_buffer("dct_mat", dct_mat, persistent=False)
+        self.log_mels = log_mels
+
+    def forward(self, waveform: Tensor) -> Tensor:
+        fb = F.melscale_fbanks(
+            self.n_stft, self.f_min, self.f_max, self.n_mels, self.sample_rate, self.norm, self.mel_scale
+        )
+        self.register_buffer("fb", fb, persistent=False)
+
+    def forward(self, melspec: Tensor) -> Tensor:
+        r"""
+        fb = F.melscale_fbanks(
+            self.n_stft, self.f_min, self.f_max, self.n_mels, self.sample_rate, self.norm, self.mel_scale
+        )
+        self.register_buffer("fb", fb, persistent=False)
+
+    def forward(self, specgram: Tensor) -> Tensor:
+        r"""
+        self.win_length = win_length if win_length is not None else n_fft
+        self.hop_length = hop_length if hop_length is not None else self.win_length // 2
+        window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
+        self.register_buffer("window", window, persistent=False)
+        self.length = length
+        self.power = power
+        self.momentum = momentum
+        self.win_length = win_length if win_length is not None else n_fft
+        self.hop_length = hop_length if hop_length is not None else self.win_length // 2
+        window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
+        self.register_buffer("window", window, persistent=False)
+        self.pad = pad
+        self.normalized = normalized
+        self.center = center
+        self.win_length = win_length if win_length is not None else n_fft
+        self.hop_length = hop_length if hop_length is not None else self.win_length // 2
+        window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
+        self.register_buffer("window", window, persistent=False)
+        self.pad = pad
+        self.power = power
+        self.normalized = normalized

--- a/fix-issue-3059/transforms.py
+++ b/fix-issue-3059/transforms.py
@@ -1,0 +1,80 @@
+        self.win_length = win_length if win_length is not None else n_fft
+        self.hop_length = hop_length if hop_length is not None else self.win_length // 4
+        window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
+        self.register_buffer("window", window, persistent=False)
+        rate = 2.0 ** (-float(n_steps) / bins_per_octave)
+        self.orig_freq = int(sample_rate / rate)
+        self.gcd = math.gcd(int(self.orig_freq), int(sample_rate))
+        self.win_length = win_length if win_length is not None else n_fft
+        self.hop_length = hop_length if hop_length is not None else self.win_length // 2
+        window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
+        self.register_buffer("window", window, persistent=False)
+        self.pad = pad
+
+    def forward(self, waveform: Tensor) -> Tensor:
+
+        n_fft = (n_freq - 1) * 2
+        hop_length = hop_length if hop_length is not None else n_fft // 2
+        self.register_buffer("phase_advance", torch.linspace(0, math.pi * hop_length, n_freq)[..., None], persistent=False)
+
+    def forward(self, complex_specgrams: Tensor, overriding_rate: Optional[float] = None) -> Tensor:
+        r"""
+                beta,
+                dtype=dtype,
+            )
+            self.register_buffer("kernel", kernel, persistent=False)
+
+    def forward(self, waveform: Tensor) -> Tensor:
+        r"""
+            n_filter=self.n_filter,
+            sample_rate=self.sample_rate,
+        )
+        self.register_buffer("filter_mat", filter_mat, persistent=False)
+
+        dct_mat = F.create_dct(self.n_lfcc, self.n_filter, self.norm)
+        self.register_buffer("dct_mat", dct_mat, persistent=False)
+        self.log_lf = log_lf
+
+    def forward(self, waveform: Tensor) -> Tensor:
+        if self.n_mfcc > self.MelSpectrogram.n_mels:
+            raise ValueError("Cannot select more MFCC coefficients than # mel bins")
+        dct_mat = F.create_dct(self.n_mfcc, self.MelSpectrogram.n_mels, self.norm)
+        self.register_buffer("dct_mat", dct_mat, persistent=False)
+        self.log_mels = log_mels
+
+    def forward(self, waveform: Tensor) -> Tensor:
+        fb = F.melscale_fbanks(
+            self.n_stft, self.f_min, self.f_max, self.n_mels, self.sample_rate, self.norm, self.mel_scale
+        )
+        self.register_buffer("fb", fb, persistent=False)
+
+    def forward(self, melspec: Tensor) -> Tensor:
+        r"""
+        fb = F.melscale_fbanks(
+            self.n_stft, self.f_min, self.f_max, self.n_mels, self.sample_rate, self.norm, self.mel_scale
+        )
+        self.register_buffer("fb", fb, persistent=False)
+
+    def forward(self, specgram: Tensor) -> Tensor:
+        r"""
+        self.win_length = win_length if win_length is not None else n_fft
+        self.hop_length = hop_length if hop_length is not None else self.win_length // 2
+        window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
+        self.register_buffer("window", window, persistent=False)
+        self.length = length
+        self.power = power
+        self.momentum = momentum
+        self.win_length = win_length if win_length is not None else n_fft
+        self.hop_length = hop_length if hop_length is not None else self.win_length // 2
+        window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
+        self.register_buffer("window", window, persistent=False)
+        self.pad = pad
+        self.normalized = normalized
+        self.center = center
+        self.win_length = win_length if win_length is not None else n_fft
+        self.hop_length = hop_length if hop_length is not None else self.win_length // 2
+        window = window_fn(self.win_length) if wkwargs is None else window_fn(self.win_length, **wkwargs)
+        self.register_buffer("window", window, persistent=False)
+        self.pad = pad
+        self.power = power
+        self.normalized = normalized


### PR DESCRIPTION
Fix #3059

## 问题描述

在 `torchaudio.transforms` 模块中，`register_buffer()` 默认将缓冲区标记为持久化（`persistent=True`），这意味着这些缓冲区会出现在模块的 `state_dict()` 中。当用户加载预训练模型时，如果 `state_dict` 中不包含这些缓冲区（例如窗口函数、滤波器组、DCT 矩阵等），就会引发 `Missing key(s) in state_dict` 错误。

这些缓冲区本质上属于**预处理计算结果的缓存**，而非模型的可学习参数或训练状态。它们完全可以在运行时根据模块的配置参数重新计算，因此没有必要保存在 `state_dict` 中。

## 解决方案

在所有 `register_buffer()` 调用中添加 `persistent=False` 参数，使这些缓冲区不进入 `state_dict`，从而避免加载检查点时的键值不匹配错误。

### 修改范围

涉及 `torchaudio/transforms/_transforms.py` 中的 12 处 `register_buffer()` 调用：

| 类 (Class) | 缓冲区名称 | 用途 |
|---|---|---|
| Spectrogram | `window` | 窗函数 |
| InverseSpectrogram | `window` | 窗函数 |
| GriffinLim | `window` | 窗函数 |
| MelScale | `fb` | Mel 滤波器组 |
| InverseMelScale | `fb` | Mel 滤波器组 |
| MFCC | `dct_mat` | DCT 矩阵 |
| LFCC | `filter_mat` | 线性滤波器组 |
| LFCC | `dct_mat` | DCT 矩阵 |
| Resample | `kernel` | 重采样卷积核 |
| TimeStretch | `phase_advance` | 相位调整因子 |
| SpectralCentroid | `window` | 窗函数 |
| PitchShift | `window` | 窗函数 |

## 修改示例

修改前：
```python
self.register_buffer("window", window)
```

修改后：
```python
self.register_buffer("window", window, persistent=False)
```

## 兼容性

- `persistent` 参数自 PyTorch 1.6.0 起可用，`torchaudio` 已不再支持更早版本，因此改动完全向后兼容。
- 缓冲区仍然在 `module.buffer()` 中可访问，也可以通过名称直接访问（如 `self.window`），仅在 `state_dict()` 中不再出现。

## 相关链接

- [GitHub Issue #3059](https://github.com/pytorch/audio/issues/3059)
- [PyTorch `register_buffer` 文档](https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.register_buffer)