### PR TITLE
Compute _get_strided strides after padding so non-contiguous input works (closes #3856)

### DIFF
--- a/src/torchaudio/compliance/kaldi.py
+++ b/src/torchaudio/compliance/kaldi.py
@@ -58,7 +58,6 @@ def _get_strided(waveform: Tensor, window_size: int, window_shift: int, snip_edg
     """
     assert waveform.dim() == 1
     num_samples = waveform.size(0)
-    strides = (window_shift * waveform.stride(0), waveform.stride(0))
 
     if snip_edges:
         if num_samples < window_size:
@@ -79,6 +78,9 @@ def _get_strided(waveform: Tensor, window_size: int, window_shift: int, snip_edg
             # pad is negative so we want to trim the waveform at the front
             waveform = torch.cat((waveform[-pad:], pad_right), dim=0)
 
+    # The padding above rebinds ``waveform`` to a fresh contiguous tensor, so the
+    # strides must be read after it, not before.
+    strides = (window_shift * waveform.stride(0), waveform.stride(0))
     sizes = (m, window_size)
     return waveform.as_strided(sizes, strides)
 

--- a/test/torchaudio_unittest/compliance/kaldi/legacy_test.py
+++ b/test/torchaudio_unittest/compliance/kaldi/legacy_test.py
@@ -69,6 +69,23 @@ class Test_Kaldi(common_utils.TempDirMixin, common_utils.TorchaudioTestCase):
                     for snip_edges in range(0, 2):
                         self._test_get_strided_helper(num_samples, window_size, window_shift, snip_edges)
 
+    def test_get_strided_non_contiguous(self):
+        # https://github.com/pytorch/audio/issues/3856
+        waveform = torch.arange(128).float()[::2]
+        self.assertFalse(waveform.is_contiguous())
+        for snip_edges in (True, False):
+            expected = kaldi._get_strided(waveform.contiguous(), 10, 3, snip_edges)
+            actual = kaldi._get_strided(waveform, 10, 3, snip_edges)
+            self.assertEqual(actual, expected)
+
+    def test_fbank_non_contiguous(self):
+        # https://github.com/pytorch/audio/issues/3856
+        waveform = (torch.rand(1, 32000) * (1 << 15))[:, ::2]
+        self.assertFalse(waveform.is_contiguous())
+        expected = kaldi.fbank(waveform.contiguous(), snip_edges=False, dither=0.0)
+        actual = kaldi.fbank(waveform, snip_edges=False, dither=0.0)
+        self.assertEqual(actual, expected)
+
     def test_mfcc_empty(self):
         # Passing in an empty tensor should result in an error
         self.assertRaises(AssertionError, kaldi.mfcc, torch.empty(0))


### PR DESCRIPTION
Closes #3856.

`_get_strided` reads `strides = (window_shift * waveform.stride(0), waveform.stride(0))` at the top of the function, but the `snip_edges=False` branch then rebinds `waveform` to a fresh contiguous tensor returned by `torch.cat`. The stale stride from the original view is handed to `as_strided` on the new buffer, so any waveform whose last-dim stride is not 1 reads past the end of storage. That is the `(time, channel)` layout from soundfile or librosa transposed to `(channel, time)` without `.contiguous()`.

On `b85c99c`, `kaldi.fbank((torch.rand(1, 32000) * (1 << 15))[:, ::2], snip_edges=False)` raises:

```
RuntimeError: setStorage: sizes [100, 400], strides [320, 2], storage offset 0,
and itemsize 4 requiring a storage size of 129916 are out of bounds for storage of size 128480
```

`mfcc` and `spectrogram` fail identically. The fix moves the stride computation below the padding block. After it, contiguous and non-contiguous inputs agree exactly (maxdiff 0.0 for all three entry points). `snip_edges=True` never re-copies the waveform, so that path is untouched.

Two tests added to `legacy_test.py`; both fail on main and pass here. `test/torchaudio_unittest/compliance` + `functional`: 64 failed / 1607 passed on pristine main, 64 failed / 1609 passed with this branch, identical failure sets (rnnt, forced_align and librosa comparisons fail in my local build either way). flake8 and black clean.

Credit to @gau-nernst, who filed the issue with the correct diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
