### PR TITLE
[release/2.11] Pass extension sources as str, not pathlib.Path

### DIFF
--- a/tools/setup_helpers/extension.py
+++ b/tools/setup_helpers/extension.py
@@ -106,8 +106,8 @@ def get_ext_modules():
         extension(
             name="torchaudio.lib._torchaudio",
             sources=[
-                _CSRC_DIR / "_torchaudio.cpp",
-                _CSRC_DIR / "utils.cpp",
+                str(_CSRC_DIR / "_torchaudio.cpp"),
+                str(_CSRC_DIR / "utils.cpp"),
             ],
             py_limited_api=True,
             extra_compile_args=extra_compile_args,
@@ -115,7 +115,7 @@ def get_ext_modules():
         ),
         extension(
             name="torchaudio.lib.libtorchaudio",
-            sources=[_CSRC_DIR / s for s in sources],
+            sources=[str(_CSRC_DIR / s) for s in sources],
             py_limited_api=True,
             extra_compile_args=extra_compile_args,
             include_dirs=[_CSRC_DIR.parent],
@@ -127,7 +127,7 @@ def get_ext_modules():
                 extension(
                     name="torchaudio.lib.torchaudio_prefixctc",
                     sources=[
-                        _CSRC_DIR / "cuctc" / "src" / s
+                        str(_CSRC_DIR / "cuctc" / "src" / s)
                         for s in ["ctc_prefix_decoder.cpp", "ctc_prefix_decoder_kernel_v2.cu", "python_binding.cpp"]
                     ],
                     py_limited_api=True,


### PR DESCRIPTION
## Why

`get_ext_modules()` builds the extension `sources` lists from `_CSRC_DIR / "..."`, i.e. `pathlib.Path` objects. Older setuptools accepted `os.PathLike`, but newer setuptools/distutils now asserts that `sources` is a list of `str`:

```
File ".../tools/setup_helpers/extension.py", line 106, in get_ext_modules
    extension(
  ...
  File ".../setuptools/_distutils/extension.py", line 110, in __init__
    raise AssertionError("'sources' must be a list of strings")
AssertionError: 'sources' must be a list of strings
```

This breaks `python setup.py bdist_wheel` with a sufficiently new setuptools.

## Fix

Wrap each source path in `str()` in the three `extension(sources=...)` lists. `include_dirs` are left unchanged (distutils does not assert on them).
