### PR TITLE
Fix 32-bit index overflow and error-path leak in forced_align (CPU)

### DIFF
--- a/src/libtorchaudio/forced_align/cpu/compute.cpp
+++ b/src/libtorchaudio/forced_align/cpu/compute.cpp
@@ -29,12 +29,12 @@ void forced_align_impl(
   const auto S = 2 * L + 1;
 
   auto alphas_a = new scalar_t[2 * S]; // scalar_t is just logProbs.dtype()
-  for (int i = 0; i < 2 * S; i++) {
+  for (int64_t i = 0; i < 2 * S; i++) {
     alphas_a[i] = kNegInfinity;
   }
 
   auto backPtr_a = new int8_t[T * S];
-  for (int i = 0; i < T * S; i++) {
+  for (int64_t i = 0; i < T * S; i++) {
     backPtr_a[i] = -1;
   }
   auto logProbs_a = torchaudio::accessor<scalar_t, 3>(logProbs);

--- a/src/libtorchaudio/forced_align/cpu/compute.cpp
+++ b/src/libtorchaudio/forced_align/cpu/compute.cpp
@@ -6,6 +6,8 @@
 #include <torch/headeronly/core/Dispatch_v2.h>
 #include <torch/headeronly/core/ScalarType.h>
 
+#include <vector>
+
 namespace torchaudio {
 namespace alignment {
 namespace cpu {
@@ -28,15 +30,6 @@ void forced_align_impl(
   const auto L = targets.size(1);
   const auto S = 2 * L + 1;
 
-  auto alphas_a = new scalar_t[2 * S]; // scalar_t is just logProbs.dtype()
-  for (int64_t i = 0; i < 2 * S; i++) {
-    alphas_a[i] = kNegInfinity;
-  }
-
-  auto backPtr_a = new int8_t[T * S];
-  for (int64_t i = 0; i < T * S; i++) {
-    backPtr_a[i] = -1;
-  }
   auto logProbs_a = torchaudio::accessor<scalar_t, 3>(logProbs);
   auto targets_a = torchaudio::accessor<target_t, 2>(targets);
   auto paths_a = torchaudio::accessor<target_t, 2>(paths);
@@ -54,6 +47,15 @@ void forced_align_impl(
       L,
       ", and number of repeats: ",
       R);
+
+  // scalar_t is just logProbs.dtype(). Both buffers are allocated after the
+  // length check: backPtr is T * S bytes, gigabytes for long audio, and the
+  // vectors own their memory so that a throw cannot leak them.
+  std::vector<scalar_t> alphas(2 * S, kNegInfinity);
+  auto alphas_a = alphas.data();
+
+  std::vector<int8_t> backPtr(T * S, -1);
+  auto backPtr_a = backPtr.data();
   auto start = T - (L + R) > 0 ? 0 : 1;
   auto end = (S == 1) ? 1 : 2;
   for (auto i = start; i < end; i++) {
@@ -128,14 +130,12 @@ void forced_align_impl(
   auto ltrIdx = alphas_a[S * idx1 + S - 1] > alphas_a[S * idx1 + S - 2]
       ? S - 1
       : S - 2; // alphas_a[idx1][S - 1], alphas_a[idx1][S - 2]
-  delete[] alphas_a;
   // path stores the token index for each time step after force alignment.
   for (auto t = T - 1; t > -1; t--) {
     auto lbl_idx = ltrIdx % 2 == 0 ? blank : targets_a[batchIndex][ltrIdx / 2];
     paths_a[batchIndex][t] = lbl_idx;
     ltrIdx -= backPtr_a[t * S + ltrIdx]; // backPtr_a[t][ltrIdx]
   }
-  delete[] backPtr_a;
 }
 
 std::tuple<Tensor, Tensor> compute(


### PR DESCRIPTION
Fixes #4208

## Summary

`forced_align` (CPU) segfaults when `frames * (2 * target_length + 1)` exceeds 2^31, and leaks its whole DP buffer whenever the `targets length is too long for CTC` check fires. Both come from the same handful of lines: `forced_align_impl` allocates two raw buffers, fills them through 32-bit loop indices, and frees them only at the very end of the function.

```cpp
auto backPtr_a = new int8_t[T * S];   // T, S are int64_t -- allocation is fine
for (int i = 0; i < T * S; i++) {     // int i overflows at 2^31 (UB)
  backPtr_a[i] = -1;
}
```

Once `i` wraps, the store lands at `backPtr_a - 2^31` bytes → SIGSEGV. This is reachable with realistic inputs: the crash case below is 23 minutes of ordinary speech at 50 fps and ~11 characters per second. int64 targets crash identically, since the dispatch only changes `target_t`. Full analysis, including a crash report whose fault address is exactly `buffer_base - 0x80000000`, in #4208.

This is a **regression**. #4021 (`ea7855b`, Aug 2025) replaced `backPtr`'s `torch::Tensor ... .fill_(-1)`, which handles 64-bit sizes correctly, with the raw array and the `int` fill loop above. (`alphas` had been converted three days earlier by #4020.) #4021 merged five days after v2.8.0 shipped, so **2.8 is not affected** — the regression reaches users in 2.9 and runs through 2.11.

## The change

Let `std::vector` size and fill both buffers:

```cpp
std::vector<scalar_t> alphas(2 * S, kNegInfinity);
auto alphas_a = alphas.data();

std::vector<int8_t> backPtr(T * S, -1);
auto backPtr_a = backPtr.data();
```

The overflowing loops are gone rather than widened, and the buffers cannot outlive a throw. The accessors, the repeat count and the `targets length is too long for CTC` check also move above the allocations — none of them depend on the buffers, and an unalignable input is now rejected without allocating anything, where before it built the whole `backPtr` first. RAII is then a safety net rather than the mechanism.

Per review feedback from @pearu. The first commit widened the indices to `int64_t`, the second replaces the buffers outright; both are kept so the review history reads in order. **Please squash on merge and keep the second commit's message** — concatenating them would leave `main` claiming the indices were widened, which the final diff does not do.

The pointer aliases stay so the ~90 lines of untouched loop body keep indexing exactly as before, and so the innermost DP loop still stores through a raw pointer. `std::vector` rather than `new_empty` + `fill_` as on the GPU side: there the tensor is load-bearing (it is the destination of a `cudaMemcpyAsync`), here the buffers are function-local scratch that never crosses the ABI boundary. It matches what the sibling CPU kernel already does for host scratch (`rnnt/cpu/cpu_kernels.h`) and preserves the flat 1-D indexing #4020/#4021 introduced. After this change there is no raw `new[]` left anywhere under `src/libtorchaudio/`.

One behaviour change worth naming: `alphas` was freed before the final backtrace loop and now lives to end of scope. That holds `2 * S * sizeof(scalar_t)` longer — 242 KiB against `backPtr`'s 2.02 GiB in the case above — and it is untouched during that loop, so it costs neither cache nor TLB pressure. `shrink_to_fit` would reallocate and copy, which is strictly worse.

## Verification

macOS 27 arm64 (M1 Max), torch 2.13.0, against a **locally built stock `main` with identical flags** — the released wheel is not a fair baseline, its CI toolchain differs.

**The overflow**

| Case | stock `main` | this branch |
|---|---|---|
| T=70 000, L=15 500 (2.17e9 cells), int32 targets | 💥 crash | ✅ correct, 7.2 s |
| same, int64 targets | 💥 crash | ✅ 7.4 s, paths and scores identical to int32 |

**The leak** — all-repeat targets one frame below the threshold (L=15 500, T=2L−2, so `backPtr` is 961 MB per call), RSS after each raise:

| | stock `main` | this branch |
|---|---|---|
| RSS before | 201.8 MB | 199.2 MB |
| RSS after 1 / 2 / 3 raises | 1120.0 / 2036.7 / 2953.4 MB | 200.8 / 200.8 / 200.9 MB |
| peak RSS (`ru_maxrss`) over 3 raises | +2751.9 MB | +1.7 MB |

917 MiB leaked per raise — the whole `backPtr` allocation (`T * S` = 960,968,998 B), plus `alphas` riding along.

The peak row is why the check moved rather than only the ownership: with `std::vector` but the allocations still above the check, the leak is gone but peak RSS is +918.4 MiB, because every rejected input still builds and discards the whole buffer. Below the check it is +1.7 MB.

**No change in results or speed**

- 43 recorded small/medium alignment cases (random emissions, heavy repeats, tight `T == L+R` fits, single-token targets) plus `merge_tokens`: bit-identical
- all six dispatch instantiations — float32/float64/float16 × int32/int64 targets — bit-identical to stock across paths and scores
- `functional_cpu_test.py -k forced_align`, including `test_forced_align_fail`: 12 passed — note this is pre-existing coverage over small inputs, so it shows nothing broke rather than that the fix is covered; a repro for the overflow needs ~2.2 GB of RAM and I did not judge it CI-appropriate, happy to add one if you disagree
- 2.10e9 cells, the largest case stock survives: 6.93 s best / 6.94 s median on **both** builds — the value-init costs nothing measurable

Repro script for the crash in #4208 (needs ~2.2 GB RAM; kills the interpreter without this patch).
