### PR TITLE
Build a single abi3 wheel instead of one per Python version

### DIFF
--- a/.github/actions/test-abi3-wheel/action.yml
+++ b/.github/actions/test-abi3-wheel/action.yml
@@ -1,0 +1,37 @@
+name: Test abi3 wheel
+description: >
+  Install the abi3 wheel built by the build job into a different Python version
+  than the one it was built with, and run the smoke test.
+
+inputs:
+  python-version:
+    description: Python version to install the wheel into
+    required: true
+  artifact-pattern:
+    description: Pattern matching the artifact holding the CPU wheel
+    required: true
+  wheel-glob:
+    description: Glob the downloaded wheel must match, asserting its tags
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+        # 3.15 is still a CPython pre-release.
+        allow-prereleases: true
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: ${{ inputs.artifact-pattern }}
+        merge-multiple: true
+        path: dist
+    - shell: bash
+      run: |
+        set -euxo pipefail
+        # Fails the job if the wheel isn't tagged the way we expect.
+        wheel=$(ls ${{ inputs.wheel-glob }})
+        pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
+        pip install "${wheel}"
+        python test/smoke_test/smoke_test_no_ffmpeg.py

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -55,3 +55,17 @@ jobs:
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+  # Only the newest Python here; build_wheels_linux.yml sweeps the whole range.
+  test-abi3-wheel:
+    needs: build
+    name: test-abi3-wheel-py3.15
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/test-abi3-wheel
+        with:
+          python-version: "3.15"
+          # The macOS build matrix pins .0 point versions, but the artifact name
+          # is built from the short version. It carries no arch suffix.
+          artifact-pattern: "*_3.10_cpu_*"
+          wheel-glob: "dist/torchaudio-*-abi3-macosx_*_arm64.whl"

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -23,12 +23,13 @@ permissions:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: NicolasHug/test-infra/.github/workflows/generate_binary_build_matrix.yml@abiabiabiabia
     with:
       package-type: wheel
       os: macos-arm64
-      test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-repository: NicolasHug/test-infra
+      test-infra-ref: abiabiabiabia
+      python-abi3: enable
   build:
     needs: generate-matrix
     strategy:
@@ -39,12 +40,12 @@ jobs:
             smoke-test-script: test/smoke_test/smoke_test_no_ffmpeg.py
             package-name: torchaudio
     name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_macos.yml@main
+    uses: NicolasHug/test-infra/.github/workflows/build_wheels_macos.yml@abiabiabiabia
     with:
       repository: ${{ matrix.repository }}
       ref: ""
-      test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-repository: NicolasHug/test-infra
+      test-infra-ref: abiabiabiabia
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
       runner-type: macos-m1-stable

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -23,12 +23,12 @@ permissions:
 
 jobs:
   generate-matrix:
-    uses: NicolasHug/test-infra/.github/workflows/generate_binary_build_matrix.yml@abiabiabiabia
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: wheel
       os: macos-arm64
-      test-infra-repository: NicolasHug/test-infra
-      test-infra-ref: abiabiabiabia
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
       python-abi3: enable
   build:
     needs: generate-matrix
@@ -40,12 +40,12 @@ jobs:
             smoke-test-script: test/smoke_test/smoke_test_no_ffmpeg.py
             package-name: torchaudio
     name: ${{ matrix.repository }}
-    uses: NicolasHug/test-infra/.github/workflows/build_wheels_macos.yml@abiabiabiabia
+    uses: pytorch/test-infra/.github/workflows/build_wheels_macos.yml@main
     with:
       repository: ${{ matrix.repository }}
       ref: ""
-      test-infra-repository: NicolasHug/test-infra
-      test-infra-ref: abiabiabiabia
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
       runner-type: macos-m1-stable

--- a/.github/workflows/build_wheels_aarch64_linux.yml
+++ b/.github/workflows/build_wheels_aarch64_linux.yml
@@ -59,3 +59,15 @@ jobs:
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+  # Only the newest Python here; build_wheels_linux.yml sweeps the whole range.
+  test-abi3-wheel:
+    needs: build
+    name: test-abi3-wheel-py3.15
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/test-abi3-wheel
+        with:
+          python-version: "3.15"
+          artifact-pattern: "*_3.10_cpu_aarch64"
+          wheel-glob: "dist/torchaudio-*-abi3-manylinux*_aarch64.whl"

--- a/.github/workflows/build_wheels_aarch64_linux.yml
+++ b/.github/workflows/build_wheels_aarch64_linux.yml
@@ -23,12 +23,12 @@ permissions:
 
 jobs:
   generate-matrix:
-    uses: NicolasHug/test-infra/.github/workflows/generate_binary_build_matrix.yml@abiabiabiabia
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: wheel
       os: linux-aarch64
-      test-infra-repository: NicolasHug/test-infra
-      test-infra-ref: abiabiabiabia
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
       with-cuda: enable
       python-abi3: enable
   build:
@@ -41,12 +41,12 @@ jobs:
             smoke-test-script: test/smoke_test/smoke_test.py
             package-name: torchaudio
     name: ${{ matrix.repository }}
-    uses: NicolasHug/test-infra/.github/workflows/build_wheels_linux.yml@abiabiabiabia
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
     with:
       repository: ${{ matrix.repository }}
       ref: ""
-      test-infra-repository: NicolasHug/test-infra
-      test-infra-ref: abiabiabiabia
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}

--- a/.github/workflows/build_wheels_aarch64_linux.yml
+++ b/.github/workflows/build_wheels_aarch64_linux.yml
@@ -23,13 +23,14 @@ permissions:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: NicolasHug/test-infra/.github/workflows/generate_binary_build_matrix.yml@abiabiabiabia
     with:
       package-type: wheel
       os: linux-aarch64
-      test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-repository: NicolasHug/test-infra
+      test-infra-ref: abiabiabiabia
       with-cuda: enable
+      python-abi3: enable
   build:
     needs: generate-matrix
     strategy:
@@ -40,12 +41,12 @@ jobs:
             smoke-test-script: test/smoke_test/smoke_test.py
             package-name: torchaudio
     name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    uses: NicolasHug/test-infra/.github/workflows/build_wheels_linux.yml@abiabiabiabia
     with:
       repository: ${{ matrix.repository }}
       ref: ""
-      test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-repository: NicolasHug/test-infra
+      test-infra-ref: abiabiabiabia
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -23,12 +23,12 @@ permissions:
 
 jobs:
   generate-matrix:
-    uses: NicolasHug/test-infra/.github/workflows/generate_binary_build_matrix.yml@abiabiabiabia
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: wheel
       os: linux
-      test-infra-repository: NicolasHug/test-infra
-      test-infra-ref: abiabiabiabia
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
       with-xpu: enable
       python-abi3: enable
   build:
@@ -41,12 +41,12 @@ jobs:
             smoke-test-script: test/smoke_test/smoke_test_no_ffmpeg.py
             package-name: torchaudio
     name: ${{ matrix.repository }}
-    uses: NicolasHug/test-infra/.github/workflows/build_wheels_linux.yml@abiabiabiabia
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
     with:
       repository: ${{ matrix.repository }}
       ref: ""
-      test-infra-repository: NicolasHug/test-infra
-      test-infra-ref: abiabiabiabia
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
       package-name: ${{ matrix.package-name }}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -57,31 +57,22 @@ jobs:
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
   # The build job only ever installs the wheel back into the interpreter that built
   # it, so it cannot catch an abi3 wheel that fails to load on a newer CPython.
+  # This is the platform we sweep the full version range on; the others only check
+  # the newest version, which is the one the build interpreter is furthest from.
   test-abi3-wheel:
     needs: build
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
     name: test-abi3-wheel-py${{ matrix.python-version }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: ./.github/actions/test-abi3-wheel
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Download the CPU wheel
-        uses: actions/download-artifact@v4
-        with:
           # The build job names its artifact after the interpreter it built with,
           # which for the abi3 wheel is the oldest supported one.
-          pattern: "*_3.10_cpu_x86_64"
-          merge-multiple: true
-          path: dist
-      - name: Install and smoke test
-        run: |
-          set -euxo pipefail
-          wheel=$(ls dist/torchaudio-*-abi3-manylinux*_x86_64.whl)
-          pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
-          pip install "${wheel}"
-          python test/smoke_test/smoke_test_no_ffmpeg.py
+          artifact-pattern: "*_3.10_cpu_x86_64"
+          wheel-glob: "dist/torchaudio-*-abi3-manylinux*_x86_64.whl"

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -23,13 +23,14 @@ permissions:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: NicolasHug/test-infra/.github/workflows/generate_binary_build_matrix.yml@abiabiabiabia
     with:
       package-type: wheel
       os: linux
-      test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-repository: NicolasHug/test-infra
+      test-infra-ref: abiabiabiabia
       with-xpu: enable
+      python-abi3: enable
   build:
     needs: generate-matrix
     strategy:
@@ -40,12 +41,12 @@ jobs:
             smoke-test-script: test/smoke_test/smoke_test_no_ffmpeg.py
             package-name: torchaudio
     name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    uses: NicolasHug/test-infra/.github/workflows/build_wheels_linux.yml@abiabiabiabia
     with:
       repository: ${{ matrix.repository }}
       ref: ""
-      test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-repository: NicolasHug/test-infra
+      test-infra-ref: abiabiabiabia
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
       package-name: ${{ matrix.package-name }}
@@ -54,3 +55,33 @@ jobs:
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+  # The build job only ever installs the wheel back into the interpreter that built
+  # it, so it cannot catch an abi3 wheel that fails to load on a newer CPython.
+  test-abi3-wheel:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    name: test-abi3-wheel-py${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Download the CPU wheel
+        uses: actions/download-artifact@v4
+        with:
+          # The build job names its artifact after the interpreter it built with,
+          # which for the abi3 wheel is the oldest supported one.
+          pattern: "*_3.10_cpu_x86_64"
+          merge-multiple: true
+          path: dist
+      - name: Install and smoke test
+        run: |
+          set -euxo pipefail
+          wheel=$(ls dist/torchaudio-*-abi3-manylinux*_x86_64.whl)
+          pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
+          pip install "${wheel}"
+          python test/smoke_test/smoke_test_no_ffmpeg.py

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -53,3 +53,15 @@ jobs:
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+  # Only the newest Python here; build_wheels_linux.yml sweeps the whole range.
+  test-abi3-wheel:
+    needs: build
+    name: test-abi3-wheel-py3.15
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/test-abi3-wheel
+        with:
+          python-version: "3.15"
+          artifact-pattern: "*_3.10_cpu_x64"
+          wheel-glob: "dist/torchaudio-*-abi3-win_amd64.whl"

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -19,13 +19,14 @@ permissions:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: NicolasHug/test-infra/.github/workflows/generate_binary_build_matrix.yml@abiabiabiabia
     with:
       package-type: wheel
       os: windows
-      test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-repository: NicolasHug/test-infra
+      test-infra-ref: abiabiabiabia
       with-xpu: enable
+      python-abi3: enable
   build:
     needs: generate-matrix
     strategy:
@@ -34,16 +35,15 @@ jobs:
         include:
           - repository: pytorch/audio
             env-script: packaging/vc_env_helper.bat
-            wheel-build-params: "--plat-name win_amd64"
             smoke-test-script: test/smoke_test/smoke_test_no_ffmpeg.py
             package-name: torchaudio
     name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_windows.yml@main
+    uses: NicolasHug/test-infra/.github/workflows/build_wheels_windows.yml@abiabiabiabia
     with:
       repository: ${{ matrix.repository }}
       ref: ""
-      test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-repository: NicolasHug/test-infra
+      test-infra-ref: abiabiabiabia
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       env-script: ${{ matrix.env-script }}
       package-name: ${{ matrix.package-name }}

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -19,12 +19,12 @@ permissions:
 
 jobs:
   generate-matrix:
-    uses: NicolasHug/test-infra/.github/workflows/generate_binary_build_matrix.yml@abiabiabiabia
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: wheel
       os: windows
-      test-infra-repository: NicolasHug/test-infra
-      test-infra-ref: abiabiabiabia
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
       with-xpu: enable
       python-abi3: enable
   build:
@@ -38,12 +38,12 @@ jobs:
             smoke-test-script: test/smoke_test/smoke_test_no_ffmpeg.py
             package-name: torchaudio
     name: ${{ matrix.repository }}
-    uses: NicolasHug/test-infra/.github/workflows/build_wheels_windows.yml@abiabiabiabia
+    uses: pytorch/test-infra/.github/workflows/build_wheels_windows.yml@main
     with:
       repository: ${{ matrix.repository }}
       ref: ""
-      test-infra-repository: NicolasHug/test-infra
-      test-infra-ref: abiabiabiabia
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       env-script: ${{ matrix.env-script }}
       package-name: ${{ matrix.package-name }}

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -55,6 +55,11 @@ PyTorch 2.11 and all later versions. Earlier TorchAudio releases contain
 extension modules linked against a single PyTorch version, and cannot be mixed
 with a different PyTorch release.
 
+TorchAudio's extension modules also target CPython's stable ABI (``abi3``), so a
+single wheel per platform covers every supported Python version. Free-threaded
+CPython builds are the exception: they cannot use ``abi3`` wheels, so they get a
+dedicated wheel of their own.
+
 .. list-table::
    :header-rows: 1
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -55,11 +55,6 @@ PyTorch 2.11 and all later versions. Earlier TorchAudio releases contain
 extension modules linked against a single PyTorch version, and cannot be mixed
 with a different PyTorch release.
 
-TorchAudio's extension modules also target CPython's stable ABI (``abi3``), so a
-single wheel per platform covers every supported Python version. Free-threaded
-CPython builds are the exception: they cannot use ``abi3`` wheels, so they get a
-dedicated wheel of their own.
-
 .. list-table::
    :header-rows: 1
 

--- a/setup.py
+++ b/setup.py
@@ -134,11 +134,13 @@ def _main():
         ],
         packages=find_packages(where="src"),
         package_dir={"": "src"},
+        python_requires=">=3.10",
         ext_modules=setup_helpers.get_ext_modules(),
         cmdclass={
             "build_ext": setup_helpers.get_build_ext(),
             "clean": clean,
         },
+        options=setup_helpers.get_bdist_wheel_options(),
         install_requires=[],
         zip_safe=False,
     )

--- a/tools/setup_helpers/extension.py
+++ b/tools/setup_helpers/extension.py
@@ -1,13 +1,15 @@
 import os
 import platform
+import sysconfig
 from pathlib import Path
 
 import torch
-from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDAExtension
+from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDAExtension, min_supported_cpython
 
 __all__ = [
     "get_ext_modules",
     "get_build_ext",
+    "get_bdist_wheel_options",
 ]
 
 _THIS_DIR = Path(__file__).parent.resolve()
@@ -38,6 +40,10 @@ _BUILD_CUDA_CTC_DECODER = _get_build("BUILD_CUDA_CTC_DECODER", _USE_CUDA)
 _USE_OPENMP = _get_build("USE_OPENMP", True) and "ATen parallel backend: OpenMP" in torch.__config__.parallel_info()
 _TORCH_CUDA_ARCH_LIST = os.environ.get("TORCH_CUDA_ARCH_LIST", None)
 
+# Free-threaded interpreters do not support the limited API, and pip refuses to install
+# an abi3 wheel on them. See packaging.tags._abi3_applies.
+_USE_PY_LIMITED_API = not sysconfig.get_config_var("Py_GIL_DISABLED")
+
 
 class BuildExtensionAsLibrary(BuildExtension):
     def get_export_symbols(self, ext):
@@ -53,6 +59,20 @@ def get_build_ext():
         no_python_abi_suffix=False,
         use_ninja=True,
     )
+
+
+def get_bdist_wheel_options():
+    """Tag the wheel abi3 so that a single wheel covers every supported CPython.
+
+    The tag must match the ``Py_LIMITED_API`` level that torch compiles the extensions
+    with, otherwise the wheel would claim a compatibility it doesn't have.
+    """
+    if not _USE_PY_LIMITED_API:
+        return {}
+    # min_supported_cpython is a Python hexversion, e.g. "0x030A0000" for 3.10.
+    hexversion = int(min_supported_cpython, 16)
+    major, minor = (hexversion >> 24) & 0xFF, (hexversion >> 16) & 0xFF
+    return {"bdist_wheel": {"py_limited_api": f"cp{major}{minor}"}}
 
 
 def get_ext_modules():
@@ -109,14 +129,14 @@ def get_ext_modules():
                 _CSRC_DIR / "_torchaudio.cpp",
                 _CSRC_DIR / "utils.cpp",
             ],
-            py_limited_api=True,
+            py_limited_api=_USE_PY_LIMITED_API,
             extra_compile_args=extra_compile_args,
             include_dirs=[_CSRC_DIR.parent],
         ),
         extension(
             name="torchaudio.lib.libtorchaudio",
             sources=[_CSRC_DIR / s for s in sources],
-            py_limited_api=True,
+            py_limited_api=_USE_PY_LIMITED_API,
             extra_compile_args=extra_compile_args,
             include_dirs=[_CSRC_DIR.parent],
         ),
@@ -130,7 +150,7 @@ def get_ext_modules():
                         _CSRC_DIR / "cuctc" / "src" / s
                         for s in ["ctc_prefix_decoder.cpp", "ctc_prefix_decoder_kernel_v2.cu", "python_binding.cpp"]
                     ],
-                    py_limited_api=True,
+                    py_limited_api=_USE_PY_LIMITED_API,
                     extra_compile_args=extra_compile_args,
                     include_dirs=[_CSRC_DIR / "cuctc", _CSRC_DIR.parent],
                 ),


### PR DESCRIPTION
The extensions are already built with `Py_LIMITED_API` (they contain zero Python C-API and ship as `*.abi3.so`), but nothing passed `py_limited_api` to `bdist_wheel`, so we still tagged and built one wheel per Python version.

Setting it in `setup.py` gives `torchaudio-<ver>-cp310-abi3-<plat>.whl`, and `python-abi3: enable` collapses the build matrix from 8 Python versions to 3. Free-threaded builds can't use abi3 wheels, so they opt out and keep their own wheel.

Also adds a `test-abi3-wheel` job, since the existing smoke test only installs the wheel back into the interpreter that built it.

Verified locally: built on 3.11, installed via plain `pip install` on 3.10 / 3.11 / 3.12 against three different torch versions, smoke test passed on all.

Depends on https://github.com/pytorch/test-infra/pull/8708. Will change back the refs to `main` before merging this.