### PR TITLE
Enable Windows ARM64 native wheel builds

### DIFF
--- a/.github/workflows/build_wheel_windows_arm64.yml
+++ b/.github/workflows/build_wheel_windows_arm64.yml
@@ -1,0 +1,57 @@
+name: Build Windows ARM64 Wheels
+
+on:
+  pull_request:
+  push:
+    branches:
+      - nightly
+      - main
+      - release/*
+    tags:
+        # NOTE: Binary build pipelines should only get triggered on release candidate builds
+        # Release candidate tags look like: v1.11.0-rc1
+        - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  generate-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: wheel
+      os: windows-arm64
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      with-cuda: disable
+
+  build:
+    needs: generate-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repository: pytorch/audio
+            pre-script: packaging/pre_build_script_arm64.sh
+            smoke-test-script: test/smoke_test/smoke_test_no_ffmpeg.py
+            package-name: torchaudio
+            architecture: "arm64"
+    name: ${{ matrix.repository }}
+    uses: pytorch/test-infra/.github/workflows/build_wheels_windows.yml@main
+    with:
+      repository: ${{ matrix.repository }}
+      ref: ""
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      pre-script: ${{ matrix.pre-script }}
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      package-name: ${{ matrix.package-name }}
+      smoke-test-script: ${{ matrix.smoke-test-script }}
+      trigger-event: ${{ github.event_name }}
+      architecture: ${{ matrix.architecture }}
+    secrets:
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}

--- a/packaging/pre_build_script_arm64.sh
+++ b/packaging/pre_build_script_arm64.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+echo "Building torchaudio dependencies and wheel started."
+
+export SRC_PATH="$GITHUB_WORKSPACE/$SRC_DIR"
+export PYTORCH_VERSION="$PYTORCH_VERSION"
+export CHANNEL="$CHANNEL"
+
+# Source directory
+cd "$SRC_PATH" || exit
+
+# Create virtual environment
+python -m pip install --upgrade pip
+python -m venv .venv
+echo "*" > .venv/.gitignore
+source .venv/Scripts/activate
+
+if [ "$CHANNEL" = "release" ]; then
+  echo "Installing latest stable version of PyTorch."
+  pip3 install --pre torch --index-url https://download.pytorch.org/whl/torch/
+elif [ "$CHANNEL" = "test" ]; then
+  echo "Installing PyTorch version $PYTORCH_VERSION."
+  pip3 install --pre torch=="$PYTORCH_VERSION" --index-url https://download.pytorch.org/whl/test
+else
+  echo "CHANNEL is not set, installing PyTorch from nightly."
+  pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
+fi
+
+echo "Dependencies install finished successfully."

--- a/tools/setup_helpers/extension.py
+++ b/tools/setup_helpers/extension.py
@@ -106,8 +106,8 @@ def get_ext_modules():
         extension(
             name="torchaudio.lib._torchaudio",
             sources=[
-                _CSRC_DIR / "_torchaudio.cpp",
-                _CSRC_DIR / "utils.cpp",
+                str(_CSRC_DIR / "_torchaudio.cpp"),
+                str(_CSRC_DIR / "utils.cpp"),
             ],
             py_limited_api=True,
             extra_compile_args=extra_compile_args,
@@ -115,7 +115,7 @@ def get_ext_modules():
         ),
         extension(
             name="torchaudio.lib.libtorchaudio",
-            sources=[_CSRC_DIR / s for s in sources],
+            sources=[str(_CSRC_DIR / s) for s in sources],
             py_limited_api=True,
             extra_compile_args=extra_compile_args,
             include_dirs=[_CSRC_DIR.parent],
@@ -127,7 +127,7 @@ def get_ext_modules():
                 extension(
                     name="torchaudio.lib.torchaudio_prefixctc",
                     sources=[
-                        _CSRC_DIR / "cuctc" / "src" / s
+                        str(_CSRC_DIR / "cuctc" / "src" / s)
                         for s in ["ctc_prefix_decoder.cpp", "ctc_prefix_decoder_kernel_v2.cu", "python_binding.cpp"]
                     ],
                     py_limited_api=True,


### PR DESCRIPTION
This PR enables native Windows ARM64 wheel builds for Torchaudio in CI.

**Changes included:**
1. **New CI Workflow**: Added `build_wheel_windows_arm64.yml` to trigger the `build_wheels_windows.yml` reusable workflow from `pytorch/test-infra` specifically for the `arm64` architecture.
2. **Environment Bootstrapping**: Added `pre_build_script_arm64.sh`. Because `test-infra` currently bypasses the standard `env-script` (which uses Conda/vc_env_helper) for ARM64, this bash script is required to manually bootstrap a `.venv` and install the correct PyTorch wheels (Stable/Test/Nightly) prior to compilation.
3. **Setuptools Compatibility Fix**: Modified `tools/setup_helpers/extension.py` to cast `pathlib.Path` objects in the C++ extension `sources` lists to strings using `str()`. This prevents an `AssertionError` crash in Python (which relies on `setuptools._distutils` >= 72.0, where strict string typing is enforced).