### PR TITLE
Raise in vad on non-finite input instead of reporting silence (closes #4216)

### DIFF
--- a/src/torchaudio/functional/filtering.py
+++ b/src/torchaudio/functional/filtering.py
@@ -1567,18 +1567,6 @@ def vad(
     """
     device = waveform.device
 
-    if not bool(torch.isfinite(waveform).all()):
-        # The trigger measure is a running mean, so one non-finite sample poisons it
-        # permanently, and every later comparison against `trigger_level` is False.
-        # Nothing ever triggers and the whole waveform is reported as silence, which
-        # returns an empty tensor with no warning. Fail here instead.
-        raise ValueError(
-            "waveform must be finite everywhere, but it contains NaN or infinite values. "
-            "Vad tracks a running measure of the signal, and a single non-finite sample "
-            "makes every later comparison against trigger_level false, so the whole input "
-            "would be discarded as silence."
-        )
-
     if waveform.ndim > 2:
         warnings.warn(
             "Expected input tensor dimension of 1 for single channel"
@@ -1706,6 +1694,19 @@ def vad(
             flushedLen_ns = (measures_len - num_measures_to_flush) * measure_period_ns
             break
     # end for window
+    if not has_triggered and not bool(torch.isfinite(waveform).all()):
+        # Nothing triggered. Either the signal really is silent, or the running trigger
+        # measure was poisoned: one non-finite sample makes it non-finite for the rest of
+        # the waveform, so every later comparison against trigger_level is false and the
+        # whole input is discarded as silence. Only the second case is an error, and the
+        # scan sits in this branch so a waveform that triggers never pays for it.
+        raise ValueError(
+            "waveform must be finite everywhere, but it contains NaN or infinite values. "
+            "Vad tracks a running measure of the signal, and a single non-finite sample "
+            "makes every later comparison against trigger_level false, so the whole input "
+            "would be discarded as silence."
+        )
+
     if not has_triggered and shape[-1] >= fixed_pre_trigger_len_ns:
         return waveform[..., :fixed_pre_trigger_len_ns].view(shape[:-1] + torch.Size([fixed_pre_trigger_len_ns]))
 

--- a/src/torchaudio/functional/filtering.py
+++ b/src/torchaudio/functional/filtering.py
@@ -1567,6 +1567,18 @@ def vad(
     """
     device = waveform.device
 
+    if not bool(torch.isfinite(waveform).all()):
+        # The trigger measure is a running mean, so one non-finite sample poisons it
+        # permanently, and every later comparison against `trigger_level` is False.
+        # Nothing ever triggers and the whole waveform is reported as silence, which
+        # returns an empty tensor with no warning. Fail here instead.
+        raise ValueError(
+            "waveform must be finite everywhere, but it contains NaN or infinite values. "
+            "Vad tracks a running measure of the signal, and a single non-finite sample "
+            "makes every later comparison against trigger_level false, so the whole input "
+            "would be discarded as silence."
+        )
+
     if waveform.ndim > 2:
         warnings.warn(
             "Expected input tensor dimension of 1 for single channel"

--- a/test/torchaudio_unittest/transforms/transforms_test_impl.py
+++ b/test/torchaudio_unittest/transforms/transforms_test_impl.py
@@ -498,3 +498,18 @@ class TransformsTestBase(TestBaseMixin):
         expected_output = torch.zeros(output_shape, dtype=self.dtype, device=self.device)
         result = T.Vad(sample_rate, pre_trigger_time=pre_trigger_time)(inpt)
         self.assertEqual(result, expected_output)
+
+    @parameterized.expand([(float("nan"),), (float("inf"),), (float("-inf"),)])
+    def test_vad_rejects_non_finite_audio(self, bad_value: float):
+        """VAD should raise on non-finite input rather than report the signal as silence.
+
+        The trigger measure is a running mean, so one non-finite sample poisons it and
+        every later comparison against trigger_level is false. Nothing triggers and the
+        whole waveform is discarded, returning an empty Tensor. See
+        https://github.com/pytorch/audio/issues/4216.
+        """
+        sample_rate = 16000
+        waveform = torch.zeros(sample_rate, dtype=self.dtype, device=self.device)
+        waveform[100] = bad_value
+        with self.assertRaisesRegex(ValueError, "finite"):
+            T.Vad(sample_rate)(waveform)


### PR DESCRIPTION
Closes #4216.

### The bug

`vad` builds a running trigger measure:

```python
mean_meas[i] = mean_meas[i] * trigger_meas_time_mult + meas * (1.0 - trigger_meas_time_mult)
has_triggered = has_triggered or (mean_meas[i] >= trigger_level)
```

One non-finite sample makes `meas` non-finite, and the recurrence then keeps
`mean_meas[i]` non-finite for the rest of the waveform. Every later comparison
against `trigger_level` is false, so nothing triggers and the whole input is
reported as silence. The caller gets an empty Tensor, with no warning and no
exception.

It is position dependent, which is what makes it easy to miss:

```
clean                              kept 2.10s of 3.00s  shape=(33600,)
NaN in leading silence (idx 100)   kept 0.00s of 3.00s  shape=(0,)
NaN inside speech (idx 24000)      kept 2.10s of 3.00s  shape=(33600,)
```

The third row is not a working case. That output still contains the NaN, so
`vad` hands back a waveform that is just as broken, only without the obvious
symptom.

### The fix

Check the input once at the top of `functional.vad` and raise. This file already
raises `ValueError` for out-of-range arguments in several places, so the shape is
consistent with the surrounding code.

### Behaviour change

Input containing NaN or infinity now raises `ValueError` where it previously
returned a Tensor. That includes the "NaN inside speech" case above, which used to
return trimmed audio. Given that output still carried the non-finite sample, an
error seems better than a result the caller is likely to trust.

Clean input is unaffected.

### Verification

- The reproduction in the issue: clean input still returns 2.10s of 3.00s;
  NaN and infinity now raise instead of returning an empty Tensor.
- `torch.isfinite` is safe for every dtype `vad` accepts, including integer
  tensors, where it is true everywhere.
- **TorchScript**: `Vad` is covered by `torchscript_consistency_impl.py`, so I
  checked the guard compiles under `torch.jit.script` and raises correctly when
  scripted. `bool()` on the 0-dim result is required for that.
- No existing test feeds non-finite audio to `vad`, so nothing already in the
  suite changes meaning.
- `transforms_cpu_test.py -k vad`: 24 passed. The 6 new cases (3 values x 2
  dtypes) fail with `AssertionError: ValueError not raised` without the guard.
- flake8 and black clean at the repo's 120 column setting.

I could not build torchaudio from source on this machine, so the behavioural runs
above were done by applying the same guard to an installed 2.11.0 and restoring it
afterwards. CI is authoritative over my numbers.

### Note

@adityaanikam confirmed the root cause on the issue and stood aside for me to open
this, which I appreciated.

I also saw the notice that this repository is no longer actively monitored, so no
expectation of a quick review. The fix is small and self-contained if it is ever
useful.
