### PR TITLE
Return a most-likely path from forced_align when predecessors tie

### DIFF
--- a/src/libtorchaudio/forced_align/cpu/compute.cpp
+++ b/src/libtorchaudio/forced_align/cpu/compute.cpp
@@ -113,7 +113,7 @@ void forced_align_impl(
       if (x2 > x1 && x2 > x0) {
         result = x2;
         backPtr_a[t * S + i] = 2; // backPtr_a[t][i] = 2
-      } else if (x1 > x0 && x1 > x2) {
+      } else if (x1 > x0) {
         result = x1;
         backPtr_a[t * S + i] = 1; // backPtr_a[t][i] = 1
       } else {

--- a/src/libtorchaudio/forced_align/gpu/compute.cu
+++ b/src/libtorchaudio/forced_align/gpu/compute.cu
@@ -90,7 +90,7 @@ __global__ void falign_cuda_step_kernel(
     if (x2 > x1 && x2 > x0) {
       result = x2;
       backPtrBuffer_a[backPtrBufferLen][i] = 2;
-    } else if (x1 > x0 && x1 > x2) {
+    } else if (x1 > x0) {
       result = x1;
       backPtrBuffer_a[backPtrBufferLen][i] = 1;
     } else {

--- a/test/torchaudio_unittest/functional/functional_impl.py
+++ b/test/torchaudio_unittest/functional/functional_impl.py
@@ -1169,6 +1169,35 @@ class Functional(TestBaseMixin):
         self.assertEqual(hyp_scores, ref_scores)
 
     @parameterized.expand([(torch.int32,), (torch.int64,)])
+    def test_forced_align_optimal_on_ties(self, targets_dtype):
+        """The alignment returned must be a most-likely path, also when two
+        candidate predecessors of a cell score exactly the same.
+
+        The search space here is only 3**3 paths, five of which spell the
+        target; enumerating them gives a best score of -1.0, reached by
+        [1, 0, 2] and by [0, 1, 2]. Which of the two is returned is a
+        tie-breaking convention and is deliberately not asserted -- the score
+        is the invariant. Before this case was fixed the kernel returned
+        [1, 2, 2], scoring -3.0.
+        """
+        log_probs = torch.tensor(
+            [[[0.0, -1.0, -1.0], [0.0, -1.0, -2.0], [-2.0, 0.0, 0.0]]],
+            dtype=self.dtype,
+            device=self.device,
+        )
+        targets = torch.tensor([[1, 2]], dtype=targets_dtype, device=self.device)
+        blank = 0
+        input_lengths = torch.tensor([log_probs.shape[1]], device=self.device)
+        target_lengths = torch.tensor([targets.shape[1]], device=self.device)
+        hyp_path, hyp_scores = F.forced_align(log_probs, targets, input_lengths, target_lengths, blank)
+        # the path spells the target once repeats and blanks are collapsed ...
+        path = hyp_path[0].tolist()
+        collapsed = [t for i, t in enumerate(path) if t != blank and (i == 0 or t != path[i - 1])]
+        self.assertEqual(collapsed, targets[0].tolist())
+        # ... and it is a most likely one
+        self.assertEqual(hyp_scores.sum().item(), -1.0)
+
+    @parameterized.expand([(torch.int32,), (torch.int64,)])
     def test_forced_align_fail(self, targets_dtype):
         log_probs = torch.rand(1, 5, 6, dtype=self.dtype, device=self.device)
         targets = torch.tensor([[0, 1, 2, 3, 4, 4]], dtype=targets_dtype, device=self.device)


### PR DESCRIPTION
Fixes #4221

`forced_align` can return an alignment that is not a most-likely path. The per-cell choice is

```cpp
if (x2 > x1 && x2 > x0)      { result = x2; backPtr = 2; }
else if (x1 > x0 && x1 > x2) { result = x1; backPtr = 1; }
else                         { result = x0; backPtr = 0; }
```

and when `x1 == x2` with both above `x0`, neither condition holds, so the `else` branch takes `x0` — the strictly worst of the three. Both the CPU and the CUDA kernel carry the identical chain, so both are corrected here.

### Why `x1 > x0` alone is correct

Reaching the second branch already implies `x2` is not strictly greater than both others:

* branch 1 returns `x2` with `x2 > x1` and `x2 > x0` — the maximum;
* branch 2 returns `x1` with `x1 > x0`; had `x2 > x1` held, then `x2 > x1 > x0` would have taken branch 1, so `x2 ≤ x1` — the maximum;
* branch 3 returns `x0` with `x0 ≥ x1`; had `x2 > x0` held, then `x2 > x0 ≥ x1` would have taken branch 1, so `x2 ≤ x0` — the maximum.

So the only behaviour that changes is that exact ties now route to the larger value instead of to `x0`.

### Verification

* **Exhaustive**, against the best score over all enumerated valid paths, on 3243 random small cases (`T ≤ 5`, vocabulary `≤ 4`, integer log-probabilities so ties are exact): **92 sub-optimal before, 0 after**, worst deficit 3.0 log-probability.
* **No change on existing behaviour.** 43 recorded reference alignments (seeded random log-softmax emissions, including heavy-repeat targets and tight `T == L + repeats` fits) are bit-identical before and after, as are the existing `test_forced_align` expectations.
* **No change on a real workload.** Aligning a 737 s speech recording against its transcript with a wav2vec2 CTC model (36 820 frames, 10 044 target tokens): the tie condition fires 55 921 times out of 740 M cells, but never on the winning path, and all 2 253 word timestamps are identical before and after. Users on ordinary continuous emissions should see no difference at all.
* **Two independent implementations agree.** A scalar Python port of this loop matches stock 234/234 *with* the clause and matches the fixed kernel 234/234 *without* it; a separate NumPy Viterbi matches the fixed kernel on 277/277 cases, against 264/277 for stock.
* Built from `main` (4e3e282) with `USE_CUDA=0 USE_ROCM=0 BUILD_SOX=0 USE_FFMPEG=0`; the whole of `test/torchaudio_unittest/functional/functional_cpu_test.py` passes — 700 passed, 1 xfailed — including the 4 added cases. The CUDA kernel is changed identically but I have no CUDA device to test on; the added test lives in `Functional`, which `functional_cuda_test.py` also instantiates, so CI covers both backends.

### About the added test

It asserts the **score**, not the path. Whenever this bug can fire, `x1 == x2` means two distinct paths reach that cell with equal score, so an optimum is never unique — which of the equally-good paths is returned is a tie-breaking convention, and pinning it in a test would only make the test brittle.

### Note

This touches `forced_align_impl` in the same region as #4209 (32-bit index overflow, approved and unmerged). The two changes are independent — that one replaces the DP buffers, this one changes a condition — but whichever lands second will want a trivial rebase.
