### PR TITLE
Fix transforms.Fade silently promoting float16/bfloat16 waveforms to float32

### DIFF
--- a/src/torchaudio/transforms/_transforms.py
+++ b/src/torchaudio/transforms/_transforms.py
@@ -1128,11 +1128,12 @@ class Fade(torch.nn.Module):
         """
         waveform_length = waveform.size()[-1]
         device = waveform.device
-        return self._fade_in(waveform_length, device) * self._fade_out(waveform_length, device) * waveform
+        dtype = waveform.dtype
+        return self._fade_in(waveform_length, device, dtype) * self._fade_out(waveform_length, device, dtype) * waveform
 
-    def _fade_in(self, waveform_length: int, device: torch.device) -> Tensor:
-        fade = torch.linspace(0, 1, self.fade_in_len, device=device)
-        ones = torch.ones(waveform_length - self.fade_in_len, device=device)
+    def _fade_in(self, waveform_length: int, device: torch.device, dtype: torch.dtype = torch.float32) -> Tensor:
+        fade = torch.linspace(0, 1, self.fade_in_len, device=device, dtype=dtype)
+        ones = torch.ones(waveform_length - self.fade_in_len, device=device, dtype=dtype)
 
         if self.fade_shape == "linear":
             fade = fade
@@ -1151,9 +1152,9 @@ class Fade(torch.nn.Module):
 
         return torch.cat((fade, ones)).clamp_(0, 1)
 
-    def _fade_out(self, waveform_length: int, device: torch.device) -> Tensor:
-        fade = torch.linspace(0, 1, self.fade_out_len, device=device)
-        ones = torch.ones(waveform_length - self.fade_out_len, device=device)
+    def _fade_out(self, waveform_length: int, device: torch.device, dtype: torch.dtype = torch.float32) -> Tensor:
+        fade = torch.linspace(0, 1, self.fade_out_len, device=device, dtype=dtype)
+        ones = torch.ones(waveform_length - self.fade_out_len, device=device, dtype=dtype)
 
         if self.fade_shape == "linear":
             fade = -fade + 1

--- a/test/torchaudio_unittest/transforms/transforms_test_impl.py
+++ b/test/torchaudio_unittest/transforms/transforms_test_impl.py
@@ -151,6 +151,24 @@ class TransformsTestBase(TestBaseMixin):
         specgram_enhanced = transform(specgram, mask_s, mask_n)
         assert specgram_enhanced.dtype == dtype
 
+    @parameterized.expand(
+        [
+            param(torch.float64),
+            param(torch.float32),
+            param(torch.float16),
+            param(torch.bfloat16),
+        ]
+    )
+    def test_fade_preserves_dtype(self, dtype):
+        """Fade must return the input's dtype. The fade envelope was built with
+        an implicit float32 dtype, so a lower-precision waveform (float16 /
+        bfloat16) was silently promoted to float32 by the envelope multiply."""
+        for fade_shape in ("linear", "exponential", "logarithmic", "quarter_sine", "half_sine"):
+            transform = T.Fade(fade_in_len=8, fade_out_len=8, fade_shape=fade_shape)
+            waveform = torch.rand(2, 64, dtype=dtype)
+            faded = transform(waveform)
+            assert faded.dtype == dtype, f"{fade_shape}: {faded.dtype} != {dtype}"
+
     def test_pitch_shift_resample_kernel(self):
         """The resampling kernel in PitchShift is identical to what helper function generates.
         There should be no numerical difference caused by dtype conversion.


### PR DESCRIPTION
## Fix `transforms.Fade` silently promoting float16 / bfloat16 waveforms to float32

### Symptom

`Fade` does not preserve the input waveform's dtype for low-precision inputs:

```python
import torch
from torchaudio.transforms import Fade

for dt in (torch.float64, torch.float32, torch.float16, torch.bfloat16):
    y = Fade(fade_in_len=5, fade_out_len=5)(torch.rand(2, 40, dtype=dt))
    print(dt, "->", y.dtype)
# torch.float64  -> torch.float64
# torch.float32  -> torch.float32
# torch.float16  -> torch.float32     # <-- dtype silently lost
# torch.bfloat16 -> torch.float32     # <-- dtype silently lost
```

No error is raised; the waveform is just upcast. In a CUDA AMP / `float16`
inference pipeline this breaks dtype consistency and doubles the memory of that
tensor. `.. devices:: CPU CUDA` and the docstring place no dtype restriction on
the transform.

### Root cause

`Fade._fade_in` / `_fade_out` build the fade envelope with `torch.linspace` and
`torch.ones` passing `device=` but **not** `dtype=`, so the envelope is always
`float32`. `forward` then returns `fade_in * fade_out * waveform`:

* `float32_envelope * float64_waveform` promotes **up** to `float64` — so float64
  happens to survive, which is why the bug is easy to miss;
* `float32_envelope * float16_waveform` resolves to `float32` — the waveform's
  dtype is lost. Same for `bfloat16`.

Only `device` was threaded through from the waveform; `dtype` was not.

### Fix

Thread `dtype` through exactly as `device` already is. The `= torch.float32`
default on the private helpers keeps any existing 2-arg call site and TorchScript
working.

```python
def forward(self, waveform: Tensor) -> Tensor:
    waveform_length = waveform.size()[-1]
    device = waveform.device
    dtype = waveform.dtype
    return self._fade_in(waveform_length, device, dtype) * self._fade_out(waveform_length, device, dtype) * waveform

def _fade_in(self, waveform_length: int, device: torch.device, dtype: torch.dtype = torch.float32) -> Tensor:
    fade = torch.linspace(0, 1, self.fade_in_len, device=device, dtype=dtype)
    ones = torch.ones(waveform_length - self.fade_in_len, device=device, dtype=dtype)
    ...
```

### Verification

* `float32` and `float64` outputs are **byte-identical** before/after
  (`torch.equal`) — no numerical change on the common paths.
* All five `fade_shape`s work in `float16` / `bfloat16` on CPU and CUDA with
  torch >= 2.x (`sin` / `log10` / `pow` support half there).
* `torch.jit.script(Fade(...))` compiles and preserves dtype for every fade
  shape.

### Test

`test/torchaudio_unittest/transforms/transforms_test_impl.py::test_fade_preserves_dtype`
— parametrised over `{float64, float32, float16, bfloat16}` × all five fade
shapes, asserts `Fade(...)(waveform).dtype == waveform.dtype`. Fails on `main`
(float16 / bfloat16), passes with this change. Mirrors the existing
`test_mvdr` ("Make sure the output dtype is the same as the input dtype").

Local run (fix applied): `transforms_cpu`, `batch_consistency`,
`torchscript_consistency_cpu`, `autograd_cpu` Fade tests — **16 passed**.

### Before submitting

- [x] bug fix, filed directly (per CONTRIBUTING.md, bug fixes need no prior issue)
- [x] added a regression test under `test/torchaudio_unittest/`
- [x] `ufmt` (black 22.3, line-length 120) and `flake8` clean on the changed files
- [x] no API change; no docs change needed
